### PR TITLE
feat(agent-org): add multi-target Group work and Linked Inbox

### DIFF
--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/schema.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/schema.rs
@@ -146,6 +146,8 @@ fn create_agent_inbox_table(conn: &Connection) -> SqliteResult<()> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS agent_org_runtime_inbox (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            delivery_class TEXT NOT NULL DEFAULT 'formal_work'
+                CHECK(delivery_class IN ('formal_work','user_directed')),
             recipient_agent_id TEXT NOT NULL,
             recipient_member_id TEXT,
             sender_agent_id TEXT NOT NULL,
@@ -183,6 +185,7 @@ mod tests {
         assert!(columns.iter().any(|column| column == "causation_inbox_id"));
         assert!(columns.iter().any(|column| column == "display_text"));
         assert!(columns.iter().any(|column| column == "client_message_id"));
+        assert!(columns.iter().any(|column| column == "delivery_class"));
         assert!(conn
             .query_row(
                 "SELECT EXISTS(

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/store_drain.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/store_drain.rs
@@ -84,6 +84,7 @@ impl AgentInboxStore {
                   AND task.owner=?1
                  WHERE inbox.recipient_member_id=?1
                    AND inbox.org_run_id=?2
+                   AND inbox.delivery_class='formal_work'
                    AND inbox.read_at IS NULL
                    AND NOT EXISTS (
                        SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
@@ -157,7 +158,7 @@ impl AgentInboxStore {
                                 created_at,
                                 read_at
                          FROM agent_org_runtime_inbox
-                         WHERE id=?1 AND org_run_id=?2",
+                         WHERE id=?1 AND org_run_id=?2 AND delivery_class='formal_work'",
                         params![inbox_id, org_run_id],
                         row_to_record,
                     )
@@ -198,6 +199,7 @@ impl AgentInboxStore {
                  SELECT 1 FROM agent_org_runtime_inbox
                  WHERE recipient_member_id = ?1
                    AND org_run_id = ?2
+                   AND delivery_class='formal_work'
                    AND read_at IS NULL
                    AND NOT EXISTS (
                        SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
@@ -232,6 +234,7 @@ impl AgentInboxStore {
                  FROM agent_org_runtime_inbox
                  WHERE recipient_member_id = ?1
                    AND org_run_id = ?2
+                   AND delivery_class='formal_work'
                    AND read_at IS NULL
                    AND NOT EXISTS (
                        SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
@@ -262,6 +265,7 @@ impl AgentInboxStore {
             "SELECT MAX(id) FROM agent_org_runtime_inbox
              WHERE recipient_member_id=?1
                AND org_run_id=?2
+               AND delivery_class='formal_work'
                AND read_at IS NULL
                AND NOT EXISTS (
                    SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
@@ -288,6 +292,7 @@ impl AgentInboxStore {
                  WHERE recipient_member_id=?1
                    AND org_run_id=?2
                    AND id<=?3
+                   AND delivery_class='formal_work'
                    AND read_at IS NULL
                    AND NOT EXISTS (
                        SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
@@ -338,6 +343,7 @@ impl AgentInboxStore {
                  FROM agent_org_runtime_inbox
                  WHERE recipient_member_id = ?1
                    AND org_run_id = ?2
+                   AND delivery_class='formal_work'
                    AND read_at IS NULL
                    AND NOT EXISTS (
                        SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
@@ -431,7 +437,7 @@ impl AgentInboxStore {
                         request_id,created_at,read_at
                  FROM agent_org_runtime_inbox
                  WHERE id=?1 AND recipient_member_id='coordinator'
-                   AND org_run_id=?3 AND read_at IS NULL
+                   AND org_run_id=?3 AND delivery_class='formal_work' AND read_at IS NULL
                    AND NOT EXISTS (
                        SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
                        WHERE resolution.inbox_id=agent_org_runtime_inbox.id
@@ -804,6 +810,7 @@ fn resume_continuation_owns_assignment(
                AND original.owner_member_id=handoff.participant_id
                AND task.status IN ('in_progress','completed')
                AND task.owner=handoff.participant_id
+               AND inbox.delivery_class='formal_work'
                AND inbox.read_at IS NULL
                AND inbox.payload_kind='task_assigned'
                AND json_valid(inbox.payload_json)

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/store_read.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/store_read.rs
@@ -25,6 +25,7 @@ pub(super) const UNREAD_COUNTS_BY_RECIPIENT_SQL: &str = "SELECT recipient_agent_
             MAX(id) AS max_unread_id
      FROM agent_org_runtime_inbox INDEXED BY idx_agent_org_runtime_inbox_run_unread_recipient
      WHERE org_run_id = ?1
+       AND delivery_class='formal_work'
        AND read_at IS NULL
        AND NOT EXISTS (
             SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
@@ -454,7 +455,7 @@ impl AgentInboxStore {
             .query_row(
                 "SELECT recipient_member_id, read_at
                      FROM agent_org_runtime_inbox
-                     WHERE id=?1 AND org_run_id=?2
+                     WHERE id=?1 AND org_run_id=?2 AND delivery_class='formal_work'
                      LIMIT 1",
                 params![params.inbox_id, &params.org_run_id],
                 |row| Ok((row.get(0)?, row.get(1)?)),
@@ -522,6 +523,7 @@ impl AgentInboxStore {
                                 )
                          FROM agent_org_runtime_inbox inbox
                          WHERE inbox.id=?1 AND inbox.org_run_id=?2
+                           AND inbox.delivery_class='formal_work'
                          LIMIT 1",
                     params![replacement_inbox_id, &params.org_run_id],
                     |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
@@ -820,7 +822,7 @@ impl AgentInboxStore {
                 "SELECT recipient_agent_id,
                         recipient_member_id,
                         COUNT(*) AS activity_count,
-                        SUM(CASE WHEN read_at IS NULL
+                        SUM(CASE WHEN delivery_class='formal_work' AND read_at IS NULL
                                       AND NOT EXISTS (
                                           SELECT 1
                                           FROM agent_org_runtime_inbox_delivery_resolutions resolution
@@ -903,6 +905,7 @@ impl AgentInboxStore {
                  FROM agent_org_runtime_inbox
                  WHERE recipient_member_id=?1
                    AND org_run_id=?2
+                   AND delivery_class='formal_work'
                    AND read_at IS NULL
                    AND NOT EXISTS (
                        SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/store_write.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/store_write.rs
@@ -22,8 +22,8 @@ impl AgentInboxStore {
     /// cancellation so they no longer cause an impossible wake loop or block
     /// Team Quiescence forever.
     ///
-    /// This is intentionally limited to the pre-UserDirectedWork formal
-    /// message classes. PR 9's user-directed Inbox rows have their own exact
+    /// This is intentionally limited to formal message classes. User-directed
+    /// Inbox rows have their own exact
     /// source authority and must never be swept by this fallback.
     pub(crate) fn resolve_obsolete_formal_rows_after_successful_member_turn(
         org_run_id: &str,
@@ -64,6 +64,7 @@ impl AgentInboxStore {
                      FROM agent_org_runtime_inbox inbox
                      WHERE inbox.org_run_id=?1
                        AND inbox.recipient_member_id=?2
+                       AND inbox.delivery_class='formal_work'
                        AND inbox.read_at IS NULL
                        AND inbox.payload_kind IN (
                            'plain','task_assigned','plan_approval_response','shutdown_request'

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/task_bindings.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/task_bindings.rs
@@ -70,11 +70,13 @@ impl AgentInboxStore {
                   AND source_context.turn_intent_id=?5
                   AND source_context.participant_id='coordinator'
                   AND source_context.turn_kind='coordinator'
+                  AND source_context.source_kind='root_turn'
                   AND source_context.activation_generation=run.activation_generation
                  WHERE inbox.id=?2
                    AND inbox.org_run_id=?1
                    AND inbox.recipient_member_id=?4
                    AND inbox.sender_member_id='coordinator'
+                   AND inbox.delivery_class='formal_work'
                    AND inbox.payload_kind='plain'",
                 params![
                     org_run_id,
@@ -124,6 +126,7 @@ pub(crate) fn oldest_unread_task_message_binding_with_connection(
           AND source_context.turn_intent_id=binding.source_turn_intent_id
           AND source_context.participant_id='coordinator'
           AND source_context.turn_kind='coordinator'
+          AND source_context.source_kind='root_turn'
           AND source_context.activation_generation=run.activation_generation
          WHERE binding.org_run_id=?1
            AND binding.recipient_member_id=?2
@@ -132,6 +135,7 @@ pub(crate) fn oldest_unread_task_message_binding_with_connection(
            AND inbox.org_run_id=binding.org_run_id
            AND inbox.recipient_member_id=binding.recipient_member_id
            AND inbox.sender_member_id='coordinator'
+           AND inbox.delivery_class='formal_work'
            AND inbox.payload_kind='plain'
            AND inbox.read_at IS NULL
            AND NOT EXISTS (
@@ -176,6 +180,7 @@ pub(crate) fn backfill_task_message_bindings(conn: &Connection) -> rusqlite::Res
           AND source_context.turn_intent_id=receipt.turn_intent_id
           AND source_context.participant_id='coordinator'
           AND source_context.turn_kind='coordinator'
+          AND source_context.source_kind='root_turn'
          JOIN json_each(
              CASE WHEN json_valid(receipt.result_text)
                   THEN receipt.result_text ELSE '{}' END,
@@ -188,6 +193,7 @@ pub(crate) fn backfill_task_message_bindings(conn: &Connection) -> rusqlite::Res
               delivered.value,'$.recipient_member_id'
           )
           AND inbox.sender_member_id='coordinator'
+          AND inbox.delivery_class='formal_work'
           AND inbox.payload_kind='plain'
          JOIN agent_org_runtime_tasks task
            ON task.org_run_id=inbox.org_run_id

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_member_interventions.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_member_interventions.rs
@@ -12,6 +12,7 @@ use database::db::{get_connection, with_sessions_writer};
 use super::agent_org_runs::AgentOrgRunStatus;
 use super::agent_org_runs::COORDINATOR_MEMBER_ID;
 use super::agent_org_turn_contexts::{self, AgentOrgTurnAdmission, AgentOrgTurnContext};
+use super::agent_org_user_directed_work::{self, NewUserDirectedDelivery, UserDirectedSourceKind};
 use crate::foundation::session_bridge::TurnIntentBridgeStatus;
 
 mod persistence;
@@ -170,6 +171,7 @@ pub(crate) struct EnqueueUserDirectedWorkResult {
 
 #[derive(Debug, Clone)]
 pub(crate) struct RecoverableUserDirectedWork {
+    pub recovery_key: i64,
     pub org_run_id: String,
     pub session_id: String,
     pub turn_intent_id: String,
@@ -275,7 +277,7 @@ impl AgentMemberInterventionStore {
                     .map_err(|error| error.to_string())?;
                 if queued_count >= queue_cap {
                     return Err(format!(
-                        "user_directed_queue_full: Member {} already has {queued_count} queued/running direct Turns (cap {queue_cap})",
+                        "user_directed_queue_full: Member {} already has {queued_count} queued/running UDW Turns (cap {queue_cap})",
                         params.member_id
                     ));
                 }
@@ -294,6 +296,29 @@ impl AgentMemberInterventionStore {
                 "agent_org_turn_context_invalid: UserDirectedWork has no Member FIFO sequence"
                     .to_string()
             })?;
+            let root_delivery = NewUserDirectedDelivery {
+                org_run_id: &params.org_run_id,
+                session_id: &params.session_id,
+                turn_intent_id: &params.turn_intent_id,
+                root_authority_turn_id: &params.turn_intent_id,
+                parent_delivery_id: None,
+                parent_inbox_id: None,
+                source_kind: UserDirectedSourceKind::DirectMember,
+                source_event_id: Some(&params.source_event_id),
+                source_inbox_id: None,
+                dispatch_member_id: &params.member_id,
+                member_dispatch_sequence: sequence,
+                depth: 0,
+                delivery_ordinal: 1,
+                dispatch_content: &params.dispatch_content,
+                display_content: &params.source_display_content,
+                images: params.source_images.as_deref(),
+            };
+            let (_, root_duplicate) =
+                agent_org_user_directed_work::insert_root_delivery_with_connection(
+                    &tx,
+                    &root_delivery,
+                )?;
 
             if let Some((
                 receipt_id,
@@ -306,6 +331,7 @@ impl AgentMemberInterventionStore {
                 if existing_sequence != sequence
                     || existing_dispatch_content != params.dispatch_content
                     || existing_display_content != params.source_display_content
+                    || !root_duplicate
                 {
                     return Err(
                         "user_directed_replay_conflict: Member sequence or content changed"
@@ -678,10 +704,17 @@ impl AgentMemberInterventionStore {
     pub(crate) fn recoverable_queued_turns(
         limit: usize,
     ) -> Result<Vec<RecoverableUserDirectedWork>, String> {
+        Self::recoverable_queued_turns_after(None, limit)
+    }
+
+    pub(crate) fn recoverable_queued_turns_after(
+        after_key: Option<i64>,
+        limit: usize,
+    ) -> Result<Vec<RecoverableUserDirectedWork>, String> {
         let conn = get_connection().map_err(|error| error.to_string())?;
         let mut statement = conn
             .prepare(
-                "SELECT context.org_run_id,chain.session_id,chain.turn_intent_id,
+                "SELECT chain.rowid,context.org_run_id,chain.session_id,chain.turn_intent_id,
                         chain.source_event_id,chain.dispatch_content,
                         chain.display_content,intent.client_message_id,event.result_json
                  FROM agent_org_runtime_member_intervention_turns chain
@@ -698,31 +731,34 @@ impl AgentMemberInterventionStore {
                   AND event.session_id=chain.session_id
                  JOIN agent_org_runtime_runs run ON run.id=context.org_run_id
                  WHERE chain.status='queued' AND intent.status='queued'
+                   AND chain.rowid>COALESCE(?1,0)
                    AND context.turn_kind='user_directed_work'
                    AND context.source_kind='direct_member'
                    AND intervention.status IN ('yield_requested','active','return_requested')
                    AND run.status IN ('running','idle','paused')
-                 ORDER BY context.org_run_id,context.member_dispatch_sequence
-                 LIMIT ?1",
+                 ORDER BY chain.rowid
+                 LIMIT ?2",
             )
             .map_err(|error| error.to_string())?;
         let rows = statement
-            .query_map([limit as i64], |row| {
+            .query_map(params![after_key, limit.clamp(1, 100) as i64], |row| {
                 Ok((
-                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, String>(2)?,
                     row.get::<_, String>(3)?,
                     row.get::<_, String>(4)?,
                     row.get::<_, String>(5)?,
-                    row.get::<_, Option<String>>(6)?,
-                    row.get::<_, String>(7)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, Option<String>>(7)?,
+                    row.get::<_, String>(8)?,
                 ))
             })
             .map_err(|error| error.to_string())?;
         let mut recovered = Vec::new();
         for row in rows {
             let (
+                recovery_key,
                 org_run_id,
                 session_id,
                 turn_intent_id,
@@ -739,6 +775,7 @@ impl AgentMemberInterventionStore {
                     )
                 })?;
             recovered.push(RecoverableUserDirectedWork {
+                recovery_key,
                 org_run_id,
                 session_id,
                 turn_intent_id,
@@ -1468,52 +1505,69 @@ fn update_chain_status(
         let tx = conn
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
             .map_err(|error| error.to_string())?;
-        let now = chrono::Utc::now().to_rfc3339();
-        let changed = tx
-            .execute(
-                "UPDATE agent_org_runtime_member_intervention_turns
+        let changed = update_chain_status_with_connection(
+            &tx,
+            session_id,
+            turn_intent_id,
+            status,
+            failure_reason,
+        )?;
+        tx.commit().map_err(|error| error.to_string())?;
+        Ok(changed)
+    })
+}
+
+pub(crate) fn update_chain_status_with_connection(
+    conn: &Connection,
+    session_id: &str,
+    turn_intent_id: &str,
+    status: &str,
+    failure_reason: Option<&str>,
+) -> Result<bool, String> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let changed = conn
+        .execute(
+            "UPDATE agent_org_runtime_member_intervention_turns
              SET status=?4,terminal_at=?3,failure_reason=?5
              WHERE session_id=?1 AND turn_intent_id=?2 AND status IN ('queued','running')",
-                params![session_id, turn_intent_id, now, status, failure_reason],
-            )
-            .map_err(|error| error.to_string())?;
-        if changed == 1 {
-            let intent_status = match status {
-                "completed" => "completed",
-                "failed" | "abandoned" => "failed",
-                "cancelled" => "cancelled",
-                _ => unreachable!("validated direct terminal status"),
-            };
-            tx.execute(
-                "UPDATE session_turn_intents
+            params![session_id, turn_intent_id, now, status, failure_reason],
+        )
+        .map_err(|error| error.to_string())?;
+    if changed == 1 {
+        let intent_status = match status {
+            "completed" => "completed",
+            "failed" | "abandoned" => "failed",
+            "cancelled" => "cancelled",
+            _ => unreachable!("validated direct terminal status"),
+        };
+        conn.execute(
+            "UPDATE session_turn_intents
                  SET status=?3,updated_at=?4
                  WHERE session_id=?1 AND turn_intent_id=?2
                    AND status IN ('queued','running')",
-                params![session_id, turn_intent_id, intent_status, &now],
-            )
-            .map_err(|error| error.to_string())?;
-        }
-        if changed == 1 && matches!(status, "failed" | "abandoned") {
-            let failure_code = if status == "abandoned" {
-                "user_directed_turn_abandoned"
-            } else {
-                "user_directed_turn_failed"
-            };
-            tx.execute(
-                "UPDATE agent_org_runtime_member_interventions
+            params![session_id, turn_intent_id, intent_status, &now],
+        )
+        .map_err(|error| error.to_string())?;
+    }
+    if changed == 1 && matches!(status, "failed" | "abandoned") {
+        let failure_code = if status == "abandoned" {
+            "user_directed_turn_abandoned"
+        } else {
+            "user_directed_turn_failed"
+        };
+        conn.execute(
+            "UPDATE agent_org_runtime_member_interventions
                  SET failure_reason=?3,updated_at=?4
                  WHERE intervention_receipt_id=(
                      SELECT intervention_receipt_id
                      FROM agent_org_runtime_member_intervention_turns
                      WHERE session_id=?1 AND turn_intent_id=?2
                  )",
-                params![session_id, turn_intent_id, failure_code, now],
-            )
-            .map_err(|error| error.to_string())?;
-        }
-        tx.commit().map_err(|error| error.to_string())?;
-        Ok(changed == 1)
-    })
+            params![session_id, turn_intent_id, failure_code, now],
+        )
+        .map_err(|error| error.to_string())?;
+    }
+    Ok(changed == 1)
 }
 
 fn notify_run_for_receipt(receipt_id: &str) {

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_member_interventions_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_member_interventions_tests.rs
@@ -451,6 +451,39 @@ fn direct_images_are_source_verified_and_recovered_from_the_exact_event() {
 }
 
 #[test]
+fn direct_startup_recovery_uses_a_stable_keyset_across_pages() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let fixture = create_fixture("recovery-keyset", AgentOrgRunStatus::Idle);
+    for (event_id, turn_id, content) in [
+        ("event-keyset-a", "turn-keyset-a", "first pending direct"),
+        ("event-keyset-b", "turn-keyset-b", "second pending direct"),
+    ] {
+        seed_direct_source(&fixture, event_id, turn_id, content);
+        enqueue(&fixture, event_id, turn_id, content, 32).expect("accept pending direct Turn");
+    }
+
+    let first = AgentMemberInterventionStore::recoverable_queued_turns_after(None, 1)
+        .expect("read first direct recovery page");
+    assert_eq!(first.len(), 1);
+    let second = AgentMemberInterventionStore::recoverable_queued_turns_after(
+        Some(first[0].recovery_key),
+        1,
+    )
+    .expect("read second direct recovery page");
+    assert_eq!(second.len(), 1);
+    assert_ne!(first[0].turn_intent_id, second[0].turn_intent_id);
+    assert!(second[0].recovery_key > first[0].recovery_key);
+    assert!(
+        AgentMemberInterventionStore::recoverable_queued_turns_after(
+            Some(second[0].recovery_key),
+            1,
+        )
+        .expect("read exhausted direct recovery page")
+        .is_empty()
+    );
+}
+
+#[test]
 fn exact_replay_returns_the_same_receipt_and_never_allocates_again() {
     let _sandbox = test_helpers::test_env::sandbox();
     let fixture = create_fixture("replay", AgentOrgRunStatus::Idle);
@@ -617,7 +650,10 @@ fn mismatched_source_or_replayed_identity_is_rejected_without_mutation() {
             queue_cap: 32,
         })
         .expect_err("same visible source cannot replay with another Provider prompt");
-    assert!(wrong_dispatch.contains("user_directed_replay_conflict"));
+    assert!(
+        wrong_dispatch.contains("user_directed_idempotency_conflict"),
+        "unexpected replay error: {wrong_dispatch}"
+    );
     let wrong_source = enqueue(
         &fixture,
         "event-other",

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_formal_triggers/claim.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_formal_triggers/claim.rs
@@ -30,6 +30,8 @@ pub(crate) fn claim_for_coordinator_turn(
         if context.org_run_id != org_run_id
             || context.turn_kind
                 != crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator
+            || context.source_kind
+                != crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::RootTurn
         {
             return Err(
                 "FormalTriggerReceipt claim requires exact Coordinator Turn authority".to_string(),
@@ -51,6 +53,7 @@ pub(crate) fn claim_for_coordinator_turn(
                      WHERE attempt.session_id=?1 AND attempt.turn_intent_id=?2
                        AND attempt.status IN ('queued','running')
                        AND receipt.org_run_id=?3 AND receipt.status='materialized'
+                       AND inbox.delivery_class='formal_work'
                        AND inbox.read_at IS NULL
                      ORDER BY receipt.created_at,receipt.inbox_id,receipt.receipt_id",
                 )
@@ -117,6 +120,7 @@ pub(crate) fn claim_for_coordinator_turn(
                   AND attempt.status IN ('queued','running')
                  WHERE receipt.org_run_id=?1 AND receipt.status IN ('pending','materialized')
                    AND receipt.doorbell_status IN ('missing','delivered')
+                   AND inbox.delivery_class='formal_work'
                    AND inbox.read_at IS NULL
                    AND NOT EXISTS (
                        SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_pause.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_pause.rs
@@ -682,6 +682,7 @@ fn resolve_terminal_task_assignment_after_resume_skip(
          FROM agent_org_runtime_inbox inbox
          WHERE inbox.org_run_id=?1
            AND inbox.recipient_member_id=?2
+           AND inbox.delivery_class='formal_work'
            AND inbox.payload_kind='task_assigned'
            AND json_extract(inbox.payload_json,'$.task_id')=?3
            AND inbox.read_at IS NULL",

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/mod.rs
@@ -278,6 +278,43 @@ impl AgentOrgRunContext {
         allowed
     }
 
+    /// Static schema surface for `org_send_message`. Member tools expose the
+    /// Coordinator plus peers linked in the immutable launch snapshot; the
+    /// exact persisted Turn still decides which subset is legal at execution.
+    pub fn user_directed_recipient_member_ids_for(&self, sender_member_id: &str) -> Vec<String> {
+        if self.participant_by_member_id(sender_member_id).is_none() {
+            return Vec::new();
+        }
+        if sender_member_id == COORDINATOR_MEMBER_ID {
+            return self.allowed_recipient_member_ids_for(sender_member_id);
+        }
+        let mut allowed = vec![COORDINATOR_MEMBER_ID.to_string()];
+        allowed.extend(
+            self.members
+                .iter()
+                .filter(|member| {
+                    member.member_id != sender_member_id
+                        && self
+                            .capability_index
+                            .members_can_communicate(sender_member_id, &member.member_id)
+                })
+                .map(|member| member.member_id.clone()),
+        );
+        allowed.sort();
+        allowed.dedup();
+        allowed
+    }
+
+    pub fn user_directed_can_message(
+        &self,
+        sender_member_id: &str,
+        recipient_member_id: &str,
+    ) -> bool {
+        self.user_directed_recipient_member_ids_for(sender_member_id)
+            .iter()
+            .any(|member_id| member_id == recipient_member_id)
+    }
+
     /// Task assignees that `caller_member_id` is authorized to manage.
     ///
     /// - coordinator: itself plus every roster member;

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/progress.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/progress.rs
@@ -149,6 +149,8 @@ pub(super) fn stage_coordinator_presented_for_turn_with_conn(
     if context.org_run_id != org_run_id
         || context.turn_kind
             != crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator
+        || context.source_kind
+            != crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::RootTurn
     {
         return Err(
             "agent_org_turn_context_invalid: Coordinator freshness authority mismatch".to_string(),
@@ -161,7 +163,7 @@ pub(super) fn stage_coordinator_presented_for_turn_with_conn(
                 "UPDATE agent_org_runtime_turn_contexts
                  SET coordinator_work_revision=?4,terminal_reason=NULL
                  WHERE org_run_id=?1 AND session_id=?2 AND turn_intent_id=?3
-                   AND turn_kind='coordinator'",
+                   AND turn_kind='coordinator' AND source_kind='root_turn'",
                 params![org_run_id, session_id, turn_intent_id, revision],
             )
             .map_err(|error| error.to_string())?;

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/quiescence.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/quiescence.rs
@@ -349,6 +349,7 @@ pub(crate) fn guaranteed_current_turn_effects_with_connection(
              JOIN agent_org_runtime_inbox_materializations receipt
                ON receipt.inbox_id=inbox.id AND receipt.session_id=?2
              WHERE inbox.id=?1 AND inbox.org_run_id=?3 AND inbox.read_at IS NULL
+               AND inbox.delivery_class='formal_work'
                AND NOT EXISTS (
                    SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
                    WHERE resolution.inbox_id=inbox.id
@@ -525,7 +526,9 @@ pub(super) fn load_and_assess(
                    ON intent.session_id=context.session_id
                   AND intent.turn_intent_id=context.turn_intent_id
                  WHERE context.org_run_id=?1
-                   AND context.turn_kind IN ('coordinator','task_execution')
+                   AND (context.turn_kind='task_execution'
+                        OR (context.turn_kind='coordinator'
+                            AND context.source_kind='root_turn'))
                    AND intent.status IN ('optimistic','queued','running')",
             )
             .map_err(|error| error.to_string())?;
@@ -639,7 +642,7 @@ pub(super) fn load_and_assess(
         .query_row(
             "SELECT COUNT(*)
              FROM agent_org_runtime_inbox
-             WHERE org_run_id=?1 AND read_at IS NULL
+             WHERE org_run_id=?1 AND delivery_class='formal_work' AND read_at IS NULL
                AND NOT EXISTS (
                    SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
                    WHERE resolution.inbox_id=agent_org_runtime_inbox.id
@@ -652,7 +655,8 @@ pub(super) fn load_and_assess(
         .query_row(
             "SELECT COUNT(*)
              FROM agent_org_runtime_inbox inbox
-             WHERE inbox.org_run_id=?1 AND inbox.read_at IS NULL
+             WHERE inbox.org_run_id=?1 AND inbox.delivery_class='formal_work'
+               AND inbox.read_at IS NULL
                AND NOT EXISTS (
                    SELECT 1 FROM agent_org_runtime_inbox_delivery_resolutions resolution
                    WHERE resolution.inbox_id=inbox.id
@@ -688,7 +692,9 @@ pub(super) fn load_and_assess(
                ON context.session_id=intent.session_id
               AND context.turn_intent_id=intent.turn_intent_id
              WHERE intent.org_run_id=?1
-               AND context.turn_kind IN ('coordinator','task_execution')
+               AND (context.turn_kind='task_execution'
+                    OR (context.turn_kind='coordinator'
+                        AND context.source_kind='root_turn'))
                AND intent.status IN (?2, ?3, ?4)",
             params![
                 run_id,
@@ -707,7 +713,9 @@ pub(super) fn load_and_assess(
                ON context.session_id=intent.session_id
               AND context.turn_intent_id=intent.turn_intent_id
              WHERE intent.org_run_id=?1
-               AND context.turn_kind IN ('coordinator','task_execution')
+               AND (context.turn_kind='task_execution'
+                    OR (context.turn_kind='coordinator'
+                        AND context.source_kind='root_turn'))
                AND intent.status NOT IN (
                    'optimistic', 'queued', 'running', 'completed', 'failed',
                    'cancelled', 'stale', 'coalesced', 'rejected'
@@ -1189,7 +1197,8 @@ mod tests {
              );
              CREATE TABLE agent_org_runtime_inbox(
                  id INTEGER PRIMARY KEY,org_run_id TEXT,read_at TEXT,
-                 payload_kind TEXT,payload_json TEXT,sender_agent_id TEXT,created_at TEXT
+                 payload_kind TEXT,payload_json TEXT,sender_agent_id TEXT,created_at TEXT,
+                 delivery_class TEXT NOT NULL DEFAULT 'formal_work'
              );
              CREATE TABLE agent_org_runtime_inbox_materializations(
                  inbox_id INTEGER,session_id TEXT
@@ -1217,8 +1226,9 @@ mod tests {
         )
         .expect("member idle json");
         conn.execute(
-            "INSERT INTO agent_org_runtime_inbox VALUES
-                 (7,'run',NULL,'member_idle',?1,'_system','2026-01-01T00:00:02Z')",
+            "INSERT INTO agent_org_runtime_inbox(
+                 id,org_run_id,read_at,payload_kind,payload_json,sender_agent_id,created_at
+             ) VALUES (7,'run',NULL,'member_idle',?1,'_system','2026-01-01T00:00:02Z')",
             [&idle],
         )
         .expect("fresh idle row");

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store/delete.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store/delete.rs
@@ -16,6 +16,63 @@ impl AgentOrgRunDeleteOutcome {
     }
 }
 
+fn delete_user_directed_work_for_run_with_connection(
+    conn: &Connection,
+    run_id: &str,
+) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM agent_org_runtime_user_directed_coordinator_bindings
+         WHERE org_run_id=?1",
+        params![run_id],
+    )
+    .map_err(|err| {
+        format!("failed to delete user-directed Coordinator bindings for {run_id}: {err}")
+    })?;
+
+    let mut remaining = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM agent_org_runtime_user_directed_deliveries
+             WHERE org_run_id=?1",
+            params![run_id],
+            |row| row.get::<_, usize>(0),
+        )
+        .map_err(|err| format!("failed to count user-directed deliveries for {run_id}: {err}"))?;
+    while remaining > 0 {
+        let deleted = conn
+            .execute(
+                "DELETE FROM agent_org_runtime_user_directed_deliveries
+                 WHERE delivery_id IN (
+                     SELECT parent.delivery_id
+                     FROM agent_org_runtime_user_directed_deliveries parent
+                     WHERE parent.org_run_id=?1
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM agent_org_runtime_user_directed_deliveries child
+                           WHERE child.parent_delivery_id=parent.delivery_id
+                       )
+                 )",
+                params![run_id],
+            )
+            .map_err(|err| {
+                format!("failed to delete user-directed delivery leaves for {run_id}: {err}")
+            })?;
+        if deleted == 0 || deleted > remaining {
+            return Err(format!(
+                "user_directed_delete_causal_cycle: Run {run_id} has {remaining} delivery row(s) but no removable causal leaf"
+            ));
+        }
+        remaining -= deleted;
+    }
+
+    conn.execute(
+        "DELETE FROM agent_org_runtime_user_directed_roots WHERE org_run_id=?1",
+        params![run_id],
+    )
+    .map_err(|err| format!("failed to delete user-directed roots for {run_id}: {err}"))?;
+    Ok(())
+}
+
 impl AgentOrgRunStore {
     pub fn delete_by_id(run_id: &str) -> Result<(), String> {
         let outcome = with_sessions_writer(|| -> Result<AgentOrgRunDeleteOutcome, String> {
@@ -57,6 +114,13 @@ impl AgentOrgRunStore {
             rows.collect::<Result<Vec<_>, _>>()
                 .map_err(|err| err.to_string())?
         };
+
+        // User-directed deliveries deliberately use RESTRICT for their
+        // parent-Inbox and parent-delivery authority. Tear the causal graph
+        // down from its leaves before deleting Turn intents or Inbox rows;
+        // otherwise those cascades can try to remove a parent while a linked
+        // child still proves that it was derived from it.
+        delete_user_directed_work_for_run_with_connection(conn, run_id)?;
 
         // Intent ownership is explicit. The hierarchy delete caller rejects
         // nested run roots before reaching this helper; standalone run cleanup

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store/lifecycle.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store/lifecycle.rs
@@ -158,8 +158,16 @@ impl AgentOrgRunStore {
         }
         let is_coordinator = context.participant_id == COORDINATOR_MEMBER_ID
             && context.turn_kind
-                == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator;
-        let is_user_directed_writer = if context.turn_kind
+                == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator
+            && context.source_kind
+                == crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::RootTurn;
+        let is_user_directed_coordinator = context.participant_id == COORDINATOR_MEMBER_ID
+            && context.turn_kind
+                == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator
+            && context.source_kind
+                == crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::MemberInbox
+            && context.activation_generation.is_none();
+        let is_user_directed_member_writer = if context.turn_kind
             == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::UserDirectedWork
             && context.participant_id != COORDINATOR_MEMBER_ID
             && context.dispatch_member_id.as_deref() == Some(context.participant_id.as_str())
@@ -182,7 +190,7 @@ impl AgentOrgRunStore {
         } else {
             false
         };
-        if !is_coordinator && !is_user_directed_writer {
+        if !is_coordinator && !is_user_directed_coordinator && !is_user_directed_member_writer {
             return Err(
                 "task_graph_writer_idle_activation_requires_canonical_writer_turn".to_string(),
             );
@@ -212,6 +220,7 @@ impl AgentOrgRunStore {
                      SET activation_generation=?4
                      WHERE session_id=?1 AND turn_intent_id=?2 AND org_run_id=?3
                        AND participant_id='coordinator' AND turn_kind='coordinator'
+                       AND source_kind='root_turn'
                        AND activation_generation=?5",
                     params![
                         session_id,

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/actor.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/actor.rs
@@ -7,7 +7,7 @@ use rusqlite::{params, OptionalExtension};
 
 use crate::coordination::agent_org_runs::{AgentOrgRunStatus, COORDINATOR_MEMBER_ID};
 use crate::coordination::agent_org_turn_contexts::{
-    require_context_with_connection, AgentOrgTurnKind,
+    require_context_with_connection, AgentOrgTurnKind, AgentOrgTurnSourceKind,
 };
 
 #[derive(Debug, Clone)]
@@ -45,7 +45,8 @@ impl TaskGraphWriterAdmin {
         let is_coordinator = context.turn_kind == AgentOrgTurnKind::Coordinator
             && context.participant_id == COORDINATOR_MEMBER_ID
             && context.task_id.is_none()
-            && context.owner_member_id.is_none();
+            && context.owner_member_id.is_none()
+            && context.source_kind == AgentOrgTurnSourceKind::RootTurn;
         if is_coordinator {
             validate_running_generation(
                 org_run_id,
@@ -83,6 +84,11 @@ impl TaskGraphWriterAdmin {
                     .additional_task_graph_writer_member_ids
                     .iter()
                     .any(|member_id| member_id == &context.participant_id);
+            let is_user_directed_coordinator = context.turn_kind == AgentOrgTurnKind::Coordinator
+                && context.participant_id == COORDINATOR_MEMBER_ID
+                && context.task_id.is_none()
+                && context.owner_member_id.is_none()
+                && context.source_kind == AgentOrgTurnSourceKind::MemberInbox;
             if is_bound_writer_execution {
                 validate_running_generation(
                     org_run_id,
@@ -90,7 +96,7 @@ impl TaskGraphWriterAdmin {
                     generation,
                     context.activation_generation,
                 )?;
-            } else if is_user_directed_writer {
+            } else if is_user_directed_writer || is_user_directed_coordinator {
                 crate::coordination::agent_org_turn_contexts::revalidate_context_with_connection(
                     conn,
                     &self.session_id,

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store/fsm.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store/fsm.rs
@@ -78,6 +78,7 @@ fn task_assignment_is_materialized_for_turn(
                  WHERE inbox.id=?1
                    AND inbox.org_run_id=?3
                    AND inbox.recipient_member_id=?4
+                   AND inbox.delivery_class='formal_work'
                    AND inbox.read_at IS NULL
                    AND inbox.payload_kind='task_assigned'
                    AND json_valid(inbox.payload_json)

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/task_store_contract_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/task_store_contract_tests.rs
@@ -55,6 +55,9 @@ fn fixture() -> Fixture {
     crate::coordination::agent_org_runs::init_schema(&conn).expect("run schema");
     crate::coordination::agent_org_turn_contexts::create_schema(&conn)
         .expect("Turn context schema");
+    crate::coordination::agent_inbox::create_schema(&conn).expect("Agent Inbox schema");
+    crate::coordination::agent_org_user_directed_work::create_schema(&conn)
+        .expect("UserDirectedWork authority schema");
     crate::coordination::agent_org_watchdog::init_schema(&conn).expect("recovery schema");
     init_schema(&conn).expect("Task schema");
     crate::coordination::agent_org_task_handoffs::create_schema(&conn)
@@ -278,6 +281,28 @@ fn insert_direct_context(
         ],
     )
     .expect("direct UserDirectedWork context");
+    crate::coordination::agent_org_user_directed_work::insert_root_delivery_with_connection(
+        conn,
+        &crate::coordination::agent_org_user_directed_work::NewUserDirectedDelivery {
+            org_run_id: RUN_ID,
+            session_id,
+            turn_intent_id: turn_id,
+            root_authority_turn_id: turn_id,
+            parent_delivery_id: None,
+            parent_inbox_id: None,
+            source_kind: crate::coordination::agent_org_user_directed_work::UserDirectedSourceKind::DirectMember,
+            source_event_id: Some(&source_event_id),
+            source_inbox_id: None,
+            dispatch_member_id: member_id,
+            member_dispatch_sequence: sequence,
+            depth: 0,
+            delivery_ordinal: 1,
+            dispatch_content: "direct graph work",
+            display_content: "direct graph work",
+            images: None,
+        },
+    )
+    .expect("direct UserDirectedWork authority");
 }
 
 fn graph_actor() -> TaskGraphWriterAdmin {

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_turn_contexts.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_turn_contexts.rs
@@ -145,15 +145,26 @@ enum AdmissionKind {
     },
     UserDirectedWork {
         dispatch_member_id: String,
-        source: UserDirectedSource,
+        source: UserDirectedAdmissionSource,
+    },
+    CoordinatorMemberInbox {
+        source_inbox_id: i64,
+        root_authority_turn_id: String,
     },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum UserDirectedSource {
-    DirectMember { source_event_id: String },
-    GroupMention { source_inbox_id: i64 },
-    MemberInbox { source_inbox_id: i64 },
+enum UserDirectedAdmissionSource {
+    DirectMember {
+        source_event_id: String,
+    },
+    GroupMention {
+        source_inbox_id: i64,
+    },
+    MemberInbox {
+        source_inbox_id: i64,
+        root_authority_turn_id: String,
+    },
 }
 
 /// Closed construction surface for all Agent Org Turn kinds. Product entry
@@ -272,7 +283,7 @@ impl AgentOrgTurnAdmission {
             base_source: TurnIntentBridgeSource::AgentOrg,
             kind: AdmissionKind::UserDirectedWork {
                 dispatch_member_id: dispatch_member_id.into(),
-                source: UserDirectedSource::DirectMember {
+                source: UserDirectedAdmissionSource::DirectMember {
                     source_event_id: source_event_id.into(),
                 },
             },
@@ -296,7 +307,7 @@ impl AgentOrgTurnAdmission {
             base_source: TurnIntentBridgeSource::AgentOrg,
             kind: AdmissionKind::UserDirectedWork {
                 dispatch_member_id: dispatch_member_id.into(),
-                source: UserDirectedSource::GroupMention { source_inbox_id },
+                source: UserDirectedAdmissionSource::GroupMention { source_inbox_id },
             },
         }
     }
@@ -309,6 +320,7 @@ impl AgentOrgTurnAdmission {
         client_message_id: Option<String>,
         dispatch_member_id: impl Into<String>,
         source_inbox_id: i64,
+        root_authority_turn_id: impl Into<String>,
     ) -> Self {
         Self {
             org_run_id: org_run_id.into(),
@@ -318,7 +330,31 @@ impl AgentOrgTurnAdmission {
             base_source: TurnIntentBridgeSource::AgentOrg,
             kind: AdmissionKind::UserDirectedWork {
                 dispatch_member_id: dispatch_member_id.into(),
-                source: UserDirectedSource::MemberInbox { source_inbox_id },
+                source: UserDirectedAdmissionSource::MemberInbox {
+                    source_inbox_id,
+                    root_authority_turn_id: root_authority_turn_id.into(),
+                },
+            },
+        }
+    }
+
+    pub(crate) fn coordinator_member_inbox(
+        org_run_id: impl Into<String>,
+        session_id: impl Into<String>,
+        turn_intent_id: impl Into<String>,
+        client_message_id: Option<String>,
+        source_inbox_id: i64,
+        root_authority_turn_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            org_run_id: org_run_id.into(),
+            session_id: session_id.into(),
+            turn_intent_id: turn_intent_id.into(),
+            client_message_id,
+            base_source: TurnIntentBridgeSource::AgentOrg,
+            kind: AdmissionKind::CoordinatorMemberInbox {
+                source_inbox_id,
+                root_authority_turn_id: root_authority_turn_id.into(),
             },
         }
     }
@@ -368,11 +404,21 @@ pub(super) fn create_schema(conn: &Connection) -> rusqlite::Result<()> {
                  AND participant_id='coordinator'
                  AND task_id IS NULL AND owner_member_id IS NULL
                  AND dispatch_member_id IS NULL AND member_dispatch_sequence IS NULL
-                 AND source_kind='root_turn' AND source_id=turn_intent_id
-                 AND root_authority_turn_id IS NULL AND actor_version IS NULL
-                 AND activation_generation IS NOT NULL AND activation_generation >= 1
-                 AND (coordinator_work_revision IS NULL OR coordinator_work_revision >= 0)
-                 AND (terminal_reason IS NULL OR terminal_reason='waiting_for_org_event'))
+                 AND (
+                    (source_kind='root_turn' AND source_id=turn_intent_id
+                     AND root_authority_turn_id IS NULL AND actor_version IS NULL
+                     AND activation_generation IS NOT NULL AND activation_generation >= 1
+                     AND (coordinator_work_revision IS NULL OR coordinator_work_revision >= 0)
+                     AND (terminal_reason IS NULL OR terminal_reason='waiting_for_org_event'))
+                    OR
+                    (source_kind='member_inbox'
+                     AND root_authority_turn_id IS NOT NULL
+                     AND length(trim(root_authority_turn_id)) > 0
+                     AND actor_version IS NOT NULL AND actor_version >= 1
+                     AND activation_generation IS NULL
+                     AND coordinator_work_revision IS NULL
+                     AND coordinator_observed_task_ids_json='[]' AND terminal_reason IS NULL)
+                 ))
                 OR
                 (turn_kind='task_execution'
                  AND task_id IS NOT NULL AND length(trim(task_id)) > 0
@@ -401,7 +447,8 @@ pub(super) fn create_schema(conn: &Connection) -> rusqlite::Result<()> {
                      AND root_authority_turn_id=turn_intent_id)
                     OR
                     (source_kind='member_inbox'
-                     AND root_authority_turn_id IS NULL)
+                     AND root_authority_turn_id IS NOT NULL
+                     AND length(trim(root_authority_turn_id)) > 0)
                  ))
             )
         );
@@ -415,6 +462,42 @@ pub(super) fn create_schema(conn: &Connection) -> rusqlite::Result<()> {
                 org_run_id, source_kind, source_id, context_id
             );",
     )
+}
+
+/// Check the one persisted Member FIFO shared by TaskExecution and every UDW
+/// source. Direct intervention may bypass only earlier formal TaskExecution
+/// after its separate durable yield receipt becomes active; it may never pass
+/// an earlier UDW item.
+pub(crate) fn member_dispatch_is_fifo_head_with_connection(
+    conn: &Connection,
+    org_run_id: &str,
+    member_id: &str,
+    member_dispatch_sequence: i64,
+    direct_intervention_may_bypass_formal: bool,
+) -> Result<bool, String> {
+    conn.query_row(
+        "SELECT NOT EXISTS(
+             SELECT 1
+             FROM agent_org_runtime_turn_contexts earlier
+             JOIN session_turn_intents intent
+               ON intent.session_id=earlier.session_id
+              AND intent.turn_intent_id=earlier.turn_intent_id
+             WHERE earlier.org_run_id=?1
+               AND earlier.dispatch_member_id=?2
+               AND earlier.member_dispatch_sequence<?3
+               AND earlier.turn_kind IN ('task_execution','user_directed_work')
+               AND intent.status IN ('optimistic','queued','running')
+               AND (earlier.turn_kind='user_directed_work' OR ?4=0)
+         )",
+        params![
+            org_run_id,
+            member_id,
+            member_dispatch_sequence,
+            i64::from(direct_intervention_may_bypass_formal),
+        ],
+        |row| row.get(0),
+    )
+    .map_err(|error| error.to_string())
 }
 
 /// Open the canonical writer transaction and accept exactly one typed turn.
@@ -626,6 +709,8 @@ fn revalidate_live_context_with_connection(
     let lifecycle_allows_turn = match context.turn_kind {
         AgentOrgTurnKind::Coordinator => {
             matches!(status, AgentOrgRunStatus::Running | AgentOrgRunStatus::Idle)
+                || (context.source_kind == AgentOrgTurnSourceKind::MemberInbox
+                    && status == AgentOrgRunStatus::Paused)
         }
         AgentOrgTurnKind::TaskExecution => status == AgentOrgRunStatus::Running,
         AgentOrgTurnKind::UserDirectedWork => matches!(
@@ -654,18 +739,72 @@ fn revalidate_live_context_with_connection(
         AgentOrgTurnKind::Coordinator => {
             if root_session_id.as_deref() != Some(session_id)
                 || context.participant_id != COORDINATOR_MEMBER_ID
-                || context.activation_generation != Some(generation)
             {
                 return Err(invariant_error(
-                    "Coordinator Turn no longer matches canonical Root/generation".to_string(),
+                    "Coordinator Turn no longer matches the canonical Root".to_string(),
                 ));
             }
-            resolve_materialization_version_for_context(
+            let materialization_version = resolve_materialization_version_for_context(
                 conn,
                 &context,
                 COORDINATOR_MEMBER_ID,
                 &snapshot.coordinator_agent_id,
             )?;
+            if context.source_kind == AgentOrgTurnSourceKind::RootTurn {
+                if context.activation_generation != Some(generation)
+                    || context.actor_version.is_some()
+                    || context.root_authority_turn_id.is_some()
+                {
+                    return Err(invariant_error(
+                        "formal Coordinator Turn no longer matches its generation".to_string(),
+                    ));
+                }
+            } else if context.source_kind == AgentOrgTurnSourceKind::MemberInbox {
+                if context.root_authority_turn_id.is_none()
+                    || context.activation_generation.is_some()
+                    || context.actor_version != Some(materialization_version)
+                {
+                    return Err(invariant_error(
+                        "Coordinator MemberInbox Turn no longer matches its durable authority"
+                            .to_string(),
+                    ));
+                }
+                let binding_matches: bool = conn
+                    .query_row(
+                        "SELECT EXISTS(
+                             SELECT 1
+                             FROM agent_org_runtime_user_directed_coordinator_bindings binding
+                             JOIN agent_org_runtime_inbox inbox ON inbox.id=binding.source_inbox_id
+                             WHERE binding.org_run_id=?1
+                               AND binding.session_id=?2
+                               AND binding.turn_intent_id=?3
+                               AND binding.source_inbox_id=CAST(?4 AS INTEGER)
+                               AND binding.root_authority_turn_id=?5
+                               AND binding.status IN ('pending','started')
+                               AND inbox.delivery_class='user_directed'
+                               AND inbox.recipient_member_id='coordinator'
+                         )",
+                        params![
+                            &context.org_run_id,
+                            session_id,
+                            turn_intent_id,
+                            &context.source_id,
+                            context.root_authority_turn_id.as_deref(),
+                        ],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| error.to_string())?;
+                if !binding_matches {
+                    return Err(invariant_error(
+                        "Coordinator MemberInbox binding no longer matches the exact Turn"
+                            .to_string(),
+                    ));
+                }
+            } else {
+                return Err(invariant_error(
+                    "Coordinator Turn has an unsupported source kind".to_string(),
+                ));
+            }
         }
         AgentOrgTurnKind::TaskExecution => {
             let task_id = context.task_id.as_deref().ok_or_else(|| {
@@ -692,14 +831,17 @@ fn revalidate_live_context_with_connection(
                 invariant_error("UserDirectedWork context has no dispatch Member".to_string())
             })?;
             if context.participant_id != member_id
-                || context.source_kind != AgentOrgTurnSourceKind::DirectMember
-                || context.root_authority_turn_id.as_deref()
-                    != Some(context.turn_intent_id.as_str())
+                || !matches!(
+                    context.source_kind,
+                    AgentOrgTurnSourceKind::DirectMember
+                        | AgentOrgTurnSourceKind::GroupMention
+                        | AgentOrgTurnSourceKind::MemberInbox
+                )
+                || context.root_authority_turn_id.is_none()
                 || context.activation_generation.is_some()
             {
                 return Err(invariant_error(
-                    "UserDirectedWork no longer matches direct source/participant authority"
-                        .to_string(),
+                    "UserDirectedWork no longer matches source/participant authority".to_string(),
                 ));
             }
             let agent_id = snapshot_member_agent_id(&snapshot, member_id)?;
@@ -711,21 +853,70 @@ fn revalidate_live_context_with_connection(
                     context.actor_version
                 )));
             }
-            let source_exists: bool = conn
+            let source_exists: bool = match context.source_kind {
+                AgentOrgTurnSourceKind::DirectMember => conn
+                    .query_row(
+                        "SELECT EXISTS(
+                             SELECT 1 FROM events
+                             WHERE id=?1 AND session_id=?2 AND function_name='user_message'
+                         )",
+                        params![&context.source_id, session_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| error.to_string())?,
+                AgentOrgTurnSourceKind::GroupMention | AgentOrgTurnSourceKind::MemberInbox => conn
+                    .query_row(
+                        "SELECT EXISTS(
+                             SELECT 1 FROM agent_org_runtime_inbox
+                             WHERE id=CAST(?1 AS INTEGER) AND org_run_id=?2
+                               AND recipient_member_id=?3
+                               AND delivery_class='user_directed'
+                         )",
+                        params![&context.source_id, &context.org_run_id, member_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| error.to_string())?,
+                _ => false,
+            };
+            if !source_exists {
+                return Err(invariant_error(format!(
+                    "UserDirectedWork source {} disappeared",
+                    context.source_id
+                )));
+            }
+            let delivery_matches: bool = conn
                 .query_row(
                     "SELECT EXISTS(
-                         SELECT 1 FROM events
-                         WHERE id=?1 AND session_id=?2 AND function_name='user_message'
+                         SELECT 1
+                         FROM agent_org_runtime_user_directed_deliveries delivery
+                         WHERE delivery.org_run_id=?1
+                           AND delivery.session_id=?2
+                           AND delivery.turn_intent_id=?3
+                           AND delivery.dispatch_member_id=?4
+                           AND delivery.member_dispatch_sequence=?5
+                           AND delivery.source_kind=?6
+                           AND COALESCE(CAST(delivery.source_inbox_id AS TEXT),delivery.source_event_id)=?7
+                           AND delivery.root_authority_turn_id=?8
+                           AND delivery.status IN ('pending','started')
                      )",
-                    params![&context.source_id, session_id],
+                    params![
+                        &context.org_run_id,
+                        session_id,
+                        turn_intent_id,
+                        member_id,
+                        context.member_dispatch_sequence,
+                        context.source_kind.as_str(),
+                        &context.source_id,
+                        context.root_authority_turn_id.as_deref(),
+                    ],
                     |row| row.get(0),
                 )
                 .map_err(|error| error.to_string())?;
-            if !source_exists {
-                return Err(invariant_error(format!(
-                    "DirectMember source event {} disappeared",
-                    context.source_id
-                )));
+            if !delivery_matches {
+                return Err(invariant_error(
+                    "UserDirectedWork delivery receipt no longer matches the exact Turn"
+                        .to_string(),
+                ));
             }
         }
     }
@@ -891,6 +1082,7 @@ fn resolve_next_task_wake_binding(
              FROM agent_org_runtime_inbox
              WHERE org_run_id=?1
                AND recipient_member_id=?2
+               AND delivery_class='formal_work'
                AND read_at IS NULL
                AND payload_kind IN ('task_assigned','plan_approval_response')
                AND NOT EXISTS (
@@ -1377,6 +1569,52 @@ fn resolve_canonical_admission(
                 activation_generation: Some(generation),
             })
         }
+        AdmissionKind::CoordinatorMemberInbox {
+            source_inbox_id,
+            root_authority_turn_id,
+        } => {
+            if !matches!(
+                status,
+                AgentOrgRunStatus::Running | AgentOrgRunStatus::Idle | AgentOrgRunStatus::Paused
+            ) {
+                return Err(invariant_error(format!(
+                    "Coordinator MemberInbox cannot enter Team status {status}"
+                )));
+            }
+            let root_session_id = root_session_id.ok_or_else(|| {
+                invariant_error(format!("run {} has no canonical Root", request.org_run_id))
+            })?;
+            if root_session_id != request.session_id {
+                return Err(invariant_error(format!(
+                    "session {} is not canonical Root {}",
+                    request.session_id, root_session_id
+                )));
+            }
+            let actor_version = resolve_materialization_version(
+                conn,
+                request,
+                COORDINATOR_MEMBER_ID,
+                &snapshot.coordinator_agent_id,
+            )?;
+            validate_source_inbox(
+                conn,
+                &request.org_run_id,
+                COORDINATOR_MEMBER_ID,
+                *source_inbox_id,
+            )?;
+            Ok(CanonicalAdmission {
+                participant_id: COORDINATOR_MEMBER_ID.to_string(),
+                turn_kind: AgentOrgTurnKind::Coordinator,
+                task_id: None,
+                owner_member_id: None,
+                dispatch_member_id: None,
+                source_kind: AgentOrgTurnSourceKind::MemberInbox,
+                source_id: source_inbox_id.to_string(),
+                root_authority_turn_id: Some(root_authority_turn_id.clone()),
+                actor_version: Some(actor_version),
+                activation_generation: None,
+            })
+        }
         AdmissionKind::UserDirectedWork {
             dispatch_member_id,
             source,
@@ -1401,7 +1639,7 @@ fn resolve_canonical_admission(
             let actor_version =
                 resolve_materialization_version(conn, request, dispatch_member_id, agent_id)?;
             let (source_kind, source_id, root_authority_turn_id) = match source {
-                UserDirectedSource::DirectMember { source_event_id } => {
+                UserDirectedAdmissionSource::DirectMember { source_event_id } => {
                     let source_exists: bool = conn
                         .query_row(
                             "SELECT EXISTS(
@@ -1422,7 +1660,7 @@ fn resolve_canonical_admission(
                         Some(request.turn_intent_id.clone()),
                     )
                 }
-                UserDirectedSource::GroupMention { source_inbox_id } => {
+                UserDirectedAdmissionSource::GroupMention { source_inbox_id } => {
                     validate_source_inbox(
                         conn,
                         &request.org_run_id,
@@ -1435,7 +1673,10 @@ fn resolve_canonical_admission(
                         Some(request.turn_intent_id.clone()),
                     )
                 }
-                UserDirectedSource::MemberInbox { source_inbox_id } => {
+                UserDirectedAdmissionSource::MemberInbox {
+                    source_inbox_id,
+                    root_authority_turn_id,
+                } => {
                     validate_source_inbox(
                         conn,
                         &request.org_run_id,
@@ -1445,7 +1686,7 @@ fn resolve_canonical_admission(
                     (
                         AgentOrgTurnSourceKind::MemberInbox,
                         source_inbox_id.to_string(),
-                        None,
+                        Some(root_authority_turn_id.clone()),
                     )
                 }
             };
@@ -1578,6 +1819,7 @@ fn validate_source_inbox(
             "SELECT EXISTS(
                 SELECT 1 FROM agent_org_runtime_inbox
                 WHERE id=?1 AND org_run_id=?2 AND recipient_member_id=?3
+                  AND delivery_class='user_directed'
              )",
             params![source_inbox_id, org_run_id, dispatch_member_id],
             |row| row.get(0),
@@ -1684,27 +1926,42 @@ fn ensure_context_matches(
                 && context.source_id == *task_id
                 && context.activation_generation == Some(*activation_generation)
         }
+        AdmissionKind::CoordinatorMemberInbox {
+            source_inbox_id,
+            root_authority_turn_id,
+        } => {
+            context.turn_kind == AgentOrgTurnKind::Coordinator
+                && context.participant_id == COORDINATOR_MEMBER_ID
+                && context.source_kind == AgentOrgTurnSourceKind::MemberInbox
+                && context.source_id == source_inbox_id.to_string()
+                && context.root_authority_turn_id.as_deref()
+                    == Some(root_authority_turn_id.as_str())
+        }
         AdmissionKind::UserDirectedWork {
             dispatch_member_id,
             source,
         } => {
             let source_matches = match source {
-                UserDirectedSource::DirectMember { source_event_id } => {
+                UserDirectedAdmissionSource::DirectMember { source_event_id } => {
                     context.source_kind == AgentOrgTurnSourceKind::DirectMember
                         && context.source_id == *source_event_id
                         && context.root_authority_turn_id.as_deref()
                             == Some(request.turn_intent_id.as_str())
                 }
-                UserDirectedSource::GroupMention { source_inbox_id } => {
+                UserDirectedAdmissionSource::GroupMention { source_inbox_id } => {
                     context.source_kind == AgentOrgTurnSourceKind::GroupMention
                         && context.source_id == source_inbox_id.to_string()
                         && context.root_authority_turn_id.as_deref()
                             == Some(request.turn_intent_id.as_str())
                 }
-                UserDirectedSource::MemberInbox { source_inbox_id } => {
+                UserDirectedAdmissionSource::MemberInbox {
+                    source_inbox_id,
+                    root_authority_turn_id,
+                } => {
                     context.source_kind == AgentOrgTurnSourceKind::MemberInbox
                         && context.source_id == source_inbox_id.to_string()
-                        && context.root_authority_turn_id.is_none()
+                        && context.root_authority_turn_id.as_deref()
+                            == Some(root_authority_turn_id.as_str())
                 }
             };
             context.turn_kind == AgentOrgTurnKind::UserDirectedWork
@@ -1808,7 +2065,10 @@ pub(crate) fn mark_waiting_for_org_event_if_current(
         let conn = database::db::get_connection().map_err(|error| error.to_string())?;
         let tx = database::db::begin_immediate(&conn).map_err(|error| error.to_string())?;
         let context = revalidate_context_with_connection(&tx, session_id, turn_intent_id)?;
-        if context.org_run_id != org_run_id || context.turn_kind != AgentOrgTurnKind::Coordinator {
+        if context.org_run_id != org_run_id
+            || context.turn_kind != AgentOrgTurnKind::Coordinator
+            || context.source_kind != AgentOrgTurnSourceKind::RootTurn
+        {
             return Err(invariant_error(
                 "waiting_for_org_event requires exact Coordinator authority".to_string(),
             ));
@@ -1858,7 +2118,8 @@ pub(crate) fn mark_waiting_for_org_event_if_current(
                 "UPDATE agent_org_runtime_turn_contexts
                  SET terminal_reason='waiting_for_org_event'
                  WHERE org_run_id=?1 AND session_id=?2 AND turn_intent_id=?3
-                   AND turn_kind='coordinator' AND terminal_reason IS NULL",
+                   AND turn_kind='coordinator' AND source_kind='root_turn'
+                   AND terminal_reason IS NULL",
                 params![org_run_id, session_id, turn_intent_id],
             )
             .map_err(|error| error.to_string())?;
@@ -1887,7 +2148,10 @@ pub(crate) fn claim_coordinator_task_observation(
         let conn = database::db::get_connection().map_err(|error| error.to_string())?;
         let tx = database::db::begin_immediate(&conn).map_err(|error| error.to_string())?;
         let context = revalidate_context_with_connection(&tx, session_id, turn_intent_id)?;
-        if context.org_run_id != org_run_id || context.turn_kind != AgentOrgTurnKind::Coordinator {
+        if context.org_run_id != org_run_id
+            || context.turn_kind != AgentOrgTurnKind::Coordinator
+            || context.source_kind != AgentOrgTurnSourceKind::RootTurn
+        {
             return Err(invariant_error(
                 "Task observation requires exact Coordinator authority".to_string(),
             ));
@@ -1973,10 +2237,10 @@ pub(crate) fn validate_formal_turn_generation_with_connection(
     turn_intent_id: &str,
 ) -> Result<AgentOrgTurnContext, String> {
     let context = require_context_with_connection(conn, session_id, turn_intent_id)?;
-    if !matches!(
-        context.turn_kind,
-        AgentOrgTurnKind::Coordinator | AgentOrgTurnKind::TaskExecution
-    ) {
+    if context.turn_kind != AgentOrgTurnKind::TaskExecution
+        && !(context.turn_kind == AgentOrgTurnKind::Coordinator
+            && context.source_kind == AgentOrgTurnSourceKind::RootTurn)
+    {
         return Err(invariant_error(
             "Inbox acknowledgement requires a formal Turn".to_string(),
         ));
@@ -2131,7 +2395,7 @@ pub fn reconcile_in_flight_after_restart(conn: &Connection) -> Result<usize, Str
            AND EXISTS (
                SELECT 1
                FROM agent_org_runtime_member_intervention_turns chain
-               WHERE chain.session_id=intent.session_id
+                   WHERE chain.session_id=intent.session_id
                  AND chain.turn_intent_id=intent.turn_intent_id
                  AND chain.status='abandoned'
            )",
@@ -2244,6 +2508,33 @@ pub fn reconcile_in_flight_after_restart(conn: &Connection) -> Result<usize, Str
                       AND intervention.status IN ('yield_requested','active','return_requested')
                       AND context.turn_kind='user_directed_work'
                       AND context.source_kind='direct_member'
+                      AND run.status IN ('running','idle','paused')
+                   )
+                   OR EXISTS (
+                    SELECT 1
+                    FROM agent_org_runtime_user_directed_deliveries delivery
+                    JOIN agent_org_runtime_turn_contexts context
+                      ON context.session_id=delivery.session_id
+                     AND context.turn_intent_id=delivery.turn_intent_id
+                    JOIN agent_org_runtime_runs run ON run.id=delivery.org_run_id
+                    WHERE delivery.session_id=intent.session_id
+                      AND delivery.turn_intent_id=intent.turn_intent_id
+                      AND delivery.status='pending'
+                      AND context.turn_kind='user_directed_work'
+                      AND run.status IN ('running','idle','paused')
+                   )
+                   OR EXISTS (
+                    SELECT 1
+                    FROM agent_org_runtime_user_directed_coordinator_bindings binding
+                    JOIN agent_org_runtime_turn_contexts context
+                      ON context.session_id=binding.session_id
+                     AND context.turn_intent_id=binding.turn_intent_id
+                    JOIN agent_org_runtime_runs run ON run.id=binding.org_run_id
+                    WHERE binding.session_id=intent.session_id
+                      AND binding.turn_intent_id=intent.turn_intent_id
+                      AND binding.status='pending'
+                      AND context.turn_kind='coordinator'
+                      AND context.source_kind='member_inbox'
                       AND run.status IN ('running','idle','paused')
                    )
                   )

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_turn_contexts/tests.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_turn_contexts/tests.rs
@@ -147,6 +147,7 @@ fn create_fixture(conn: &Connection) {
             ON agent_org_runtime_task_events(org_run_id, task_id, created_at, id);
          CREATE TABLE agent_org_runtime_inbox (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            delivery_class TEXT NOT NULL DEFAULT 'formal_work',
             recipient_agent_id TEXT NOT NULL DEFAULT 'agent-member',
             org_run_id TEXT NOT NULL,
             recipient_member_id TEXT,
@@ -174,6 +175,8 @@ fn create_fixture(conn: &Connection) {
     create_schema(conn).expect("create Turn context schema");
     crate::coordination::agent_inbox::create_task_message_binding_schema(conn)
         .expect("create task message binding schema");
+    crate::coordination::agent_org_user_directed_work::create_schema(conn)
+        .expect("create UserDirectedWork authority schema");
     crate::coordination::agent_org_task_handoffs::create_schema(conn)
         .expect("create Task execution handoff schema");
     crate::coordination::agent_member_interventions::create_schema(conn)
@@ -207,8 +210,11 @@ fn create_fixture(conn: &Connection) {
             (org_run_id,id,owner,status,execution_mode,blocked_by_json)
             VALUES ('run-a', 'task-a', 'member-a', 'pending', 'build', '[]');
          INSERT INTO events VALUES ('event-direct', 'session-member');
-         INSERT INTO agent_org_runtime_inbox (org_run_id, recipient_member_id)
-            VALUES ('run-a', 'member-a'), ('run-a', 'member-a');",
+         INSERT INTO agent_org_runtime_inbox (
+            org_run_id, recipient_member_id, delivery_class
+         ) VALUES
+            ('run-a', 'member-a', 'user_directed'),
+            ('run-a', 'member-a', 'user_directed');",
     )
     .expect("seed canonical identities and sources");
 }
@@ -328,6 +334,7 @@ fn inbox_request(turn_id: &str) -> AgentOrgTurnAdmission {
         Some(format!("message-{turn_id}")),
         MEMBER_ID,
         2,
+        "turn-group",
     )
 }
 
@@ -1044,7 +1051,48 @@ fn every_member_kind_and_source_shares_one_fifo_and_replay_does_not_bump_it() {
         contexts[2].root_authority_turn_id.as_deref(),
         Some("turn-group")
     );
-    assert_eq!(contexts[3].root_authority_turn_id, None);
+    assert_eq!(
+        contexts[3].root_authority_turn_id.as_deref(),
+        Some("turn-group")
+    );
+
+    assert!(
+        member_dispatch_is_fifo_head_with_connection(&conn, RUN_ID, MEMBER_ID, 1, false,)
+            .expect("the oldest formal Turn owns the shared FIFO")
+    );
+    assert!(
+        !member_dispatch_is_fifo_head_with_connection(&conn, RUN_ID, MEMBER_ID, 2, false,)
+            .expect("ordinary UDW cannot pass earlier formal work")
+    );
+    assert!(
+        member_dispatch_is_fifo_head_with_connection(&conn, RUN_ID, MEMBER_ID, 2, true,)
+            .expect("an admitted Direct override may pass only earlier formal work")
+    );
+    assert!(
+        !member_dispatch_is_fifo_head_with_connection(&conn, RUN_ID, MEMBER_ID, 3, true,)
+            .expect("Direct override cannot pass earlier UDW")
+    );
+
+    conn.execute(
+        "UPDATE session_turn_intents SET status='completed'
+         WHERE session_id=?1 AND turn_intent_id='turn-task'",
+        [MEMBER_SESSION_ID],
+    )
+    .expect("complete formal FIFO head");
+    assert!(
+        member_dispatch_is_fifo_head_with_connection(&conn, RUN_ID, MEMBER_ID, 2, false,)
+            .expect("the next UDW becomes the shared FIFO head")
+    );
+    conn.execute(
+        "UPDATE session_turn_intents SET status='completed'
+         WHERE session_id=?1 AND turn_intent_id='turn-direct'",
+        [MEMBER_SESSION_ID],
+    )
+    .expect("complete Direct FIFO head");
+    assert!(
+        member_dispatch_is_fifo_head_with_connection(&conn, RUN_ID, MEMBER_ID, 3, false,)
+            .expect("Group work advances only after the prior UDW is terminal")
+    );
 
     let replay = accept_in_transaction(&mut conn, &requests[0]).expect("exact replay");
     assert_eq!(replay.member_dispatch_sequence, Some(1));
@@ -1065,6 +1113,7 @@ fn every_member_kind_and_source_shares_one_fifo_and_replay_does_not_bump_it() {
         Some("message-turn-task".into()),
         MEMBER_ID,
         2,
+        "turn-group",
     );
     assert!(accept_in_transaction(&mut conn, &conflict)
         .expect_err("kind-changing replay must fail")

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_user_directed_work.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_user_directed_work.rs
@@ -1,0 +1,1328 @@
+//! Source-neutral durable ownership for Agent Org user-directed work.
+//!
+//! Direct Member chat, Group mentions, and linked Member Inbox work share
+//! this one delivery ledger. Source-specific modules may add behaviour (for
+//! example, Direct Member intervention/yield), but they do not own a second
+//! queue, lifecycle, or recovery authority.
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use database::db::{get_connection, with_sessions_writer};
+
+mod recovery;
+
+#[cfg(test)]
+pub(crate) use recovery::mark_started_unknown_after_restart;
+pub(crate) use recovery::{mark_started_unknown_after_restart_after, recoverable_pending_after};
+
+pub(crate) const USER_DIRECTED_POLICY_VERSION: i64 = 1;
+pub(crate) const DEFAULT_MAX_GROUP_TARGETS: i64 = 10;
+pub(crate) const DEFAULT_MAX_PENDING_PER_MEMBER: i64 = 32;
+pub(crate) const DEFAULT_MAX_DELIVERIES_PER_ROOT: i64 = 8;
+pub(crate) const DEFAULT_MAX_CASCADE_DEPTH: i64 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UserDirectedSourceKind {
+    DirectMember,
+    GroupMention,
+    MemberInbox,
+}
+
+impl UserDirectedSourceKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::DirectMember => "direct_member",
+            Self::GroupMention => "group_mention",
+            Self::MemberInbox => "member_inbox",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum UserDirectedDeliveryStatus {
+    Pending,
+    Started,
+    Completed,
+    Failed,
+    Cancelled,
+    Abandoned,
+    Unknown,
+}
+
+impl UserDirectedDeliveryStatus {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Started => "started",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Abandoned => "abandoned",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "pending" => Self::Pending,
+            "started" => Self::Started,
+            "completed" => Self::Completed,
+            "failed" => Self::Failed,
+            "cancelled" => Self::Cancelled,
+            "abandoned" => Self::Abandoned,
+            "unknown" => Self::Unknown,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NewUserDirectedDelivery<'a> {
+    pub org_run_id: &'a str,
+    pub session_id: &'a str,
+    pub turn_intent_id: &'a str,
+    pub root_authority_turn_id: &'a str,
+    pub parent_delivery_id: Option<i64>,
+    pub parent_inbox_id: Option<i64>,
+    pub source_kind: UserDirectedSourceKind,
+    pub source_event_id: Option<&'a str>,
+    pub source_inbox_id: Option<i64>,
+    pub dispatch_member_id: &'a str,
+    pub member_dispatch_sequence: i64,
+    pub depth: i64,
+    pub delivery_ordinal: i64,
+    pub dispatch_content: &'a str,
+    pub display_content: &'a str,
+    pub images: Option<&'a [String]>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NewLinkedMemberDelivery<'a> {
+    pub org_run_id: &'a str,
+    pub source_session_id: &'a str,
+    pub source_turn_intent_id: &'a str,
+    pub recipient_session_id: &'a str,
+    pub recipient_member_id: &'a str,
+    pub child_turn_intent_id: &'a str,
+    pub source_inbox_id: i64,
+    pub dispatch_content: &'a str,
+    pub display_content: &'a str,
+    pub images: Option<&'a [String]>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NewLinkedCoordinatorDelivery<'a> {
+    pub org_run_id: &'a str,
+    pub source_session_id: &'a str,
+    pub source_turn_intent_id: &'a str,
+    pub coordinator_session_id: &'a str,
+    pub child_turn_intent_id: &'a str,
+    pub source_inbox_id: i64,
+    pub dispatch_content: &'a str,
+    pub display_content: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UserDirectedCoordinatorBinding {
+    pub org_run_id: String,
+    pub session_id: String,
+    pub turn_intent_id: String,
+    pub root_authority_turn_id: String,
+    pub source_inbox_id: i64,
+    pub depth: i64,
+    pub delivery_ordinal: i64,
+    pub status: UserDirectedDeliveryStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UserDirectedDeliveryRecord {
+    pub delivery_id: i64,
+    pub org_run_id: String,
+    pub session_id: String,
+    pub turn_intent_id: String,
+    pub root_authority_turn_id: String,
+    pub parent_delivery_id: Option<i64>,
+    pub parent_inbox_id: Option<i64>,
+    pub source_kind: UserDirectedSourceKind,
+    pub source_event_id: Option<String>,
+    pub source_inbox_id: Option<i64>,
+    pub dispatch_member_id: String,
+    pub member_dispatch_sequence: i64,
+    pub depth: i64,
+    pub delivery_ordinal: i64,
+    pub request_digest: String,
+    pub status: UserDirectedDeliveryStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecoverableUserDirectedDispatch {
+    pub recovery_key: String,
+    pub org_run_id: String,
+    pub recipient_member_id: String,
+    pub recipient_session_id: String,
+    pub turn_intent_id: String,
+    pub content: String,
+    pub display_text: String,
+    pub images: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct UserDirectedCausalReply {
+    pub source_kind: String,
+    pub source_inbox_id: Option<i64>,
+    pub parent_inbox_id: Option<i64>,
+    pub root_authority_turn_id: String,
+    pub depth: i64,
+    pub delivery_ordinal: i64,
+}
+
+pub(super) fn create_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS agent_org_runtime_user_directed_roots (
+            org_run_id TEXT NOT NULL,
+            root_authority_turn_id TEXT NOT NULL CHECK(length(trim(root_authority_turn_id)) > 0),
+            policy_version INTEGER NOT NULL CHECK(policy_version >= 1),
+            max_deliveries INTEGER NOT NULL CHECK(max_deliveries >= 1),
+            max_cascade_depth INTEGER NOT NULL CHECK(max_cascade_depth >= 0),
+            next_delivery_ordinal INTEGER NOT NULL CHECK(next_delivery_ordinal >= 2),
+            created_at TEXT NOT NULL,
+            PRIMARY KEY(org_run_id, root_authority_turn_id),
+            FOREIGN KEY(org_run_id) REFERENCES agent_org_runtime_runs(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS agent_org_runtime_user_directed_deliveries (
+            delivery_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            org_run_id TEXT NOT NULL,
+            session_id TEXT NOT NULL CHECK(length(trim(session_id)) > 0),
+            turn_intent_id TEXT NOT NULL CHECK(length(trim(turn_intent_id)) > 0),
+            root_authority_turn_id TEXT NOT NULL CHECK(length(trim(root_authority_turn_id)) > 0),
+            parent_delivery_id INTEGER,
+            parent_inbox_id INTEGER,
+            source_kind TEXT NOT NULL
+                CHECK(source_kind IN ('direct_member','group_mention','member_inbox')),
+            source_event_id TEXT,
+            source_inbox_id INTEGER,
+            dispatch_member_id TEXT NOT NULL CHECK(length(trim(dispatch_member_id)) > 0),
+            member_dispatch_sequence INTEGER NOT NULL CHECK(member_dispatch_sequence >= 1),
+            depth INTEGER NOT NULL CHECK(depth >= 0),
+            delivery_ordinal INTEGER NOT NULL CHECK(delivery_ordinal >= 1),
+            request_digest TEXT NOT NULL
+                CHECK(length(request_digest)=64 AND request_digest NOT GLOB '*[^0-9a-f]*'),
+            dispatch_content TEXT NOT NULL CHECK(length(trim(dispatch_content)) > 0),
+            display_content TEXT NOT NULL CHECK(length(trim(display_content)) > 0),
+            images_json TEXT NOT NULL DEFAULT '[]'
+                CHECK(json_valid(images_json)=1 AND json_type(images_json)='array'),
+            status TEXT NOT NULL
+                CHECK(status IN ('pending','started','completed','failed','cancelled','abandoned','unknown')),
+            created_at TEXT NOT NULL,
+            started_at TEXT,
+            terminal_at TEXT,
+            failure_reason TEXT,
+            UNIQUE(session_id, turn_intent_id),
+            UNIQUE(org_run_id, root_authority_turn_id, delivery_ordinal),
+            FOREIGN KEY(org_run_id, root_authority_turn_id)
+                REFERENCES agent_org_runtime_user_directed_roots(org_run_id, root_authority_turn_id)
+                ON DELETE CASCADE,
+            FOREIGN KEY(session_id, turn_intent_id)
+                REFERENCES agent_org_runtime_turn_contexts(session_id, turn_intent_id)
+                ON DELETE CASCADE,
+            FOREIGN KEY(parent_delivery_id)
+                REFERENCES agent_org_runtime_user_directed_deliveries(delivery_id) ON DELETE RESTRICT,
+            FOREIGN KEY(source_inbox_id)
+                REFERENCES agent_org_runtime_inbox(id) ON DELETE RESTRICT,
+            FOREIGN KEY(parent_inbox_id)
+                REFERENCES agent_org_runtime_inbox(id) ON DELETE RESTRICT,
+            CHECK(
+                (source_kind='direct_member'
+                 AND source_event_id IS NOT NULL
+                 AND source_inbox_id IS NULL AND parent_delivery_id IS NULL
+                 AND parent_inbox_id IS NULL
+                 AND depth=0 AND root_authority_turn_id=turn_intent_id)
+                OR
+                (source_kind='group_mention'
+                 AND source_event_id IS NULL
+                 AND source_inbox_id IS NOT NULL AND parent_delivery_id IS NULL
+                 AND parent_inbox_id IS NULL
+                 AND depth=0 AND root_authority_turn_id=turn_intent_id)
+                OR
+                (source_kind='member_inbox'
+                 AND source_event_id IS NULL
+                 AND source_inbox_id IS NOT NULL AND parent_delivery_id IS NOT NULL
+                 AND depth>=1)
+            ),
+            CHECK(
+                (status='pending' AND started_at IS NULL AND terminal_at IS NULL AND failure_reason IS NULL)
+                OR
+                (status='started' AND started_at IS NOT NULL AND terminal_at IS NULL AND failure_reason IS NULL)
+                OR
+                (status IN ('completed','cancelled') AND started_at IS NOT NULL AND terminal_at IS NOT NULL)
+                OR
+                (status IN ('failed','abandoned','unknown') AND terminal_at IS NOT NULL)
+            )
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_org_runtime_udw_source_inbox
+            ON agent_org_runtime_user_directed_deliveries(source_inbox_id)
+            WHERE source_inbox_id IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_agent_org_runtime_udw_member_fifo
+            ON agent_org_runtime_user_directed_deliveries(
+                org_run_id, dispatch_member_id, member_dispatch_sequence
+            ) WHERE status IN ('pending','started');
+        CREATE INDEX IF NOT EXISTS idx_agent_org_runtime_udw_pending_recovery
+            ON agent_org_runtime_user_directed_deliveries(delivery_id)
+            WHERE status='pending';
+
+        CREATE TABLE IF NOT EXISTS agent_org_runtime_user_directed_coordinator_bindings (
+            binding_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            org_run_id TEXT NOT NULL,
+            session_id TEXT NOT NULL CHECK(length(trim(session_id)) > 0),
+            turn_intent_id TEXT NOT NULL CHECK(length(trim(turn_intent_id)) > 0),
+            root_authority_turn_id TEXT NOT NULL CHECK(length(trim(root_authority_turn_id)) > 0),
+            parent_delivery_id INTEGER NOT NULL,
+            parent_inbox_id INTEGER,
+            source_inbox_id INTEGER NOT NULL,
+            depth INTEGER NOT NULL CHECK(depth >= 1),
+            delivery_ordinal INTEGER NOT NULL CHECK(delivery_ordinal >= 2),
+            request_digest TEXT NOT NULL
+                CHECK(length(request_digest)=64 AND request_digest NOT GLOB '*[^0-9a-f]*'),
+            dispatch_content TEXT NOT NULL CHECK(length(trim(dispatch_content)) > 0),
+            display_content TEXT NOT NULL CHECK(length(trim(display_content)) > 0),
+            status TEXT NOT NULL
+                CHECK(status IN ('pending','started','completed','failed','cancelled','abandoned','unknown')),
+            created_at TEXT NOT NULL,
+            started_at TEXT,
+            terminal_at TEXT,
+            failure_reason TEXT,
+            UNIQUE(session_id,turn_intent_id),
+            UNIQUE(source_inbox_id),
+            UNIQUE(org_run_id,root_authority_turn_id,delivery_ordinal),
+            FOREIGN KEY(org_run_id,root_authority_turn_id)
+                REFERENCES agent_org_runtime_user_directed_roots(org_run_id,root_authority_turn_id)
+                ON DELETE CASCADE,
+            FOREIGN KEY(session_id,turn_intent_id)
+                REFERENCES agent_org_runtime_turn_contexts(session_id,turn_intent_id)
+                ON DELETE CASCADE,
+            FOREIGN KEY(parent_delivery_id)
+                REFERENCES agent_org_runtime_user_directed_deliveries(delivery_id) ON DELETE RESTRICT,
+            FOREIGN KEY(parent_inbox_id) REFERENCES agent_org_runtime_inbox(id) ON DELETE RESTRICT,
+            FOREIGN KEY(source_inbox_id) REFERENCES agent_org_runtime_inbox(id) ON DELETE RESTRICT,
+            CHECK(parent_inbox_id IS NULL OR parent_inbox_id<>source_inbox_id),
+            CHECK(
+                (status='pending' AND started_at IS NULL AND terminal_at IS NULL AND failure_reason IS NULL)
+                OR
+                (status='started' AND started_at IS NOT NULL AND terminal_at IS NULL AND failure_reason IS NULL)
+                OR
+                (status IN ('completed','cancelled') AND started_at IS NOT NULL AND terminal_at IS NOT NULL)
+                OR
+                (status IN ('failed','abandoned','unknown') AND terminal_at IS NOT NULL)
+            )
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_org_runtime_udw_coordinator_pending
+            ON agent_org_runtime_user_directed_coordinator_bindings(binding_id)
+            WHERE status='pending';",
+    )
+}
+
+pub(crate) fn canonical_delivery_digest(
+    request: &NewUserDirectedDelivery<'_>,
+) -> Result<String, String> {
+    let value = serde_json::json!({
+        "org_run_id": request.org_run_id,
+        "session_id": request.session_id,
+        "turn_intent_id": request.turn_intent_id,
+        "root_authority_turn_id": request.root_authority_turn_id,
+        "parent_delivery_id": request.parent_delivery_id,
+        "parent_inbox_id": request.parent_inbox_id,
+        "source_kind": request.source_kind.as_str(),
+        "source_event_id": request.source_event_id,
+        "source_inbox_id": request.source_inbox_id,
+        "dispatch_member_id": request.dispatch_member_id,
+        "member_dispatch_sequence": request.member_dispatch_sequence,
+        "depth": request.depth,
+        "delivery_ordinal": request.delivery_ordinal,
+        "dispatch_content": request.dispatch_content,
+        "display_content": request.display_content,
+        "images": request.images.unwrap_or(&[]),
+    });
+    let encoded = serde_json::to_vec(&value).map_err(|error| error.to_string())?;
+    Ok(format!("{:x}", Sha256::digest(encoded)))
+}
+
+pub(crate) fn insert_root_delivery_with_connection(
+    conn: &Connection,
+    request: &NewUserDirectedDelivery<'_>,
+) -> Result<(UserDirectedDeliveryRecord, bool), String> {
+    if request.depth != 0
+        || request.delivery_ordinal != 1
+        || request.root_authority_turn_id != request.turn_intent_id
+        || !matches!(
+            request.source_kind,
+            UserDirectedSourceKind::DirectMember | UserDirectedSourceKind::GroupMention
+        )
+    {
+        return Err("user_directed_root_invalid: root delivery identity is not canonical".into());
+    }
+    validate_non_empty(request)?;
+    let digest = canonical_delivery_digest(request)?;
+    if let Some(existing) =
+        get_by_turn_with_connection(conn, request.session_id, request.turn_intent_id)?
+    {
+        if existing.request_digest == digest {
+            return Ok((existing, true));
+        }
+        return Err("user_directed_idempotency_conflict: Turn identity was reused".into());
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO agent_org_runtime_user_directed_roots (
+            org_run_id,root_authority_turn_id,policy_version,max_deliveries,
+            max_cascade_depth,next_delivery_ordinal,created_at
+         ) VALUES (?1,?2,?3,?4,?5,2,?6)
+         ON CONFLICT(org_run_id,root_authority_turn_id) DO NOTHING",
+        params![
+            request.org_run_id,
+            request.root_authority_turn_id,
+            USER_DIRECTED_POLICY_VERSION,
+            DEFAULT_MAX_DELIVERIES_PER_ROOT,
+            DEFAULT_MAX_CASCADE_DEPTH,
+            &now,
+        ],
+    )
+    .map_err(|error| error.to_string())?;
+    insert_delivery(conn, request, &digest, &now)?;
+    let record = get_by_turn_with_connection(conn, request.session_id, request.turn_intent_id)?
+        .ok_or_else(|| {
+            "user_directed_delivery_missing: accepted delivery disappeared".to_string()
+        })?;
+    Ok((record, false))
+}
+
+pub(crate) fn insert_linked_member_delivery_with_connection(
+    conn: &Connection,
+    request: &NewLinkedMemberDelivery<'_>,
+) -> Result<UserDirectedDeliveryRecord, String> {
+    let parent = get_by_turn_with_connection(
+        conn,
+        request.source_session_id,
+        request.source_turn_intent_id,
+    )?
+    .ok_or_else(|| "linked_inbox_stale_source: caller has no UDW delivery".to_string())?;
+    if parent.org_run_id != request.org_run_id
+        || parent.status != UserDirectedDeliveryStatus::Started
+    {
+        return Err(
+            "linked_inbox_stale_source: caller delivery is not the current started UDW".to_string(),
+        );
+    }
+    let parent_inbox_id = parent.source_inbox_id;
+    let root_limits: Option<i64> = conn
+        .query_row(
+            "SELECT max_cascade_depth
+             FROM agent_org_runtime_user_directed_roots
+             WHERE org_run_id=?1 AND root_authority_turn_id=?2",
+            params![request.org_run_id, &parent.root_authority_turn_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let max_depth = root_limits
+        .ok_or_else(|| "linked_inbox_stale_source: root receipt is missing".to_string())?;
+    let depth = parent.depth + 1;
+    if depth > max_depth {
+        return Err(format!(
+            "linked_inbox_depth_limit: depth {depth} exceeds root limit {max_depth}"
+        ));
+    }
+    let pending: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM agent_org_runtime_user_directed_deliveries
+             WHERE org_run_id=?1 AND dispatch_member_id=?2
+               AND status IN ('pending','started')",
+            params![request.org_run_id, request.recipient_member_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if pending >= DEFAULT_MAX_PENDING_PER_MEMBER {
+        return Err(format!(
+            "user_directed_queue_full: Member {} already has {pending} pending/started deliveries (cap {DEFAULT_MAX_PENDING_PER_MEMBER})",
+            request.recipient_member_id
+        ));
+    }
+
+    let admission =
+        crate::coordination::agent_org_turn_contexts::AgentOrgTurnAdmission::member_inbox(
+            request.org_run_id,
+            request.recipient_session_id,
+            request.child_turn_intent_id,
+            Some(request.child_turn_intent_id.to_string()),
+            request.recipient_member_id,
+            request.source_inbox_id,
+            &parent.root_authority_turn_id,
+        );
+    let context =
+        crate::coordination::agent_org_turn_contexts::accept_with_connection(conn, &admission)?;
+    let sequence = context.member_dispatch_sequence.ok_or_else(|| {
+        "agent_org_turn_context_invalid: linked UDW has no Member FIFO sequence".to_string()
+    })?;
+    let delivery_ordinal: Option<i64> = conn
+        .query_row(
+            "UPDATE agent_org_runtime_user_directed_roots
+             SET next_delivery_ordinal=next_delivery_ordinal+1
+             WHERE org_run_id=?1 AND root_authority_turn_id=?2
+               AND next_delivery_ordinal<=max_deliveries+1
+             RETURNING next_delivery_ordinal-1",
+            params![request.org_run_id, &parent.root_authority_turn_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let delivery_ordinal = delivery_ordinal.ok_or_else(|| {
+        "linked_inbox_delivery_limit: root delivery budget is exhausted".to_string()
+    })?;
+    let child = NewUserDirectedDelivery {
+        org_run_id: request.org_run_id,
+        session_id: request.recipient_session_id,
+        turn_intent_id: request.child_turn_intent_id,
+        root_authority_turn_id: &parent.root_authority_turn_id,
+        parent_delivery_id: Some(parent.delivery_id),
+        parent_inbox_id,
+        source_kind: UserDirectedSourceKind::MemberInbox,
+        source_event_id: None,
+        source_inbox_id: Some(request.source_inbox_id),
+        dispatch_member_id: request.recipient_member_id,
+        member_dispatch_sequence: sequence,
+        depth,
+        delivery_ordinal,
+        dispatch_content: request.dispatch_content,
+        display_content: request.display_content,
+        images: request.images,
+    };
+    validate_non_empty(&child)?;
+    let digest = canonical_delivery_digest(&child)?;
+    let now = chrono::Utc::now().to_rfc3339();
+    insert_delivery(conn, &child, &digest, &now)?;
+    get_by_turn_with_connection(
+        conn,
+        request.recipient_session_id,
+        request.child_turn_intent_id,
+    )?
+    .ok_or_else(|| "linked_inbox_delivery_missing: accepted child disappeared".to_string())
+}
+
+pub(crate) fn insert_linked_coordinator_delivery_with_connection(
+    conn: &Connection,
+    request: &NewLinkedCoordinatorDelivery<'_>,
+) -> Result<UserDirectedCoordinatorBinding, String> {
+    let parent = get_by_turn_with_connection(
+        conn,
+        request.source_session_id,
+        request.source_turn_intent_id,
+    )?
+    .ok_or_else(|| "linked_inbox_stale_source: caller has no UDW delivery".to_string())?;
+    if parent.org_run_id != request.org_run_id
+        || parent.status != UserDirectedDeliveryStatus::Started
+    {
+        return Err(
+            "linked_inbox_stale_source: caller delivery is not the current started UDW".to_string(),
+        );
+    }
+    let parent_inbox_id = parent.source_inbox_id;
+    let max_depth: Option<i64> = conn
+        .query_row(
+            "SELECT max_cascade_depth
+             FROM agent_org_runtime_user_directed_roots
+             WHERE org_run_id=?1 AND root_authority_turn_id=?2",
+            params![request.org_run_id, &parent.root_authority_turn_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let max_depth = max_depth
+        .ok_or_else(|| "linked_inbox_stale_source: root receipt is missing".to_string())?;
+    let depth = parent.depth + 1;
+    if depth > max_depth {
+        return Err(format!(
+            "linked_inbox_depth_limit: depth {depth} exceeds root limit {max_depth}"
+        ));
+    }
+    let delivery_ordinal: Option<i64> = conn
+        .query_row(
+            "UPDATE agent_org_runtime_user_directed_roots
+             SET next_delivery_ordinal=next_delivery_ordinal+1
+             WHERE org_run_id=?1 AND root_authority_turn_id=?2
+               AND next_delivery_ordinal<=max_deliveries+1
+             RETURNING next_delivery_ordinal-1",
+            params![request.org_run_id, &parent.root_authority_turn_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let delivery_ordinal = delivery_ordinal.ok_or_else(|| {
+        "linked_inbox_delivery_limit: root delivery budget is exhausted".to_string()
+    })?;
+
+    let admission =
+        crate::coordination::agent_org_turn_contexts::AgentOrgTurnAdmission::coordinator_member_inbox(
+            request.org_run_id,
+            request.coordinator_session_id,
+            request.child_turn_intent_id,
+            Some(request.child_turn_intent_id.to_string()),
+            request.source_inbox_id,
+            &parent.root_authority_turn_id,
+        );
+    crate::coordination::agent_org_turn_contexts::accept_with_connection(conn, &admission)?;
+    let digest_value = serde_json::json!({
+        "org_run_id": request.org_run_id,
+        "session_id": request.coordinator_session_id,
+        "turn_intent_id": request.child_turn_intent_id,
+        "root_authority_turn_id": parent.root_authority_turn_id,
+        "parent_delivery_id": parent.delivery_id,
+        "parent_inbox_id": parent_inbox_id,
+        "source_inbox_id": request.source_inbox_id,
+        "depth": depth,
+        "delivery_ordinal": delivery_ordinal,
+        "dispatch_content": request.dispatch_content,
+        "display_content": request.display_content,
+    });
+    let encoded = serde_json::to_vec(&digest_value).map_err(|error| error.to_string())?;
+    let digest = format!("{:x}", Sha256::digest(encoded));
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO agent_org_runtime_user_directed_coordinator_bindings (
+            org_run_id,session_id,turn_intent_id,root_authority_turn_id,
+            parent_delivery_id,parent_inbox_id,source_inbox_id,depth,delivery_ordinal,request_digest,
+            dispatch_content,display_content,status,created_at
+         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,'pending',?13)",
+        params![
+            request.org_run_id,
+            request.coordinator_session_id,
+            request.child_turn_intent_id,
+            &parent.root_authority_turn_id,
+            parent.delivery_id,
+            parent_inbox_id,
+            request.source_inbox_id,
+            depth,
+            delivery_ordinal,
+            digest,
+            request.dispatch_content,
+            request.display_content,
+            &now,
+        ],
+    )
+    .map_err(map_constraint_error)?;
+    get_coordinator_binding_with_connection(
+        conn,
+        request.coordinator_session_id,
+        request.child_turn_intent_id,
+    )?
+    .ok_or_else(|| "linked_coordinator_binding_missing: accepted binding disappeared".to_string())
+}
+
+fn get_coordinator_binding_with_connection(
+    conn: &Connection,
+    session_id: &str,
+    turn_intent_id: &str,
+) -> Result<Option<UserDirectedCoordinatorBinding>, String> {
+    conn.query_row(
+        "SELECT org_run_id,session_id,turn_intent_id,root_authority_turn_id,
+                source_inbox_id,depth,delivery_ordinal,status
+         FROM agent_org_runtime_user_directed_coordinator_bindings
+         WHERE session_id=?1 AND turn_intent_id=?2",
+        params![session_id, turn_intent_id],
+        |row| {
+            let status_raw: String = row.get(7)?;
+            let status = UserDirectedDeliveryStatus::parse(&status_raw)
+                .ok_or(rusqlite::Error::InvalidQuery)?;
+            Ok(UserDirectedCoordinatorBinding {
+                org_run_id: row.get(0)?,
+                session_id: row.get(1)?,
+                turn_intent_id: row.get(2)?,
+                root_authority_turn_id: row.get(3)?,
+                source_inbox_id: row.get(4)?,
+                depth: row.get(5)?,
+                delivery_ordinal: row.get(6)?,
+                status,
+            })
+        },
+    )
+    .optional()
+    .map_err(|error| error.to_string())
+}
+
+fn insert_delivery(
+    conn: &Connection,
+    request: &NewUserDirectedDelivery<'_>,
+    digest: &str,
+    now: &str,
+) -> Result<(), String> {
+    let images_json =
+        serde_json::to_string(request.images.unwrap_or(&[])).map_err(|error| error.to_string())?;
+    conn.execute(
+        "INSERT INTO agent_org_runtime_user_directed_deliveries (
+            org_run_id,session_id,turn_intent_id,root_authority_turn_id,
+            parent_delivery_id,parent_inbox_id,source_kind,source_event_id,source_inbox_id,
+            dispatch_member_id,member_dispatch_sequence,depth,delivery_ordinal,
+            request_digest,dispatch_content,display_content,images_json,status,created_at
+         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,'pending',?18)",
+        params![
+            request.org_run_id,
+            request.session_id,
+            request.turn_intent_id,
+            request.root_authority_turn_id,
+            request.parent_delivery_id,
+            request.parent_inbox_id,
+            request.source_kind.as_str(),
+            request.source_event_id,
+            request.source_inbox_id,
+            request.dispatch_member_id,
+            request.member_dispatch_sequence,
+            request.depth,
+            request.delivery_ordinal,
+            digest,
+            request.dispatch_content,
+            request.display_content,
+            images_json,
+            now,
+        ],
+    )
+    .map_err(map_constraint_error)?;
+    Ok(())
+}
+
+pub(crate) fn get_by_turn_with_connection(
+    conn: &Connection,
+    session_id: &str,
+    turn_intent_id: &str,
+) -> Result<Option<UserDirectedDeliveryRecord>, String> {
+    conn.query_row(
+        "SELECT delivery_id,org_run_id,session_id,turn_intent_id,
+                root_authority_turn_id,parent_delivery_id,parent_inbox_id,source_kind,source_event_id,
+                source_inbox_id,dispatch_member_id,member_dispatch_sequence,depth,
+                delivery_ordinal,request_digest,status
+         FROM agent_org_runtime_user_directed_deliveries
+         WHERE session_id=?1 AND turn_intent_id=?2",
+        params![session_id, turn_intent_id],
+        row_to_delivery,
+    )
+    .optional()
+    .map_err(|error| error.to_string())
+}
+
+pub(crate) fn status_by_turn(
+    session_id: &str,
+    turn_intent_id: &str,
+) -> Result<Option<UserDirectedDeliveryStatus>, String> {
+    let conn = get_connection().map_err(|error| error.to_string())?;
+    if let Some(record) = get_by_turn_with_connection(&conn, session_id, turn_intent_id)? {
+        return Ok(Some(record.status));
+    }
+    Ok(
+        get_coordinator_binding_with_connection(&conn, session_id, turn_intent_id)?
+            .map(|binding| binding.status),
+    )
+}
+
+pub(crate) fn causal_reply_for_turn(
+    session_id: &str,
+    turn_intent_id: &str,
+) -> Result<Option<UserDirectedCausalReply>, String> {
+    let conn = get_connection().map_err(|error| error.to_string())?;
+    if let Some(record) = get_by_turn_with_connection(&conn, session_id, turn_intent_id)? {
+        return Ok(Some(UserDirectedCausalReply {
+            source_kind: record.source_kind.as_str().to_string(),
+            source_inbox_id: record.source_inbox_id,
+            parent_inbox_id: record.parent_inbox_id,
+            root_authority_turn_id: record.root_authority_turn_id,
+            depth: record.depth,
+            delivery_ordinal: record.delivery_ordinal,
+        }));
+    }
+    conn.query_row(
+        "SELECT source_inbox_id,parent_inbox_id,root_authority_turn_id,
+                depth,delivery_ordinal
+         FROM agent_org_runtime_user_directed_coordinator_bindings
+         WHERE session_id=?1 AND turn_intent_id=?2",
+        params![session_id, turn_intent_id],
+        |row| {
+            Ok(UserDirectedCausalReply {
+                source_kind: UserDirectedSourceKind::MemberInbox.as_str().to_string(),
+                source_inbox_id: Some(row.get(0)?),
+                parent_inbox_id: row.get(1)?,
+                root_authority_turn_id: row.get(2)?,
+                depth: row.get(3)?,
+                delivery_ordinal: row.get(4)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(|error| error.to_string())
+}
+
+/// Atomically claim the exact pending UDW delivery immediately before
+/// Provider execution. The scheduler remains the runtime owner; this ledger
+/// prevents a stale or replayed scheduler callback from starting side effects.
+pub(crate) fn mark_turn_started_with_connection(
+    conn: &Connection,
+    session_id: &str,
+    turn_intent_id: &str,
+) -> Result<bool, String> {
+    let Some(record) = get_by_turn_with_connection(conn, session_id, turn_intent_id)? else {
+        let binding = get_coordinator_binding_with_connection(conn, session_id, turn_intent_id)?
+            .ok_or_else(|| {
+                "user_directed_stale_source: delivery/binding receipt is missing".to_string()
+            })?;
+        if binding.status != UserDirectedDeliveryStatus::Pending {
+            return Ok(false);
+        }
+        let changed = conn
+            .execute(
+                "UPDATE agent_org_runtime_user_directed_coordinator_bindings AS binding
+                 SET status='started',started_at=?3
+                 WHERE binding.session_id=?1 AND binding.turn_intent_id=?2
+                   AND binding.status='pending'
+                   AND NOT EXISTS (
+                       SELECT 1
+                       FROM agent_org_runtime_user_directed_coordinator_bindings earlier
+                       WHERE earlier.org_run_id=binding.org_run_id
+                         AND earlier.binding_id<binding.binding_id
+                         AND earlier.status IN ('pending','started')
+                   )",
+                params![session_id, turn_intent_id, chrono::Utc::now().to_rfc3339()],
+            )
+            .map_err(|error| error.to_string())?;
+        if changed == 0 {
+            requeue_running_turn_intent(conn, session_id, turn_intent_id)?;
+        }
+        if changed == 1 {
+            claim_exact_source_inbox(
+                conn,
+                &binding.org_run_id,
+                binding.source_inbox_id,
+                crate::coordination::agent_org_runs::COORDINATOR_MEMBER_ID,
+            )?;
+        }
+        return Ok(changed == 1);
+    };
+    if record.status != UserDirectedDeliveryStatus::Pending {
+        return Ok(false);
+    }
+    if !crate::coordination::agent_org_turn_contexts::member_dispatch_is_fifo_head_with_connection(
+        conn,
+        &record.org_run_id,
+        &record.dispatch_member_id,
+        record.member_dispatch_sequence,
+        record.source_kind == UserDirectedSourceKind::DirectMember,
+    )? {
+        requeue_running_turn_intent(conn, session_id, turn_intent_id)?;
+        return Ok(false);
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let changed = conn
+        .execute(
+            "UPDATE agent_org_runtime_user_directed_deliveries AS delivery
+             SET status='started',started_at=?3
+             WHERE delivery.session_id=?1 AND delivery.turn_intent_id=?2
+               AND delivery.status='pending'
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM agent_org_runtime_user_directed_deliveries earlier
+                   WHERE earlier.org_run_id=delivery.org_run_id
+                     AND earlier.dispatch_member_id=delivery.dispatch_member_id
+                     AND earlier.member_dispatch_sequence<delivery.member_dispatch_sequence
+                     AND earlier.status IN ('pending','started')
+               )",
+            params![session_id, turn_intent_id, &now],
+        )
+        .map_err(|error| error.to_string())?;
+    if changed != 1 {
+        requeue_running_turn_intent(conn, session_id, turn_intent_id)?;
+        return Ok(false);
+    }
+
+    if record.source_kind == UserDirectedSourceKind::DirectMember
+        && !crate::coordination::agent_member_interventions::AgentMemberInterventionStore::mark_turn_running_with_connection(
+            conn,
+            session_id,
+            turn_intent_id,
+        )?
+    {
+        conn.execute(
+            "UPDATE agent_org_runtime_user_directed_deliveries
+             SET status='pending',started_at=NULL
+             WHERE session_id=?1 AND turn_intent_id=?2 AND status='started'",
+            params![session_id, turn_intent_id],
+        )
+        .map_err(|error| error.to_string())?;
+        return Ok(false);
+    }
+    if let Some(source_inbox_id) = record.source_inbox_id {
+        claim_exact_source_inbox(
+            conn,
+            &record.org_run_id,
+            source_inbox_id,
+            &record.dispatch_member_id,
+        )?;
+    }
+    Ok(true)
+}
+
+fn requeue_running_turn_intent(
+    conn: &Connection,
+    session_id: &str,
+    turn_intent_id: &str,
+) -> Result<(), String> {
+    conn.execute(
+        "UPDATE session_turn_intents SET status='queued',updated_at=?3
+         WHERE session_id=?1 AND turn_intent_id=?2 AND status='running'",
+        params![session_id, turn_intent_id, chrono::Utc::now().to_rfc3339()],
+    )
+    .map(|_| ())
+    .map_err(|error| error.to_string())
+}
+
+fn claim_exact_source_inbox(
+    conn: &Connection,
+    org_run_id: &str,
+    source_inbox_id: i64,
+    recipient_member_id: &str,
+) -> Result<(), String> {
+    let changed = conn
+        .execute(
+            "UPDATE agent_org_runtime_inbox
+             SET read_at=COALESCE(read_at,?4)
+             WHERE id=?1 AND org_run_id=?2 AND recipient_member_id=?3
+               AND delivery_class='user_directed'",
+            params![
+                source_inbox_id,
+                org_run_id,
+                recipient_member_id,
+                chrono::Utc::now().to_rfc3339(),
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+    if changed != 1 {
+        return Err(
+            "user_directed_stale_source: exact source Inbox is missing or changed".to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn mark_turn_terminal(
+    session_id: &str,
+    turn_intent_id: &str,
+    status: UserDirectedDeliveryStatus,
+    failure_reason: Option<&str>,
+) -> Result<bool, String> {
+    if !matches!(
+        status,
+        UserDirectedDeliveryStatus::Completed
+            | UserDirectedDeliveryStatus::Failed
+            | UserDirectedDeliveryStatus::Cancelled
+            | UserDirectedDeliveryStatus::Abandoned
+            | UserDirectedDeliveryStatus::Unknown
+    ) {
+        return Err("user_directed_terminal_invalid: status is not terminal".to_string());
+    }
+    let (changed, org_run_id) = with_sessions_writer(|| {
+        let mut conn = get_connection().map_err(|error| error.to_string())?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|error| error.to_string())?;
+        let member_record = get_by_turn_with_connection(&tx, session_id, turn_intent_id)?;
+        if member_record.is_none() {
+            let binding = get_coordinator_binding_with_connection(&tx, session_id, turn_intent_id)?
+                .ok_or_else(|| {
+                    "user_directed_stale_source: delivery/binding receipt is missing".to_string()
+                })?;
+            if matches!(
+                binding.status,
+                UserDirectedDeliveryStatus::Completed
+                    | UserDirectedDeliveryStatus::Failed
+                    | UserDirectedDeliveryStatus::Cancelled
+                    | UserDirectedDeliveryStatus::Abandoned
+                    | UserDirectedDeliveryStatus::Unknown
+            ) {
+                if binding.status != status {
+                    return Err(
+                        "user_directed_terminal_conflict: terminal status changed on replay"
+                            .to_string(),
+                    );
+                }
+                tx.commit().map_err(|error| error.to_string())?;
+                return Ok((false, binding.org_run_id));
+            }
+            let now = chrono::Utc::now().to_rfc3339();
+            let changed = tx
+                .execute(
+                    "UPDATE agent_org_runtime_user_directed_coordinator_bindings
+                     SET status=?3,started_at=COALESCE(started_at,?4),terminal_at=?4,
+                         failure_reason=?5
+                     WHERE session_id=?1 AND turn_intent_id=?2
+                       AND status IN ('pending','started')",
+                    params![
+                        session_id,
+                        turn_intent_id,
+                        status.as_str(),
+                        &now,
+                        failure_reason,
+                    ],
+                )
+                .map_err(|error| error.to_string())?;
+            if changed != 1 {
+                return Err(
+                    "user_directed_terminal_conflict: Coordinator binding changed concurrently"
+                        .to_string(),
+                );
+            }
+            let intent_status = match status {
+                UserDirectedDeliveryStatus::Completed => "completed",
+                UserDirectedDeliveryStatus::Cancelled => "cancelled",
+                UserDirectedDeliveryStatus::Failed
+                | UserDirectedDeliveryStatus::Abandoned
+                | UserDirectedDeliveryStatus::Unknown => "failed",
+                _ => unreachable!("validated terminal status"),
+            };
+            tx.execute(
+                "UPDATE session_turn_intents SET status=?3,updated_at=?4
+                 WHERE session_id=?1 AND turn_intent_id=?2
+                   AND status IN ('queued','running')",
+                params![session_id, turn_intent_id, intent_status, &now],
+            )
+            .map_err(|error| error.to_string())?;
+            tx.commit().map_err(|error| error.to_string())?;
+            return Ok((true, binding.org_run_id));
+        }
+        let record = member_record.expect("checked member delivery above");
+        if matches!(
+            record.status,
+            UserDirectedDeliveryStatus::Completed
+                | UserDirectedDeliveryStatus::Failed
+                | UserDirectedDeliveryStatus::Cancelled
+                | UserDirectedDeliveryStatus::Abandoned
+                | UserDirectedDeliveryStatus::Unknown
+        ) {
+            if record.status != status {
+                return Err(
+                    "user_directed_terminal_conflict: terminal status changed on replay"
+                        .to_string(),
+                );
+            }
+            tx.commit().map_err(|error| error.to_string())?;
+            return Ok((false, record.org_run_id));
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let changed = tx
+            .execute(
+                "UPDATE agent_org_runtime_user_directed_deliveries
+                 SET status=?3,started_at=COALESCE(started_at,?4),terminal_at=?4,
+                     failure_reason=?5
+                 WHERE session_id=?1 AND turn_intent_id=?2
+                   AND status IN ('pending','started')",
+                params![
+                    session_id,
+                    turn_intent_id,
+                    status.as_str(),
+                    &now,
+                    failure_reason,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+        if changed != 1 {
+            return Err("user_directed_terminal_conflict: delivery changed concurrently".into());
+        }
+
+        let intent_status = match status {
+            UserDirectedDeliveryStatus::Completed => "completed",
+            UserDirectedDeliveryStatus::Cancelled => "cancelled",
+            UserDirectedDeliveryStatus::Failed
+            | UserDirectedDeliveryStatus::Abandoned
+            | UserDirectedDeliveryStatus::Unknown => "failed",
+            _ => unreachable!("validated terminal status"),
+        };
+        tx.execute(
+            "UPDATE session_turn_intents
+             SET status=?3,updated_at=?4
+             WHERE session_id=?1 AND turn_intent_id=?2
+               AND status IN ('queued','running')",
+            params![session_id, turn_intent_id, intent_status, &now],
+        )
+        .map_err(|error| error.to_string())?;
+
+        if record.source_kind == UserDirectedSourceKind::DirectMember {
+            let direct_status = match status {
+                UserDirectedDeliveryStatus::Unknown => "abandoned",
+                _ => status.as_str(),
+            };
+            crate::coordination::agent_member_interventions::update_chain_status_with_connection(
+                &tx,
+                session_id,
+                turn_intent_id,
+                direct_status,
+                failure_reason,
+            )?;
+        }
+        tx.commit().map_err(|error| error.to_string())?;
+        Ok((true, record.org_run_id))
+    })?;
+
+    if changed {
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(&org_run_id);
+    }
+    Ok(changed)
+}
+
+/// Return the next durable UDW FIFO item after any Agent Org Turn on the same
+/// runtime finishes. This closes commit-before-kick holes in both directions:
+/// a formal Task/Root Turn can release queued UDW, and a UDW Turn can release
+/// the next UDW before the formal Inbox wake is rechecked.
+pub(crate) fn next_pending_after_terminal(
+    session_id: &str,
+    turn_intent_id: &str,
+) -> Result<Option<RecoverableUserDirectedDispatch>, String> {
+    let conn = get_connection().map_err(|error| error.to_string())?;
+    let owner: Option<(String, String, Option<String>)> = conn
+        .query_row(
+            "SELECT org_run_id,participant_id,dispatch_member_id
+             FROM agent_org_runtime_turn_contexts
+             WHERE session_id=?1 AND turn_intent_id=?2",
+            params![session_id, turn_intent_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let Some((org_run_id, participant_id, dispatch_member_id)) = owner else {
+        return Ok(None);
+    };
+    let raw: Option<(String, String, String, String, String, String, String)> =
+        if let Some(dispatch_member_id) = dispatch_member_id {
+            conn.query_row(
+                "SELECT delivery.org_run_id,delivery.dispatch_member_id,
+                        delivery.session_id,delivery.turn_intent_id,
+                        delivery.dispatch_content,delivery.display_content,
+                        delivery.images_json
+                 FROM agent_org_runtime_user_directed_deliveries delivery
+                 JOIN agent_org_runtime_turn_contexts context
+                   ON context.session_id=delivery.session_id
+                  AND context.turn_intent_id=delivery.turn_intent_id
+                 JOIN session_turn_intents intent
+                   ON intent.session_id=delivery.session_id
+                  AND intent.turn_intent_id=delivery.turn_intent_id
+                 JOIN agent_org_runtime_runs run ON run.id=delivery.org_run_id
+                 WHERE delivery.org_run_id=?1
+                   AND delivery.dispatch_member_id=?2
+                   AND delivery.status='pending'
+                   AND context.turn_kind='user_directed_work'
+                   AND intent.status='queued'
+                   AND run.status IN ('running','idle','paused')
+                 ORDER BY delivery.member_dispatch_sequence,delivery.delivery_id
+                 LIMIT 1",
+                params![org_run_id, dispatch_member_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|error| error.to_string())?
+        } else if participant_id == crate::coordination::agent_org_runs::COORDINATOR_MEMBER_ID {
+            conn.query_row(
+                "SELECT binding.org_run_id,'coordinator',binding.session_id,
+                        binding.turn_intent_id,binding.dispatch_content,
+                        binding.display_content,'[]'
+                 FROM agent_org_runtime_user_directed_coordinator_bindings binding
+                 JOIN agent_org_runtime_turn_contexts context
+                   ON context.session_id=binding.session_id
+                  AND context.turn_intent_id=binding.turn_intent_id
+                 JOIN session_turn_intents intent
+                   ON intent.session_id=binding.session_id
+                  AND intent.turn_intent_id=binding.turn_intent_id
+                 JOIN agent_org_runtime_runs run ON run.id=binding.org_run_id
+                 WHERE binding.org_run_id=?1 AND binding.status='pending'
+                   AND context.turn_kind='coordinator'
+                   AND context.source_kind='member_inbox'
+                   AND intent.status='queued'
+                   AND run.status IN ('running','idle','paused')
+                 ORDER BY binding.binding_id
+                 LIMIT 1",
+                [&org_run_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|error| error.to_string())?
+        } else {
+            None
+        };
+    let Some((
+        org_run_id,
+        recipient_member_id,
+        recipient_session_id,
+        next_turn_intent_id,
+        content,
+        display_text,
+        images_json,
+    )) = raw
+    else {
+        return Ok(None);
+    };
+    let images: Vec<String> =
+        serde_json::from_str(&images_json).map_err(|error| error.to_string())?;
+    Ok(Some(RecoverableUserDirectedDispatch {
+        recovery_key: String::new(),
+        org_run_id,
+        recipient_member_id,
+        recipient_session_id,
+        turn_intent_id: next_turn_intent_id,
+        content,
+        display_text,
+        images: (!images.is_empty()).then_some(images),
+    }))
+}
+
+pub(crate) fn dispatch_owner_for_turn(
+    session_id: &str,
+    turn_intent_id: &str,
+) -> Result<Option<(String, String)>, String> {
+    let conn = get_connection().map_err(|error| error.to_string())?;
+    conn.query_row(
+        "SELECT org_run_id,dispatch_member_id
+         FROM agent_org_runtime_turn_contexts
+         WHERE session_id=?1 AND turn_intent_id=?2
+           AND dispatch_member_id IS NOT NULL",
+        params![session_id, turn_intent_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .optional()
+    .map_err(|error| error.to_string())
+}
+
+fn row_to_delivery(row: &rusqlite::Row<'_>) -> rusqlite::Result<UserDirectedDeliveryRecord> {
+    let source_raw: String = row.get(7)?;
+    let status_raw: String = row.get(15)?;
+    let source_kind = match source_raw.as_str() {
+        "direct_member" => UserDirectedSourceKind::DirectMember,
+        "group_mention" => UserDirectedSourceKind::GroupMention,
+        "member_inbox" => UserDirectedSourceKind::MemberInbox,
+        _ => return Err(rusqlite::Error::InvalidQuery),
+    };
+    let status =
+        UserDirectedDeliveryStatus::parse(&status_raw).ok_or(rusqlite::Error::InvalidQuery)?;
+    Ok(UserDirectedDeliveryRecord {
+        delivery_id: row.get(0)?,
+        org_run_id: row.get(1)?,
+        session_id: row.get(2)?,
+        turn_intent_id: row.get(3)?,
+        root_authority_turn_id: row.get(4)?,
+        parent_delivery_id: row.get(5)?,
+        parent_inbox_id: row.get(6)?,
+        source_kind,
+        source_event_id: row.get(8)?,
+        source_inbox_id: row.get(9)?,
+        dispatch_member_id: row.get(10)?,
+        member_dispatch_sequence: row.get(11)?,
+        depth: row.get(12)?,
+        delivery_ordinal: row.get(13)?,
+        request_digest: row.get(14)?,
+        status,
+    })
+}
+
+fn validate_non_empty(request: &NewUserDirectedDelivery<'_>) -> Result<(), String> {
+    if request.org_run_id.trim().is_empty()
+        || request.session_id.trim().is_empty()
+        || request.turn_intent_id.trim().is_empty()
+        || request.root_authority_turn_id.trim().is_empty()
+        || request.dispatch_member_id.trim().is_empty()
+        || request.dispatch_content.trim().is_empty()
+        || request.display_content.trim().is_empty()
+        || request.member_dispatch_sequence < 1
+    {
+        return Err("user_directed_delivery_invalid: required value is empty".into());
+    }
+    Ok(())
+}
+
+fn map_constraint_error(error: rusqlite::Error) -> String {
+    if let rusqlite::Error::SqliteFailure(code, _) = &error {
+        if code.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
+            || code.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY
+        {
+            return "user_directed_idempotency_conflict: durable identity already exists".into();
+        }
+    }
+    error.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_rejects_invalid_source_combinations() {
+        let conn = Connection::open_in_memory().expect("open database");
+        conn.execute_batch(
+            "PRAGMA foreign_keys=ON;
+             CREATE TABLE agent_org_runtime_runs(id TEXT PRIMARY KEY);
+             CREATE TABLE agent_org_runtime_inbox(id INTEGER PRIMARY KEY);
+             CREATE TABLE agent_org_runtime_turn_contexts(
+                session_id TEXT NOT NULL, turn_intent_id TEXT NOT NULL,
+                UNIQUE(session_id,turn_intent_id)
+             );",
+        )
+        .expect("create dependencies");
+        create_schema(&conn).expect("create UDW schema");
+        conn.execute("INSERT INTO agent_org_runtime_runs(id) VALUES ('run')", [])
+            .expect("insert run");
+        conn.execute(
+            "INSERT INTO agent_org_runtime_turn_contexts(session_id,turn_intent_id)
+             VALUES ('session','turn')",
+            [],
+        )
+        .expect("insert context");
+        conn.execute(
+            "INSERT INTO agent_org_runtime_user_directed_roots(
+                org_run_id,root_authority_turn_id,policy_version,max_deliveries,
+                max_cascade_depth,next_delivery_ordinal,created_at
+             ) VALUES ('run','turn',1,8,2,2,'now')",
+            [],
+        )
+        .expect("insert root");
+        let error = conn
+            .execute(
+                "INSERT INTO agent_org_runtime_user_directed_deliveries(
+                    org_run_id,session_id,turn_intent_id,root_authority_turn_id,
+                    source_kind,source_event_id,dispatch_member_id,
+                    member_dispatch_sequence,depth,delivery_ordinal,request_digest,
+                    dispatch_content,display_content,status,created_at
+                 ) VALUES ('run','session','turn','turn','group_mention','event',
+                           'member',1,0,1,?1,'body','body','pending','now')",
+                [&"a".repeat(64)],
+            )
+            .expect_err("invalid Group source must fail");
+        assert!(matches!(error, rusqlite::Error::SqliteFailure(_, _)));
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_user_directed_work/recovery.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_user_directed_work/recovery.rs
@@ -1,0 +1,232 @@
+//! Bounded startup reconciliation for durable user-directed work.
+
+use rusqlite::params;
+
+use database::db::{get_connection, with_sessions_writer};
+
+use super::RecoverableUserDirectedDispatch;
+
+/// On process restart, a delivery that had already crossed the durable
+/// `started` boundary is never replayed. Its file/provider/external effects
+/// may have happened even if no terminal receipt was written, so surface an
+/// explicit unknown outcome and leave recovery to the user.
+#[cfg(test)]
+pub(crate) fn mark_started_unknown_after_restart() -> Result<usize, String> {
+    let mut changed = 0usize;
+    let mut after_key: Option<String> = None;
+    loop {
+        let page = mark_started_unknown_after_restart_after(after_key.as_deref(), 100)?;
+        if page.is_empty() {
+            break;
+        }
+        changed = changed.saturating_add(page.len());
+        after_key = page.last().cloned();
+        if page.len() < 100 {
+            break;
+        }
+    }
+    Ok(changed)
+}
+
+/// Classify one bounded keyset page of pre-restart started work. The startup
+/// owner yields between pages; no transaction scans or rewrites the full UDW
+/// history, and only rows that still hold the exact `started` state change.
+pub(crate) fn mark_started_unknown_after_restart_after(
+    after_key: Option<&str>,
+    limit: usize,
+) -> Result<Vec<String>, String> {
+    with_sessions_writer(|| {
+        let mut conn = get_connection().map_err(|error| error.to_string())?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|error| error.to_string())?;
+        let now = chrono::Utc::now().to_rfc3339();
+        let reason = "app_restarted_after_user_directed_work_started";
+        let interrupted = {
+            let mut statement = tx
+                .prepare(
+                    "WITH interrupted AS (
+                         SELECT 'm:' || printf('%020d',delivery_id) AS recovery_key,
+                                'member' AS recovery_kind,delivery_id AS row_id,
+                                org_run_id,session_id,turn_intent_id
+                         FROM agent_org_runtime_user_directed_deliveries
+                         WHERE status='started'
+                         UNION ALL
+                         SELECT 'c:' || printf('%020d',binding_id) AS recovery_key,
+                                'coordinator' AS recovery_kind,binding_id AS row_id,
+                                org_run_id,session_id,turn_intent_id
+                         FROM agent_org_runtime_user_directed_coordinator_bindings
+                         WHERE status='started'
+                     )
+                     SELECT recovery_key,recovery_kind,row_id,org_run_id,
+                            session_id,turn_intent_id
+                     FROM interrupted
+                     WHERE recovery_key>COALESCE(?1,'')
+                     ORDER BY recovery_key
+                     LIMIT ?2",
+                )
+                .map_err(|error| error.to_string())?;
+            let rows = statement
+                .query_map(params![after_key, limit.clamp(1, 100) as i64], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, String>(5)?,
+                    ))
+                })
+                .map_err(|error| error.to_string())?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(|error| error.to_string())?
+        };
+        let mut changed_keys = Vec::with_capacity(interrupted.len());
+        let mut run_ids = std::collections::HashSet::new();
+        for (recovery_key, recovery_kind, row_id, org_run_id, session_id, turn_intent_id) in
+            interrupted
+        {
+            let changed = if recovery_kind == "member" {
+                tx.execute(
+                    "UPDATE agent_org_runtime_member_intervention_turns
+                     SET status='abandoned',terminal_at=?3,failure_reason=?4
+                     WHERE session_id=?1 AND turn_intent_id=?2 AND status='running'",
+                    params![&session_id, &turn_intent_id, &now, reason],
+                )
+                .map_err(|error| error.to_string())?;
+                tx.execute(
+                    "UPDATE agent_org_runtime_user_directed_deliveries
+                     SET status='unknown',terminal_at=?2,failure_reason=?3
+                     WHERE delivery_id=?1 AND status='started'",
+                    params![row_id, &now, reason],
+                )
+                .map_err(|error| error.to_string())?
+            } else {
+                tx.execute(
+                    "UPDATE agent_org_runtime_user_directed_coordinator_bindings
+                     SET status='unknown',terminal_at=?2,failure_reason=?3
+                     WHERE binding_id=?1 AND status='started'",
+                    params![row_id, &now, reason],
+                )
+                .map_err(|error| error.to_string())?
+            };
+            if changed == 1 {
+                tx.execute(
+                    "UPDATE session_turn_intents
+                     SET status='failed',updated_at=?3
+                     WHERE session_id=?1 AND turn_intent_id=?2 AND status='running'",
+                    params![&session_id, &turn_intent_id, &now],
+                )
+                .map_err(|error| error.to_string())?;
+                changed_keys.push(recovery_key);
+                run_ids.insert(org_run_id);
+            }
+        }
+        tx.commit().map_err(|error| error.to_string())?;
+        for run_id in run_ids {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(&run_id);
+        }
+        Ok(changed_keys)
+    })
+}
+
+/// Read one bounded keyset page of never-started linked/group UDW. Direct
+/// Member work keeps its event-backed recovery path because it must restore
+/// the intervention chain as well as the neutral delivery receipt.
+pub(crate) fn recoverable_pending_after(
+    after_key: Option<&str>,
+    limit: usize,
+) -> Result<Vec<RecoverableUserDirectedDispatch>, String> {
+    let conn = get_connection().map_err(|error| error.to_string())?;
+    let mut statement = conn
+        .prepare(
+            "WITH recoverable AS (
+                 SELECT 'm:' || printf('%020d',delivery.delivery_id) AS recovery_key,
+                        delivery.org_run_id,delivery.dispatch_member_id,
+                        delivery.session_id,delivery.turn_intent_id,
+                        delivery.dispatch_content,delivery.display_content,delivery.images_json
+                 FROM agent_org_runtime_user_directed_deliveries delivery
+                 JOIN agent_org_runtime_turn_contexts context
+                   ON context.session_id=delivery.session_id
+                  AND context.turn_intent_id=delivery.turn_intent_id
+                 JOIN session_turn_intents intent
+                   ON intent.session_id=delivery.session_id
+                  AND intent.turn_intent_id=delivery.turn_intent_id
+                 JOIN agent_org_runtime_runs run ON run.id=delivery.org_run_id
+                 JOIN agent_org_runtime_inbox inbox ON inbox.id=delivery.source_inbox_id
+                 WHERE delivery.status='pending'
+                   AND delivery.source_kind IN ('group_mention','member_inbox')
+                   AND context.turn_kind='user_directed_work'
+                   AND intent.status='queued'
+                   AND run.status IN ('running','idle','paused')
+                   AND inbox.delivery_class='user_directed'
+                 UNION ALL
+                 SELECT 'c:' || printf('%020d',binding.binding_id) AS recovery_key,
+                        binding.org_run_id,'coordinator',binding.session_id,
+                        binding.turn_intent_id,binding.dispatch_content,
+                        binding.display_content,'[]'
+                 FROM agent_org_runtime_user_directed_coordinator_bindings binding
+                 JOIN agent_org_runtime_turn_contexts context
+                   ON context.session_id=binding.session_id
+                  AND context.turn_intent_id=binding.turn_intent_id
+                 JOIN session_turn_intents intent
+                   ON intent.session_id=binding.session_id
+                  AND intent.turn_intent_id=binding.turn_intent_id
+                 JOIN agent_org_runtime_runs run ON run.id=binding.org_run_id
+                 JOIN agent_org_runtime_inbox inbox ON inbox.id=binding.source_inbox_id
+                 WHERE binding.status='pending'
+                   AND context.turn_kind='coordinator'
+                   AND context.source_kind='member_inbox'
+                   AND intent.status='queued'
+                   AND run.status IN ('running','idle','paused')
+                   AND inbox.delivery_class='user_directed'
+             )
+             SELECT recovery_key,org_run_id,dispatch_member_id,session_id,
+                    turn_intent_id,dispatch_content,display_content,images_json
+             FROM recoverable
+             WHERE recovery_key>COALESCE(?1,'')
+             ORDER BY recovery_key
+             LIMIT ?2",
+        )
+        .map_err(|error| error.to_string())?;
+    let rows = statement
+        .query_map(params![after_key, limit.clamp(1, 100) as i64], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, String>(7)?,
+            ))
+        })
+        .map_err(|error| error.to_string())?;
+    let mut recovered = Vec::new();
+    for row in rows {
+        let (
+            recovery_key,
+            org_run_id,
+            recipient_member_id,
+            recipient_session_id,
+            turn_intent_id,
+            content,
+            display_text,
+            images_json,
+        ) = row.map_err(|error| error.to_string())?;
+        let images: Vec<String> =
+            serde_json::from_str(&images_json).map_err(|error| error.to_string())?;
+        recovered.push(RecoverableUserDirectedDispatch {
+            recovery_key,
+            org_run_id,
+            recipient_member_id,
+            recipient_session_id,
+            turn_intent_id,
+            content,
+            display_text,
+            images: (!images.is_empty()).then_some(images),
+        });
+    }
+    Ok(recovered)
+}

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_work_episodes.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_work_episodes.rs
@@ -228,6 +228,7 @@ fn is_new_user_root_turn(
              JOIN agent_org_runtime_runs run ON run.id=context.org_run_id
              WHERE context.org_run_id=?1 AND context.turn_intent_id=?2
                AND context.turn_kind='coordinator'
+               AND context.source_kind='root_turn'
                AND intent.session_id=run.root_session_id
                AND intent.source IN (
                    'user_submit','queue','force_send','wingman','mobile_remote'

--- a/src-tauri/crates/agent-core/src/core/coordination/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/mod.rs
@@ -38,6 +38,7 @@ pub mod agent_org_task_handoffs;
 pub mod agent_org_tasks;
 pub(crate) mod agent_org_tool_receipts;
 pub(crate) mod agent_org_turn_contexts;
+pub(crate) mod agent_org_user_directed_work;
 pub mod agent_org_watchdog;
 pub(crate) mod agent_org_work_episodes;
 pub mod child_done_wake;

--- a/src-tauri/crates/agent-core/src/core/coordination/schema.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/schema.rs
@@ -14,10 +14,11 @@ use super::{
     agent_inbox, agent_member_interventions, agent_org_archive, agent_org_final_summary,
     agent_org_formal_triggers, agent_org_pause, agent_org_plan_approvals, agent_org_run_completion,
     agent_org_runs, agent_org_task_handoffs, agent_org_tasks, agent_org_tool_receipts,
-    agent_org_turn_contexts, agent_org_watchdog, agent_org_work_episodes,
+    agent_org_turn_contexts, agent_org_user_directed_work, agent_org_watchdog,
+    agent_org_work_episodes,
 };
 
-const RUNTIME_TABLES: [&str; 30] = [
+const RUNTIME_TABLES: [&str; 33] = [
     "agent_org_runtime_runs",
     "agent_org_runtime_run_progress",
     "agent_org_runtime_work_episodes",
@@ -43,6 +44,9 @@ const RUNTIME_TABLES: [&str; 30] = [
     "agent_org_runtime_member_intervention_turns",
     "agent_org_runtime_member_dispatch_allocators",
     "agent_org_runtime_turn_contexts",
+    "agent_org_runtime_user_directed_roots",
+    "agent_org_runtime_user_directed_deliveries",
+    "agent_org_runtime_user_directed_coordinator_bindings",
     "agent_org_runtime_pause_episodes",
     "agent_org_runtime_pause_handoffs",
     "agent_org_runtime_archive_episodes",
@@ -223,6 +227,7 @@ fn create_runtime_schema(conn: &Connection) -> SqliteResult<()> {
     agent_member_interventions::create_schema(conn)?;
     agent_org_watchdog::create_schema(conn)?;
     agent_org_turn_contexts::create_schema(conn)?;
+    agent_org_user_directed_work::create_schema(conn)?;
     agent_org_pause::create_schema(conn)?;
     agent_org_archive::create_schema(conn)?;
     agent_org_tool_receipts::create_schema(conn)

--- a/src-tauri/crates/agent-core/src/core/session/launch/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/launch/mod.rs
@@ -13,6 +13,7 @@ mod launch_tests;
 mod launch_workspace;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tauri::Manager;
 
@@ -1218,6 +1219,15 @@ pub(crate) async fn launch_rust_agent_run(
 }
 
 const AGENT_ORG_STARTUP_RECOVERY_LIMIT: usize = 100;
+static AGENT_ORG_UDW_RECOVERY_RUNNING: AtomicBool = AtomicBool::new(false);
+
+struct UserDirectedRecoveryGuard;
+
+impl Drop for UserDirectedRecoveryGuard {
+    fn drop(&mut self) {
+        AGENT_ORG_UDW_RECOVERY_RUNNING.store(false, Ordering::Release);
+    }
+}
 
 /// Run the one-shot Starting/initial-input recovery owner after app state and
 /// the EventStore bridge are ready. This is intentionally separate from the
@@ -1274,22 +1284,123 @@ async fn recover_agent_org_return_continuations(state: &AgentAppState) -> Result
 }
 
 async fn recover_agent_org_user_directed_dispatches(state: &AgentAppState) -> Result<(), String> {
-    let turns = tokio::task::spawn_blocking(|| {
-        crate::coordination::agent_member_interventions::AgentMemberInterventionStore::recoverable_queued_turns(
-            AGENT_ORG_STARTUP_RECOVERY_LIMIT,
-        )
-    })
-    .await
-    .map_err(|error| error.to_string())??;
-    for turn in turns {
-        if let Err(error) =
-            crate::state::commands::session::message::send_message_impl_for_direct_recovery(
-                state, turn,
+    if AGENT_ORG_UDW_RECOVERY_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Ok(());
+    }
+    let _single_flight = UserDirectedRecoveryGuard;
+    let mut interrupted_after_key: Option<String> = None;
+    loop {
+        let cursor = interrupted_after_key.clone();
+        let changed = tokio::task::spawn_blocking(move || {
+            crate::coordination::agent_org_user_directed_work::mark_started_unknown_after_restart_after(
+                cursor.as_deref(),
+                AGENT_ORG_STARTUP_RECOVERY_LIMIT,
             )
-            .await
-        {
-            tracing::warn!(error = %error, "[agent-org-startup] queued direct Turn recovery deferred");
+        })
+        .await
+        .map_err(|error| error.to_string())??;
+        if changed.is_empty() {
+            break;
         }
+        let page_len = changed.len();
+        interrupted_after_key = changed.last().cloned();
+        if page_len < AGENT_ORG_STARTUP_RECOVERY_LIMIT {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    let mut direct_after_key = None;
+    let mut direct_yield_deadline =
+        std::time::Instant::now() + std::time::Duration::from_millis(50);
+    loop {
+        let cursor = direct_after_key;
+        let turns = tokio::task::spawn_blocking(move || {
+            crate::coordination::agent_member_interventions::AgentMemberInterventionStore::recoverable_queued_turns_after(
+                cursor,
+                AGENT_ORG_STARTUP_RECOVERY_LIMIT,
+            )
+        })
+        .await
+        .map_err(|error| error.to_string())??;
+        if turns.is_empty() {
+            break;
+        }
+        let page_len = turns.len();
+        for turn in turns {
+            direct_after_key = Some(turn.recovery_key);
+            if let Err(error) =
+                crate::state::commands::session::message::send_message_impl_for_direct_recovery(
+                    state, turn,
+                )
+                .await
+            {
+                tracing::warn!(error = %error, "[agent-org-startup] queued direct Turn recovery deferred");
+            }
+            if std::time::Instant::now() >= direct_yield_deadline {
+                tokio::task::yield_now().await;
+                direct_yield_deadline =
+                    std::time::Instant::now() + std::time::Duration::from_millis(50);
+            }
+        }
+        if page_len < AGENT_ORG_STARTUP_RECOVERY_LIMIT {
+            break;
+        }
+        tokio::task::yield_now().await;
+        direct_yield_deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
+    }
+
+    let mut after_key: Option<String> = None;
+    let mut yield_deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
+    loop {
+        let cursor = after_key.clone();
+        let dispatches = tokio::task::spawn_blocking(move || {
+            crate::coordination::agent_org_user_directed_work::recoverable_pending_after(
+                cursor.as_deref(),
+                AGENT_ORG_STARTUP_RECOVERY_LIMIT,
+            )
+        })
+        .await
+        .map_err(|error| error.to_string())??;
+        if dispatches.is_empty() {
+            break;
+        }
+        let page_len = dispatches.len();
+        for dispatch in dispatches {
+            after_key = Some(dispatch.recovery_key.clone());
+            let wake = crate::tools::impls::orchestration::org_send_message::UserDirectedWake {
+                org_run_id: dispatch.org_run_id,
+                recipient_member_id: dispatch.recipient_member_id,
+                recipient_session_id: dispatch.recipient_session_id,
+                turn_intent_id: dispatch.turn_intent_id,
+                content: dispatch.content,
+                display_text: dispatch.display_text,
+                images: dispatch.images,
+            };
+            if let Err(error) =
+                crate::state::commands::session::message::send_message_impl_for_user_directed_wake(
+                    state, wake,
+                )
+                .await
+            {
+                tracing::warn!(
+                    error = %error,
+                    "[agent-org-startup] pending linked/group UDW recovery deferred"
+                );
+            }
+            if std::time::Instant::now() >= yield_deadline {
+                tokio::task::yield_now().await;
+                yield_deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
+            }
+        }
+        if page_len < AGENT_ORG_STARTUP_RECOVERY_LIMIT {
+            break;
+        }
+        tokio::task::yield_now().await;
+        yield_deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
     }
     Ok(())
 }

--- a/src-tauri/crates/agent-core/src/core/session/scheduler.rs
+++ b/src-tauri/crates/agent-core/src/core/session/scheduler.rs
@@ -584,7 +584,9 @@ impl WorkerTask {
                         ) {
                             Ok(Some(context))
                                 if context.turn_kind
-                                    == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator =>
+                                    == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator
+                                    && context.source_kind
+                                        == crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::RootTurn =>
                             {
                                 if let Err(error) = crate::coordination::agent_org_turn_contexts::mark_waiting_for_org_event_if_current(
                                     run_id,

--- a/src-tauri/crates/agent-core/src/core/session/turn/event_handler/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/event_handler/mod.rs
@@ -514,6 +514,51 @@ impl UnifiedEventHandler {
         }
     }
 
+    /// Bind every Direct/Group/Linked assistant event to the exact durable
+    /// UDW receipt. PR10 can project replies from this causal authority without
+    /// guessing from timestamps, display names, or adjacent transcript rows.
+    fn attach_agent_org_user_directed_reply(
+        &self,
+        session_id: &str,
+        event: &mut SessionEvent,
+    ) -> bool {
+        let Some(turn_intent_id) = self.config.agent_org_turn_intent_id.as_deref() else {
+            return true;
+        };
+        match crate::coordination::agent_org_user_directed_work::causal_reply_for_turn(
+            session_id,
+            turn_intent_id,
+        ) {
+            Ok(Some(authority)) => {
+                let Some(result) = event.result.as_object_mut() else {
+                    self.record_assistant_persistence_error(
+                        "assistant UDW causal reply target is not an object".to_string(),
+                    );
+                    return false;
+                };
+                match serde_json::to_value(authority) {
+                    Ok(authority) => {
+                        result.insert("agent_org_user_directed_reply".to_string(), authority);
+                        true
+                    }
+                    Err(error) => {
+                        self.record_assistant_persistence_error(format!(
+                            "assistant UDW causal reply serialization failed: {error}"
+                        ));
+                        false
+                    }
+                }
+            }
+            Ok(None) => true,
+            Err(error) => {
+                self.record_assistant_persistence_error(format!(
+                    "assistant UDW causal reply lookup failed: {error}"
+                ));
+                false
+            }
+        }
+    }
+
     /// Bind a backend-issued completion certificate to the exact final
     /// assistant event.  The model's prose is deliberately not authoritative:
     /// consumers can project Delivered only from this typed metadata.
@@ -569,6 +614,7 @@ impl UnifiedEventHandler {
         event: &mut SessionEvent,
     ) -> bool {
         self.attach_agent_org_direct_reply(session_id, event)
+            && self.attach_agent_org_user_directed_reply(session_id, event)
             && self.attach_agent_org_completion_certificate(session_id, event)
     }
 

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/inbox_drain/drain.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/inbox_drain/drain.rs
@@ -153,6 +153,11 @@ fn drain_and_render_deferred_impl(
         }
         Some(crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator) => {
             let context = turn_context.expect("Coordinator arm requires persisted context");
+            if context.source_kind
+                == crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::MemberInbox
+            {
+                return DrainGuard::empty(&org_context.run_id, recipient_member_id_value);
+            }
             match crate::coordination::agent_org_final_summary::is_summary_turn(
                 &context.session_id,
                 &context.turn_intent_id,

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/inbox_drain/guard.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/inbox_drain/guard.rs
@@ -71,11 +71,13 @@ impl DrainGuard {
         mut self,
         turn_context: &crate::coordination::agent_org_turn_contexts::AgentOrgTurnContext,
     ) -> Self {
-        if matches!(
-            turn_context.turn_kind,
-            crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator
-                | crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::TaskExecution
-        ) {
+        if turn_context.turn_kind
+            == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::TaskExecution
+            || (turn_context.turn_kind
+                == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator
+                && turn_context.source_kind
+                    == crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::RootTurn)
+        {
             self.formal_turn_intent_id = Some(turn_context.turn_intent_id.clone());
         }
         self

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/prompt.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/prompt.rs
@@ -249,15 +249,39 @@ impl UnifiedMessageProcessor {
             match tokio::task::spawn_blocking(move || {
                 let (task_snapshot, presented_revision, completion_candidate) = if coordinator_prompt {
                     match coordinator_turn_intent_id.as_deref() {
-                        Some(turn_intent_id) => match crate::coordination::agent_org_runs::AgentOrgRunStore::stage_coordinator_work_revision_and_load_tasks(
-                            &context_snapshot.run_id,
-                            &coordinator_session_id,
-                            turn_intent_id,
-                            &projected_inbox_ids,
-                        ) {
-                            Ok((revision, tasks, candidate)) => (Ok(tasks), revision, Some(candidate)),
-                            Err(error) => (Err(error), None, None),
-                        },
+                        Some(turn_intent_id) => {
+                            let member_inbox_side_quest = crate::coordination::agent_org_turn_contexts::optional_context_for_session(
+                                &coordinator_session_id,
+                                turn_intent_id,
+                            )
+                            .map(|context| {
+                                context.is_some_and(|context| {
+                                    context.turn_kind
+                                        == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator
+                                        && context.source_kind
+                                            == crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::MemberInbox
+                                })
+                            });
+                            match member_inbox_side_quest {
+                                Ok(true) => (
+                                    crate::coordination::agent_org_tasks::AgentOrgTaskStore::list_operational(
+                                        &context_snapshot.run_id,
+                                    ),
+                                    None,
+                                    None,
+                                ),
+                                Ok(false) => match crate::coordination::agent_org_runs::AgentOrgRunStore::stage_coordinator_work_revision_and_load_tasks(
+                                    &context_snapshot.run_id,
+                                    &coordinator_session_id,
+                                    turn_intent_id,
+                                    &projected_inbox_ids,
+                                ) {
+                                    Ok((revision, tasks, candidate)) => (Ok(tasks), revision, Some(candidate)),
+                                    Err(error) => (Err(error), None, None),
+                                },
+                                Err(error) => (Err(error), None, None),
+                            }
+                        }
                         None => (
                             Err("Coordinator prompt requires an exact Turn intent id".to_string()),
                             None,

--- a/src-tauri/crates/agent-core/src/core/tools/call_context.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/call_context.rs
@@ -272,16 +272,33 @@ impl CallContext {
         .is_some_and(|context| {
             let persisted_profile = match context.turn_kind {
                 crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator => {
-                    let is_summary_turn = database::db::get_connection()
-                        .map_err(|error| error.to_string())
-                        .and_then(|conn| {
-                            crate::coordination::agent_org_final_summary::is_summary_turn_with_connection(
-                                &conn,
-                                &context.session_id,
-                                &context.turn_intent_id,
-                            )
-                        });
-                    coordinator_replay_profile(is_summary_turn)
+                    if context.source_kind
+                        == crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::MemberInbox
+                    {
+                        match crate::coordination::agent_org_runs::AgentOrgRunStore::get_run_status(
+                            &context.org_run_id,
+                        ) {
+                            Ok(Some(
+                                crate::coordination::agent_org_runs::AgentOrgRunStatus::Paused,
+                            )) => Some(AgentOrgTurnToolProfile::SummaryOnly),
+                            Ok(Some(
+                                crate::coordination::agent_org_runs::AgentOrgRunStatus::Running
+                                | crate::coordination::agent_org_runs::AgentOrgRunStatus::Idle,
+                            )) => Some(AgentOrgTurnToolProfile::CoordinatorOrchestration),
+                            _ => None,
+                        }
+                    } else {
+                        let is_summary_turn = database::db::get_connection()
+                            .map_err(|error| error.to_string())
+                            .and_then(|conn| {
+                                crate::coordination::agent_org_final_summary::is_summary_turn_with_connection(
+                                    &conn,
+                                    &context.session_id,
+                                    &context.turn_intent_id,
+                                )
+                            });
+                        coordinator_replay_profile(is_summary_turn)
+                    }
                 }
                 crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::TaskExecution => {
                     Some(AgentOrgTurnToolProfile::TaskExecution)

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent_org/send_message.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent_org/send_message.rs
@@ -37,11 +37,14 @@ mod persistence;
 #[cfg(test)]
 mod tests;
 
-pub use hooks::{InboxWakeHook, NoopInboxWakeHook, NoopSelfAbortHook, SelfAbortHook};
+pub use hooks::{
+    InboxWakeHook, NoopInboxWakeHook, NoopSelfAbortHook, SelfAbortHook, UserDirectedWake,
+};
 pub use params::{MemberCoordinationPurpose, OrgSendMessageParams};
 use persistence::{
     ensure_recipients_deliverable_in_tx, persist_ordinary_message_in_tx,
-    OrdinaryMessagePersistOutcome, OrgRecipientTarget,
+    persist_user_directed_coordinator_message_in_tx, persist_user_directed_member_message_in_tx,
+    user_directed_link_allowed_in_tx, OrdinaryMessagePersistOutcome, OrgRecipientTarget,
 };
 
 fn parse_agent_org_remote_mode(
@@ -118,7 +121,7 @@ impl OrgSendMessageTool {
 
     fn allowed_recipient_member_ids(&self) -> Vec<String> {
         self.org_context
-            .allowed_recipient_member_ids_for(&self.sender.member_id)
+            .user_directed_recipient_member_ids_for(&self.sender.member_id)
     }
 
     fn allowed_message_kinds(&self) -> Vec<&'static str> {
@@ -139,7 +142,7 @@ impl OrgSendMessageTool {
         if self.sender.is_coordinator {
             "coordinator may message any member"
         } else {
-            "member may message the coordinator; peer delivery remains disabled until the peer-send phase"
+            "member schema includes the coordinator and immutable-snapshot linked peers; the exact persisted Turn narrows execution permission"
         }
     }
 
@@ -149,7 +152,7 @@ impl OrgSendMessageTool {
         let direction_rule = if self.sender.is_coordinator {
             "Coordinator → Member rule:\n- For `kind=plain`, include the exact unresolved `related_task_id` already owned by the recipient.\n- Do not include `purpose`; that field exists only in the Member → Coordinator schema.\n- Reply to a Member's blocker/risk with a normal plain message. A message retry is not a reason to cancel or replace the active Task."
         } else {
-            "Member → Coordinator coordination rule:\n- Routine work progress is NOT a message or assistant reply: call the next tool directly instead of announcing that you are starting, what modules you finished, what you will do next, a retry, or a problem you already resolved yourself. Never imitate routing with `@Coordinator` prose.\n- Record normal progress in Task state. Record completion once with `task_update operation=complete` and TaskOutput; do not send a duplicate completion chat.\n- A TaskExecution member may send `kind=plain` to the Coordinator only when the Coordinator needs to act. Include the exact current `related_task_id` and one purpose: `blocker | decision_required | material_change | risk | requested_reply`.\n- `requested_reply` is only for an explicit mid-task reply requested by the Coordinator."
+            "Member routing is decided from the exact persisted Turn:\n- During UserDirectedWork, send exactly one `kind=plain` message to the Coordinator or a snapshot-linked peer; omit related_task_id and purpose. This creates a bounded child side quest, not a formal Task.\n- During TaskExecution, routine progress is NOT a message or assistant reply: call the next tool directly instead of narrating progress or retries. Record progress in Task state and completion once in TaskOutput.\n- A TaskExecution member may send `kind=plain` only to the Coordinator when action is needed. Include the exact current `related_task_id` and one purpose: `blocker | decision_required | material_change | risk | requested_reply`."
         };
         let planning_rule = if self.sender.is_coordinator {
             "\n\nCoordinator planning protocol:\n- Create planning work with `task_create execution_mode=\"plan\"`; the assigned Planner starts in Plan mode automatically.\n- A member's `create_plan` call creates a durable approval bound to that planning task.\n- To answer a submitted member plan, send `kind = \"plan_approval_response\"`, echo the inbox `request_id`, and set `accepted = true` to complete the planning task and unlock its dependants, or `accepted = false` with non-empty `feedback` to wake the Planner once for revision."
@@ -219,7 +222,7 @@ impl OrgSendMessageTool {
                 json!({
                     "type": "string",
                     "enum": ["blocker", "decision_required", "material_change", "risk", "requested_reply"],
-                    "description": "Required for kind=plain from this TaskExecution member to the Coordinator. Choose the reason the Coordinator must act; routine progress is not a valid purpose."
+                    "description": "Required only for kind=plain from a TaskExecution Member to the Coordinator. Omit for UserDirectedWork linked side quests."
                 }),
             );
         }
@@ -248,6 +251,10 @@ impl OrgSendMessageTool {
             .map(str::trim)
             .filter(|member_id| !member_id.is_empty())
             .ok_or_else(|| "recipient_member_id is required".to_string())?;
+
+        if recipient_member_id == self.sender.member_id {
+            return Err("linked_inbox_self_send: a Member cannot send work to itself".to_string());
+        }
 
         let allowed = self.allowed_recipient_member_ids();
         if !allowed
@@ -456,8 +463,8 @@ impl Tool for OrgSendMessageTool {
             "  - 'plan_approval_response' for the coordinator to approve a member plan (completes its planning task) or request a revision.\n",
             "Messages are persisted to the org inbox and surfaced to the recipient on its next turn. ",
             "Normal text output is not visible to other agents; use this tool to communicate. ",
-            "Messaging permission is not task authority: every plain message to a worker requires related_task_id for an unresolved, dependency-ready task already owned by that worker. Eligibility alone is not assignment. ",
-            "A TaskExecution member may send plain text to the Coordinator only for an actionable blocker, decision, material change, risk, or explicitly requested reply, with the exact current related_task_id and purpose. Routine progress belongs in Task state and completion belongs in TaskOutput."
+            "The persisted current Turn decides authority. During UserDirectedWork, a Member may send one plain child side quest to the Coordinator or a snapshot-linked peer without task fields; depth, delivery budget, FIFO, and link checks are server-owned. ",
+            "During formal TaskExecution, messaging is not task authority: a Member may message only the Coordinator for an actionable reason using the exact related_task_id and purpose, and a Coordinator message to a worker requires that worker's already-owned unresolved task."
         )
     }
 
@@ -538,23 +545,17 @@ impl Tool for OrgSendMessageTool {
             }
         }
 
-        for recipient in &recipients {
-            if let RoutingDecision::Blocked(hint) = self
-                .org_context
-                .check_routing(&self.sender.member_id, &recipient.member_id)
-            {
-                return Err(ToolError::InvalidParams(hint));
-            }
-        }
         let run_id = self.org_context.run_id.clone();
         let sender = self.sender.clone();
+        let org_context = Arc::clone(&self.org_context);
         let receipt_key = AgentOrgToolReceiptKey::from_call_context(run_id.clone(), call_ctx)?;
         let call_session_id = call_ctx.session_id.clone();
         let call_turn_intent_id = call_ctx.turn_intent_id.clone();
         let operation = message.kind_tag();
-        let (receipt, wake_member_ids, abort_sender_after_commit) =
+        let (receipt, wake_member_ids, user_directed_wakes, abort_sender_after_commit) =
             tokio::task::spawn_blocking(move || {
                 let mut wake_member_ids = Vec::new();
+                let mut user_directed_wakes = Vec::new();
                 let mut abort_sender_after_commit = false;
                 let receipt = AgentOrgToolReceiptStore::execute(
                     receipt_key,
@@ -579,6 +580,106 @@ impl Tool for OrgSendMessageTool {
                                         .to_string(),
                                 ),
                             ));
+                        }
+
+                        if context.is_user_directed_work() {
+                            if sender.is_coordinator {
+                                return Err(AgentOrgToolReceiptAbort::rejected(
+                                    ToolError::PermissionDenied(
+                                        "Coordinator formal tools cannot impersonate Member UserDirectedWork"
+                                            .to_string(),
+                                    ),
+                                ));
+                            }
+                            if recipients.len() != 1 {
+                                return Err(AgentOrgToolReceiptAbort::rejected(
+                                    ToolError::InvalidParams(
+                                        "UserDirectedWork must target exactly one participant"
+                                            .to_string(),
+                                    ),
+                                ));
+                            }
+                            let recipient = &recipients[0];
+                            if recipient.member_id == sender.member_id {
+                                return Err(AgentOrgToolReceiptAbort::rejected(
+                                    ToolError::InvalidParams(
+                                        "linked_inbox_self_send: a Member cannot send work to itself"
+                                            .to_string(),
+                                    ),
+                                ));
+                            }
+                            let link_allowed = match user_directed_link_allowed_in_tx(
+                                tx,
+                                &run_id,
+                                &sender.member_id,
+                                &recipient.member_id,
+                            ) {
+                                Ok(allowed) => allowed,
+                                Err(error) => return classify_message_tool_error(error),
+                            };
+                            if !link_allowed {
+                                return Err(AgentOrgToolReceiptAbort::rejected(
+                                    ToolError::PermissionDenied(format!(
+                                        "linked_inbox_link_denied: {} cannot message {} in the frozen Team snapshot",
+                                        sender.member_id, recipient.member_id
+                                    )),
+                                ));
+                            }
+                            let child_result = if recipient.member_id == COORDINATOR_MEMBER_ID {
+                                persist_user_directed_coordinator_message_in_tx(
+                                    tx, &run_id, &sender, &context, &params, &message, recipient,
+                                )
+                            } else {
+                                persist_user_directed_member_message_in_tx(
+                                    tx, &run_id, &sender, &context, &params, &message, recipient,
+                                )
+                            };
+                            let child = match child_result {
+                                Ok(child) => child,
+                                // Linked delivery validation and allocation share this
+                                // receipt transaction with the source Inbox insert. Any
+                                // rejection must abort the transaction so a failed depth,
+                                // budget, target, or queue check cannot leave an orphan
+                                // Inbox row or consume a root ordinal.
+                                Err(error) => {
+                                    return Err(AgentOrgToolReceiptAbort::rejected(error));
+                                }
+                            };
+                            user_directed_wakes.push(UserDirectedWake {
+                                org_run_id: run_id.clone(),
+                                recipient_member_id: child.recipient_member_id.clone(),
+                                recipient_session_id: child.recipient_session_id.clone(),
+                                turn_intent_id: child.turn_intent_id.clone(),
+                                content: child.content.clone(),
+                                display_text: child.display_text.clone(),
+                                images: None,
+                            });
+                            return serde_json::to_string(&json!({
+                                "kind": "plain",
+                                "org_run_id": run_id,
+                                "sender_member_id": sender.member_id,
+                                "delivered": [{
+                                    "recipient_member_id": child.recipient_member_id,
+                                    "inbox_id": child.inbox_id,
+                                    "turn_intent_id": child.turn_intent_id,
+                                    "member_dispatch_sequence": child.member_dispatch_sequence,
+                                    "root_authority_turn_id": context.root_authority_turn_id,
+                                }],
+                                "user_directed": true,
+                                "live_channel": false,
+                            }))
+                            .map(Ok)
+                            .map_err(AgentOrgToolReceiptAbort::storage);
+                        }
+
+                        for recipient in &recipients {
+                            if let RoutingDecision::Blocked(hint) = org_context
+                                .check_routing(&sender.member_id, &recipient.member_id)
+                            {
+                                return Err(AgentOrgToolReceiptAbort::rejected(
+                                    ToolError::InvalidParams(hint),
+                                ));
+                            }
                         }
 
                         if let AgentMessage::PlanApprovalResponse {
@@ -754,6 +855,7 @@ impl Tool for OrgSendMessageTool {
                 Ok::<_, ToolError>((
                     receipt,
                     wake_member_ids,
+                    user_directed_wakes,
                     abort_sender_after_commit,
                 ))
             })
@@ -798,6 +900,9 @@ impl Tool for OrgSendMessageTool {
             for member_id in &wake_member_ids {
                 self.wake_hook
                     .wake_member(member_id, &self.org_context.run_id);
+            }
+            for wake in user_directed_wakes {
+                self.wake_hook.wake_user_directed_member(wake);
             }
             if abort_sender_after_commit {
                 self.self_abort_hook

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent_org/send_message/hooks.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent_org/send_message/hooks.rs
@@ -19,6 +19,17 @@
 /// logged at the hook implementation. The persisted inbox row is the
 /// source of truth; if the wake never happens, the row is still drained
 /// the next time the recipient session takes a turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserDirectedWake {
+    pub org_run_id: String,
+    pub recipient_member_id: String,
+    pub recipient_session_id: String,
+    pub turn_intent_id: String,
+    pub content: String,
+    pub display_text: String,
+    pub images: Option<Vec<String>>,
+}
+
 pub trait InboxWakeHook: Send + Sync {
     fn wake_member(&self, member_id: &str, org_run_id: &str);
 
@@ -33,6 +44,11 @@ pub trait InboxWakeHook: Send + Sync {
     ) {
         self.wake_member(member_id, org_run_id);
     }
+
+    /// Dispatch one already-committed UDW delivery using its exact persisted
+    /// Session/Turn identity. Implementations must not route this through the
+    /// broad formal Inbox wake path.
+    fn wake_user_directed_member(&self, _wake: UserDirectedWake) {}
 }
 
 /// No-op hook — used by tests and by org sessions that don't have a

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent_org/send_message/persistence.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent_org/send_message/persistence.rs
@@ -12,7 +12,9 @@ use crate::coordination::agent_org_runs::{
 };
 use crate::coordination::agent_org_tasks::AgentOrgTaskStore;
 use crate::coordination::agent_org_turn_contexts::{AgentOrgTurnContext, AgentOrgTurnKind};
+use crate::coordination::agent_org_user_directed_work::{self, NewLinkedMemberDelivery};
 use crate::core::session::SessionStatus;
+use crate::definitions::orgs::{AgentOrgCapabilityIndex, AgentOrgLaunchSnapshot};
 use crate::tools::traits::ToolError;
 
 use super::super::tasks::task_dependencies_resolved;
@@ -38,6 +40,326 @@ pub(super) struct OrgRecipientTarget {
 pub(super) enum OrdinaryMessagePersistOutcome {
     Guidance(String),
     Delivered { rows: Vec<(String, i64)> },
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct UserDirectedMessagePersistOutcome {
+    pub recipient_member_id: String,
+    pub recipient_session_id: String,
+    pub turn_intent_id: String,
+    pub inbox_id: i64,
+    pub member_dispatch_sequence: Option<i64>,
+    pub content: String,
+    pub display_text: String,
+}
+
+/// Re-read the immutable launch snapshot inside the same transaction that
+/// persists a linked Inbox child. The tool's in-memory snapshot shapes its
+/// static schema, but it is not routing authority for the current call.
+pub(super) fn user_directed_link_allowed_in_tx(
+    conn: &Connection,
+    run_id: &str,
+    sender_member_id: &str,
+    recipient_member_id: &str,
+) -> Result<bool, ToolError> {
+    if sender_member_id == recipient_member_id {
+        return Ok(false);
+    }
+    if recipient_member_id == COORDINATOR_MEMBER_ID {
+        return Ok(true);
+    }
+    let snapshot_json: Option<String> = conn
+        .query_row(
+            "SELECT org_snapshot_json FROM agent_org_runtime_runs WHERE id=?1",
+            [run_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| ToolError::ExecutionFailed(error.to_string()))?;
+    let snapshot_json = snapshot_json.ok_or_else(|| {
+        ToolError::ExecutionFailed(format!(
+            "linked_inbox_stale_source: Agent Org run {run_id} has no frozen snapshot"
+        ))
+    })?;
+    let snapshot: AgentOrgLaunchSnapshot = serde_json::from_str(&snapshot_json).map_err(|error| {
+        ToolError::ExecutionFailed(format!(
+            "linked_inbox_stale_source: Agent Org run {run_id} has an invalid frozen snapshot: {error}"
+        ))
+    })?;
+    let sender_exists = snapshot
+        .members
+        .iter()
+        .any(|member| member.member_id == sender_member_id);
+    let recipient_exists = snapshot
+        .members
+        .iter()
+        .any(|member| member.member_id == recipient_member_id);
+    if !sender_exists || !recipient_exists {
+        return Ok(false);
+    }
+    Ok(AgentOrgCapabilityIndex::from_snapshot(&snapshot)
+        .members_can_communicate(sender_member_id, recipient_member_id))
+}
+
+pub(super) fn persist_user_directed_member_message_in_tx(
+    conn: &Connection,
+    run_id: &str,
+    sender: &AgentOrgParticipant,
+    context: &AgentOrgTurnContext,
+    params: &OrgSendMessageParams,
+    message: &AgentMessage,
+    recipient: &OrgRecipientTarget,
+) -> Result<UserDirectedMessagePersistOutcome, ToolError> {
+    if context.turn_kind != AgentOrgTurnKind::UserDirectedWork
+        || context.participant_id != sender.member_id
+        || sender.is_coordinator
+    {
+        return Err(ToolError::PermissionDenied(
+            "linked Inbox requires the sender's exact Member UserDirectedWork Turn".to_string(),
+        ));
+    }
+    if recipient.member_id == COORDINATOR_MEMBER_ID {
+        return Err(ToolError::InvalidParams(
+            "linked_coordinator_route_requires_root_binding: Coordinator side quests use the Root queue"
+                .to_string(),
+        ));
+    }
+    if !matches!(message, AgentMessage::Plain { .. }) {
+        return Err(ToolError::InvalidParams(
+            "UserDirectedWork may send only kind=plain".to_string(),
+        ));
+    }
+    if params.related_task_id.is_some() || params.purpose.is_some() {
+        return Err(ToolError::InvalidParams(
+            "UserDirectedWork messages do not accept related_task_id or purpose".to_string(),
+        ));
+    }
+    let status: Option<String> = conn
+        .query_row(
+            "SELECT status FROM agent_org_runtime_runs WHERE id=?1",
+            [run_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| ToolError::ExecutionFailed(error.to_string()))?;
+    match status.as_deref() {
+        Some("running" | "idle" | "paused") => {}
+        Some("archived") => {
+            return Err(ToolError::ExecutionFailed(
+                crate::coordination::agent_org_runs::mutation_blocked_error(run_id, "archived"),
+            ));
+        }
+        Some(other) => {
+            return Err(ToolError::InvalidParams(format!(
+                "team_unavailable: linked Inbox cannot enter Team status {other}"
+            )));
+        }
+        None => {
+            return Err(ToolError::InvalidParams(format!(
+                "team_unavailable: Agent Org run {run_id} is missing"
+            )));
+        }
+    }
+
+    let runtime = AgentOrgRunStore::list_worker_sessions_by_member_ids_with_connection(
+        conn,
+        run_id,
+        std::slice::from_ref(&recipient.member_id),
+    )
+    .map_err(ToolError::ExecutionFailed)?
+    .into_iter()
+    .find(|runtime| runtime.member_id.as_deref() == Some(recipient.member_id.as_str()))
+    .ok_or_else(|| {
+        ToolError::InvalidParams(format!(
+            "linked_inbox_target_unavailable: Member {} has no canonical runtime",
+            recipient.member_id
+        ))
+    })?;
+    if runtime.status == SessionStatus::Archived {
+        return Err(ToolError::InvalidParams(format!(
+            "linked_inbox_target_removed: Member {} is archived",
+            recipient.member_id
+        )));
+    }
+    let (content, summary) = match message {
+        AgentMessage::Plain { summary, text } => (text.trim(), summary.trim()),
+        _ => unreachable!("validated plain message"),
+    };
+    let record = AgentInboxStore::insert_in_tx_without_formal_trigger(
+        conn,
+        InsertInboxParams {
+            recipient_agent_id: recipient.agent_id.clone(),
+            recipient_member_id: Some(recipient.member_id.clone()),
+            sender_agent_id: sender.agent_id.clone(),
+            sender_member_id: Some(sender.member_id.clone()),
+            org_run_id: Some(run_id.to_string()),
+            message: message.clone(),
+        },
+    )
+    .map_err(ToolError::ExecutionFailed)?;
+    let display_text = if summary.is_empty() {
+        content.to_string()
+    } else {
+        format!("{summary}\n\n{content}")
+    };
+    conn.execute(
+        "UPDATE agent_org_runtime_inbox
+         SET delivery_class='user_directed',display_text=?2
+         WHERE id=?1 AND delivery_class='formal_work'",
+        params![record.id, &display_text],
+    )
+    .map_err(|error| ToolError::ExecutionFailed(error.to_string()))?;
+
+    let child_turn_intent_id = uuid::Uuid::new_v4().to_string();
+    let child = agent_org_user_directed_work::insert_linked_member_delivery_with_connection(
+        conn,
+        &NewLinkedMemberDelivery {
+            org_run_id: run_id,
+            source_session_id: &context.session_id,
+            source_turn_intent_id: &context.turn_intent_id,
+            recipient_session_id: &runtime.session_id,
+            recipient_member_id: &recipient.member_id,
+            child_turn_intent_id: &child_turn_intent_id,
+            source_inbox_id: record.id,
+            dispatch_content: content,
+            display_content: &display_text,
+            images: None,
+        },
+    )
+    .map_err(ToolError::InvalidParams)?;
+    Ok(UserDirectedMessagePersistOutcome {
+        recipient_member_id: recipient.member_id.clone(),
+        recipient_session_id: runtime.session_id,
+        turn_intent_id: child_turn_intent_id,
+        inbox_id: record.id,
+        member_dispatch_sequence: Some(child.member_dispatch_sequence),
+        content: content.to_string(),
+        display_text,
+    })
+}
+
+pub(super) fn persist_user_directed_coordinator_message_in_tx(
+    conn: &Connection,
+    run_id: &str,
+    sender: &AgentOrgParticipant,
+    context: &AgentOrgTurnContext,
+    params: &OrgSendMessageParams,
+    message: &AgentMessage,
+    recipient: &OrgRecipientTarget,
+) -> Result<UserDirectedMessagePersistOutcome, ToolError> {
+    if context.turn_kind != AgentOrgTurnKind::UserDirectedWork
+        || context.participant_id != sender.member_id
+        || sender.is_coordinator
+        || recipient.member_id != COORDINATOR_MEMBER_ID
+    {
+        return Err(ToolError::PermissionDenied(
+            "Coordinator side quest requires an exact Member UserDirectedWork caller".to_string(),
+        ));
+    }
+    if !matches!(message, AgentMessage::Plain { .. }) {
+        return Err(ToolError::InvalidParams(
+            "UserDirectedWork may send only kind=plain".to_string(),
+        ));
+    }
+    if params.related_task_id.is_some() || params.purpose.is_some() {
+        return Err(ToolError::InvalidParams(
+            "UserDirectedWork messages do not accept related_task_id or purpose".to_string(),
+        ));
+    }
+    let status: Option<String> = conn
+        .query_row(
+            "SELECT status FROM agent_org_runtime_runs WHERE id=?1",
+            [run_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| ToolError::ExecutionFailed(error.to_string()))?;
+    match status.as_deref() {
+        Some("running" | "idle" | "paused") => {}
+        Some("archived") => {
+            return Err(ToolError::ExecutionFailed(
+                crate::coordination::agent_org_runs::mutation_blocked_error(run_id, "archived"),
+            ));
+        }
+        Some(other) => {
+            return Err(ToolError::InvalidParams(format!(
+                "team_unavailable: Coordinator side quest cannot enter Team status {other}"
+            )));
+        }
+        None => {
+            return Err(ToolError::InvalidParams(format!(
+                "team_unavailable: Agent Org run {run_id} is missing"
+            )));
+        }
+    }
+    let runtime = AgentOrgRunStore::find_coordinator_session_by_member_id_with_connection(
+        conn,
+        run_id,
+        COORDINATOR_MEMBER_ID,
+    )
+    .map_err(ToolError::ExecutionFailed)?
+    .ok_or_else(|| {
+        ToolError::InvalidParams(
+            "linked_inbox_target_unavailable: canonical Coordinator runtime is missing".to_string(),
+        )
+    })?;
+    if runtime.status == SessionStatus::Archived {
+        return Err(ToolError::InvalidParams(
+            "linked_inbox_target_removed: Coordinator session is archived".to_string(),
+        ));
+    }
+    let (content, summary) = match message {
+        AgentMessage::Plain { summary, text } => (text.trim(), summary.trim()),
+        _ => unreachable!("validated plain message"),
+    };
+    let record = AgentInboxStore::insert_in_tx_without_formal_trigger(
+        conn,
+        InsertInboxParams {
+            recipient_agent_id: recipient.agent_id.clone(),
+            recipient_member_id: Some(COORDINATOR_MEMBER_ID.to_string()),
+            sender_agent_id: sender.agent_id.clone(),
+            sender_member_id: Some(sender.member_id.clone()),
+            org_run_id: Some(run_id.to_string()),
+            message: message.clone(),
+        },
+    )
+    .map_err(ToolError::ExecutionFailed)?;
+    let display_text = if summary.is_empty() {
+        content.to_string()
+    } else {
+        format!("{summary}\n\n{content}")
+    };
+    conn.execute(
+        "UPDATE agent_org_runtime_inbox
+         SET delivery_class='user_directed',display_text=?2
+         WHERE id=?1 AND delivery_class='formal_work'",
+        params![record.id, &display_text],
+    )
+    .map_err(|error| ToolError::ExecutionFailed(error.to_string()))?;
+    let child_turn_intent_id = uuid::Uuid::new_v4().to_string();
+    agent_org_user_directed_work::insert_linked_coordinator_delivery_with_connection(
+        conn,
+        &crate::coordination::agent_org_user_directed_work::NewLinkedCoordinatorDelivery {
+            org_run_id: run_id,
+            source_session_id: &context.session_id,
+            source_turn_intent_id: &context.turn_intent_id,
+            coordinator_session_id: &runtime.session_id,
+            child_turn_intent_id: &child_turn_intent_id,
+            source_inbox_id: record.id,
+            dispatch_content: content,
+            display_content: &display_text,
+        },
+    )
+    .map_err(ToolError::InvalidParams)?;
+    Ok(UserDirectedMessagePersistOutcome {
+        recipient_member_id: COORDINATOR_MEMBER_ID.to_string(),
+        recipient_session_id: runtime.session_id,
+        turn_intent_id: child_turn_intent_id,
+        inbox_id: record.id,
+        member_dispatch_sequence: None,
+        content: content.to_string(),
+        display_text,
+    })
 }
 
 fn member_coordination_guidance(

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent_org/send_message/tests.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent_org/send_message/tests.rs
@@ -6,7 +6,8 @@ use super::*;
 use crate::coordination::agent_inbox::AgentInboxStore;
 use crate::coordination::agent_org_runs::{AgentOrgContextMember, COORDINATOR_MEMBER_ID};
 use crate::coordination::agent_org_tasks::{
-    new_task_id, AgentOrgTaskStore, CreateTaskParams, TaskStatus, TASK_METADATA_ELIGIBLE_MEMBER_IDS,
+    new_task_id, AgentOrgTaskStore, CreateTaskParams, TaskGraphWriterAdmin, TaskStatus,
+    TASK_METADATA_ELIGIBLE_MEMBER_IDS,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -36,6 +37,14 @@ fn call_context(sender_member_id: &str) -> crate::tools::call_context::CallConte
     )
 }
 
+fn call_context_with_new_id(
+    template: &crate::tools::call_context::CallContext,
+) -> crate::tools::call_context::CallContext {
+    let mut call = template.clone();
+    call.call_id = format!("send-call-{}", NEXT_CALL_ID.fetch_add(1, Ordering::Relaxed));
+    call
+}
+
 fn context() -> Arc<AgentOrgRunContext> {
     Arc::new(AgentOrgRunContext {
         run_id: "run-1".to_string(),
@@ -63,6 +72,41 @@ fn context() -> Arc<AgentOrgRunContext> {
         capability_index: Default::default(),
         root_session_id: Some("root-1".to_string()),
     })
+}
+
+fn linked_context() -> Arc<AgentOrgRunContext> {
+    let snapshot = crate::definitions::orgs::AgentOrgLaunchSnapshot {
+        schema_version: 1,
+        org_id: "org-1".to_string(),
+        org_name: "Org".to_string(),
+        coordinator_role: "lead".to_string(),
+        coordinator_agent_id: "agent-coord".to_string(),
+        members: vec![
+            crate::definitions::orgs::FlatOrgMember {
+                member_id: "planner".to_string(),
+                name: "Planner".to_string(),
+                role: "plan".to_string(),
+                agent_id: "agent-shared".to_string(),
+                runtime_config: None,
+            },
+            crate::definitions::orgs::FlatOrgMember {
+                member_id: "builder".to_string(),
+                name: "Builder".to_string(),
+                role: "build".to_string(),
+                agent_id: "agent-shared".to_string(),
+                runtime_config: None,
+            },
+        ],
+        plan_approval_policy: crate::definitions::orgs::PlanApprovalPolicy::Coordinator,
+        additional_task_graph_writer_member_ids: Vec::new(),
+        member_communication_links: vec![
+            crate::definitions::orgs::MemberCommunicationLink::canonical("builder", "planner"),
+        ],
+    };
+    let mut run_context = (*context()).clone();
+    run_context.capability_index =
+        crate::definitions::orgs::AgentOrgCapabilityIndex::from_snapshot(&snapshot);
+    Arc::new(run_context)
 }
 
 fn params(recipient_member_id: &str) -> serde_json::Value {
@@ -97,11 +141,16 @@ fn seed_owned_task(owner_member_id: &str) -> String {
 #[derive(Default, Debug)]
 struct RecordingWakeHook {
     calls: Mutex<Vec<(String, String)>>,
+    user_directed_calls: Mutex<Vec<UserDirectedWake>>,
 }
 
 impl RecordingWakeHook {
     fn snapshot(&self) -> Vec<(String, String)> {
         self.calls.lock().unwrap().clone()
+    }
+
+    fn user_directed_snapshot(&self) -> Vec<UserDirectedWake> {
+        self.user_directed_calls.lock().unwrap().clone()
     }
 }
 
@@ -111,6 +160,10 @@ impl InboxWakeHook for RecordingWakeHook {
             .lock()
             .unwrap()
             .push((member_id.to_string(), org_run_id.to_string()));
+    }
+
+    fn wake_user_directed_member(&self, wake: UserDirectedWake) {
+        self.user_directed_calls.lock().unwrap().push(wake);
     }
 }
 
@@ -264,6 +317,170 @@ fn init_inbox_schema() -> test_helpers::test_env::SandboxGuard {
     sandbox
 }
 
+fn upsert_linked_turn_intent(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+    turn_intent_id: &str,
+    client_message_id: Option<&str>,
+    org_run_id: Option<&str>,
+    source: crate::foundation::session_bridge::TurnIntentBridgeSource,
+    status: crate::foundation::session_bridge::TurnIntentBridgeStatus,
+) -> Result<(), String> {
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT OR IGNORE INTO session_turn_intents (
+             session_id,turn_intent_id,client_message_id,org_run_id,source,status,
+             created_at,updated_at
+         ) VALUES (?1,?2,?3,?4,?5,?6,?7,?7)",
+        rusqlite::params![
+            session_id,
+            turn_intent_id,
+            client_message_id,
+            org_run_id,
+            source.as_str(),
+            status.as_str(),
+            &now,
+        ],
+    )
+    .map(|_| ())
+    .map_err(|error| error.to_string())
+}
+
+fn seed_started_group_udw_with_link() -> crate::tools::call_context::CallContext {
+    crate::foundation::session_bridge::register_upsert_turn_intent_with_connection(
+        upsert_linked_turn_intent,
+    );
+    let conn = database::db::get_connection().expect("test sqlite connection");
+    let mut snapshot: crate::definitions::orgs::AgentOrgLaunchSnapshot = conn
+        .query_row(
+            "SELECT org_snapshot_json FROM agent_org_runtime_runs WHERE id='run-1'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .map(|json| serde_json::from_str(&json).expect("decode launch snapshot"))
+        .expect("load launch snapshot");
+    snapshot.member_communication_links =
+        vec![crate::definitions::orgs::MemberCommunicationLink::canonical("builder", "planner")];
+    conn.execute(
+        "UPDATE agent_org_runtime_runs SET org_snapshot_json=?1 WHERE id='run-1'",
+        [serde_json::to_string(&snapshot).expect("encode launch snapshot")],
+    )
+    .expect("install frozen communication link");
+    conn.execute(
+        "UPDATE session_turn_intents SET status='completed'
+         WHERE session_id='builder-session' AND turn_intent_id='builder-turn'",
+        [],
+    )
+    .expect("finish the earlier formal Turn before starting Group UDW");
+    let now = chrono::Utc::now().to_rfc3339();
+    crate::session::persistence::upsert_session(
+        &crate::session::persistence::UnifiedSessionRecord {
+            session_id: "planner-session".to_string(),
+            name: "planner".to_string(),
+            status: "idle".to_string(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            session_type: "sde".to_string(),
+            org_member_id: Some("planner".to_string()),
+            agent_definition_id: Some("agent-shared".to_string()),
+            parent_session_id: Some("root-1".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("seed linked Planner session");
+    conn.execute(
+        "INSERT INTO agent_org_runtime_member_materializations (
+             org_run_id,member_id,agent_id,generation,session_id,
+             authority_class,status,created_at,updated_at
+         ) VALUES ('run-1','planner','agent-shared',1,'planner-session',
+                   'formal','succeeded',?1,?1)",
+        [&now],
+    )
+    .expect("seed linked Planner materialization");
+    let source = AgentInboxStore::insert_in_tx_without_formal_trigger(
+        &conn,
+        crate::coordination::agent_inbox::InsertInboxParams {
+            recipient_agent_id: "agent-shared".to_string(),
+            recipient_member_id: Some("builder".to_string()),
+            sender_agent_id: crate::coordination::agent_inbox::USER_SENDER_ID.to_string(),
+            sender_member_id: None,
+            org_run_id: Some("run-1".to_string()),
+            message: crate::coordination::agent_inbox::AgentMessage::Plain {
+                summary: "Group mention".to_string(),
+                text: "Check the boundary".to_string(),
+            },
+        },
+    )
+    .expect("seed Group source Inbox");
+    conn.execute(
+        "UPDATE agent_org_runtime_inbox
+         SET delivery_class='user_directed',display_text='@Builder Check the boundary'
+         WHERE id=?1",
+        [source.id],
+    )
+    .expect("classify Group source");
+    conn.execute(
+        "INSERT INTO session_turn_intents (
+             session_id,turn_intent_id,org_run_id,source,status,created_at,updated_at
+         ) VALUES ('builder-session','builder-udw-turn','run-1','agent_org','running',?1,?1)",
+        [&now],
+    )
+    .expect("seed UDW intent");
+    conn.execute(
+        "INSERT INTO agent_org_runtime_turn_contexts (
+             session_id,turn_intent_id,org_run_id,participant_id,turn_kind,
+             dispatch_member_id,member_dispatch_sequence,source_kind,source_id,
+             root_authority_turn_id,actor_version,created_at
+         ) VALUES ('builder-session','builder-udw-turn','run-1','builder',
+                   'user_directed_work','builder',2,'group_mention',?1,
+                   'builder-udw-turn',1,?2)",
+        rusqlite::params![source.id.to_string(), &now],
+    )
+    .expect("seed UDW Turn context");
+    let root = crate::coordination::agent_org_user_directed_work::NewUserDirectedDelivery {
+        org_run_id: "run-1",
+        session_id: "builder-session",
+        turn_intent_id: "builder-udw-turn",
+        root_authority_turn_id: "builder-udw-turn",
+        parent_delivery_id: None,
+        parent_inbox_id: None,
+        source_kind:
+            crate::coordination::agent_org_user_directed_work::UserDirectedSourceKind::GroupMention,
+        source_event_id: None,
+        source_inbox_id: Some(source.id),
+        dispatch_member_id: "builder",
+        member_dispatch_sequence: 2,
+        depth: 0,
+        delivery_ordinal: 1,
+        dispatch_content: "Check the boundary",
+        display_content: "@Builder Check the boundary",
+        images: None,
+    };
+    crate::coordination::agent_org_user_directed_work::insert_root_delivery_with_connection(
+        &conn, &root,
+    )
+    .expect("seed UDW root receipt");
+    assert!(
+        crate::coordination::agent_org_user_directed_work::mark_turn_started_with_connection(
+            &conn,
+            "builder-session",
+            "builder-udw-turn",
+        )
+        .expect("start UDW root")
+    );
+    crate::tools::call_context::CallContext {
+        session_id: "builder-session".to_string(),
+        turn_intent_id: "builder-udw-turn".to_string(),
+        call_id: format!("send-call-{}", NEXT_CALL_ID.fetch_add(1, Ordering::Relaxed)),
+        ..Default::default()
+    }
+    .with_authority(
+        crate::tools::call_context::ToolCallAuthority::PersistedAgentOrg(
+            crate::tools::call_context::AgentOrgTurnToolProfile::UserDirectedWorker,
+        ),
+    )
+}
+
 fn builder_authority_task_id() -> String {
     let conn = database::db::get_connection().expect("test sqlite connection");
     conn.query_row(
@@ -380,7 +597,8 @@ fn llm_description_carries_current_routing_hints() {
     let description = tool.llm_description().expect("description");
 
     assert!(description.contains("recipient_member_id enum: [coordinator]"));
-    assert!(description.contains("Routine work progress is NOT a message or assistant reply"));
+    assert!(description.contains("routine progress is NOT a message or assistant reply"));
+    assert!(description.contains("During UserDirectedWork"));
     assert!(description
         .contains("blocker | decision_required | material_change | risk | requested_reply"));
     assert!(!description.contains("status/escalation messages do not need"));
@@ -399,6 +617,467 @@ fn llm_description_recipient_hints_keep_peer_send_disabled() {
         .llm_description()
         .expect("description")
         .contains("recipient_member_id enum: [coordinator]"));
+}
+
+#[tokio::test]
+async fn started_udw_can_send_exactly_once_to_a_snapshot_linked_peer() {
+    let _sandbox = init_inbox_schema();
+    let call = seed_started_group_udw_with_link();
+    let wake = Arc::new(RecordingWakeHook::default());
+    let tool = OrgSendMessageTool::with_hooks(
+        linked_context(),
+        "builder".to_string(),
+        wake.clone(),
+        Arc::new(NoopSelfAbortHook),
+    );
+    let input = params("planner");
+    let first = tool
+        .execute_text(input.clone(), &call)
+        .await
+        .expect("linked peer message");
+    let replay = tool
+        .execute_text(input, &call)
+        .await
+        .expect("exact call replay");
+    assert_eq!(first, replay);
+    let value: serde_json::Value = serde_json::from_str(&first).expect("decode receipt");
+    assert_eq!(value["user_directed"], true);
+    assert_eq!(value["delivered"][0]["recipient_member_id"], "planner");
+    assert_eq!(wake.user_directed_snapshot().len(), 1);
+    let child_turn_intent_id = value["delivered"][0]["turn_intent_id"]
+        .as_str()
+        .expect("child Turn id");
+    let causal = crate::coordination::agent_org_user_directed_work::causal_reply_for_turn(
+        "planner-session",
+        child_turn_intent_id,
+    )
+    .expect("load child causal reply")
+    .expect("child causal reply exists");
+    assert_eq!(causal.source_kind, "member_inbox");
+    assert_eq!(causal.root_authority_turn_id, "builder-udw-turn");
+    assert_eq!(causal.depth, 1);
+    assert_eq!(causal.delivery_ordinal, 2);
+
+    let mut changed = params("planner");
+    changed["text"] = json!("changed after the same call_id");
+    let conflict = tool
+        .execute_text(changed, &call)
+        .await
+        .expect_err("same call_id with changed content must conflict");
+    assert!(
+        conflict
+            .to_string()
+            .contains("agent_org_tool_call_receipt_conflict"),
+        "{conflict}"
+    );
+    assert_eq!(wake.user_directed_snapshot().len(), 1);
+
+    let conn = database::db::get_connection().expect("test sqlite connection");
+    let (child_count, child_parent, child_source, child_depth): (i64, i64, i64, i64) = conn
+        .query_row(
+            "SELECT COUNT(*),MIN(parent_delivery_id),MIN(source_inbox_id),MIN(depth)
+             FROM agent_org_runtime_user_directed_deliveries
+             WHERE source_kind='member_inbox' AND dispatch_member_id='planner'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("load linked child receipt");
+    assert_eq!(child_count, 1);
+    assert!(child_parent > 0);
+    assert!(child_source > 0);
+    assert_eq!(child_depth, 1);
+}
+
+#[tokio::test]
+async fn udw_link_is_revalidated_from_the_persisted_snapshot_in_the_write_transaction() {
+    let _sandbox = init_inbox_schema();
+    let call = seed_started_group_udw_with_link();
+    let wake = Arc::new(RecordingWakeHook::default());
+    let tool = OrgSendMessageTool::with_hooks(
+        linked_context(),
+        "builder".to_string(),
+        wake.clone(),
+        Arc::new(NoopSelfAbortHook),
+    );
+    let conn = database::db::get_connection().expect("test sqlite connection");
+    let mut snapshot: crate::definitions::orgs::AgentOrgLaunchSnapshot = conn
+        .query_row(
+            "SELECT org_snapshot_json FROM agent_org_runtime_runs WHERE id='run-1'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .map(|json| serde_json::from_str(&json).expect("decode launch snapshot"))
+        .expect("load launch snapshot");
+    snapshot.member_communication_links.clear();
+    conn.execute(
+        "UPDATE agent_org_runtime_runs SET org_snapshot_json=?1 WHERE id='run-1'",
+        [serde_json::to_string(&snapshot).expect("encode launch snapshot")],
+    )
+    .expect("remove persisted link after tool assembly");
+    let before = AgentInboxStore::count_by_run("run-1").expect("Inbox count");
+
+    let error = tool
+        .execute_text(params("planner"), &call)
+        .await
+        .expect_err("stale in-memory link must not authorize a write");
+    assert!(
+        error.to_string().contains("linked_inbox_link_denied"),
+        "{error}"
+    );
+    assert_eq!(
+        AgentInboxStore::count_by_run("run-1").expect("Inbox count after rejection"),
+        before
+    );
+    assert!(wake.user_directed_snapshot().is_empty());
+}
+
+#[tokio::test]
+async fn udw_rejects_self_unknown_depth_and_delivery_budget_without_writes() {
+    let _sandbox = init_inbox_schema();
+    let call = seed_started_group_udw_with_link();
+    let tool = OrgSendMessageTool::new(linked_context(), "builder".to_string());
+    let before = AgentInboxStore::count_by_run("run-1").expect("Inbox count");
+    let self_error = tool
+        .execute_text(params("builder"), &call)
+        .await
+        .expect_err("self-send must fail");
+    assert!(self_error.to_string().contains("linked_inbox_self_send"));
+    let unknown_error = tool
+        .execute_text(params("removed-member"), &call)
+        .await
+        .expect_err("unknown target must fail");
+    assert!(unknown_error.to_string().contains("not addressable"));
+
+    let conn = database::db::get_connection().expect("test sqlite connection");
+    conn.execute(
+        "UPDATE agent_org_runtime_user_directed_roots
+         SET max_cascade_depth=0 WHERE root_authority_turn_id='builder-udw-turn'",
+        [],
+    )
+    .expect("freeze zero depth fixture");
+    let depth_error = tool
+        .execute_text(params("planner"), &call_context_with_new_id(&call))
+        .await
+        .expect_err("root depth limit must fail");
+    assert!(
+        depth_error.to_string().contains("linked_inbox_depth_limit"),
+        "{depth_error}"
+    );
+    conn.execute(
+        "UPDATE agent_org_runtime_user_directed_roots
+         SET max_cascade_depth=2,next_delivery_ordinal=max_deliveries+2
+         WHERE root_authority_turn_id='builder-udw-turn'",
+        [],
+    )
+    .expect("exhaust root delivery fixture");
+    let delivery_error = tool
+        .execute_text(params("planner"), &call_context_with_new_id(&call))
+        .await
+        .expect_err("root delivery budget must fail");
+    assert!(
+        delivery_error
+            .to_string()
+            .contains("linked_inbox_delivery_limit"),
+        "{delivery_error}"
+    );
+    assert_eq!(
+        AgentInboxStore::count_by_run("run-1").expect("Inbox count after rejects"),
+        before
+    );
+}
+
+#[tokio::test]
+async fn udw_coordinator_side_quest_uses_root_binding_without_formal_work() {
+    let _sandbox = init_inbox_schema();
+    let call = seed_started_group_udw_with_link();
+    let wake = Arc::new(RecordingWakeHook::default());
+    let tool = OrgSendMessageTool::with_hooks(
+        linked_context(),
+        "builder".to_string(),
+        wake.clone(),
+        Arc::new(NoopSelfAbortHook),
+    );
+    let conn = database::db::get_connection().expect("test sqlite connection");
+    let before_tasks: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM agent_org_runtime_tasks WHERE org_run_id='run-1'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("task snapshot");
+    let result = tool
+        .execute_text(params(COORDINATOR_MEMBER_ID), &call)
+        .await
+        .expect("Coordinator side quest");
+    let value: serde_json::Value = serde_json::from_str(&result).expect("decode receipt");
+    assert_eq!(
+        value["delivered"][0]["recipient_member_id"],
+        COORDINATOR_MEMBER_ID
+    );
+    let wakes = wake.user_directed_snapshot();
+    assert_eq!(wakes.len(), 1);
+    assert_eq!(wakes[0].recipient_session_id, "root-1");
+
+    let (binding_count, formal_count, context_kind, source_kind, activation_generation): (
+        i64,
+        i64,
+        String,
+        String,
+        Option<i64>,
+    ) = conn
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*)
+                 FROM agent_org_runtime_user_directed_coordinator_bindings),
+                (SELECT COUNT(*)
+                 FROM agent_org_runtime_formal_trigger_receipts receipt
+                 JOIN agent_org_runtime_inbox inbox ON inbox.id=receipt.inbox_id
+                 WHERE inbox.delivery_class='user_directed'),
+                (SELECT context.turn_kind
+                 FROM agent_org_runtime_turn_contexts context
+                 JOIN agent_org_runtime_user_directed_coordinator_bindings binding
+                   ON binding.session_id=context.session_id
+                  AND binding.turn_intent_id=context.turn_intent_id
+                 LIMIT 1),
+                (SELECT context.source_kind
+                 FROM agent_org_runtime_turn_contexts context
+                 JOIN agent_org_runtime_user_directed_coordinator_bindings binding
+                   ON binding.session_id=context.session_id
+                  AND binding.turn_intent_id=context.turn_intent_id
+                 LIMIT 1),
+                (SELECT context.activation_generation
+                 FROM agent_org_runtime_turn_contexts context
+                 JOIN agent_org_runtime_user_directed_coordinator_bindings binding
+                   ON binding.session_id=context.session_id
+                  AND binding.turn_intent_id=context.turn_intent_id
+                 LIMIT 1)",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .expect("load Coordinator side-quest authority");
+    assert_eq!(binding_count, 1);
+    assert_eq!(formal_count, 0);
+    assert_eq!(context_kind, "coordinator");
+    assert_eq!(source_kind, "member_inbox");
+    assert_eq!(activation_generation, None);
+    assert_eq!(
+        crate::tools::policy::resolve_persisted_agent_org_tool_authority(
+            "root-1",
+            &wakes[0].turn_intent_id,
+        )
+        .expect("Working Coordinator side quest policy")
+        .profile,
+        crate::tools::call_context::AgentOrgTurnToolProfile::CoordinatorOrchestration,
+    );
+    TaskGraphWriterAdmin::new("root-1", &wakes[0].turn_intent_id)
+        .expect("Coordinator side-quest actor identity")
+        .validate(&conn, "run-1")
+        .expect("Working Coordinator side quest may use canonical graph authority");
+    let formal_staging_error =
+        crate::coordination::agent_org_runs::AgentOrgRunStore::stage_coordinator_work_revision_and_load_tasks(
+            "run-1",
+            "root-1",
+            &wakes[0].turn_intent_id,
+            &[],
+        )
+        .expect_err("Coordinator side quest must not stage formal work freshness");
+    assert!(
+        formal_staging_error.contains("Coordinator freshness authority mismatch"),
+        "{formal_staging_error}"
+    );
+    conn.execute(
+        "UPDATE agent_org_runtime_runs SET status='idle' WHERE id='run-1'",
+        [],
+    )
+    .expect("idle Team around the same durable side quest");
+    assert!(
+        crate::coordination::agent_org_runs::AgentOrgRunStore::activate_idle_for_task_graph_in_tx(
+            &conn,
+            "run-1",
+            "root-1",
+            &wakes[0].turn_intent_id,
+        )
+        .expect("Idle Coordinator side quest may atomically activate formal work")
+    );
+    let (idle_activation_status, idle_activation_generation): (String, Option<i64>) = conn
+        .query_row(
+            "SELECT run.status,context.activation_generation
+             FROM agent_org_runtime_runs run
+             JOIN agent_org_runtime_turn_contexts context ON context.org_run_id=run.id
+             WHERE run.id='run-1' AND context.session_id='root-1'
+               AND context.turn_intent_id=?1",
+            [&wakes[0].turn_intent_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("read Idle side-quest activation");
+    assert_eq!(idle_activation_status, "running");
+    assert_eq!(idle_activation_generation, None);
+    conn.execute(
+        "UPDATE agent_org_runtime_runs SET status='paused' WHERE id='run-1'",
+        [],
+    )
+    .expect("pause Team around the same durable side quest");
+    assert_eq!(
+        crate::tools::policy::resolve_persisted_agent_org_tool_authority(
+            "root-1",
+            &wakes[0].turn_intent_id,
+        )
+        .expect("Paused Coordinator side quest policy")
+        .profile,
+        crate::tools::call_context::AgentOrgTurnToolProfile::SummaryOnly,
+    );
+    let paused_graph_error = TaskGraphWriterAdmin::new("root-1", &wakes[0].turn_intent_id)
+        .expect("Coordinator side-quest actor identity")
+        .validate(&conn, "run-1")
+        .expect_err("Paused Coordinator side quest cannot mutate formal work");
+    assert!(
+        paused_graph_error.contains("team_paused_resume_required"),
+        "{paused_graph_error}"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM agent_org_runtime_tasks WHERE org_run_id='run-1'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("task snapshot after side quest"),
+        before_tasks
+    );
+}
+
+#[tokio::test]
+async fn coordinator_side_quests_keep_durable_fifo_when_kicks_arrive_out_of_order() {
+    let _sandbox = init_inbox_schema();
+    let first_call = seed_started_group_udw_with_link();
+    let tool = OrgSendMessageTool::new(linked_context(), "builder".to_string());
+    let first: serde_json::Value = serde_json::from_str(
+        &tool
+            .execute_text(params(COORDINATOR_MEMBER_ID), &first_call)
+            .await
+            .expect("persist first Coordinator side quest"),
+    )
+    .expect("decode first receipt");
+    let second_call = call_context_with_new_id(&first_call);
+    let second: serde_json::Value = serde_json::from_str(
+        &tool
+            .execute_text(params(COORDINATOR_MEMBER_ID), &second_call)
+            .await
+            .expect("persist second Coordinator side quest"),
+    )
+    .expect("decode second receipt");
+    let first_turn = first["delivered"][0]["turn_intent_id"]
+        .as_str()
+        .expect("first Coordinator Turn");
+    let second_turn = second["delivered"][0]["turn_intent_id"]
+        .as_str()
+        .expect("second Coordinator Turn");
+    let conn = database::db::get_connection().expect("test sqlite connection");
+    crate::coordination::agent_org_turn_contexts::reconcile_in_flight_after_restart(&conn)
+        .expect("generic restart reconciliation preserves pending Coordinator side quests");
+    let queued_bindings: i64 = conn
+        .query_row(
+            "SELECT COUNT(*)
+             FROM agent_org_runtime_user_directed_coordinator_bindings binding
+             JOIN session_turn_intents intent
+               ON intent.session_id=binding.session_id
+              AND intent.turn_intent_id=binding.turn_intent_id
+             WHERE binding.status='pending' AND intent.status='queued'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("load pending Coordinator bindings after restart reconciliation");
+    assert_eq!(queued_bindings, 2);
+    conn.execute(
+        "UPDATE session_turn_intents SET status='running'
+         WHERE session_id='root-1' AND turn_intent_id=?1",
+        [second_turn],
+    )
+    .expect("mirror scheduler promotion for the later kick");
+
+    assert!(
+        !crate::coordination::agent_org_user_directed_work::mark_turn_started_with_connection(
+            &conn,
+            "root-1",
+            second_turn,
+        )
+        .expect("later kick is fenced")
+    );
+    let waiting_status: String = conn
+        .query_row(
+            "SELECT status FROM session_turn_intents
+             WHERE session_id='root-1' AND turn_intent_id=?1",
+            [second_turn],
+            |row| row.get(0),
+        )
+        .expect("load requeued Coordinator Turn");
+    assert_eq!(waiting_status, "queued");
+    assert!(
+        crate::coordination::agent_org_user_directed_work::mark_turn_started_with_connection(
+            &conn, "root-1", first_turn,
+        )
+        .expect("FIFO head starts")
+    );
+    assert!(
+        crate::coordination::agent_org_user_directed_work::mark_turn_terminal(
+            "root-1",
+            first_turn,
+            crate::coordination::agent_org_user_directed_work::UserDirectedDeliveryStatus::Completed,
+            None,
+        )
+        .expect("FIFO head completes")
+    );
+    let next = crate::coordination::agent_org_user_directed_work::next_pending_after_terminal(
+        "root-1", first_turn,
+    )
+    .expect("resolve next Coordinator binding")
+    .expect("later side quest remains pending");
+    assert_eq!(next.turn_intent_id, second_turn);
+    assert_eq!(next.recipient_session_id, "root-1");
+    assert_eq!(next.recipient_member_id, COORDINATOR_MEMBER_ID);
+}
+
+#[tokio::test]
+async fn formal_task_turn_cannot_use_peer_visible_in_static_member_schema() {
+    let _sandbox = init_inbox_schema();
+    let _ = seed_started_group_udw_with_link();
+    crate::coordination::agent_org_user_directed_work::mark_turn_terminal(
+        "builder-session",
+        "builder-udw-turn",
+        crate::coordination::agent_org_user_directed_work::UserDirectedDeliveryStatus::Completed,
+        None,
+    )
+    .expect("finish UDW fixture before restoring the formal Turn");
+    let conn = database::db::get_connection().expect("test sqlite connection");
+    conn.execute(
+        "UPDATE session_turn_intents SET status='running'
+         WHERE session_id='builder-session' AND turn_intent_id='builder-turn'",
+        [],
+    )
+    .expect("restore formal TaskExecution as the exact current Turn");
+    drop(conn);
+    let tool = OrgSendMessageTool::new(linked_context(), "builder".to_string());
+    assert_eq!(
+        tool.parameters()["properties"]["recipient_member_id"]["enum"],
+        json!(["coordinator", "planner"])
+    );
+    let error = tool
+        .execute_text(params("planner"), &call_context("builder"))
+        .await
+        .expect_err("TaskExecution may not turn a peer link into formal routing authority");
+    assert!(
+        error.to_string().contains("cannot message member")
+            || error.to_string().contains("not currently routable")
+            || error.to_string().contains("related_task_id"),
+        "{error}"
+    );
 }
 
 #[test]

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/inbox_wake.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/inbox_wake.rs
@@ -35,7 +35,7 @@ use tracing::{info, warn};
 use crate::coordination::agent_org_runs::{AgentOrgRunStatus, AgentOrgRunStore};
 use crate::core::session::SessionStatus;
 use crate::state::AgentAppState;
-use crate::tools::impls::orchestration::org_send_message::InboxWakeHook;
+use crate::tools::impls::orchestration::org_send_message::{InboxWakeHook, UserDirectedWake};
 
 /// Production [`InboxWakeHook`] that resolves the recipient session by
 /// canonical `member_id` and, when the session is idle or terminal, fires
@@ -81,6 +81,28 @@ impl InboxWakeHook for AppHandleInboxWakeHook {
         receipt_ids: &[String],
     ) {
         self.spawn_wake(member_id, org_run_id, Some(receipt_ids.to_vec()));
+    }
+
+    fn wake_user_directed_member(&self, wake: UserDirectedWake) {
+        let app_handle = self.app_handle.clone();
+        tokio::spawn(async move {
+            let Some(state) = app_handle.try_state::<AgentAppState>() else {
+                warn!(
+                    run_id = %wake.org_run_id,
+                    member_id = %wake.recipient_member_id,
+                    "cannot dispatch linked UDW without AgentAppState"
+                );
+                return;
+            };
+            if let Err(error) =
+                crate::state::commands::session::message::send_message_impl_for_user_directed_wake(
+                    &state, wake,
+                )
+                .await
+            {
+                warn!(error = %error, "linked UDW kick failed; startup recovery retains the pending receipt");
+            }
+        });
     }
 }
 

--- a/src-tauri/crates/agent-core/src/core/tools/policy.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/policy.rs
@@ -242,15 +242,31 @@ pub(crate) fn resolve_persisted_agent_org_tool_authority(
     )?;
     let fixed_profile = match context.turn_kind {
         crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::Coordinator => {
-            let conn = database::db::get_connection().map_err(|error| error.to_string())?;
-            if crate::coordination::agent_org_final_summary::is_summary_turn_with_connection(
-                &conn,
-                session_id,
-                turn_intent_id,
-            )? {
-                Some(AgentOrgTurnToolProfile::SummaryOnly)
+            if context.source_kind
+                == crate::coordination::agent_org_turn_contexts::AgentOrgTurnSourceKind::MemberInbox
+            {
+                let status = crate::coordination::agent_org_runs::AgentOrgRunStore::get_run_status(
+                    &context.org_run_id,
+                )?
+                .ok_or_else(|| format!("agent_org_run_not_found: {}", context.org_run_id))?;
+                Some(
+                    if status == crate::coordination::agent_org_runs::AgentOrgRunStatus::Paused {
+                        AgentOrgTurnToolProfile::SummaryOnly
+                    } else {
+                        AgentOrgTurnToolProfile::CoordinatorOrchestration
+                    },
+                )
             } else {
-                Some(AgentOrgTurnToolProfile::CoordinatorOrchestration)
+                let conn = database::db::get_connection().map_err(|error| error.to_string())?;
+                if crate::coordination::agent_org_final_summary::is_summary_turn_with_connection(
+                    &conn,
+                    session_id,
+                    turn_intent_id,
+                )? {
+                    Some(AgentOrgTurnToolProfile::SummaryOnly)
+                } else {
+                    Some(AgentOrgTurnToolProfile::CoordinatorOrchestration)
+                }
             }
         }
         crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::TaskExecution => {
@@ -576,8 +592,7 @@ pub(crate) fn agent_org_profile_allows_tool(
         ),
         AgentOrgTurnToolProfile::UserDirectedWorker => !matches!(
             tool_name,
-            tool_names::ORG_SEND_MESSAGE
-                | tool_names::TASK_CREATE
+            tool_names::TASK_CREATE
                 | tool_names::TASK_GRAPH_CREATE
                 | tool_names::TASK_UPDATE
                 | tool_names::ORG_RUN_COMPLETE
@@ -585,9 +600,7 @@ pub(crate) fn agent_org_profile_allows_tool(
         ),
         AgentOrgTurnToolProfile::UserDirectedWriter => !matches!(
             tool_name,
-            tool_names::ORG_SEND_MESSAGE
-                | tool_names::ORG_RUN_COMPLETE
-                | tool_names::ORG_INBOX_REPAIR
+            tool_names::ORG_RUN_COMPLETE | tool_names::ORG_INBOX_REPAIR
         ),
     }
 }

--- a/src-tauri/crates/agent-core/src/core/tools/tests/policy_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/tests/policy_tests.rs
@@ -168,6 +168,7 @@ fn user_directed_worker_hides_graph_but_keeps_real_work_tools() {
     assert!(!policy.is_allowed(crate::tools::names::TASK_CREATE));
     assert!(!policy.is_allowed(crate::tools::names::TASK_GRAPH_CREATE));
     assert!(!policy.is_allowed(crate::tools::names::TASK_UPDATE));
+    assert!(policy.is_allowed(crate::tools::names::ORG_SEND_MESSAGE));
     assert!(policy.is_allowed("read_file"));
     assert!(policy.is_allowed("write_file"));
     assert!(policy.is_allowed("run_shell"));
@@ -180,6 +181,7 @@ fn user_directed_writer_sees_only_graph_task_update_operations() {
     assert!(policy.is_allowed(crate::tools::names::TASK_CREATE));
     assert!(policy.is_allowed(crate::tools::names::TASK_GRAPH_CREATE));
     assert!(policy.is_allowed(crate::tools::names::TASK_UPDATE));
+    assert!(policy.is_allowed(crate::tools::names::ORG_SEND_MESSAGE));
     assert!(!policy.is_allowed(crate::tools::names::ORG_RUN_COMPLETE));
 
     let filtered = policy.filter_definitions(vec![serde_json::json!({

--- a/src-tauri/crates/agent-core/src/state/commands/session/message/entry_points.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message/entry_points.rs
@@ -170,6 +170,32 @@ pub(crate) async fn send_message_impl_for_direct_recovery(
     .await
 }
 
+pub(crate) async fn send_message_impl_for_user_directed_wake(
+    state: &AgentAppState,
+    wake: crate::tools::impls::orchestration::org_send_message::UserDirectedWake,
+) -> Result<AgentResponse, String> {
+    send_message_impl(
+        state,
+        wake.recipient_session_id,
+        wake.content,
+        Some(wake.display_text),
+        IdentityOverrides::default(),
+        None,
+        wake.images,
+        None,
+        false,
+        None,
+        false,
+        Some(wake.turn_intent_id.clone()),
+        Some(wake.turn_intent_id),
+        None,
+        None,
+        Some(wake.org_run_id),
+        TurnIntentBridgeSource::AgentOrg,
+    )
+    .await
+}
+
 /// Debug-only entry point for E2E follow-up turns.
 ///
 /// The production `agent_send_message` Tauri command is `pub` but

--- a/src-tauri/crates/agent-core/src/state/commands/session/message/org_wake.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message/org_wake.rs
@@ -92,14 +92,13 @@ pub(super) fn promote_agent_org_wake_session_to_running(
     .map_err(|error| error.to_string())
 }
 
-/// Promote a direct Rust Agent Org turn while its Team is Running, or while
-/// the canonical Root is answering a user message from Idle. The latter keeps
-/// the Team itself Idle until a formal writer commits new work; Q&A-only turns
-/// therefore remain side-effect free at the Team lifecycle boundary.
+/// Promote an exact, already-admitted UserDirectedWork Turn while its Team is
+/// Running, Idle, or Paused. This changes only the recipient Session runtime;
+/// it never activates or resumes the formal Team lifecycle.
 ///
 /// Submit preflight is only a snapshot, so this claim re-checks both Run state
-/// and Root identity atomically immediately before Provider execution.
-pub(super) fn promote_agent_org_direct_session_to_running(
+/// and persisted Turn identity atomically immediately before Provider work.
+pub(super) fn promote_agent_org_user_directed_session_to_running(
     conn: &rusqlite::Connection,
     run_id: &str,
     session_id: &str,
@@ -112,10 +111,7 @@ pub(super) fn promote_agent_org_direct_session_to_running(
                SELECT 1
                FROM agent_org_runtime_runs run
                WHERE run.id=?4
-                 AND (
-                     run.status=?5
-                     OR (run.status=?6 AND run.root_session_id=?3)
-                 )
+                 AND run.status IN (?5,?6,?7)
            )",
         rusqlite::params![
             crate::session::SessionStatus::Running.as_str(),
@@ -124,6 +120,7 @@ pub(super) fn promote_agent_org_direct_session_to_running(
             run_id,
             crate::coordination::agent_org_runs::AgentOrgRunStatus::Running.as_str(),
             crate::coordination::agent_org_runs::AgentOrgRunStatus::Idle.as_str(),
+            crate::coordination::agent_org_runs::AgentOrgRunStatus::Paused.as_str(),
         ],
     )
     .map_err(|error| error.to_string())
@@ -193,11 +190,7 @@ pub(crate) fn resolve_agent_org_wake_mode(
                 TaskExecutionMode::Plan => crate::session::AgentExecMode::Plan,
             })
         }
-        AgentOrgTurnKind::UserDirectedWork => {
-            return Err(
-                "UserDirectedWork is not enabled in the task-bound wake mode resolver".to_string(),
-            );
-        }
+        AgentOrgTurnKind::UserDirectedWork => None,
     };
     tx.commit().map_err(|error| error.to_string())?;
     Ok(resolved)

--- a/src-tauri/crates/agent-core/src/state/commands/session/message/send.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message/send.rs
@@ -14,6 +14,7 @@ use crate::coordination::agent_member_interventions::{
     AgentMemberInterventionStore, EnqueueUserDirectedWorkParams, EnqueueUserDirectedWorkResult,
     DEFAULT_USER_DIRECTED_QUEUE_CAP,
 };
+use crate::coordination::agent_org_user_directed_work::{self, UserDirectedDeliveryStatus};
 use crate::foundation::session_bridge::TurnIntentBridgeSource;
 use crate::persistence::AgentResponse;
 use crate::session::persistence as session_persistence;
@@ -23,7 +24,7 @@ use crate::state::AgentAppState;
 
 use super::exec_mode::{resolve_agent_mode, restore_mode_before_plan_entry};
 use super::org_wake::{
-    promote_agent_org_direct_session_to_running, promote_agent_org_wake_session_to_running,
+    promote_agent_org_user_directed_session_to_running, promote_agent_org_wake_session_to_running,
     resolve_agent_org_wake_mode,
 };
 
@@ -42,15 +43,37 @@ pub(super) fn promote_turn_to_running_in_tx(
     intent_run_id: Option<&str>,
     is_user_directed_work: bool,
 ) -> Result<bool, String> {
-    if wake_run_id.is_some() || intent_run_id.is_some() {
-        crate::coordination::agent_org_turn_contexts::revalidate_context_with_connection(
-            conn,
-            session_id,
-            turn_intent_id,
-        )?;
+    let persisted_context = if wake_run_id.is_some() || intent_run_id.is_some() {
+        Some(
+            crate::coordination::agent_org_turn_contexts::revalidate_context_with_connection(
+                conn,
+                session_id,
+                turn_intent_id,
+            )?,
+        )
+    } else {
+        None
+    };
+    if let Some(context) = persisted_context.as_ref() {
+        if context.turn_kind
+            == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::TaskExecution
+            && !crate::coordination::agent_org_turn_contexts::member_dispatch_is_fifo_head_with_connection(
+                conn,
+                &context.org_run_id,
+                context.dispatch_member_id.as_deref().ok_or_else(|| {
+                    "TaskExecution context has no dispatch Member".to_string()
+                })?,
+                context.member_dispatch_sequence.ok_or_else(|| {
+                    "TaskExecution context has no Member FIFO sequence".to_string()
+                })?,
+                false,
+            )?
+        {
+            return Ok(false);
+        }
     }
     if is_user_directed_work
-        && !AgentMemberInterventionStore::mark_turn_running_with_connection(
+        && !agent_org_user_directed_work::mark_turn_started_with_connection(
             conn,
             session_id,
             turn_intent_id,
@@ -72,7 +95,7 @@ pub(super) fn promote_turn_to_running_in_tx(
     } else if let Some(run_id) = wake_run_id {
         promote_agent_org_wake_session_to_running(conn, run_id, session_id)?
     } else if let Some(run_id) = intent_run_id {
-        promote_agent_org_direct_session_to_running(conn, run_id, session_id)?
+        promote_agent_org_user_directed_session_to_running(conn, run_id, session_id)?
     } else {
         conn.execute(
             "UPDATE agent_sessions SET status=?1, updated_at=?2 WHERE session_id=?3",
@@ -254,6 +277,19 @@ pub(crate) async fn send_message_impl(
     // server-side fallback so the bridge slot is always non-empty.
     let effective_turn_intent_id =
         turn_intent_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let preadmitted_user_directed_work = if agent_org_direct_source_event_id.is_none()
+        && intent_org_run_id.is_some()
+    {
+        let lookup_session_id = session_id.clone();
+        let lookup_turn_intent_id = effective_turn_intent_id.clone();
+        tokio::task::spawn_blocking(move || {
+            agent_org_user_directed_work::status_by_turn(&lookup_session_id, &lookup_turn_intent_id)
+        })
+        .await
+        .map_err(|error| format!("UserDirectedWork receipt lookup failed: {error}"))??
+    } else {
+        None
+    };
 
     let default_mode = crate::session::AgentExecMode::Build.as_str();
     tracing::info!(
@@ -282,6 +318,8 @@ pub(crate) async fn send_message_impl(
         (None, None) => None,
     };
     let is_direct_member = agent_org_direct_source_event_id.is_some();
+    let is_user_directed_work = is_direct_member || preadmitted_user_directed_work.is_some();
+    let has_preadmitted_user_directed_work = preadmitted_user_directed_work.is_some();
     if is_direct_member
         && (is_resume
             || content.trim().is_empty()
@@ -301,7 +339,7 @@ pub(crate) async fn send_message_impl(
         explicit_org_run_id,
         identity.agent_org_run_id_hint.as_deref(),
         identity.has_persisted_agent_org_identity,
-        is_direct_member,
+        is_user_directed_work,
     )
     .await?;
 
@@ -399,6 +437,13 @@ pub(crate) async fn send_message_impl(
                 admission_client_message_id,
                 &member_id,
             ),
+            None if has_preadmitted_user_directed_work => {
+                crate::coordination::agent_org_turn_contexts::require_existing_context(
+                    &admission_run_id,
+                    &admission_session_id,
+                    &admission_turn_intent_id,
+                )
+            }
             None
                 if resume_requires_existing_agent_org_context(source, None) =>
             {
@@ -562,6 +607,21 @@ pub(crate) async fn send_message_impl(
                     Some(_) => {}
                 }
             }
+        }
+    }
+
+    if let Some(status) = preadmitted_user_directed_work {
+        if status != UserDirectedDeliveryStatus::Pending {
+            return Ok(AgentResponse {
+                content: serde_json::json!({
+                    "queued": status == UserDirectedDeliveryStatus::Started,
+                    "duplicate": true,
+                    "turnStatus": status.as_str(),
+                })
+                .to_string(),
+                session_id,
+                model: effective_model,
+            });
         }
     }
 
@@ -759,6 +819,7 @@ pub(crate) async fn send_message_impl(
     let workspace_root_for_closure = effective_workspace_root.clone();
     let turn_intent_id_for_closure = effective_turn_intent_id.clone();
     let direct_user_directed_work_for_closure = direct_user_directed_work.clone();
+    let is_user_directed_work_for_closure = is_user_directed_work;
     let intent_org_run_id_for_closure = effective_intent_org_run_id.clone();
     // Resolve durable mode-control rows from exactly the bounded inbox batch
     // this background wake will drain. A control row in a later batch must
@@ -813,14 +874,13 @@ pub(crate) async fn send_message_impl(
         let session = session_for_closure;
         let turn_intent_id = turn_intent_id_for_closure;
         let direct_user_directed_work = direct_user_directed_work_for_closure;
+        let is_user_directed_work = is_user_directed_work_for_closure;
         let org_wake_run_id = org_wake_run_id;
         let intent_org_run_id = intent_org_run_id_for_closure;
         let app_state = app_state_for_closure;
 
         Box::pin(async move {
-            if direct_user_directed_work.is_some()
-                && session.scheduler.turn_is_invalidated(&turn_intent_id)
-            {
+            if is_user_directed_work && session.scheduler.turn_is_invalidated(&turn_intent_id) {
                 return Err(format!(
                     "{USER_DIRECTED_CANCELLED_ERROR_PREFIX} exact Turn was stopped before start"
                 ));
@@ -845,7 +905,7 @@ pub(crate) async fn send_message_impl(
             let status_wake_run_id = org_wake_run_id.clone();
             let status_intent_run_id = intent_org_run_id.clone();
             let status_turn_intent_id = turn_intent_id.clone();
-            let is_user_directed_work_turn = direct_user_directed_work.is_some();
+            let is_user_directed_work_turn = is_user_directed_work;
             match tokio::task::spawn_blocking(move || {
                 database::db::with_sessions_writer(|| -> Result<bool, String> {
                     let mut conn = database::db::get_connection().map_err(|err| err.to_string())?;
@@ -1049,7 +1109,7 @@ pub(crate) async fn send_message_impl(
             // already observe the direct FIFO slot as terminal. Keep the
             // result until after session finalization so a receipt write error
             // cannot strand the Session itself in Running.
-            let direct_terminal_result = if direct_user_directed_work.is_some() {
+            let direct_terminal_result = if is_user_directed_work {
                 let terminal_session_id = sid.clone();
                 let terminal_turn_intent_id = turn_intent_id.clone();
                 let terminal_status = match final_turn_state {
@@ -1060,10 +1120,14 @@ pub(crate) async fn send_message_impl(
                 };
                 let terminal_error = content_result.as_ref().err().map(String::as_str);
                 tokio::task::block_in_place(|| {
-                    AgentMemberInterventionStore::mark_turn_terminal(
+                    agent_org_user_directed_work::mark_turn_terminal(
                         &terminal_session_id,
                         &terminal_turn_intent_id,
-                        terminal_status,
+                        match terminal_status {
+                            "cancelled" => UserDirectedDeliveryStatus::Cancelled,
+                            "failed" => UserDirectedDeliveryStatus::Failed,
+                            _ => UserDirectedDeliveryStatus::Completed,
+                        },
                         terminal_error,
                     )
                 })
@@ -1080,7 +1144,89 @@ pub(crate) async fn send_message_impl(
                 terminal_turn,
             )
             .await;
-            direct_terminal_result?;
+            let user_directed_changed = direct_terminal_result?;
+            if intent_org_run_id.is_some() || org_wake_run_id.is_some() {
+                let completed_session_id = sid.clone();
+                let completed_turn_intent_id = turn_intent_id.clone();
+                match tokio::task::spawn_blocking(move || {
+                    agent_org_user_directed_work::next_pending_after_terminal(
+                        &completed_session_id,
+                        &completed_turn_intent_id,
+                    )
+                })
+                .await
+                {
+                    Ok(Ok(Some(next))) => {
+                        let wake = crate::tools::impls::orchestration::org_send_message::UserDirectedWake {
+                            org_run_id: next.org_run_id,
+                            recipient_member_id: next.recipient_member_id,
+                            recipient_session_id: next.recipient_session_id,
+                            turn_intent_id: next.turn_intent_id,
+                            content: next.content,
+                            display_text: next.display_text,
+                            images: next.images,
+                        };
+                        if let Some(app_handle) = app_state.app_handle.clone() {
+                            use crate::core::tools::impls::orchestration::inbox_wake::AppHandleInboxWakeHook;
+                            use crate::tools::impls::orchestration::org_send_message::InboxWakeHook;
+                            AppHandleInboxWakeHook::new(app_handle).wake_user_directed_member(wake);
+                        } else {
+                            tracing::warn!(
+                                session_id = %sid,
+                                turn_intent_id = %turn_intent_id,
+                                "next durable UDW kick has no AppHandle and is deferred to startup recovery"
+                            );
+                        }
+                    }
+                    Ok(Ok(None)) => {}
+                    Ok(Err(error)) => tracing::warn!(
+                        session_id = %sid,
+                        turn_intent_id = %turn_intent_id,
+                        error = %error,
+                        "failed to resolve next durable UDW FIFO item"
+                    ),
+                    Err(error) => tracing::warn!(
+                        session_id = %sid,
+                        turn_intent_id = %turn_intent_id,
+                        error = %error,
+                        "next durable UDW lookup task failed"
+                    ),
+                }
+            }
+            if user_directed_changed {
+                let completed_session_id = sid.clone();
+                let completed_turn_intent_id = turn_intent_id.clone();
+                let owner = tokio::task::spawn_blocking(move || {
+                    agent_org_user_directed_work::dispatch_owner_for_turn(
+                        &completed_session_id,
+                        &completed_turn_intent_id,
+                    )
+                })
+                .await;
+                match owner {
+                    Ok(Ok(Some((run_id, member_id)))) => {
+                        if let Some(app_handle) = app_state.app_handle.clone() {
+                            use crate::core::tools::impls::orchestration::inbox_wake::AppHandleInboxWakeHook;
+                            use crate::tools::impls::orchestration::org_send_message::InboxWakeHook;
+                            AppHandleInboxWakeHook::new(app_handle)
+                                .wake_member(&member_id, &run_id);
+                        }
+                    }
+                    Ok(Ok(None)) => {}
+                    Ok(Err(error)) => tracing::warn!(
+                        session_id = %sid,
+                        turn_intent_id = %turn_intent_id,
+                        error = %error,
+                        "failed to resolve completed UDW dispatch owner"
+                    ),
+                    Err(error) => tracing::warn!(
+                        session_id = %sid,
+                        turn_intent_id = %turn_intent_id,
+                        error = %error,
+                        "completed UDW owner lookup task failed"
+                    ),
+                }
+            }
 
             cancel_flag.store(false, std::sync::atomic::Ordering::SeqCst);
 
@@ -1089,7 +1235,7 @@ pub(crate) async fn send_message_impl(
     });
 
     // ── 6. Enqueue and return immediately ────────────────────────────────
-    let scheduler_client_message_id = if direct_user_directed_work.is_some() {
+    let scheduler_client_message_id = if is_user_directed_work {
         Some(effective_turn_intent_id.clone())
     } else {
         client_message_id
@@ -1127,22 +1273,24 @@ pub(crate) async fn send_message_impl(
     let enqueue_result = match session_handle.scheduler.enqueue(msg).await {
         Ok(result) => result,
         Err(error) => {
-            if direct_user_directed_work.is_some() {
+            if is_user_directed_work {
                 let failed_session_id = session_id.clone();
                 let failed_turn_intent_id = effective_turn_intent_id.clone();
                 let enqueue_failure = error.clone();
                 tokio::task::spawn_blocking(move || {
-                    if allow_admitted_direct_recovery {
+                    if has_preadmitted_user_directed_work {
+                        Ok(false)
+                    } else if allow_admitted_direct_recovery {
                         AgentMemberInterventionStore::requeue_direct_after_recovery_enqueue_failure(
                             &failed_session_id,
                             &failed_turn_intent_id,
                         )
                     } else {
                         let failure = format!("scheduler_enqueue_failed: {enqueue_failure}");
-                        AgentMemberInterventionStore::mark_turn_terminal(
+                        agent_org_user_directed_work::mark_turn_terminal(
                             &failed_session_id,
                             &failed_turn_intent_id,
-                            "failed",
+                            UserDirectedDeliveryStatus::Failed,
                             Some(&failure),
                         )
                     }

--- a/src-tauri/crates/agent-core/src/state/commands/session/message/tests.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message/tests.rs
@@ -9,7 +9,7 @@ use super::exec_mode::{
     mobile_remote_wire_mode, resolve_agent_mode, restore_mode_before_plan_entry,
 };
 use super::org_wake::{
-    promote_agent_org_direct_session_to_running, promote_agent_org_wake_session_to_running,
+    promote_agent_org_user_directed_session_to_running, promote_agent_org_wake_session_to_running,
     resolve_agent_org_wake_mode,
 };
 use super::send::{
@@ -604,17 +604,15 @@ fn invalidated_queued_wake_does_not_start_its_task() {
     let tx = conn
         .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
         .expect("turn-start transaction");
-    assert!(
-        !promote_turn_to_running_in_tx(
-            &tx,
-            &fixture.session_id,
-            turn_intent_id,
-            Some(&fixture.run_id),
-            None,
-            false,
-        )
-        .expect("invalidated wake is a durable no-op")
-    );
+    assert!(!promote_turn_to_running_in_tx(
+        &tx,
+        &fixture.session_id,
+        turn_intent_id,
+        Some(&fixture.run_id),
+        None,
+        false,
+    )
+    .expect("invalidated wake is a durable no-op"));
     tx.commit().expect("commit no-op claim");
     assert_eq!(
         AgentOrgTaskStore::get(&fixture.run_id, &fixture.task_id)
@@ -694,13 +692,11 @@ fn cancelled_queued_task_cannot_be_restarted_by_its_old_turn() {
 }
 
 #[test]
-fn direct_agent_org_turn_allows_running_or_canonical_root_idle() {
+fn user_directed_turn_allows_running_idle_and_paused_without_changing_team() {
     let fixture = setup_wake_mode_fixture("build", TaskStatus::Pending);
     let conn = database::db::get_connection().expect("test db");
     for status in [
         AgentOrgRunStatus::Starting,
-        AgentOrgRunStatus::Paused,
-        AgentOrgRunStatus::Idle,
         AgentOrgRunStatus::Failed,
         AgentOrgRunStatus::Archived,
     ] {
@@ -719,7 +715,7 @@ fn direct_agent_org_turn_allows_running_or_canonical_root_idle() {
         )
         .expect("set non-runnable run status");
         assert_eq!(
-            promote_agent_org_direct_session_to_running(
+            promote_agent_org_user_directed_session_to_running(
                 &conn,
                 &fixture.run_id,
                 &fixture.session_id,
@@ -738,41 +734,40 @@ fn direct_agent_org_turn_allows_running_or_canonical_root_idle() {
         assert_eq!(session_status, "idle");
     }
 
-    conn.execute(
-        "UPDATE agent_org_runtime_runs
-         SET status=?1,archived_at=NULL,archive_receipt_id=NULL WHERE id=?2",
-        rusqlite::params![AgentOrgRunStatus::Idle.as_str(), &fixture.run_id],
-    )
-    .expect("set idle run");
-    assert_eq!(
-        promote_agent_org_direct_session_to_running(&conn, &fixture.run_id, "root-session")
-            .expect("Idle canonical Root can start a Provider turn"),
-        1
-    );
-    let run_status = conn
-        .query_row(
-            "SELECT status FROM agent_org_runtime_runs WHERE id=?1",
-            [&fixture.run_id],
-            |row| row.get::<_, String>(0),
+    for status in [
+        AgentOrgRunStatus::Running,
+        AgentOrgRunStatus::Idle,
+        AgentOrgRunStatus::Paused,
+    ] {
+        conn.execute(
+            "UPDATE agent_org_runtime_runs
+             SET status=?1,archived_at=NULL,archive_receipt_id=NULL WHERE id=?2",
+            rusqlite::params![status.as_str(), &fixture.run_id],
         )
-        .expect("load idle run status");
-    assert_eq!(
-        run_status,
-        AgentOrgRunStatus::Idle.as_str(),
-        "Root Q&A admission must not activate formal Team work"
-    );
-
-    conn.execute(
-        "UPDATE agent_org_runtime_runs
-         SET status=?1,archived_at=NULL,archive_receipt_id=NULL WHERE id=?2",
-        rusqlite::params![AgentOrgRunStatus::Running.as_str(), &fixture.run_id],
-    )
-    .expect("restore running run");
-    assert_eq!(
-        promote_agent_org_direct_session_to_running(&conn, &fixture.run_id, &fixture.session_id)
-            .expect("running run promotes the member Session"),
-        1
-    );
+        .expect("set UDW-compatible run status");
+        conn.execute(
+            "UPDATE agent_sessions SET status='idle' WHERE session_id=?1",
+            [&fixture.session_id],
+        )
+        .expect("reset Member runtime");
+        assert_eq!(
+            promote_agent_org_user_directed_session_to_running(
+                &conn,
+                &fixture.run_id,
+                &fixture.session_id,
+            )
+            .expect("UDW-compatible Team status promotes the exact Member runtime"),
+            1
+        );
+        let run_status: String = conn
+            .query_row(
+                "SELECT status FROM agent_org_runtime_runs WHERE id=?1",
+                [&fixture.run_id],
+                |row| row.get(0),
+            )
+            .expect("load Team status");
+        assert_eq!(run_status, status.as_str());
+    }
 }
 
 #[test]

--- a/src-tauri/crates/agent-core/src/state/commands/session/org_tasks/group_chat.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/org_tasks/group_chat.rs
@@ -8,7 +8,7 @@
 
 use database::db::{get_connection, with_sessions_writer};
 use rusqlite::{params, OptionalExtension};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::coordination::agent_inbox::{
     AgentInboxRecord, AgentInboxStore, AgentMessage, InsertInboxParams, USER_SENDER_ID,
@@ -17,18 +17,47 @@ use crate::coordination::agent_org_runs::{
     AgentOrgRunContext, AgentOrgRunStatus, COORDINATOR_MEMBER_ID,
 };
 use crate::coordination::agent_org_turn_contexts::TURN_CONTEXT_INVARIANT_PREFIX;
+use crate::coordination::agent_org_user_directed_work::{
+    self, NewUserDirectedDelivery, UserDirectedDeliveryStatus, UserDirectedSourceKind,
+    DEFAULT_MAX_GROUP_TARGETS, DEFAULT_MAX_PENDING_PER_MEMBER,
+};
+use crate::foundation::session_bridge::TurnIntentBridgeSource;
+use crate::state::commands::session::identity::IdentityOverrides;
 use crate::state::AgentAppState;
 
 use super::context::session_org_read_context;
-use super::lifecycle::wake_agent_org_member;
 use super::run_view::{agent_org_session_run_view_impl, enrich_inbox_row, AgentOrgInboxRuntimeRow};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AgentOrgGroupDeliveryInput {
+    pub target_member_id: String,
+    pub turn_intent_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentOrgGroupDeliveryOutcome {
+    Accepted,
+    Existing,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentOrgGroupDeliveryResponse {
+    pub target_member_id: String,
+    pub target_member_name: String,
+    pub turn_intent_id: String,
+    pub source_inbox_id: i64,
+    pub member_dispatch_sequence: i64,
+    pub outcome: AgentOrgGroupDeliveryOutcome,
+    pub inbox_row: AgentOrgInboxRuntimeRow,
+}
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentOrgGroupChatMessageResponse {
-    pub target_member_id: String,
-    pub target_member_name: String,
-    pub inbox_row: AgentOrgInboxRuntimeRow,
+    pub deliveries: Vec<AgentOrgGroupDeliveryResponse>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -55,6 +84,46 @@ pub struct AgentOrgGroupChatHistoryPage {
 
 const GROUP_CHAT_HISTORY_PAGE_LIMIT: usize = 100;
 const GROUP_CHAT_HISTORY_PAGE_MAX_BYTES: usize = 1024 * 1024;
+
+#[cfg(debug_assertions)]
+static GROUP_DELIVERY_FAULT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+#[cfg(debug_assertions)]
+const GROUP_DELIVERY_FAULT_COMMIT_BEFORE_KICK: u8 = 1;
+#[cfg(debug_assertions)]
+const GROUP_DELIVERY_FAULT_RESPONSE_LOSS_AFTER_KICK: u8 = 2;
+
+/// Arm one isolated BuildFast/debug fault. This is deliberately absent from
+/// release builds and does not perform a user action; the packaged UI must
+/// still submit or retry the real Group command that consumes the fault.
+#[cfg(debug_assertions)]
+pub fn arm_next_group_delivery_fault(mode: &str) -> Result<(), String> {
+    let value = match mode {
+        "commit_before_kick" => GROUP_DELIVERY_FAULT_COMMIT_BEFORE_KICK,
+        "response_loss_after_kick" => GROUP_DELIVERY_FAULT_RESPONSE_LOSS_AFTER_KICK,
+        "clear" => 0,
+        _ => {
+            return Err(
+                "unknown Group delivery fault; expected commit_before_kick, response_loss_after_kick, or clear"
+                    .to_string(),
+            );
+        }
+    };
+    GROUP_DELIVERY_FAULT.store(value, std::sync::atomic::Ordering::Release);
+    Ok(())
+}
+
+#[cfg(debug_assertions)]
+fn take_group_delivery_fault(expected: u8) -> bool {
+    GROUP_DELIVERY_FAULT
+        .compare_exchange(
+            expected,
+            0,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        )
+        .is_ok()
+}
 
 /// Read-only, cursor-paged source of truth for user messages sent through the
 /// Agent Org Group Chat. Run View deliberately carries only previews; this
@@ -131,6 +200,7 @@ pub(super) fn load_group_chat_history_page(
                ON resolution.inbox_id=inbox.id
              WHERE inbox.org_run_id=?1
                AND inbox.sender_agent_id=?2
+               AND inbox.delivery_class='user_directed'
                AND inbox.payload_kind='plain'
                AND (?3 IS NULL OR inbox.id<?3)
              ORDER BY inbox.id DESC
@@ -265,92 +335,55 @@ pub(super) fn load_group_chat_history_page(
 
 #[tauri::command]
 pub async fn agent_org_send_group_chat_message(
-    app_handle: tauri::AppHandle,
     state: tauri::State<'_, AgentAppState>,
     session_id: String,
-    message_id: Option<String>,
-    target_member_id: Option<String>,
+    deliveries: Vec<AgentOrgGroupDeliveryInput>,
     content: String,
     display_text: Option<String>,
+    images: Option<Vec<String>>,
 ) -> Result<AgentOrgGroupChatMessageResponse, String> {
-    // Compatibility for an older renderer or E2E bridge running briefly
-    // against a newly restarted backend. New callers always supply the
-    // optimistic row id; an omitted id preserves the legacy one-shot send.
-    let message_id = message_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     agent_org_send_group_chat_message_impl_with_display(
-        app_handle,
         &state,
         session_id,
-        message_id,
-        target_member_id,
+        deliveries,
         content,
         display_text,
+        images,
     )
     .await
 }
 
 pub async fn agent_org_send_group_chat_message_impl(
-    app_handle: tauri::AppHandle,
     state: &AgentAppState,
     session_id: String,
-    message_id: String,
-    target_member_id: Option<String>,
+    deliveries: Vec<AgentOrgGroupDeliveryInput>,
     content: String,
 ) -> Result<AgentOrgGroupChatMessageResponse, String> {
     agent_org_send_group_chat_message_impl_with_display(
-        app_handle,
-        state,
-        session_id,
-        message_id,
-        target_member_id,
-        content,
-        None,
+        state, session_id, deliveries, content, None, None,
     )
     .await
 }
 
 async fn agent_org_send_group_chat_message_impl_with_display(
-    app_handle: tauri::AppHandle,
     state: &AgentAppState,
     session_id: String,
-    message_id: String,
-    target_member_id: Option<String>,
+    deliveries: Vec<AgentOrgGroupDeliveryInput>,
     content: String,
     display_text: Option<String>,
+    images: Option<Vec<String>>,
 ) -> Result<AgentOrgGroupChatMessageResponse, String> {
     crate::coordination::agent_org_runs::require_agent_org_redesign()?;
     let content = content.trim();
     if content.is_empty() {
         return Err("Agent Org group chat message content is required".to_string());
     }
-    let message_id = message_id.trim();
-    crate::coordination::agent_org_payload_limits::validate_required_text(
-        "message_id",
-        message_id,
-        crate::coordination::agent_org_payload_limits::MESSAGE_IDENTIFIER_MAX_CHARS,
-        crate::coordination::agent_org_payload_limits::MESSAGE_IDENTIFIER_MAX_BYTES,
-    )?;
+    validate_group_delivery_inputs(&deliveries)?;
 
     let view = agent_org_session_run_view_impl(state, &session_id)
         .await?
         .ok_or_else(|| format!("Session {session_id} is not part of an Agent Org run"))?;
-    let target_member_id = target_member_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or(COORDINATOR_MEMBER_ID);
-    let target = view
-        .members
-        .iter()
-        .find(|candidate| candidate.member_id == target_member_id)
-        .ok_or_else(|| {
-            format!("Agent Org member {target_member_id} was not found for session {session_id}")
-        })?;
-
     let durable_context = view.context.clone();
-    let durable_target_agent_id = target.agent_id.clone();
-    let durable_target_member_id = target.member_id.clone();
-    let durable_message_id = message_id.to_string();
     let durable_content = content.to_string();
     let durable_display_text = display_text
         .as_deref()
@@ -365,194 +398,503 @@ async fn agent_org_send_group_chat_message_impl_with_display(
             crate::coordination::agent_org_payload_limits::PLAIN_TEXT_MAX_BYTES,
         )?;
     }
-    let row = tokio::task::spawn_blocking(move || {
-        persist_pr3_group_chat_message(
+    let durable_images = images.filter(|items| !items.is_empty());
+    let persisted = tokio::task::spawn_blocking(move || {
+        persist_group_chat_deliveries(
             &durable_context,
-            &durable_target_agent_id,
-            &durable_target_member_id,
-            &durable_message_id,
+            &deliveries,
             &durable_content,
             durable_display_text.as_deref(),
+            durable_images.as_deref(),
         )
     })
     .await
     .map_err(|err| format!("Agent Org group message worker failed: {err}"))??;
 
-    // The transaction below accepts only a Working Team. Once committed, a
-    // wake is an acceleration hint; it must never change lifecycle status.
-    wake_agent_org_member(app_handle, &target.member_id, &view.context.run_id);
+    #[cfg(debug_assertions)]
+    if take_group_delivery_fault(GROUP_DELIVERY_FAULT_COMMIT_BEFORE_KICK) {
+        return Err(
+            "group_delivery_commit_before_kick_fault: durable deliveries are pending; quit and reopen the packaged app to exercise startup recovery"
+                .to_string(),
+        );
+    }
 
-    let inbox_row = enrich_inbox_row(&view.context, row);
-
-    Ok(AgentOrgGroupChatMessageResponse {
-        target_member_id: target.member_id.clone(),
-        target_member_name: target.name.clone(),
-        inbox_row,
-    })
-}
-
-/// PR3 wires only the canonical Coordinator/Root producer. Persisting a user
-/// message for a Member would leave a durable Inbox source that the legacy
-/// wake loop can never admit with typed Member authority, causing an endless
-/// retry instead of the required fail-closed result. Reject at the public
-/// command boundary before the Inbox or intervention transaction starts.
-pub(super) fn persist_pr3_group_chat_message(
-    context: &AgentOrgRunContext,
-    target_agent_id: &str,
-    target_member_id: &str,
-    message_id: &str,
-    content: &str,
-    display_text: Option<&str>,
-) -> Result<AgentInboxRecord, String> {
-    if target_member_id != COORDINATOR_MEMBER_ID {
+    let mut responses = Vec::with_capacity(persisted.len());
+    let mut kick_errors = Vec::new();
+    for delivery in persisted {
+        let target_name = view
+            .members
+            .iter()
+            .find(|member| member.member_id == delivery.target_member_id)
+            .map(|member| member.name.clone())
+            .unwrap_or_else(|| delivery.target_member_id.clone());
+        if delivery.status == UserDirectedDeliveryStatus::Pending {
+            if let Err(error) =
+                dispatch_group_delivery(state, &view.context.run_id, &delivery).await
+            {
+                kick_errors.push(format!("{}: {error}", delivery.target_member_id));
+            }
+        }
+        responses.push(AgentOrgGroupDeliveryResponse {
+            target_member_id: delivery.target_member_id,
+            target_member_name: target_name,
+            turn_intent_id: delivery.turn_intent_id,
+            source_inbox_id: delivery.inbox_row.id,
+            member_dispatch_sequence: delivery.member_dispatch_sequence,
+            outcome: delivery.outcome,
+            inbox_row: enrich_inbox_row(&view.context, delivery.inbox_row),
+        });
+    }
+    if !kick_errors.is_empty() {
         return Err(format!(
-            "{TURN_CONTEXT_INVARIANT_PREFIX} PR3 does not admit legacy Member group/inbox producer {target_member_id:?} without typed authority"
+            "group_delivery_kick_failed: durable deliveries are pending; retry the same envelope ({})",
+            kick_errors.join(", ")
         ));
     }
-    persist_group_chat_message(
-        context,
-        target_agent_id,
-        target_member_id,
-        message_id,
-        content,
-        display_text,
-    )
+    #[cfg(debug_assertions)]
+    if take_group_delivery_fault(GROUP_DELIVERY_FAULT_RESPONSE_LOSS_AFTER_KICK) {
+        return Err(
+            "group_delivery_response_loss_after_kick_fault: the response was intentionally dropped after durable dispatch; retry the restored composer snapshot"
+                .to_string(),
+        );
+    }
+    Ok(AgentOrgGroupChatMessageResponse {
+        deliveries: responses,
+    })
 }
 
-/// Persist the user's Group Chat message and clear the target member's direct
-/// intervention as one state transition. The Run status is re-read inside the
-/// same IMMEDIATE transaction so a stale Run View can never write into a Run
-/// that became terminal before submission. A committed `message_id` is also
-/// returned on retry before the terminal-state gate, so a lost IPC response
-/// cannot duplicate the durable Inbox row.
-pub(super) fn persist_group_chat_message(
+#[derive(Debug)]
+pub(super) struct PersistedGroupDelivery {
+    pub(super) target_member_id: String,
+    pub(super) session_id: String,
+    pub(super) turn_intent_id: String,
+    pub(super) member_dispatch_sequence: i64,
+    pub(super) status: UserDirectedDeliveryStatus,
+    pub(super) outcome: AgentOrgGroupDeliveryOutcome,
+    pub(super) content: String,
+    pub(super) display_text: String,
+    pub(super) images: Option<Vec<String>>,
+    pub(super) inbox_row: AgentInboxRecord,
+}
+
+fn validate_group_delivery_inputs(deliveries: &[AgentOrgGroupDeliveryInput]) -> Result<(), String> {
+    if deliveries.is_empty() {
+        return Err("group_target_required: select at least one Member".to_string());
+    }
+    if deliveries.len() as i64 > DEFAULT_MAX_GROUP_TARGETS {
+        return Err(format!(
+            "group_target_limit_exceeded: at most {DEFAULT_MAX_GROUP_TARGETS} Members may be selected"
+        ));
+    }
+    let mut members = std::collections::HashSet::with_capacity(deliveries.len());
+    let mut turns = std::collections::HashSet::with_capacity(deliveries.len());
+    for delivery in deliveries {
+        let member_id = delivery.target_member_id.trim();
+        let turn_id = delivery.turn_intent_id.trim();
+        if member_id.is_empty() || turn_id.is_empty() {
+            return Err("group_delivery_invalid: target Member and Turn id are required".into());
+        }
+        if member_id == COORDINATOR_MEMBER_ID {
+            return Err(
+                "group_mixed_recipient_kind: Coordinator and Member sends must be submitted separately"
+                    .into(),
+            );
+        }
+        if !members.insert(member_id) {
+            return Err(format!(
+                "group_duplicate_target: Member {member_id} appears more than once"
+            ));
+        }
+        if !turns.insert(turn_id) {
+            return Err(format!(
+                "group_duplicate_turn_id: Turn id {turn_id} was reused across targets"
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn dispatch_group_delivery(
+    state: &AgentAppState,
+    run_id: &str,
+    delivery: &PersistedGroupDelivery,
+) -> Result<(), String> {
+    super::super::message::send_message_impl(
+        state,
+        delivery.session_id.clone(),
+        delivery.content.clone(),
+        Some(delivery.display_text.clone()),
+        IdentityOverrides::default(),
+        None,
+        delivery.images.clone(),
+        None,
+        false,
+        None,
+        false,
+        Some(delivery.turn_intent_id.clone()),
+        Some(delivery.turn_intent_id.clone()),
+        None,
+        None,
+        Some(run_id.to_string()),
+        TurnIntentBridgeSource::AgentOrg,
+    )
+    .await?;
+    Ok(())
+}
+
+pub(super) fn persist_group_chat_deliveries(
     context: &AgentOrgRunContext,
-    target_agent_id: &str,
-    target_member_id: &str,
-    message_id: &str,
+    deliveries: &[AgentOrgGroupDeliveryInput],
     content: &str,
     display_text: Option<&str>,
-) -> Result<AgentInboxRecord, String> {
-    crate::coordination::agent_org_payload_limits::validate_required_text(
-        "message_id",
-        message_id,
-        crate::coordination::agent_org_payload_limits::MESSAGE_IDENTIFIER_MAX_CHARS,
-        crate::coordination::agent_org_payload_limits::MESSAGE_IDENTIFIER_MAX_BYTES,
-    )?;
-    with_sessions_writer(|| -> Result<AgentInboxRecord, String> {
-        let mut conn = get_connection().map_err(|err| err.to_string())?;
+    images: Option<&[String]>,
+) -> Result<Vec<PersistedGroupDelivery>, String> {
+    validate_group_delivery_inputs(deliveries)?;
+    let effective_display = display_text.unwrap_or(content);
+    with_sessions_writer(|| -> Result<Vec<PersistedGroupDelivery>, String> {
+        let mut conn = get_connection().map_err(|error| error.to_string())?;
         let tx = conn
             .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-            .map_err(|err| err.to_string())?;
-        let existing = tx
-            .query_row(
-                "SELECT id, recipient_agent_id, recipient_member_id,
-                        sender_agent_id, sender_member_id, org_run_id,
-                        payload_kind, payload_json, request_id, created_at,
-                        read_at, display_text
-                 FROM agent_org_runtime_inbox
-                 WHERE org_run_id=?1
-                   AND sender_agent_id=?2
-                   AND client_message_id=?3
-                 LIMIT 1",
-                params![&context.run_id, USER_SENDER_ID, message_id],
-                |row| {
-                    Ok((
-                        AgentInboxRecord {
-                            id: row.get(0)?,
-                            recipient_agent_id: row.get(1)?,
-                            recipient_member_id: row.get(2)?,
-                            sender_agent_id: row.get(3)?,
-                            sender_member_id: row.get(4)?,
-                            org_run_id: row.get(5)?,
-                            payload_kind: row.get(6)?,
-                            payload_json: row.get(7)?,
-                            request_id: row.get(8)?,
-                            created_at: row.get(9)?,
-                            read_at: row.get(10)?,
-                        },
-                        row.get::<_, Option<String>>(11)?,
-                    ))
-                },
-            )
-            .optional()
-            .map_err(|err| err.to_string())?;
-        if let Some((existing, existing_display_text)) = existing {
-            let same_message = matches!(
-                existing.decode_payload(),
-                Ok(AgentMessage::Plain { ref text, .. }) if text == content
-            );
-            if existing.recipient_agent_id != target_agent_id
-                || existing.recipient_member_id.as_deref() != Some(target_member_id)
-                || existing.payload_kind != "plain"
-                || !same_message
-                || existing_display_text.as_deref() != display_text
-            {
-                return Err(format!(
-                    "Agent Org group chat message id {message_id} was already used for a different durable message"
-                ));
-            }
-            tx.commit().map_err(|err| err.to_string())?;
-            return Ok(existing);
+            .map_err(|error| error.to_string())?;
+        validate_group_run_status(&tx, &context.run_id)?;
+
+        let mut existing = Vec::with_capacity(deliveries.len());
+        for input in deliveries {
+            existing.push(load_existing_group_delivery(
+                &tx,
+                &context.run_id,
+                input,
+                content,
+                effective_display,
+                images,
+            )?);
         }
-        let run_status: Option<String> = tx
-            .query_row(
-                "SELECT status FROM agent_org_runtime_runs WHERE id=?1",
-                params![&context.run_id],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(|err| err.to_string())?;
-        let Some(run_status) = run_status else {
-            return Err(format!("Agent Org run {} no longer exists", context.run_id));
-        };
-        let run_status = AgentOrgRunStatus::parse(&run_status).ok_or_else(|| {
-            format!(
-                "Agent Org run {} has an unrecognized status",
-                context.run_id
-            )
-        })?;
-        match run_status {
-            AgentOrgRunStatus::Running => {}
-            AgentOrgRunStatus::Archived => {
+        let existing_count = existing.iter().filter(|item| item.is_some()).count();
+        if existing_count != 0 && existing_count != deliveries.len() {
+            return Err(
+                "group_idempotency_mixed: request contains both new and existing Turn ids"
+                    .to_string(),
+            );
+        }
+        if existing_count == deliveries.len() {
+            let rows = existing
+                .into_iter()
+                .map(|item| item.expect("count proved every delivery exists"))
+                .collect();
+            tx.commit().map_err(|error| error.to_string())?;
+            return Ok(rows);
+        }
+
+        let mut targets = Vec::with_capacity(deliveries.len());
+        for input in deliveries {
+            let target = resolve_group_target(&tx, &context.run_id, &input.target_member_id)?;
+            let turn_id_conflict: bool = tx
+                .query_row(
+                    "SELECT
+                         EXISTS(
+                             SELECT 1 FROM agent_org_runtime_turn_contexts context
+                             WHERE context.org_run_id=?1 AND context.turn_intent_id=?2
+                         )
+                         OR EXISTS(
+                             SELECT 1 FROM session_turn_intents intent
+                             WHERE intent.session_id=?3 AND intent.turn_intent_id=?2
+                         )",
+                    params![&context.run_id, &input.turn_intent_id, &target.0],
+                    |row| row.get(0),
+                )
+                .map_err(|error| error.to_string())?;
+            if turn_id_conflict {
                 return Err(format!(
-                    "team_archived: Agent Org run {} is read-only",
-                    context.run_id
+                    "group_idempotency_conflict: Turn {} already belongs to another durable envelope",
+                    input.turn_intent_id
                 ));
             }
-            AgentOrgRunStatus::Starting
-            | AgentOrgRunStatus::Paused
-            | AgentOrgRunStatus::Idle
-            | AgentOrgRunStatus::Failed => {
+            targets.push(target);
+            let pending: i64 = tx
+                .query_row(
+                    "SELECT COUNT(*)
+                     FROM agent_org_runtime_user_directed_deliveries
+                     WHERE org_run_id=?1 AND dispatch_member_id=?2
+                       AND status IN ('pending','started')",
+                    params![&context.run_id, &input.target_member_id],
+                    |row| row.get(0),
+                )
+                .map_err(|error| error.to_string())?;
+            if pending >= DEFAULT_MAX_PENDING_PER_MEMBER {
                 return Err(format!(
-                    "Agent Org run {} is {}; this status does not accept new group messages",
-                    context.run_id, run_status
+                    "user_directed_queue_full: Member {} already has {pending} pending/started deliveries (cap {DEFAULT_MAX_PENDING_PER_MEMBER})",
+                    input.target_member_id
                 ));
             }
         }
 
-        let row = AgentInboxStore::insert_in_tx(
-            &tx,
-            InsertInboxParams {
-                recipient_agent_id: target_agent_id.to_string(),
-                recipient_member_id: Some(target_member_id.to_string()),
-                sender_agent_id: USER_SENDER_ID.to_string(),
-                sender_member_id: None,
-                org_run_id: Some(context.run_id.clone()),
-                message: AgentMessage::Plain {
-                    summary: "User group chat message".to_string(),
-                    text: content.to_string(),
+        let mut persisted = Vec::with_capacity(deliveries.len());
+        for (input, (target_session_id, target_agent_id)) in deliveries.iter().zip(targets) {
+            let inbox_row = AgentInboxStore::insert_in_tx_without_formal_trigger(
+                &tx,
+                InsertInboxParams {
+                    recipient_agent_id: target_agent_id,
+                    recipient_member_id: Some(input.target_member_id.clone()),
+                    sender_agent_id: USER_SENDER_ID.to_string(),
+                    sender_member_id: None,
+                    org_run_id: Some(context.run_id.clone()),
+                    message: AgentMessage::Plain {
+                        summary: "User group mention".to_string(),
+                        text: content.to_string(),
+                    },
                 },
-            },
-        )?;
-        tx.execute(
-            "UPDATE agent_org_runtime_inbox
-             SET display_text=?1, client_message_id=?2
-             WHERE id=?3",
-            params![display_text, message_id, row.id],
-        )
-        .map_err(|err| err.to_string())?;
-        tx.commit().map_err(|err| err.to_string())?;
-        Ok(row)
+            )?;
+            tx.execute(
+                "UPDATE agent_org_runtime_inbox
+                 SET delivery_class='user_directed',display_text=?2
+                 WHERE id=?1 AND delivery_class='formal_work'",
+                params![inbox_row.id, effective_display],
+            )
+            .map_err(|error| error.to_string())?;
+
+            let admission =
+                crate::coordination::agent_org_turn_contexts::AgentOrgTurnAdmission::group_mention(
+                    &context.run_id,
+                    &target_session_id,
+                    &input.turn_intent_id,
+                    Some(input.turn_intent_id.clone()),
+                    &input.target_member_id,
+                    inbox_row.id,
+                );
+            let turn_context =
+                crate::coordination::agent_org_turn_contexts::accept_with_connection(
+                    &tx, &admission,
+                )?;
+            let sequence = turn_context.member_dispatch_sequence.ok_or_else(|| {
+                format!("{TURN_CONTEXT_INVARIANT_PREFIX} Group mention has no Member FIFO sequence")
+            })?;
+            let root = NewUserDirectedDelivery {
+                org_run_id: &context.run_id,
+                session_id: &target_session_id,
+                turn_intent_id: &input.turn_intent_id,
+                root_authority_turn_id: &input.turn_intent_id,
+                parent_delivery_id: None,
+                parent_inbox_id: None,
+                source_kind: UserDirectedSourceKind::GroupMention,
+                source_event_id: None,
+                source_inbox_id: Some(inbox_row.id),
+                dispatch_member_id: &input.target_member_id,
+                member_dispatch_sequence: sequence,
+                depth: 0,
+                delivery_ordinal: 1,
+                dispatch_content: content,
+                display_content: effective_display,
+                images,
+            };
+            let (receipt, duplicate) =
+                agent_org_user_directed_work::insert_root_delivery_with_connection(&tx, &root)?;
+            if duplicate {
+                return Err(
+                    "group_idempotency_mixed: Turn appeared during the atomic insert".to_string(),
+                );
+            }
+            persisted.push(PersistedGroupDelivery {
+                target_member_id: input.target_member_id.clone(),
+                session_id: target_session_id,
+                turn_intent_id: input.turn_intent_id.clone(),
+                member_dispatch_sequence: sequence,
+                status: receipt.status,
+                outcome: AgentOrgGroupDeliveryOutcome::Accepted,
+                content: content.to_string(),
+                display_text: effective_display.to_string(),
+                images: images.map(ToOwned::to_owned),
+                inbox_row,
+            });
+        }
+        tx.commit().map_err(|error| error.to_string())?;
+        Ok(persisted)
     })
+}
+
+fn validate_group_run_status(conn: &rusqlite::Connection, run_id: &str) -> Result<(), String> {
+    let status: Option<String> = conn
+        .query_row(
+            "SELECT status FROM agent_org_runtime_runs WHERE id=?1",
+            [run_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    match status.as_deref().and_then(AgentOrgRunStatus::parse) {
+        Some(AgentOrgRunStatus::Running | AgentOrgRunStatus::Idle | AgentOrgRunStatus::Paused) => {
+            Ok(())
+        }
+        Some(AgentOrgRunStatus::Starting) => Err(format!(
+            "team_not_ready: Agent Org run {run_id} is still materializing"
+        )),
+        Some(AgentOrgRunStatus::Failed) => Err(format!(
+            "team_unavailable: Agent Org run {run_id} has failed"
+        )),
+        Some(AgentOrgRunStatus::Archived) => Err(format!(
+            "team_archived: Agent Org run {run_id} is read-only"
+        )),
+        None => Err(format!(
+            "team_unavailable: Agent Org run {run_id} does not exist"
+        )),
+    }
+}
+
+fn resolve_group_target(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    member_id: &str,
+) -> Result<(String, String), String> {
+    conn.query_row(
+        "SELECT materialization.session_id,materialization.agent_id
+         FROM agent_org_runtime_member_materializations materialization
+         JOIN agent_sessions session ON session.session_id=materialization.session_id
+         WHERE materialization.org_run_id=?1
+           AND materialization.member_id=?2
+           AND materialization.status='succeeded'
+           AND session.org_member_id=?2
+           AND session.agent_definition_id=materialization.agent_id
+           AND session.status<>'archived'
+           AND materialization.generation=(
+               SELECT MAX(latest.generation)
+               FROM agent_org_runtime_member_materializations latest
+               WHERE latest.org_run_id=?1 AND latest.member_id=?2
+                 AND latest.status='succeeded'
+           )
+         LIMIT 1",
+        params![run_id, member_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .optional()
+    .map_err(|error| error.to_string())?
+    .ok_or_else(|| format!("group_target_unavailable: canonical Member {member_id} is unavailable"))
+}
+
+fn load_existing_group_delivery(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    input: &AgentOrgGroupDeliveryInput,
+    content: &str,
+    display_text: &str,
+    images: Option<&[String]>,
+) -> Result<Option<PersistedGroupDelivery>, String> {
+    type ExistingRow = (
+        i64,
+        String,
+        String,
+        i64,
+        String,
+        String,
+        String,
+        String,
+        String,
+    );
+    let row: Option<ExistingRow> = conn
+        .query_row(
+            "SELECT delivery.source_inbox_id,delivery.session_id,
+                    delivery.dispatch_member_id,delivery.member_dispatch_sequence,
+                    delivery.status,delivery.dispatch_content,delivery.display_content,
+                    delivery.images_json,delivery.source_kind
+             FROM agent_org_runtime_user_directed_deliveries delivery
+             WHERE delivery.org_run_id=?1 AND delivery.turn_intent_id=?2",
+            params![run_id, &input.turn_intent_id],
+            |row| {
+                Ok((
+                    row.get::<_, Option<i64>>(0)?
+                        .ok_or(rusqlite::Error::InvalidQuery)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                    row.get(8)?,
+                ))
+            },
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let Some((
+        inbox_id,
+        session_id,
+        member_id,
+        sequence,
+        status_raw,
+        stored_content,
+        stored_display,
+        images_json,
+        source_kind,
+    )) = row
+    else {
+        return Ok(None);
+    };
+    let stored_images: Vec<String> =
+        serde_json::from_str(&images_json).map_err(|error| error.to_string())?;
+    if member_id != input.target_member_id
+        || source_kind != UserDirectedSourceKind::GroupMention.as_str()
+        || stored_content != content
+        || stored_display != display_text
+        || stored_images.as_slice() != images.unwrap_or(&[])
+    {
+        return Err(format!(
+            "group_idempotency_conflict: Turn {} was reused with a different target or body",
+            input.turn_intent_id
+        ));
+    }
+    let status = match status_raw.as_str() {
+        "pending" => UserDirectedDeliveryStatus::Pending,
+        "started" => UserDirectedDeliveryStatus::Started,
+        "completed" => UserDirectedDeliveryStatus::Completed,
+        "failed" => UserDirectedDeliveryStatus::Failed,
+        "cancelled" => UserDirectedDeliveryStatus::Cancelled,
+        "abandoned" => UserDirectedDeliveryStatus::Abandoned,
+        "unknown" => UserDirectedDeliveryStatus::Unknown,
+        _ => return Err("group_idempotency_conflict: stored status is invalid".into()),
+    };
+    let inbox_row = load_inbox_record(conn, run_id, inbox_id)?;
+    Ok(Some(PersistedGroupDelivery {
+        target_member_id: member_id,
+        session_id,
+        turn_intent_id: input.turn_intent_id.clone(),
+        member_dispatch_sequence: sequence,
+        status,
+        outcome: AgentOrgGroupDeliveryOutcome::Existing,
+        content: content.to_string(),
+        display_text: display_text.to_string(),
+        images: images.map(ToOwned::to_owned),
+        inbox_row,
+    }))
+}
+
+fn load_inbox_record(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    inbox_id: i64,
+) -> Result<AgentInboxRecord, String> {
+    conn.query_row(
+        "SELECT id,recipient_agent_id,recipient_member_id,sender_agent_id,
+                sender_member_id,org_run_id,payload_kind,payload_json,request_id,
+                created_at,read_at
+         FROM agent_org_runtime_inbox
+         WHERE id=?1 AND org_run_id=?2 AND delivery_class='user_directed'",
+        params![inbox_id, run_id],
+        |row| {
+            Ok(AgentInboxRecord {
+                id: row.get(0)?,
+                recipient_agent_id: row.get(1)?,
+                recipient_member_id: row.get(2)?,
+                sender_agent_id: row.get(3)?,
+                sender_member_id: row.get(4)?,
+                org_run_id: row.get(5)?,
+                payload_kind: row.get(6)?,
+                payload_json: row.get(7)?,
+                request_id: row.get(8)?,
+                created_at: row.get(9)?,
+                read_at: row.get(10)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(|error| error.to_string())?
+    .ok_or_else(|| format!("group_idempotency_conflict: Inbox source {inbox_id} is missing"))
 }

--- a/src-tauri/crates/agent-core/src/state/commands/session/org_tasks/run_view.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/org_tasks/run_view.rs
@@ -570,6 +570,7 @@ pub(super) fn latest_coordinator_is_waiting_for_org_event(
               ON intent.session_id=context.session_id
              AND intent.turn_intent_id=context.turn_intent_id
             WHERE context.org_run_id=?1 AND context.turn_kind='coordinator'
+              AND context.source_kind='root_turn'
               AND context.activation_generation=?2
             ORDER BY context.context_id DESC
             LIMIT 1

--- a/src-tauri/crates/agent-core/src/state/commands/session/org_tasks/tests.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/org_tasks/tests.rs
@@ -293,6 +293,7 @@ fn configure_pause_resume_authority(conn: &rusqlite::Connection, context: &Agent
             COORDINATOR_MEMBER_ID,
         ),
         ("planner-session", "builtin:sde", "member-planner"),
+        ("builder-session", "builtin:sde", "member-builder"),
     ] {
         conn.execute(
             "INSERT INTO agent_sessions (
@@ -326,31 +327,681 @@ fn configure_pause_resume_authority(conn: &rusqlite::Connection, context: &Agent
         params![&context.run_id, &now],
     )
     .expect("materialize planner");
+    conn.execute(
+        "INSERT INTO agent_org_runtime_member_materializations (
+            org_run_id,member_id,agent_id,generation,session_id,authority_class,
+            status,created_at,updated_at
+         ) VALUES (?1,'member-builder','builtin:sde',1,'builder-session','formal',
+                   'succeeded',?2,?2)",
+        params![&context.run_id, &now],
+    )
+    .expect("materialize builder");
 }
 
 #[test]
-fn pr3_group_chat_rejects_legacy_member_before_inbox_write() {
+fn group_chat_member_delivery_has_exact_udw_authority() {
     let _sandbox = test_helpers::test_env::sandbox();
     let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
 
-    let error = persist_pr3_group_chat_message(
+    let deliveries = persist_group_chat_deliveries(
         &context,
-        "builtin:sde",
-        "member-planner",
-        "legacy-member-message",
-        "This Member producer has no typed PR3 authority",
-        Some("@Planner This Member producer has no typed PR3 authority"),
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "group-turn-planner".to_string(),
+        }],
+        "Inspect the boundary case",
+        Some("@Planner Inspect the boundary case"),
+        None,
     )
-    .expect_err("PR3 must reject the legacy Member producer");
+    .expect("accept typed Group delivery");
+
+    assert_eq!(deliveries.len(), 1);
+    assert_eq!(inbox_count_for_member(&context, "member-planner"), 1);
+    let (delivery_class, turn_kind, source_kind): (String, String, String) = conn
+        .query_row(
+            "SELECT inbox.delivery_class,context.turn_kind,context.source_kind
+             FROM agent_org_runtime_user_directed_deliveries delivery
+             JOIN agent_org_runtime_inbox inbox ON inbox.id=delivery.source_inbox_id
+             JOIN agent_org_runtime_turn_contexts context
+               ON context.session_id=delivery.session_id
+              AND context.turn_intent_id=delivery.turn_intent_id
+             WHERE delivery.turn_intent_id='group-turn-planner'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("load exact Group authority");
+    assert_eq!(delivery_class, "user_directed");
+    assert_eq!(turn_kind, "user_directed_work");
+    assert_eq!(source_kind, "group_mention");
+}
+
+#[test]
+fn group_delivery_is_atomic_idempotent_and_conflict_safe() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+
+    let planner = AgentOrgGroupDeliveryInput {
+        target_member_id: "member-planner".to_string(),
+        turn_intent_id: "atomic-planner-root".to_string(),
+    };
+    persist_group_chat_deliveries(
+        &context,
+        std::slice::from_ref(&planner),
+        "first body",
+        Some("@Planner first body"),
+        None,
+    )
+    .expect("seed one accepted root");
+
+    let mixed = vec![
+        planner.clone(),
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-builder".to_string(),
+            turn_intent_id: "atomic-builder-mixed".to_string(),
+        },
+    ];
+    let error = persist_group_chat_deliveries(
+        &context,
+        &mixed,
+        "first body",
+        Some("@Planner first body"),
+        None,
+    )
+    .expect_err("mixed existing/new request must write nothing");
+    assert!(error.contains("group_idempotency_mixed"), "{error}");
+    let mixed_new_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM agent_org_runtime_turn_contexts
+             WHERE turn_intent_id='atomic-builder-mixed'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count rolled-back mixed context");
+    assert_eq!(mixed_new_count, 0);
+
+    let all_new = vec![
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "atomic-planner-batch".to_string(),
+        },
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-builder".to_string(),
+            turn_intent_id: "atomic-builder-batch".to_string(),
+        },
+    ];
+    let accepted = persist_group_chat_deliveries(
+        &context,
+        &all_new,
+        "same canonical body",
+        Some("@Planner @Builder same canonical body"),
+        None,
+    )
+    .expect("all-new batch commits atomically");
+    assert!(accepted
+        .iter()
+        .all(|row| row.outcome == AgentOrgGroupDeliveryOutcome::Accepted));
+
+    let replay = persist_group_chat_deliveries(
+        &context,
+        &all_new,
+        "same canonical body",
+        Some("@Planner @Builder same canonical body"),
+        None,
+    )
+    .expect("exact replay returns existing receipts");
+    assert!(replay
+        .iter()
+        .all(|row| row.outcome == AgentOrgGroupDeliveryOutcome::Existing));
+    assert_eq!(
+        replay
+            .iter()
+            .map(|row| row.inbox_row.id)
+            .collect::<Vec<_>>(),
+        accepted
+            .iter()
+            .map(|row| row.inbox_row.id)
+            .collect::<Vec<_>>()
+    );
+
+    let before_count = AgentInboxStore::count_by_run(&context.run_id).expect("Inbox count");
+    let conflict = persist_group_chat_deliveries(
+        &context,
+        &all_new,
+        "different body",
+        Some("@Planner @Builder different body"),
+        None,
+    )
+    .expect_err("same IDs with a different digest must conflict");
+    assert!(
+        conflict.contains("group_idempotency_conflict"),
+        "{conflict}"
+    );
+    assert_eq!(
+        AgentInboxStore::count_by_run(&context.run_id).expect("Inbox count after conflict"),
+        before_count
+    );
+}
+
+#[test]
+fn concurrent_exact_group_replays_commit_one_batch() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    drop(conn);
+
+    let deliveries = vec![
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "concurrent-group-planner".to_string(),
+        },
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-builder".to_string(),
+            turn_intent_id: "concurrent-group-builder".to_string(),
+        },
+    ];
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let threads = (0..2)
+        .map(|_| {
+            let context = context.clone();
+            let deliveries = deliveries.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                persist_group_chat_deliveries(
+                    &context,
+                    &deliveries,
+                    "one concurrent immutable envelope",
+                    Some("@Planner @Builder one concurrent immutable envelope"),
+                    None,
+                )
+                .expect("exact concurrent replay")
+            })
+        })
+        .collect::<Vec<_>>();
+    let outcomes = threads
+        .into_iter()
+        .map(|thread| thread.join().expect("Group writer thread"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|batch| {
+                batch
+                    .iter()
+                    .all(|row| row.outcome == AgentOrgGroupDeliveryOutcome::Accepted)
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|batch| {
+                batch
+                    .iter()
+                    .all(|row| row.outcome == AgentOrgGroupDeliveryOutcome::Existing)
+            })
+            .count(),
+        1
+    );
+
+    let conn = get_connection().expect("db connection");
+    let (inbox_count, delivery_count, context_count): (i64, i64, i64) = conn
+        .query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM agent_org_runtime_inbox
+                 WHERE org_run_id=?1 AND delivery_class='user_directed'),
+                (SELECT COUNT(*) FROM agent_org_runtime_user_directed_deliveries
+                 WHERE org_run_id=?1),
+                (SELECT COUNT(*) FROM agent_org_runtime_turn_contexts
+                 WHERE org_run_id=?1 AND turn_kind='user_directed_work')",
+            [&context.run_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("count one durable Group batch");
+    assert_eq!((inbox_count, delivery_count, context_count), (2, 2, 2));
+}
+
+#[test]
+fn group_delivery_limits_and_invalid_targets_write_nothing() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    let before = AgentInboxStore::count_by_run(&context.run_id).expect("Inbox count");
+
+    let now = chrono::Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO session_turn_intents (
+             session_id,turn_intent_id,client_message_id,org_run_id,source,status,
+             created_at,updated_at
+         ) VALUES (
+             'planner-session','preexisting-non-group-turn','preexisting-non-group-turn',
+             ?1,'agent_org','queued',?2,?2
+         )",
+        params![&context.run_id, &now],
+    )
+    .expect("seed a Turn id owned by another durable envelope");
+    let collision = persist_group_chat_deliveries(
+        &context,
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "preexisting-non-group-turn".to_string(),
+        }],
+        "body",
+        None,
+        None,
+    )
+    .expect_err("a non-Group Turn id cannot be reused as a Group envelope");
+    assert!(
+        collision.contains("group_idempotency_conflict"),
+        "{collision}"
+    );
+
+    let duplicate_target = vec![
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "duplicate-target-a".to_string(),
+        },
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "duplicate-target-b".to_string(),
+        },
+    ];
+    assert!(
+        persist_group_chat_deliveries(&context, &duplicate_target, "body", None, None)
+            .expect_err("duplicate target")
+            .contains("group_duplicate_target")
+    );
+
+    let duplicate_turn = vec![
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "same-turn".to_string(),
+        },
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-builder".to_string(),
+            turn_intent_id: "same-turn".to_string(),
+        },
+    ];
+    assert!(
+        persist_group_chat_deliveries(&context, &duplicate_turn, "body", None, None)
+            .expect_err("duplicate Turn id")
+            .contains("group_duplicate_turn_id")
+    );
+
+    let too_many = (0..11)
+        .map(|index| AgentOrgGroupDeliveryInput {
+            target_member_id: format!("member-{index}"),
+            turn_intent_id: format!("turn-{index}"),
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        persist_group_chat_deliveries(&context, &too_many, "body", None, None)
+            .expect_err("11 targets")
+            .contains("group_target_limit_exceeded")
+    );
+
+    assert!(persist_group_chat_deliveries(
+        &context,
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "removed-member".to_string(),
+            turn_intent_id: "removed-target-turn".to_string(),
+        }],
+        "body",
+        None,
+        None,
+    )
+    .expect_err("removed target")
+    .contains("group_target_unavailable"));
+    assert_eq!(
+        AgentInboxStore::count_by_run(&context.run_id).expect("Inbox count after rejects"),
+        before
+    );
+}
+
+#[test]
+fn group_delivery_enforces_the_persisted_member_queue_cap() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    for index in 0..32 {
+        persist_group_chat_deliveries(
+            &context,
+            &[AgentOrgGroupDeliveryInput {
+                target_member_id: "member-planner".to_string(),
+                turn_intent_id: format!("queue-cap-{index}"),
+            }],
+            "queued side quest",
+            None,
+            None,
+        )
+        .expect("fill bounded UDW queue");
+    }
+    let before = AgentInboxStore::count_by_run(&context.run_id).expect("Inbox count");
+    let error = persist_group_chat_deliveries(
+        &context,
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "queue-cap-overflow".to_string(),
+        }],
+        "must be rejected",
+        None,
+        None,
+    )
+    .expect_err("33rd queued item must fail");
+    assert!(error.contains("user_directed_queue_full"), "{error}");
+    assert_eq!(
+        AgentInboxStore::count_by_run(&context.run_id).expect("Inbox count after cap"),
+        before
+    );
+}
+
+#[test]
+fn formal_drain_never_claims_group_udw_and_udw_claims_only_its_source() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    let formal = AgentInboxStore::insert_in_tx(
+        &conn,
+        InsertInboxParams {
+            recipient_agent_id: "builtin:sde".to_string(),
+            recipient_member_id: Some("member-planner".to_string()),
+            sender_agent_id: "agent-coord".to_string(),
+            sender_member_id: Some(COORDINATOR_MEMBER_ID.to_string()),
+            org_run_id: Some(context.run_id.clone()),
+            message: AgentMessage::Plain {
+                summary: "Formal input".to_string(),
+                text: "Keep this for the formal path".to_string(),
+            },
+        },
+    )
+    .expect("insert formal fixture");
+    let group = persist_group_chat_deliveries(
+        &context,
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "exact-group-claim".to_string(),
+        }],
+        "Only this side quest should be claimed",
+        None,
+        None,
+    )
+    .expect("persist Group UDW");
+    let broad = AgentInboxStore::list_unread_batch_for_member("member-planner", &context.run_id)
+        .expect("load formal drain batch");
+    assert_eq!(broad.rows.len(), 1);
+    assert_eq!(broad.rows[0].id, formal.id);
 
     assert!(
-        error.starts_with(
-            crate::coordination::agent_org_turn_contexts::TURN_CONTEXT_INVARIANT_PREFIX
-        ),
-        "{error}"
+        crate::coordination::agent_org_user_directed_work::mark_turn_started_with_connection(
+            &conn,
+            "planner-session",
+            "exact-group-claim",
+        )
+        .expect("claim exact UDW")
     );
-    assert!(error.contains("without typed authority"), "{error}");
-    assert_eq!(inbox_count_for_member(&context, "member-planner"), 0);
+    let (formal_read_at, group_read_at): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT
+                 (SELECT read_at FROM agent_org_runtime_inbox WHERE id=?1),
+                 (SELECT read_at FROM agent_org_runtime_inbox WHERE id=?2)",
+            params![formal.id, group[0].inbox_row.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("load exact read watermarks");
+    assert!(formal_read_at.is_none());
+    assert!(group_read_at.is_some());
+}
+
+#[test]
+fn udw_recovery_is_keyset_bounded_and_never_replays_started_work() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    let inputs = vec![
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "recovery-planner".to_string(),
+        },
+        AgentOrgGroupDeliveryInput {
+            target_member_id: "member-builder".to_string(),
+            turn_intent_id: "recovery-builder".to_string(),
+        },
+    ];
+    persist_group_chat_deliveries(&context, &inputs, "recover me", None, None)
+        .expect("persist pending recovery fixtures");
+    crate::coordination::agent_org_turn_contexts::reconcile_in_flight_after_restart(&conn)
+        .expect("generic Agent Org restart reconciliation preserves typed pending UDW");
+    let queued_after_reconcile: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM session_turn_intents
+             WHERE turn_intent_id IN ('recovery-planner','recovery-builder')
+               AND status='queued'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("load pending UDW after generic restart reconciliation");
+    assert_eq!(queued_after_reconcile, 2);
+
+    let first_page =
+        crate::coordination::agent_org_user_directed_work::recoverable_pending_after(None, 1)
+            .expect("first keyset page");
+    assert_eq!(first_page.len(), 1);
+    let second_page = crate::coordination::agent_org_user_directed_work::recoverable_pending_after(
+        Some(&first_page[0].recovery_key),
+        1,
+    )
+    .expect("second keyset page");
+    assert_eq!(second_page.len(), 1);
+    assert_ne!(first_page[0].turn_intent_id, second_page[0].turn_intent_id);
+
+    assert!(
+        crate::coordination::agent_org_user_directed_work::mark_turn_started_with_connection(
+            &conn,
+            "planner-session",
+            "recovery-planner",
+        )
+        .expect("start one delivery")
+    );
+    conn.execute(
+        "UPDATE session_turn_intents SET status='running'
+         WHERE session_id='planner-session' AND turn_intent_id='recovery-planner'",
+        [],
+    )
+    .expect("mirror production start transaction");
+    let pending =
+        crate::coordination::agent_org_user_directed_work::recoverable_pending_after(None, 100)
+            .expect("pending-only recovery page");
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].turn_intent_id, "recovery-builder");
+
+    assert_eq!(
+        crate::coordination::agent_org_user_directed_work::mark_started_unknown_after_restart()
+            .expect("classify interrupted work"),
+        1
+    );
+    let (delivery_status, intent_status): (String, String) = conn
+        .query_row(
+            "SELECT delivery.status,intent.status
+             FROM agent_org_runtime_user_directed_deliveries delivery
+             JOIN session_turn_intents intent
+               ON intent.session_id=delivery.session_id
+              AND intent.turn_intent_id=delivery.turn_intent_id
+             WHERE delivery.turn_intent_id='recovery-planner'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("load interrupted terminal state");
+    assert_eq!(delivery_status, "unknown");
+    assert_eq!(intent_status, "failed");
+
+    conn.execute(
+        "UPDATE agent_org_runtime_runs SET status='archived',archived_at=?2,
+             archive_receipt_id='recovery-archive'
+         WHERE id=?1",
+        params![&context.run_id, chrono::Utc::now().to_rfc3339()],
+    )
+    .expect("archive recovery fixture");
+    assert!(
+        crate::coordination::agent_org_user_directed_work::recoverable_pending_after(None, 100)
+            .expect("Archived recovery query")
+            .is_empty()
+    );
+}
+
+#[test]
+fn interrupted_udw_classification_is_keyset_bounded_across_pages() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    for (member_id, turn_intent_id) in [
+        ("member-planner", "started-page-planner"),
+        ("member-builder", "started-page-builder"),
+    ] {
+        persist_group_chat_deliveries(
+            &context,
+            &[AgentOrgGroupDeliveryInput {
+                target_member_id: member_id.to_string(),
+                turn_intent_id: turn_intent_id.to_string(),
+            }],
+            "started before restart",
+            None,
+            None,
+        )
+        .expect("persist started recovery fixture");
+        assert!(
+            crate::coordination::agent_org_user_directed_work::mark_turn_started_with_connection(
+                &conn,
+                if member_id == "member-planner" {
+                    "planner-session"
+                } else {
+                    "builder-session"
+                },
+                turn_intent_id,
+            )
+            .expect("start exact UDW fixture")
+        );
+    }
+    conn.execute(
+        "UPDATE session_turn_intents SET status='running'
+         WHERE turn_intent_id IN ('started-page-planner','started-page-builder')",
+        [],
+    )
+    .expect("mirror scheduler running state");
+
+    let first = crate::coordination::agent_org_user_directed_work::mark_started_unknown_after_restart_after(
+        None, 1,
+    )
+    .expect("classify first bounded page");
+    assert_eq!(first.len(), 1);
+    let second = crate::coordination::agent_org_user_directed_work::mark_started_unknown_after_restart_after(
+        first.last().map(String::as_str), 1,
+    )
+    .expect("classify second bounded page");
+    assert_eq!(second.len(), 1);
+    assert!(crate::coordination::agent_org_user_directed_work::mark_started_unknown_after_restart_after(
+        second.last().map(String::as_str), 1,
+    )
+    .expect("classification is exhausted")
+    .is_empty());
+
+    let (unknown_deliveries, failed_intents): (i64, i64) = conn
+        .query_row(
+            "SELECT
+                 (SELECT COUNT(*) FROM agent_org_runtime_user_directed_deliveries
+                  WHERE turn_intent_id LIKE 'started-page-%' AND status='unknown'),
+                 (SELECT COUNT(*) FROM session_turn_intents
+                  WHERE turn_intent_id LIKE 'started-page-%' AND status='failed')",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("load interrupted classification outcomes");
+    assert_eq!(unknown_deliveries, 2);
+    assert_eq!(failed_intents, 2);
+}
+
+#[test]
+fn terminal_transition_returns_the_next_exact_member_fifo_item() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    for (turn_intent_id, body) in [
+        ("fifo-first", "first durable side quest"),
+        ("fifo-second", "second durable side quest"),
+    ] {
+        persist_group_chat_deliveries(
+            &context,
+            &[AgentOrgGroupDeliveryInput {
+                target_member_id: "member-planner".to_string(),
+                turn_intent_id: turn_intent_id.to_string(),
+            }],
+            body,
+            None,
+            None,
+        )
+        .expect("persist ordered UDW item");
+    }
+    conn.execute(
+        "UPDATE session_turn_intents SET status='running'
+         WHERE session_id='planner-session' AND turn_intent_id='fifo-second'",
+        [],
+    )
+    .expect("mirror scheduler promotion for an out-of-order kick");
+    assert!(
+        !crate::coordination::agent_org_user_directed_work::mark_turn_started_with_connection(
+            &conn,
+            "planner-session",
+            "fifo-second",
+        )
+        .expect("later kick is fenced")
+    );
+    let waiting_status: String = conn
+        .query_row(
+            "SELECT status FROM session_turn_intents
+             WHERE session_id='planner-session' AND turn_intent_id='fifo-second'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("load requeued out-of-order Turn");
+    assert_eq!(waiting_status, "queued");
+    assert!(
+        crate::coordination::agent_org_user_directed_work::mark_turn_started_with_connection(
+            &conn,
+            "planner-session",
+            "fifo-first",
+        )
+        .expect("start FIFO head")
+    );
+    assert!(
+        crate::coordination::agent_org_user_directed_work::mark_turn_terminal(
+            "planner-session",
+            "fifo-first",
+            crate::coordination::agent_org_user_directed_work::UserDirectedDeliveryStatus::Completed,
+            None,
+        )
+        .expect("complete FIFO head")
+    );
+    let next = crate::coordination::agent_org_user_directed_work::next_pending_after_terminal(
+        "planner-session",
+        "fifo-first",
+    )
+    .expect("resolve next durable doorbell")
+    .expect("second item remains pending");
+    assert_eq!(next.turn_intent_id, "fifo-second");
+    assert_eq!(next.recipient_session_id, "planner-session");
+    assert_eq!(next.recipient_member_id, "member-planner");
+    assert_eq!(next.content, "second durable side quest");
 }
 
 fn inbox_record(
@@ -880,6 +1531,8 @@ fn resume_wake_requires_unread_inbox() {
 fn archived_group_message_writes_neither_inbox_nor_intervention_clear() {
     let _sandbox = test_helpers::test_env::sandbox();
     let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
     AgentMemberInterventionStore::enter(EnterMemberInterventionParams {
         org_run_id: context.run_id.clone(),
         member_id: "member-planner".to_string(),
@@ -887,7 +1540,6 @@ fn archived_group_message_writes_neither_inbox_nor_intervention_clear() {
         session_id: "planner-session".to_string(),
     })
     .expect("enter intervention");
-    let conn = get_connection().expect("db connection");
     conn.execute(
         "UPDATE agent_org_runtime_runs
          SET status='archived',activation_generation=activation_generation+1,
@@ -901,12 +1553,14 @@ fn archived_group_message_writes_neither_inbox_nor_intervention_clear() {
     )
     .expect("archive test Run without clearing the corruption fixture");
 
-    let error = persist_group_chat_message(
+    let error = persist_group_chat_deliveries(
         &context,
-        "builtin:sde",
-        "member-planner",
-        "terminal-message",
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "archived-group-turn".to_string(),
+        }],
         "This must not enter an Archived run",
+        None,
         None,
     )
     .expect_err("Archived run rejects group message");
@@ -922,20 +1576,24 @@ fn archived_group_message_writes_neither_inbox_nor_intervention_clear() {
 }
 
 #[test]
-fn paused_group_message_is_rejected_without_inbox_write_or_auto_resume() {
+fn paused_group_message_is_accepted_without_auto_resume() {
     let _sandbox = test_helpers::test_env::sandbox();
     let context = prepare_command_run("paused");
-    let error = persist_group_chat_message(
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    let deliveries = persist_group_chat_deliveries(
         &context,
-        &context.coordinator_agent_id,
-        COORDINATOR_MEMBER_ID,
-        "paused-group-message",
-        "This must wait for explicit Resume",
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "paused-group-turn".to_string(),
+        }],
+        "This side quest must not Resume the Team",
+        None,
         None,
     )
-    .expect_err("Paused run rejects Group Chat submission");
-    assert!(error.contains("this status does not accept"));
-    assert_eq!(inbox_count_for_member(&context, COORDINATOR_MEMBER_ID), 0);
+    .expect("Paused Team accepts Member UDW");
+    assert_eq!(deliveries.len(), 1);
+    assert_eq!(inbox_count_for_member(&context, "member-planner"), 1);
     assert_eq!(
         AgentOrgRunStore::get_run_status(&context.run_id).expect("run status"),
         Some(AgentOrgRunStatus::Paused)
@@ -946,23 +1604,26 @@ fn paused_group_message_is_rejected_without_inbox_write_or_auto_resume() {
 fn ordinary_group_message_is_not_a_formal_lifecycle_trigger() {
     let _sandbox = test_helpers::test_env::sandbox();
     let context = prepare_command_run("running");
-    let row = persist_pr3_group_chat_message(
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
+    let rows = persist_group_chat_deliveries(
         &context,
-        &context.coordinator_agent_id,
-        COORDINATOR_MEMBER_ID,
-        "ordinary-coordinator-group-message",
-        "Queue this for the Coordinator",
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "non-formal-group-turn".to_string(),
+        }],
+        "Queue this side quest for Planner",
+        None,
         None,
     )
-    .expect("persist legacy Coordinator Group source");
+    .expect("persist Member Group source");
 
-    let conn = get_connection().expect("db connection");
     let receipt_count: i64 = conn
         .query_row(
             "SELECT COUNT(*)
              FROM agent_org_runtime_formal_trigger_receipts
              WHERE org_run_id=?1 AND inbox_id=?2",
-            params![&context.run_id, row.id],
+            params![&context.run_id, rows[0].inbox_row.id],
             |db_row| db_row.get(0),
         )
         .expect("count formal lifecycle receipts");
@@ -973,6 +1634,8 @@ fn ordinary_group_message_is_not_a_formal_lifecycle_trigger() {
 fn group_message_does_not_clear_direct_intervention() {
     let _sandbox = test_helpers::test_env::sandbox();
     let context = prepare_command_run("running");
+    let conn = get_connection().expect("db connection");
+    configure_pause_resume_authority(&conn, &context);
     AgentMemberInterventionStore::enter(EnterMemberInterventionParams {
         org_run_id: context.run_id.clone(),
         member_id: "member-planner".to_string(),
@@ -980,12 +1643,14 @@ fn group_message_does_not_clear_direct_intervention() {
         session_id: "planner-session".to_string(),
     })
     .expect("enter intervention");
-    persist_group_chat_message(
+    persist_group_chat_deliveries(
         &context,
-        "builtin:sde",
-        "member-planner",
-        "independent-group-message",
+        &[AgentOrgGroupDeliveryInput {
+            target_member_id: "member-planner".to_string(),
+            turn_intent_id: "group-behind-direct-turn".to_string(),
+        }],
         "Group chat must not Return a direct intervention",
+        None,
         None,
     )
     .expect("persist independent group message");
@@ -997,91 +1662,6 @@ fn group_message_does_not_clear_direct_intervention() {
             .is_some(),
         "group messaging cannot substitute for explicit receipt-based Return"
     );
-}
-
-#[test]
-fn group_message_retry_reuses_the_committed_inbox_row() {
-    let _sandbox = test_helpers::test_env::sandbox();
-    let context = prepare_command_run("running");
-
-    let first = persist_group_chat_message(
-        &context,
-        "builtin:sde",
-        "member-planner",
-        "stable-group-message",
-        "Send this exactly once",
-        Some("@Planner Send this exactly once"),
-    )
-    .expect("persist first attempt");
-
-    let conn = get_connection().expect("db connection");
-    conn.execute(
-        "UPDATE agent_org_runtime_runs SET status='failed' WHERE id=?1",
-        params![&context.run_id],
-    )
-    .expect("mark run terminal after committed response was lost");
-    drop(conn);
-
-    let retried = persist_group_chat_message(
-        &context,
-        "builtin:sde",
-        "member-planner",
-        "stable-group-message",
-        "Send this exactly once",
-        Some("@Planner Send this exactly once"),
-    )
-    .expect("a retry after commit returns the durable row");
-
-    assert_eq!(retried.id, first.id);
-    assert_eq!(inbox_count_for_member(&context, "member-planner"), 1);
-}
-
-#[test]
-fn group_message_id_reuse_with_different_content_display_or_target_is_rejected() {
-    let _sandbox = test_helpers::test_env::sandbox();
-    let context = prepare_command_run("running");
-
-    persist_group_chat_message(
-        &context,
-        "builtin:sde",
-        "member-planner",
-        "conflicting-group-message",
-        "Original payload",
-        Some("@Planner Original payload"),
-    )
-    .expect("persist original message");
-
-    for (target_member_id, content, display_text) in [
-        (
-            "member-planner",
-            "Different payload",
-            "@Planner Different payload",
-        ),
-        (
-            "member-planner",
-            "Original payload",
-            "@Planner Edited display",
-        ),
-        (
-            "member-builder",
-            "Original payload",
-            "@Builder Original payload",
-        ),
-    ] {
-        let error = persist_group_chat_message(
-            &context,
-            "builtin:sde",
-            target_member_id,
-            "conflicting-group-message",
-            content,
-            Some(display_text),
-        )
-        .expect_err("a stable id cannot be rebound to another durable message");
-        assert!(error.contains("already used for a different durable message"));
-    }
-
-    assert_eq!(inbox_count_for_member(&context, "member-planner"), 1);
-    assert_eq!(inbox_count_for_member(&context, "member-builder"), 0);
 }
 
 #[test]
@@ -1099,15 +1679,28 @@ fn group_chat_history_pages_all_rows_and_preserves_long_display_text_after_reloa
                 "@Planner historical group message",
             )
         };
-        persist_group_chat_message(
-            &context,
-            "builtin:sde",
-            "member-planner",
-            &format!("history-message-{index}"),
-            body,
-            Some(display),
+        let conn = get_connection().expect("db connection");
+        let row = AgentInboxStore::insert_in_tx_without_formal_trigger(
+            &conn,
+            InsertInboxParams {
+                recipient_agent_id: "builtin:sde".to_string(),
+                recipient_member_id: Some("member-planner".to_string()),
+                sender_agent_id: USER_SENDER_ID.to_string(),
+                sender_member_id: None,
+                org_run_id: Some(context.run_id.clone()),
+                message: AgentMessage::Plain {
+                    summary: "User group mention".to_string(),
+                    text: body.to_string(),
+                },
+            },
         )
-        .expect("persist history row");
+        .expect("insert isolated Group history fixture");
+        conn.execute(
+            "UPDATE agent_org_runtime_inbox
+             SET delivery_class='user_directed',display_text=?2 WHERE id=?1",
+            params![row.id, display],
+        )
+        .expect("classify Group history fixture");
     }
 
     let first =

--- a/src-tauri/crates/agent-core/src/state/commands/session/persistence.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/persistence.rs
@@ -445,6 +445,19 @@ fn delete_agent_org_session_hierarchy(
         }
         validate_agent_org_delete_ready_with_connection(&tx, &current_plan)?;
 
+        // Run-owned coordination rows include Linked Inbox children whose
+        // authority intentionally RESTRICTs deletion of their parent Turn and
+        // Inbox. Remove that run-owned causal graph first; the Run store does
+        // so leaf-first, while this same transaction still owns the complete
+        // Team plan and can roll everything back on any later Session error.
+        let outcome = AgentOrgRunStore::delete_by_id_with_connection(&tx, &expected_plan.run_id)?;
+        if !outcome.deleted() {
+            return Err(format!(
+                "Refusing to commit Agent Org run {} deletion: run row disappeared during deletion",
+                expected_plan.run_id
+            ));
+        }
+
         for node in &expected_plan.sessions {
             delete_agent_org_session_history_with_connection(&tx, &node.session_id).map_err(
                 |err| {
@@ -456,13 +469,6 @@ fn delete_agent_org_session_hierarchy(
             )?;
             session_persistence::delete_session_with_connection(&tx, &node.session_id)
                 .map_err(|err| format!("delete session {}: {err}", node.session_id))?;
-        }
-        let outcome = AgentOrgRunStore::delete_by_id_with_connection(&tx, &expected_plan.run_id)?;
-        if !outcome.deleted() {
-            return Err(format!(
-                "Refusing to commit Agent Org run {} deletion: run row disappeared during deletion",
-                expected_plan.run_id
-            ));
         }
         ensure_agent_org_hierarchy_absent(&tx, expected_plan)?;
         tx.commit().map_err(|err| err.to_string())?;

--- a/src-tauri/crates/agent-core/src/state/commands/session/persistence_tests.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/persistence_tests.rs
@@ -524,6 +524,205 @@ fn seed_run_owned_rows(run_id: &str) {
     .expect("seed run handoff history");
 }
 
+fn seed_linked_user_directed_history(
+    run_id: &str,
+    root_session_id: &str,
+    root_member_session_id: &str,
+    linked_member_session_id: &str,
+) {
+    let conn = get_connection().expect("sandbox DB");
+    let now = "2026-07-16T00:00:00Z";
+    let root_turn_intent_id = format!("intent-{root_member_session_id}");
+    let linked_turn_intent_id = format!("intent-{linked_member_session_id}");
+    let coordinator_turn_intent_id = format!("intent-{root_session_id}");
+    for session_id in [
+        root_session_id,
+        root_member_session_id,
+        linked_member_session_id,
+    ] {
+        conn.execute(
+            "UPDATE session_turn_intents SET org_run_id=?1 WHERE session_id=?2",
+            rusqlite::params![run_id, session_id],
+        )
+        .expect("bind test Turn intent to run");
+    }
+
+    let root_inbox_id = conn
+        .query_row(
+            "INSERT INTO agent_org_runtime_inbox (
+                 delivery_class,recipient_agent_id,recipient_member_id,
+                 sender_agent_id,sender_member_id,org_run_id,payload_kind,
+                 payload_json,created_at,display_text
+             ) VALUES (
+                 'user_directed','root-member-agent','root-member',
+                 'coordinator-agent','coordinator',?1,'plain',
+                 '{\"summary\":\"root\",\"text\":\"root\"}',?2,'root'
+             ) RETURNING id",
+            rusqlite::params![run_id, now],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("seed root UDW Inbox");
+    let linked_inbox_id = conn
+        .query_row(
+            "INSERT INTO agent_org_runtime_inbox (
+                 delivery_class,recipient_agent_id,recipient_member_id,
+                 sender_agent_id,sender_member_id,org_run_id,payload_kind,
+                 payload_json,created_at,causation_inbox_id,display_text
+             ) VALUES (
+                 'user_directed','linked-member-agent','linked-member',
+                 'root-member-agent','root-member',?1,'plain',
+                 '{\"summary\":\"linked\",\"text\":\"linked\"}',?2,?3,'linked'
+             ) RETURNING id",
+            rusqlite::params![run_id, now, root_inbox_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("seed linked UDW Inbox");
+    let coordinator_inbox_id = conn
+        .query_row(
+            "INSERT INTO agent_org_runtime_inbox (
+                 delivery_class,recipient_agent_id,recipient_member_id,
+                 sender_agent_id,sender_member_id,org_run_id,payload_kind,
+                 payload_json,created_at,causation_inbox_id,display_text
+             ) VALUES (
+                 'user_directed','coordinator-agent','coordinator',
+                 'linked-member-agent','linked-member',?1,'plain',
+                 '{\"summary\":\"coordinator\",\"text\":\"coordinator\"}',?2,?3,'coordinator'
+             ) RETURNING id",
+            rusqlite::params![run_id, now, linked_inbox_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("seed Coordinator UDW Inbox");
+
+    conn.execute(
+        "INSERT INTO agent_org_runtime_turn_contexts (
+             session_id,turn_intent_id,org_run_id,participant_id,turn_kind,
+             dispatch_member_id,member_dispatch_sequence,source_kind,source_id,
+             root_authority_turn_id,actor_version,created_at
+         ) VALUES (?1,?2,?3,'root-member','user_directed_work',
+                   'root-member',1,'group_mention',?4,?2,1,?5)",
+        rusqlite::params![
+            root_member_session_id,
+            &root_turn_intent_id,
+            run_id,
+            root_inbox_id.to_string(),
+            now,
+        ],
+    )
+    .expect("seed root UDW Turn context");
+    conn.execute(
+        "INSERT INTO agent_org_runtime_turn_contexts (
+             session_id,turn_intent_id,org_run_id,participant_id,turn_kind,
+             dispatch_member_id,member_dispatch_sequence,source_kind,source_id,
+             root_authority_turn_id,actor_version,created_at
+         ) VALUES (?1,?2,?3,'linked-member','user_directed_work',
+                   'linked-member',1,'member_inbox',?4,?5,1,?6)",
+        rusqlite::params![
+            linked_member_session_id,
+            &linked_turn_intent_id,
+            run_id,
+            linked_inbox_id.to_string(),
+            &root_turn_intent_id,
+            now,
+        ],
+    )
+    .expect("seed linked UDW Turn context");
+    conn.execute(
+        "INSERT INTO agent_org_runtime_turn_contexts (
+             session_id,turn_intent_id,org_run_id,participant_id,turn_kind,
+             source_kind,source_id,root_authority_turn_id,actor_version,created_at
+         ) VALUES (?1,?2,?3,'coordinator','coordinator',
+                   'member_inbox',?4,?5,1,?6)",
+        rusqlite::params![
+            root_session_id,
+            &coordinator_turn_intent_id,
+            run_id,
+            coordinator_inbox_id.to_string(),
+            &root_turn_intent_id,
+            now,
+        ],
+    )
+    .expect("seed Coordinator side-quest Turn context");
+    conn.execute(
+        "INSERT INTO agent_org_runtime_user_directed_roots (
+             org_run_id,root_authority_turn_id,policy_version,max_deliveries,
+             max_cascade_depth,next_delivery_ordinal,created_at
+         ) VALUES (?1,?2,1,8,2,4,?3)",
+        rusqlite::params![run_id, &root_turn_intent_id, now],
+    )
+    .expect("seed UDW root authority");
+    let root_delivery_id = conn
+        .query_row(
+            "INSERT INTO agent_org_runtime_user_directed_deliveries (
+                 org_run_id,session_id,turn_intent_id,root_authority_turn_id,
+                 source_kind,source_inbox_id,dispatch_member_id,
+                 member_dispatch_sequence,depth,delivery_ordinal,request_digest,
+                 dispatch_content,display_content,status,created_at,started_at,terminal_at
+             ) VALUES (
+                 ?1,?2,?3,?3,'group_mention',?4,'root-member',1,0,1,?5,
+                 'root','root','completed',?6,?6,?6
+             ) RETURNING delivery_id",
+            rusqlite::params![
+                run_id,
+                root_member_session_id,
+                &root_turn_intent_id,
+                root_inbox_id,
+                "a".repeat(64),
+                now,
+            ],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("seed root UDW delivery");
+    let linked_delivery_id = conn
+        .query_row(
+            "INSERT INTO agent_org_runtime_user_directed_deliveries (
+                 org_run_id,session_id,turn_intent_id,root_authority_turn_id,
+                 parent_delivery_id,parent_inbox_id,source_kind,source_inbox_id,
+                 dispatch_member_id,member_dispatch_sequence,depth,delivery_ordinal,
+                 request_digest,dispatch_content,display_content,status,
+                 created_at,started_at,terminal_at
+             ) VALUES (
+                 ?1,?2,?3,?4,?5,?6,'member_inbox',?7,
+                 'linked-member',1,1,2,?8,'linked','linked','completed',?9,?9,?9
+             ) RETURNING delivery_id",
+            rusqlite::params![
+                run_id,
+                linked_member_session_id,
+                &linked_turn_intent_id,
+                &root_turn_intent_id,
+                root_delivery_id,
+                root_inbox_id,
+                linked_inbox_id,
+                "b".repeat(64),
+                now,
+            ],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("seed linked UDW delivery");
+    conn.execute(
+        "INSERT INTO agent_org_runtime_user_directed_coordinator_bindings (
+             org_run_id,session_id,turn_intent_id,root_authority_turn_id,
+             parent_delivery_id,parent_inbox_id,source_inbox_id,depth,
+             delivery_ordinal,request_digest,dispatch_content,display_content,
+             status,created_at,started_at,terminal_at
+         ) VALUES (
+             ?1,?2,?3,?4,?5,?6,?7,2,3,?8,
+             'coordinator','coordinator','completed',?9,?9,?9
+         )",
+        rusqlite::params![
+            run_id,
+            root_session_id,
+            &coordinator_turn_intent_id,
+            &root_turn_intent_id,
+            linked_delivery_id,
+            linked_inbox_id,
+            coordinator_inbox_id,
+            "c".repeat(64),
+            now,
+        ],
+    )
+    .expect("seed Coordinator UDW binding");
+}
+
 fn seed_active_session_registry(session_id: &str) {
     crate::session::file_registry::register_session(
         &crate::session::file_registry::SessionRegistryEntry {
@@ -572,6 +771,7 @@ fn session_hierarchy_delete_removes_all_rust_descendants_and_run_history() {
     }
     seed_run_owned_rows("hierarchy-delete-run");
     seed_run_owned_rows("hierarchy-delete-other-run");
+    seed_linked_user_directed_history("hierarchy-delete-run", root, worker, grandchild);
 
     let conn = get_connection().expect("sandbox DB");
     let plan = load_agent_org_session_delete_plan(&conn, root)
@@ -640,6 +840,13 @@ fn session_hierarchy_delete_removes_all_rust_descendants_and_run_history() {
         "org_run_id",
         "hierarchy-delete-run"
     ));
+    for table in [
+        "agent_org_runtime_user_directed_coordinator_bindings",
+        "agent_org_runtime_user_directed_deliveries",
+        "agent_org_runtime_user_directed_roots",
+    ] {
+        assert!(!row_exists(table, "org_run_id", "hierarchy-delete-run"));
+    }
     assert!(row_exists("agent_sessions", "session_id", unrelated));
     assert!(row_exists("agent_messages", "session_id", unrelated));
     assert!(row_exists(

--- a/src-tauri/src/api/agent/mod.rs
+++ b/src-tauri/src/api/agent/mod.rs
@@ -764,6 +764,14 @@ pub fn create_routes() -> Router {
             post(test::agent_org::test_agent_org_simulate_app_restart),
         )
         .route(
+            "/test/agent-org/user-directed/fault",
+            post(test::agent_org_user_directed::test_agent_org_user_directed_fault),
+        )
+        .route(
+            "/test/agent-org/user-directed/evidence",
+            post(test::agent_org_user_directed::test_agent_org_user_directed_evidence),
+        )
+        .route(
             "/test/agent-org/check-member-spawn-gate",
             post(test::agent_org::test_agent_org_check_member_spawn_gate),
         )

--- a/src-tauri/src/api/agent/test/agent_org_user_directed.rs
+++ b/src-tauri/src/api/agent/test/agent_org_user_directed.rs
@@ -1,0 +1,175 @@
+//! Debug-only fault setup and read-only evidence for UserDirectedWork.
+//!
+//! These endpoints cannot submit, retry, pause, resume, archive, or delete a
+//! Team. They only arm one BuildFast fault or inspect bounded durable rows so
+//! Computer Use can remain the sole operator of every visible user action.
+
+use axum::Json;
+use rusqlite::params;
+
+pub async fn test_agent_org_user_directed_fault(
+    Json(body): Json<serde_json::Value>,
+) -> Json<serde_json::Value> {
+    let Some(mode) = body.get("mode").and_then(serde_json::Value::as_str) else {
+        return Json(serde_json::json!({
+            "ok": false,
+            "error": "mode is required"
+        }));
+    };
+    match agent_core::state::commands::session::org_tasks::arm_next_group_delivery_fault(mode) {
+        Ok(()) => Json(serde_json::json!({ "ok": true, "mode": mode })),
+        Err(error) => Json(serde_json::json!({ "ok": false, "error": error })),
+    }
+}
+
+pub async fn test_agent_org_user_directed_evidence(
+    Json(body): Json<serde_json::Value>,
+) -> Json<serde_json::Value> {
+    let Some(org_run_id) = body
+        .get("org_run_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+    else {
+        return Json(serde_json::json!({
+            "ok": false,
+            "error": "org_run_id is required"
+        }));
+    };
+
+    let result = tokio::task::spawn_blocking(move || load_evidence(&org_run_id)).await;
+    match result {
+        Err(error) => Json(serde_json::json!({
+            "ok": false,
+            "error": format!("evidence worker failed: {error}")
+        })),
+        Ok(Err(error)) => Json(serde_json::json!({ "ok": false, "error": error })),
+        Ok(Ok(value)) => Json(value),
+    }
+}
+
+fn load_evidence(org_run_id: &str) -> Result<serde_json::Value, String> {
+    let conn = database::db::get_connection().map_err(|error| error.to_string())?;
+    let mut delivery_statement = conn
+        .prepare(
+            "SELECT delivery_id,session_id,turn_intent_id,root_authority_turn_id,
+                    parent_delivery_id,parent_inbox_id,source_kind,source_inbox_id,
+                    dispatch_member_id,member_dispatch_sequence,depth,delivery_ordinal,status
+             FROM agent_org_runtime_user_directed_deliveries
+             WHERE org_run_id=?1
+             ORDER BY delivery_id
+             LIMIT 200",
+        )
+        .map_err(|error| error.to_string())?;
+    let deliveries = delivery_statement
+        .query_map([org_run_id], |row| {
+            Ok(serde_json::json!({
+                "delivery_id": row.get::<_, i64>(0)?,
+                "session_id": row.get::<_, String>(1)?,
+                "turn_intent_id": row.get::<_, String>(2)?,
+                "root_authority_turn_id": row.get::<_, String>(3)?,
+                "parent_delivery_id": row.get::<_, Option<i64>>(4)?,
+                "parent_inbox_id": row.get::<_, Option<i64>>(5)?,
+                "source_kind": row.get::<_, String>(6)?,
+                "source_inbox_id": row.get::<_, Option<i64>>(7)?,
+                "dispatch_member_id": row.get::<_, String>(8)?,
+                "member_dispatch_sequence": row.get::<_, i64>(9)?,
+                "depth": row.get::<_, i64>(10)?,
+                "delivery_ordinal": row.get::<_, i64>(11)?,
+                "status": row.get::<_, String>(12)?,
+            }))
+        })
+        .map_err(|error| error.to_string())?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| error.to_string())?;
+
+    let mut binding_statement = conn
+        .prepare(
+            "SELECT binding_id,session_id,turn_intent_id,root_authority_turn_id,
+                    parent_delivery_id,parent_inbox_id,source_inbox_id,depth,
+                    delivery_ordinal,status
+             FROM agent_org_runtime_user_directed_coordinator_bindings
+             WHERE org_run_id=?1
+             ORDER BY binding_id
+             LIMIT 200",
+        )
+        .map_err(|error| error.to_string())?;
+    let coordinator_bindings = binding_statement
+        .query_map([org_run_id], |row| {
+            Ok(serde_json::json!({
+                "binding_id": row.get::<_, i64>(0)?,
+                "session_id": row.get::<_, String>(1)?,
+                "turn_intent_id": row.get::<_, String>(2)?,
+                "root_authority_turn_id": row.get::<_, String>(3)?,
+                "parent_delivery_id": row.get::<_, i64>(4)?,
+                "parent_inbox_id": row.get::<_, Option<i64>>(5)?,
+                "source_inbox_id": row.get::<_, i64>(6)?,
+                "depth": row.get::<_, i64>(7)?,
+                "delivery_ordinal": row.get::<_, i64>(8)?,
+                "status": row.get::<_, String>(9)?,
+            }))
+        })
+        .map_err(|error| error.to_string())?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| error.to_string())?;
+
+    let mut inbox_statement = conn
+        .prepare(
+            "SELECT id,recipient_member_id,sender_member_id,read_at
+             FROM agent_org_runtime_inbox
+             WHERE org_run_id=?1 AND delivery_class='user_directed'
+             ORDER BY id
+             LIMIT 200",
+        )
+        .map_err(|error| error.to_string())?;
+    let inbox = inbox_statement
+        .query_map([org_run_id], |row| {
+            Ok(serde_json::json!({
+                "id": row.get::<_, i64>(0)?,
+                "recipient_member_id": row.get::<_, Option<String>>(1)?,
+                "sender_member_id": row.get::<_, Option<String>>(2)?,
+                "read_at": row.get::<_, Option<String>>(3)?,
+            }))
+        })
+        .map_err(|error| error.to_string())?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| error.to_string())?;
+
+    let (root_count, context_count, intent_count, tool_receipt_count): (i64, i64, i64, i64) = conn
+        .query_row(
+            "SELECT
+                 (SELECT COUNT(*) FROM agent_org_runtime_user_directed_roots
+                  WHERE org_run_id=?1),
+                 (SELECT COUNT(*) FROM agent_org_runtime_turn_contexts
+                  WHERE org_run_id=?1 AND (
+                    turn_kind='user_directed_work'
+                    OR (turn_kind='coordinator' AND source_kind='member_inbox')
+                  )),
+                 (SELECT COUNT(*) FROM session_turn_intents WHERE org_run_id=?1),
+                 (SELECT COUNT(*) FROM agent_org_runtime_tool_call_receipts
+                  WHERE org_run_id=?1)",
+            params![org_run_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .map_err(|error| error.to_string())?;
+
+    Ok(serde_json::json!({
+        "ok": true,
+        "org_run_id": org_run_id,
+        "bounded": true,
+        "row_limit": 200,
+        "counts": {
+            "roots": root_count,
+            "user_directed_contexts": context_count,
+            "all_run_intents": intent_count,
+            "tool_receipts": tool_receipt_count,
+            "deliveries": deliveries.len(),
+            "coordinator_bindings": coordinator_bindings.len(),
+            "user_directed_inbox": inbox.len(),
+        },
+        "deliveries": deliveries,
+        "coordinator_bindings": coordinator_bindings,
+        "inbox": inbox,
+    }))
+}

--- a/src-tauri/src/api/agent/test/mod.rs
+++ b/src-tauri/src/api/agent/test/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod agent_org;
 pub mod agent_org_formal_convergence;
+pub mod agent_org_user_directed;
 pub mod cli;
 pub mod core;
 pub mod desktop;

--- a/src/api/tauri/agent/orgTasks.ts
+++ b/src/api/tauri/agent/orgTasks.ts
@@ -378,10 +378,23 @@ export interface AgentOrgPlanRevision {
 /** @deprecated Use AgentOrgPlanRevision. */
 export type AgentOrgPlanApproval = AgentOrgPlanRevision;
 
-export interface AgentOrgGroupChatMessageResponse {
+export interface AgentOrgGroupDeliveryInput {
+  targetMemberId: string;
+  turnIntentId: string;
+}
+
+export interface AgentOrgGroupDeliveryResponse {
   targetMemberId: string;
   targetMemberName: string;
+  turnIntentId: string;
+  sourceInboxId: number;
+  memberDispatchSequence: number;
+  outcome: "accepted" | "existing";
   inboxRow: AgentOrgInboxRuntimeRow;
+}
+
+export interface AgentOrgGroupChatMessageResponse {
+  deliveries: AgentOrgGroupDeliveryResponse[];
 }
 
 type AgentOrgStateChangeSubscriber = (sessionId: string) => void;
@@ -742,19 +755,19 @@ export async function returnAgentOrgSessionToWork(
 
 export async function sendAgentOrgGroupChatMessage(
   sessionId: string,
-  messageId: string,
-  targetMemberId: string | null,
+  deliveries: AgentOrgGroupDeliveryInput[],
   content: string,
-  displayText?: string
+  displayText?: string,
+  images?: string[]
 ): Promise<AgentOrgGroupChatMessageResponse> {
   const response = await invokeTauri<AgentOrgGroupChatMessageResponse>(
     "agent_org_send_group_chat_message",
     {
       sessionId,
-      messageId,
-      targetMemberId,
+      deliveries,
       content,
       displayText: displayText ?? null,
+      images: images?.length ? images : null,
     }
   );
   publishAgentOrgStateChange(sessionId);

--- a/src/engines/ChatPanel/ChatFloatingComposer.tsx
+++ b/src/engines/ChatPanel/ChatFloatingComposer.tsx
@@ -65,6 +65,9 @@ interface AgentOrgInterventionView {
 
 interface GroupChatPendingMessageView {
   targetMemberName: string;
+  retryError: string | null;
+  retrying: boolean;
+  onRetry: () => Promise<void>;
 }
 
 interface CanvasPreviewPillView {
@@ -330,15 +333,45 @@ const ChatFloatingComposer: React.FC<ChatFloatingComposerProps> = memo(
             <div
               data-testid="agent-org-group-chat-pending"
               data-target-name={groupChatPendingMessage.targetMemberName}
+              data-delivery-state={
+                groupChatPendingMessage.retryError ? "unknown" : "pending"
+              }
               className="bg-background-2 mx-auto flex items-center gap-2 rounded-full border border-solid border-border-2 px-3 py-1 text-[12px] text-text-2 shadow-xs"
             >
-              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-6" />
-              <span>
-                {t("groupChat.userMessagePending", {
-                  member: groupChatPendingMessage.targetMemberName,
-                  defaultValue: "{{member}} is picking up your message",
-                })}
-              </span>
+              {groupChatPendingMessage.retryError ? (
+                <>
+                  <span className="h-1.5 w-1.5 rounded-full bg-warning-6" />
+                  <span title={groupChatPendingMessage.retryError}>
+                    {t("groupChat.userMessageOutcomeUnknown", {
+                      defaultValue:
+                        "Delivery outcome unknown. Retry with the same IDs.",
+                    })}
+                  </span>
+                  <Button
+                    data-testid="agent-org-group-chat-retry"
+                    variant="secondary"
+                    appearance="outline"
+                    size="mini"
+                    shape="round"
+                    htmlType="button"
+                    loading={groupChatPendingMessage.retrying}
+                    disabled={groupChatPendingMessage.retrying}
+                    onClick={() => void groupChatPendingMessage.onRetry()}
+                  >
+                    {t("common:actions.retry", { defaultValue: "Retry" })}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-6" />
+                  <span>
+                    {t("groupChat.userMessagePending", {
+                      member: groupChatPendingMessage.targetMemberName,
+                      defaultValue: "{{member}} is picking up your message",
+                    })}
+                  </span>
+                </>
+              )}
             </div>
           )}
 

--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -455,12 +455,11 @@ const ResolvedChatView: React.FC<ResolvedChatViewProps> = memo(
         followUpSuggestions,
         onFollowUpSuggestionSent: clearFollowUpSuggestions,
         submitDisabled:
-          (groupChatViewActive && agentOrgRunView?.runStatus === "paused") ||
-          (!groupChatViewActive &&
-            currentAgentOrgMember !== null &&
-            !currentAgentOrgMember.isCoordinator &&
-            (agentOrgRunView?.runStatus === "starting" ||
-              agentOrgRunView?.runStatus === "failed")),
+          !groupChatViewActive &&
+          currentAgentOrgMember !== null &&
+          !currentAgentOrgMember.isCoordinator &&
+          (agentOrgRunView?.runStatus === "starting" ||
+            agentOrgRunView?.runStatus === "failed"),
       }),
       [
         sessionId,

--- a/src/engines/ChatPanel/ChatViewComposerSection.types.ts
+++ b/src/engines/ChatPanel/ChatViewComposerSection.types.ts
@@ -34,6 +34,9 @@ interface AgentOrgInterventionView {
 
 interface GroupChatPendingMessageView {
   targetMemberName: string;
+  retryError: string | null;
+  retrying: boolean;
+  onRetry: () => Promise<void>;
 }
 
 export interface ChatViewComposerSectionProps {

--- a/src/engines/ChatPanel/hooks/groupChatRouting.test.ts
+++ b/src/engines/ChatPanel/hooks/groupChatRouting.test.ts
@@ -1,89 +1,59 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  parseGroupChatRoute,
-  resolveGroupChatOutgoing,
-} from "./groupChatRouting";
+import { resolveGroupChatOutgoing } from "./groupChatRouting";
 
 const members = [
-  { memberId: "coord", name: "Lead", isCoordinator: true },
-  { memberId: "alice", name: "Alice", isCoordinator: false },
+  { memberId: "coordinator", name: "Lead", isCoordinator: true },
+  { memberId: "alice", name: "Same Name", isCoordinator: false },
+  { memberId: "bob", name: "Same Name", isCoordinator: false },
 ] as const;
 
-describe("parseGroupChatRoute", () => {
-  it("routes @mentions and strips the mention header from the body", () => {
-    const route = parseGroupChatRoute("@Alice please review", members);
-    expect(route.targetMemberId).toBe("alice");
-    expect(route.body).toBe("please review");
-    expect(route.displayText).toBe("@Alice please review");
-  });
-
-  it("routes unmentioned text to the coordinator", () => {
-    const route = parseGroupChatRoute("hello team", members);
-    expect(route.targetMemberId).toBeNull();
-    expect(route.body).toBe("hello team");
-  });
-
-  it("throws for unknown mentions", () => {
-    expect(() => parseGroupChatRoute("@Nobody hi", members)).toThrow(
-      "Unknown Agent Team mention"
-    );
-  });
-});
+function input(memberIds: string[]) {
+  return {
+    displayText: "@Same Name @Same Name please review",
+    memberMentions: memberIds.map((memberId) => ({
+      memberId,
+      displayName: "Same Name",
+    })),
+    displayTextWithoutMemberMentions: "please review",
+    agentContentWithoutMemberMentions: "please review",
+  };
+}
 
 describe("resolveGroupChatOutgoing", () => {
-  it("uses the display body when no agent projection exists", () => {
-    const outgoing = resolveGroupChatOutgoing(
-      { displayText: "@Alice please review" },
-      members
-    );
-    expect(outgoing.targetMemberId).toBe("alice");
+  it("routes by canonical pill ids even when display names collide", () => {
+    const outgoing = resolveGroupChatOutgoing(input(["alice", "bob"]), members);
+    expect(outgoing.targetMemberIds).toEqual(["alice", "bob"]);
     expect(outgoing.agentBody).toBe("please review");
   });
 
-  it("strips the same mention header from an agent projection that still routes identically", () => {
+  it("deduplicates repeated pills by id while preserving first order", () => {
     const outgoing = resolveGroupChatOutgoing(
-      {
-        displayText: "@Alice statusline [skill:/statusline] please",
-        agentContent: "@Alice /statusline please",
-      },
+      input(["bob", "alice", "bob"]),
       members
     );
-    expect(outgoing.targetMemberId).toBe("alice");
-    // Display side keeps the pill serialization…
-    expect(outgoing.displayText).toBe(
-      "@Alice statusline [skill:/statusline] please"
-    );
-    // …the member inbox receives the projected body without the header.
-    expect(outgoing.agentBody).toBe("/statusline please");
+    expect(outgoing.targetMemberIds).toEqual(["bob", "alice"]);
   });
 
-  it("sends a rewritten agent projection (canvas contract) whole", () => {
-    const contract =
-      "[Canvas Creation Request]\nCreate a new interactive inline Canvas for the user request below. Call render_inline_canvas exactly once for the finished Canvas.\n\n[User Request]\nbuild a timer";
-    const outgoing = resolveGroupChatOutgoing(
-      {
-        displayText: "@Alice canvas [skill:/canvas] build a timer",
-        agentContent: contract,
-      },
-      members
-    );
-    expect(outgoing.targetMemberId).toBe("alice");
-    expect(outgoing.displayText).toBe(
-      "@Alice canvas [skill:/canvas] build a timer"
-    );
-    expect(outgoing.agentBody).toBe(contract);
+  it("keeps zero targets on the ordinary Root path", () => {
+    const outgoing = resolveGroupChatOutgoing(input([]), members);
+    expect(outgoing.targetMemberIds).toEqual([]);
   });
 
-  it("routes on the display text even when the agent copy could not parse", () => {
-    const outgoing = resolveGroupChatOutgoing(
-      {
-        displayText: "@Alice go",
-        agentContent: "@UnknownMember go",
-      },
-      members
+  it("keeps a Coordinator-only pill on the ordinary Root path", () => {
+    const outgoing = resolveGroupChatOutgoing(input(["coordinator"]), members);
+    expect(outgoing.targetMemberIds).toEqual([]);
+  });
+
+  it("rejects mixed Coordinator and Member pills", () => {
+    expect(() =>
+      resolveGroupChatOutgoing(input(["coordinator", "alice"]), members)
+    ).toThrow("must be sent separately");
+  });
+
+  it("rejects a stale or forged member id", () => {
+    expect(() => resolveGroupChatOutgoing(input(["removed"]), members)).toThrow(
+      "Unknown Agent Team Member pill"
     );
-    expect(outgoing.targetMemberId).toBe("alice");
-    expect(outgoing.agentBody).toBe("@UnknownMember go");
   });
 });

--- a/src/engines/ChatPanel/hooks/groupChatRouting.ts
+++ b/src/engines/ChatPanel/hooks/groupChatRouting.ts
@@ -1,13 +1,7 @@
 /**
- * groupChatRouting — pure @-mention routing + display/agent body split for
- * Agent Team group chat submissions.
- *
- * Extracted from useAgentOrgGroupChatController so the projection-sensitive
- * logic is unit-testable: the composer hands the override BOTH message
- * copies (`displayText` with pill serialization for the transcript,
- * `agentContent` with the projected agent payload). Routing and the visible
- * row must come from the display copy; the member-inbox body must carry the
- * agent copy.
+ * Pure structured Member-pill routing for Agent Team Group submissions.
+ * Display names are presentation only; `memberId` from `member://...` is the
+ * sole routing authority.
  */
 
 export interface GroupChatRouteMember {
@@ -16,113 +10,50 @@ export interface GroupChatRouteMember {
   isCoordinator: boolean;
 }
 
-export interface GroupChatRoute {
-  targetMemberId: string | null;
-  body: string;
+export interface GroupChatOutgoing {
+  targetMemberIds: string[];
   displayText: string;
-}
-
-export interface GroupChatOutgoing extends GroupChatRoute {
-  /** Body for the member inbox / agent payload (projected copy). */
   agentBody: string;
 }
 
-function normalizeMentionToken(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]+/g, "");
+export interface StructuredGroupChatInput {
+  displayText: string;
+  memberMentions: ReadonlyArray<{
+    memberId: string;
+    displayName: string;
+  }>;
+  displayTextWithoutMemberMentions: string;
+  agentContentWithoutMemberMentions: string;
 }
 
-export function parseGroupChatRoute(
-  rawText: string,
-  members: ReadonlyArray<GroupChatRouteMember>
-): GroupChatRoute {
-  const trimmed = rawText.trim();
-  if (!trimmed.startsWith("@")) {
-    return { targetMemberId: null, body: trimmed, displayText: trimmed };
-  }
-
-  const mentionText = trimmed.slice(1).trimStart();
-  const mentionLower = mentionText.toLowerCase();
-  const routeCandidates = members
-    .flatMap((member) => {
-      const labels = [member.name, member.memberId];
-      if (member.isCoordinator) {
-        labels.push("Coordinator");
-      }
-      return labels.map((label) => ({ label: label.trim(), member }));
-    })
-    .filter((candidate) => candidate.label.length > 0)
-    .sort((left, right) => right.label.length - left.label.length);
-
-  for (const candidate of routeCandidates) {
-    const labelLower = candidate.label.toLowerCase();
-    if (
-      mentionLower === labelLower ||
-      mentionLower.startsWith(`${labelLower} `) ||
-      mentionLower.startsWith(`${labelLower}\n`)
-    ) {
-      return {
-        targetMemberId: candidate.member.isCoordinator
-          ? null
-          : candidate.member.memberId,
-        body: mentionText.slice(candidate.label.length).trim(),
-        displayText: trimmed,
-      };
-    }
-  }
-
-  const tokenMatch = mentionText.match(/^(\S+)\s*(.*)$/s);
-  const token = normalizeMentionToken(tokenMatch?.[1] ?? "");
-  const member = members.find((candidate) => {
-    const candidateNames = [candidate.memberId, candidate.name].map(
-      normalizeMentionToken
-    );
-    return candidateNames.includes(token);
-  });
-  if (!member) {
-    throw new Error(`Unknown Agent Team mention: @${tokenMatch?.[1] ?? ""}`);
-  }
-  return {
-    targetMemberId: member.isCoordinator ? null : member.memberId,
-    body: tokenMatch?.[2].trim() ?? "",
-    displayText: trimmed,
-  };
-}
-
-/**
- * Resolve a group chat submission from both projection fields.
- *
- * Routing (`@member`) and `displayText` always come from the display copy —
- * that is what the user typed and what the transcript renders. The member
- * inbox body comes from the agent copy when the composer produced one:
- * when the agent projection still carries the same mention header (skill
- * expansion / base64 strip preserve it) the header is stripped via the same
- * parse; when an interceptor rewrote the whole message (e.g. the Canvas
- * contract) the full agent content becomes the body.
- *
- * Throws for an unknown display-side mention (same contract as
- * parseGroupChatRoute).
- */
 export function resolveGroupChatOutgoing(
-  input: { displayText: string; agentContent?: string },
+  input: StructuredGroupChatInput,
   members: ReadonlyArray<GroupChatRouteMember>
 ): GroupChatOutgoing {
-  const route = parseGroupChatRoute(input.displayText, members);
-
-  if (input.agentContent === undefined) {
-    return { ...route, agentBody: route.body };
-  }
-
-  try {
-    const agentRoute = parseGroupChatRoute(input.agentContent, members);
-    if (agentRoute.targetMemberId === route.targetMemberId) {
-      return { ...route, agentBody: agentRoute.body };
+  const canonicalMembers = new Map(
+    members.map((member) => [member.memberId, member] as const)
+  );
+  const seen = new Set<string>();
+  const selected: GroupChatRouteMember[] = [];
+  for (const mention of input.memberMentions) {
+    if (seen.has(mention.memberId)) continue;
+    const member = canonicalMembers.get(mention.memberId);
+    if (!member) {
+      throw new Error(`Unknown Agent Team Member pill: ${mention.memberId}`);
     }
-  } catch {
-    // The agent projection no longer parses as a routed message — fall
-    // through and send it whole.
+    seen.add(mention.memberId);
+    selected.push(member);
   }
-  return { ...route, agentBody: input.agentContent.trim() };
+
+  const selectedCoordinator = selected.some((member) => member.isCoordinator);
+  const selectedMembers = selected.filter((member) => !member.isCoordinator);
+  if (selectedCoordinator && selectedMembers.length > 0) {
+    throw new Error("Coordinator and Member messages must be sent separately");
+  }
+
+  return {
+    targetMemberIds: selectedMembers.map((member) => member.memberId),
+    displayText: input.displayText.trim(),
+    agentBody: input.agentContentWithoutMemberMentions.trim(),
+  };
 }

--- a/src/engines/ChatPanel/hooks/useAgentOrgGroupChatController.test.ts
+++ b/src/engines/ChatPanel/hooks/useAgentOrgGroupChatController.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  groupChatRetryRequest,
   isDirectAgentOrgMemberView,
+  isDurableGroupDeliveryOutcomeUnknown,
   shouldBlockPausedAgentOrgGroupChatSubmit,
   shouldRouteAgentOrgGroupChatSubmit,
   shouldUseAgentOrgMemberGroupTransport,
@@ -19,52 +21,76 @@ describe("Agent Org group chat routing boundary", () => {
   });
 
   it("does not let a stale root Group Chat selection capture Member direct input", () => {
-    expect(shouldRouteAgentOrgGroupChatSubmit(true, true, "fix the file")).toBe(
-      false
-    );
-    expect(
-      shouldRouteAgentOrgGroupChatSubmit(true, true, "@planner fix the file")
-    ).toBe(false);
+    expect(shouldRouteAgentOrgGroupChatSubmit(true, true, 0)).toBe(false);
+    expect(shouldRouteAgentOrgGroupChatSubmit(true, true, 1)).toBe(false);
   });
 
-  it("preserves existing root Group Chat and mention routing", () => {
-    expect(shouldRouteAgentOrgGroupChatSubmit(true, false, "hello")).toBe(true);
-    expect(
-      shouldRouteAgentOrgGroupChatSubmit(false, false, "@planner hello")
-    ).toBe(true);
-    expect(shouldRouteAgentOrgGroupChatSubmit(false, false, "hello")).toBe(
-      false
-    );
+  it("routes Group view and structured Member pills without text parsing", () => {
+    expect(shouldRouteAgentOrgGroupChatSubmit(true, false, 0)).toBe(true);
+    expect(shouldRouteAgentOrgGroupChatSubmit(false, false, 1)).toBe(true);
+    expect(shouldRouteAgentOrgGroupChatSubmit(false, false, 0)).toBe(false);
   });
 
   it("delegates default and explicit Coordinator messages to the canonical Root queue", () => {
-    expect(shouldUseAgentOrgMemberGroupTransport(null)).toBe(false);
-    expect(shouldUseAgentOrgMemberGroupTransport("sde-planner")).toBe(true);
+    expect(shouldUseAgentOrgMemberGroupTransport([])).toBe(false);
+    expect(shouldUseAgentOrgMemberGroupTransport(["sde-planner"])).toBe(true);
   });
 
-  it("blocks paused Group Chat but lets canonical Member direct fall through", () => {
+  it("allows paused Member Group work but keeps Root submission behind Resume", () => {
+    expect(shouldBlockPausedAgentOrgGroupChatSubmit("paused", [])).toBe(true);
     expect(
-      shouldBlockPausedAgentOrgGroupChatSubmit(
-        "paused",
-        true,
-        false,
-        "group message"
+      shouldBlockPausedAgentOrgGroupChatSubmit("paused", ["planner"])
+    ).toBe(false);
+    expect(shouldBlockPausedAgentOrgGroupChatSubmit("running", [])).toBe(false);
+  });
+
+  it("replays an immutable Group envelope with the exact original Turn ids", () => {
+    const envelope = {
+      fingerprint: "immutable-request",
+      deliveries: [
+        { targetMemberId: "implementer", turnIntentId: "turn-a" },
+        { targetMemberId: "reviewer", turnIntentId: "turn-b" },
+      ],
+      content: "Check the discount boundary",
+      displayText: "@Implementer @Reviewer Check the discount boundary",
+      images: ["data:image/png;base64,one"],
+      targetMemberNames: ["Implementer", "Reviewer"],
+    };
+
+    const first = groupChatRetryRequest(envelope);
+    first.deliveries[0].turnIntentId = "mutated-copy";
+    first.images?.push("data:image/png;base64,two");
+
+    expect(groupChatRetryRequest(envelope)).toEqual({
+      deliveries: [
+        { targetMemberId: "implementer", turnIntentId: "turn-a" },
+        { targetMemberId: "reviewer", turnIntentId: "turn-b" },
+      ],
+      content: "Check the discount boundary",
+      displayText: "@Implementer @Reviewer Check the discount boundary",
+      images: ["data:image/png;base64,one"],
+    });
+  });
+
+  it("only exposes Retry after an error that may follow a durable commit", () => {
+    expect(
+      isDurableGroupDeliveryOutcomeUnknown(
+        new Error("group_delivery_response_loss_after_kick_fault: dropped")
       )
     ).toBe(true);
     expect(
-      shouldBlockPausedAgentOrgGroupChatSubmit(
-        "paused",
-        false,
-        false,
-        "@planner group message"
+      isDurableGroupDeliveryOutcomeUnknown(
+        new Error("group_delivery_commit_before_kick_fault: pending")
       )
     ).toBe(true);
     expect(
-      shouldBlockPausedAgentOrgGroupChatSubmit(
-        "paused",
-        true,
-        true,
-        "direct side quest"
+      isDurableGroupDeliveryOutcomeUnknown(
+        new Error("group_delivery_kick_failed: pending")
+      )
+    ).toBe(true);
+    expect(
+      isDurableGroupDeliveryOutcomeUnknown(
+        new Error("group_target_limit_exceeded: at most 10 Members")
       )
     ).toBe(false);
   });

--- a/src/engines/ChatPanel/hooks/useAgentOrgGroupChatController.ts
+++ b/src/engines/ChatPanel/hooks/useAgentOrgGroupChatController.ts
@@ -5,6 +5,7 @@ import {
   AGENT_ORG_RUN_STATUS,
   AGENT_ORG_USER_SENDER_ID,
   type AgentOrgGroupChatHistoryRow,
+  type AgentOrgGroupDeliveryInput,
   type AgentOrgInboxRuntimeRow,
   type AgentOrgRunMemberView,
   type AgentOrgRunView,
@@ -20,13 +21,10 @@ import {
   isGroupChatPendingDeliverySettled,
   useAgentOrgGroupChatHistory,
 } from "@src/engines/ChatPanel/hooks/useAgentOrgGroupChatHistory";
+import { SubmissionOutcomeUnknownError } from "@src/engines/ChatPanel/hooks/useInputArea/submissionErrors";
 import type {
   CustomMentionOption,
   SubmitOverrideInput,
-} from "@src/engines/ChatPanel/hooks/useInputArea/types";
-import {
-  SubmitRetainedDeliveryError,
-  SubmitValidationError,
 } from "@src/engines/ChatPanel/hooks/useInputArea/types";
 import { createLogger } from "@src/hooks/logger";
 import { activeSessionIdAtom } from "@src/store/session";
@@ -35,17 +33,46 @@ import { groupChatViewSessionIdAtom } from "@src/store/ui/chatPanel/displayPrefs
 const logger = createLogger("ChatView");
 
 interface GroupChatPendingMessage {
-  /** Stable across retries so the recipient inbox can deduplicate delivery. */
-  messageId: string;
   rowId: number;
+  turnIntentId: string;
   targetMemberId: string;
   targetMemberName: string;
   createdAt: string;
   displayText: string;
   text: string;
   inboxRow: AgentOrgInboxRuntimeRow;
-  deliveryStatus: "pending" | "sent" | "failed";
-  deliveryError: string | null;
+}
+
+export interface GroupChatRetryEnvelope {
+  fingerprint: string;
+  deliveries: AgentOrgGroupDeliveryInput[];
+  content: string;
+  displayText: string;
+  images?: string[];
+  targetMemberNames: string[];
+}
+
+export function groupChatRetryRequest(envelope: GroupChatRetryEnvelope): {
+  deliveries: AgentOrgGroupDeliveryInput[];
+  content: string;
+  displayText: string;
+  images?: string[];
+} {
+  return {
+    deliveries: envelope.deliveries.map((delivery) => ({ ...delivery })),
+    content: envelope.content,
+    displayText: envelope.displayText,
+    images: envelope.images?.slice(),
+  };
+}
+
+export function isDurableGroupDeliveryOutcomeUnknown(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("group_delivery_commit_before_kick_fault") ||
+    message.includes("group_delivery_response_loss_after_kick_fault") ||
+    message.includes("group_delivery_kick_failed")
+  );
 }
 
 interface UseAgentOrgGroupChatControllerOptions {
@@ -64,13 +91,10 @@ export function isDirectAgentOrgMemberView(
 export function shouldRouteAgentOrgGroupChatSubmit(
   groupChatViewActive: boolean,
   directMemberView: boolean,
-  displayText: string
+  memberMentionCount: number
 ): boolean {
-  // A canonical non-coordinator Member page is the sole PR8 direct-work
-  // source. A stale root Group Chat selection must never capture its input,
-  // including text beginning with "@"; member/group fan-out belongs to PR9.
   if (directMemberView) return false;
-  return groupChatViewActive || displayText.trim().startsWith("@");
+  return groupChatViewActive || memberMentionCount > 0;
 }
 
 /**
@@ -78,28 +102,21 @@ export function shouldRouteAgentOrgGroupChatSubmit(
  * must fall through to the canonical user-intent queue so Idle follow-ups can
  * answer or create a new work episode, and busy follow-ups retain their FIFO
  * identity. The Group Inbox transport is reserved for an explicit Member
- * target (PR9); using it for Root messages creates an unread row plus an empty
+ * target; using it for Root messages creates an unread row plus an empty
  * wake that the Coordinator cannot claim.
  */
 export function shouldUseAgentOrgMemberGroupTransport(
-  targetMemberId: string | null
+  targetMemberIds: ReadonlyArray<string>
 ): boolean {
-  return targetMemberId !== null;
+  return targetMemberIds.length > 0;
 }
 
 export function shouldBlockPausedAgentOrgGroupChatSubmit(
   runStatus: AgentOrgRunView["runStatus"],
-  groupChatViewActive: boolean,
-  directMemberView: boolean,
-  displayText: string
+  targetMemberIds: ReadonlyArray<string>
 ): boolean {
   return (
-    runStatus === AGENT_ORG_RUN_STATUS.PAUSED &&
-    shouldRouteAgentOrgGroupChatSubmit(
-      groupChatViewActive,
-      directMemberView,
-      displayText
-    )
+    runStatus === AGENT_ORG_RUN_STATUS.PAUSED && targetMemberIds.length === 0
   );
 }
 
@@ -154,10 +171,18 @@ export function useAgentOrgGroupChatController({
   const [groupChatPendingMessages, setGroupChatPendingMessages] = useState<
     GroupChatPendingMessage[]
   >([]);
+  const groupChatRetryEnvelopeRef = useRef<GroupChatRetryEnvelope | null>(null);
+  const [groupChatRetryError, setGroupChatRetryError] = useState<string | null>(
+    null
+  );
+  const [isRetryingGroupChat, setIsRetryingGroupChat] = useState(false);
   const [isResumingGroupChat, setIsResumingGroupChat] = useState(false);
 
   useEffect(() => {
     setGroupChatPendingMessages([]);
+    groupChatRetryEnvelopeRef.current = null;
+    setGroupChatRetryError(null);
+    setIsRetryingGroupChat(false);
   }, [sessionId]);
 
   const directMemberView = isDirectAgentOrgMemberView(currentAgentOrgMember);
@@ -222,28 +247,26 @@ export function useAgentOrgGroupChatController({
     groupChatHistoryRefreshToken
   );
   const groupChatHistoryRows = useMemo<AgentOrgGroupChatHistoryRow[]>(() => {
+    if (groupChatPendingMessages.length === 0)
+      return durableGroupChatHistoryRows;
     const durableIds = new Set(
       durableGroupChatHistoryRows.map((row) => row.inboxId)
     );
-    const optimisticRows = groupChatPendingMessages
-      .filter((pending) => !durableIds.has(pending.rowId))
-      .map((pending) => ({
-        inboxId: pending.rowId,
-        targetMemberId: pending.targetMemberId,
-        targetMemberName: pending.targetMemberName,
-        text: pending.text,
-        displayText: pending.displayText,
-        createdAt: pending.createdAt,
-        readAt: null,
-        deliveryResolution: null,
-        clientDeliveryStatus: pending.deliveryStatus,
-        clientDeliveryError: pending.deliveryError,
-      }));
-    return [...durableGroupChatHistoryRows, ...optimisticRows].sort(
-      (left, right) =>
-        left.createdAt.localeCompare(right.createdAt) ||
-        left.inboxId - right.inboxId
-    );
+    return [
+      ...durableGroupChatHistoryRows,
+      ...groupChatPendingMessages
+        .filter((pending) => !durableIds.has(pending.rowId))
+        .map((pending) => ({
+          inboxId: pending.rowId,
+          targetMemberId: pending.targetMemberId,
+          targetMemberName: pending.targetMemberName,
+          text: pending.text,
+          displayText: pending.displayText,
+          createdAt: pending.createdAt,
+          readAt: null,
+          deliveryResolution: null,
+        })),
+    ].sort((left, right) => left.inboxId - right.inboxId);
   }, [durableGroupChatHistoryRows, groupChatPendingMessages]);
 
   const {
@@ -275,8 +298,8 @@ export function useAgentOrgGroupChatController({
 
   useEffect(() => {
     if (groupChatPendingMessages.length === 0 || !agentOrgRunView) return;
-    setGroupChatPendingMessages((current) =>
-      current.filter((pending) => {
+    setGroupChatPendingMessages((current) => {
+      const remaining = current.filter((pending) => {
         const pendingRow = agentOrgRunView.inbox.find(
           (row) => row.id === pending.rowId
         );
@@ -285,13 +308,10 @@ export function useAgentOrgGroupChatController({
           pendingRow,
           durableGroupChatHistoryRows
         );
-      })
-    );
-  }, [
-    agentOrgRunView,
-    durableGroupChatHistoryRows,
-    groupChatPendingMessages.length,
-  ]);
+      });
+      return remaining.length === current.length ? current : remaining;
+    });
+  }, [agentOrgRunView, durableGroupChatHistoryRows, groupChatPendingMessages]);
 
   const handleResumeGroupChatRun = useCallback(async () => {
     if (!sessionId || isResumingGroupChat) return;
@@ -306,193 +326,253 @@ export function useAgentOrgGroupChatController({
     }
   }, [isResumingGroupChat, refreshAgentOrgRunView, sessionId]);
 
-  const deliverPendingGroupChatMessage = useCallback(
-    async (pendingMessage: GroupChatPendingMessage): Promise<void> => {
-      try {
-        const response = await sendAgentOrgGroupChatMessage(
-          sessionId,
-          pendingMessage.messageId,
-          pendingMessage.targetMemberId,
-          pendingMessage.text,
-          pendingMessage.displayText
-        );
-        setGroupChatPendingMessages((current) =>
-          current.map((pending) =>
-            pending.rowId === pendingMessage.rowId
-              ? {
-                  messageId: pendingMessage.messageId,
-                  rowId: response.inboxRow.id,
-                  targetMemberId: response.targetMemberId,
-                  targetMemberName: response.targetMemberName,
-                  createdAt: response.inboxRow.createdAt,
-                  displayText: pendingMessage.displayText,
-                  text: pendingMessage.text,
-                  inboxRow: response.inboxRow,
-                  deliveryStatus: "sent",
-                  deliveryError: null,
-                }
-              : pending
-          )
-        );
-        void refreshAgentOrgRunView().catch((err: unknown) => {
-          logger.error(
-            "Failed to refresh Agent Team run after group chat send:",
-            err
-          );
-        });
-      } catch (err) {
-        setGroupChatPendingMessages((current) =>
-          current.map((pending) =>
-            pending.rowId === pendingMessage.rowId
-              ? {
-                  ...pending,
-                  deliveryStatus: "failed",
-                  deliveryError:
-                    err instanceof Error ? err.message : String(err),
-                }
-              : pending
-          )
-        );
-        throw new SubmitRetainedDeliveryError(err);
-      }
-    },
-    [refreshAgentOrgRunView, sessionId]
-  );
-
   const handleGroupChatSubmitOverride = useCallback(
     async (input: SubmitOverrideInput): Promise<boolean> => {
       if (!agentOrgRunView) return false;
       if (
-        shouldBlockPausedAgentOrgGroupChatSubmit(
-          agentOrgRunView.runStatus,
-          groupChatViewActive,
-          directMemberView,
-          input.displayText
-        )
-      ) {
-        throw new Error("Resume this Agent Team before sending a message");
-      }
-      // Route on the DISPLAY copy: the `@member` header is what the user
-      // typed and what the transcript renders. The agent copy may have been
-      // rewritten by an interceptor (canvas contract) and must only feed the
-      // member-inbox body — resolveGroupChatOutgoing owns that split.
-      if (
         !shouldRouteAgentOrgGroupChatSubmit(
           groupChatViewActive,
           directMemberView,
-          input.displayText
+          input.memberMentions?.length ?? 0
         )
       ) {
         return false;
       }
-      let route: GroupChatOutgoing;
-      try {
-        route = resolveGroupChatOutgoing(input, agentOrgRunView.members);
-      } catch (err) {
-        if (!groupChatViewActive) return false;
-        throw new SubmitValidationError(
-          err instanceof Error ? err.message : String(err)
-        );
-      }
-      if (!shouldUseAgentOrgMemberGroupTransport(route.targetMemberId)) {
+      const route: GroupChatOutgoing = resolveGroupChatOutgoing(
+        {
+          displayText: input.displayText,
+          memberMentions: input.memberMentions ?? [],
+          displayTextWithoutMemberMentions:
+            input.displayTextWithoutMemberMentions ?? input.displayText,
+          agentContentWithoutMemberMentions:
+            input.agentContentWithoutMemberMentions ??
+            input.displayTextWithoutMemberMentions ??
+            input.agentContent ??
+            input.displayText,
+        },
+        agentOrgRunView.members
+      );
+      if (!shouldUseAgentOrgMemberGroupTransport(route.targetMemberIds)) {
         // The ordinary submit path already targets `sessionId`, which is the
         // canonical Root while Group Chat is active. It owns durable queueing,
         // Turn identity, EventStore persistence, busy-session FIFO, restart
         // recovery, and provider observation for this user fact.
         return false;
       }
-      if (input.imageDataUrls && input.imageDataUrls.length > 0) {
-        throw new SubmitValidationError(
-          "Group chat does not support image attachments yet"
-        );
-      }
       if (!route.agentBody.trim()) {
-        throw new SubmitValidationError(
-          "Agent Team group chat message content is required"
-        );
+        throw new Error("Agent Team group chat message content is required");
       }
-      const targetMember = route.targetMemberId
-        ? agentOrgRunView.members.find(
-            (member) => member.memberId === route.targetMemberId
-          )
-        : agentOrgRunView.members.find((member) => member.isCoordinator);
-      if (!targetMember) {
-        throw new SubmitValidationError(
-          "Agent Team group chat target member was not found"
-        );
+      if (
+        shouldBlockPausedAgentOrgGroupChatSubmit(
+          agentOrgRunView.runStatus,
+          route.targetMemberIds
+        )
+      ) {
+        throw new Error("Resume this Agent Team before sending a Root message");
       }
-      const optimisticRowId = nextOptimisticInboxRowIdRef.current--;
-      const optimisticRow = makeOptimisticInboxRow({
-        id: optimisticRowId,
-        targetMemberId: targetMember.memberId,
-        targetMemberName: targetMember.name,
-        targetAgentId: targetMember.agentId,
+      const targets = route.targetMemberIds.map((memberId) => {
+        const member = agentOrgRunView.members.find(
+          (candidate) => candidate.memberId === memberId
+        );
+        if (!member || member.isCoordinator) {
+          throw new Error(`Agent Team Member ${memberId} was not found`);
+        }
+        return member;
+      });
+      const fingerprint = JSON.stringify({
+        targets: route.targetMemberIds,
         body: route.agentBody,
         displayText: route.displayText,
+        images: input.imageDataUrls ?? [],
       });
-      const pendingMessage: GroupChatPendingMessage = {
-        messageId: crypto.randomUUID(),
-        rowId: optimisticRowId,
-        targetMemberId: targetMember.memberId,
-        targetMemberName: targetMember.name,
-        createdAt: optimisticRow.createdAt,
-        displayText: route.displayText,
-        text: route.agentBody,
-        inboxRow: optimisticRow,
-        deliveryStatus: "pending",
-        deliveryError: null,
-      };
-      setGroupChatPendingMessages((current) => [...current, pendingMessage]);
-      await deliverPendingGroupChatMessage(pendingMessage);
+      let envelope = groupChatRetryEnvelopeRef.current;
+      if (!envelope || envelope.fingerprint !== fingerprint) {
+        envelope = {
+          fingerprint,
+          deliveries: targets.map((member) => ({
+            targetMemberId: member.memberId,
+            turnIntentId: crypto.randomUUID(),
+          })),
+          content: route.agentBody,
+          displayText: route.displayText,
+          images: input.imageDataUrls?.slice(),
+          targetMemberNames: targets.map((member) => member.name),
+        };
+        groupChatRetryEnvelopeRef.current = envelope;
+        setGroupChatRetryError(null);
+      }
+      const optimistic = envelope.deliveries.map((delivery) => {
+        const target = targets.find(
+          (member) => member.memberId === delivery.targetMemberId
+        );
+        if (!target) throw new Error("Group delivery target changed");
+        const existing = groupChatPendingMessages.find(
+          (pending) => pending.turnIntentId === delivery.turnIntentId
+        );
+        if (existing) return existing;
+        const row = makeOptimisticInboxRow({
+          id: nextOptimisticInboxRowIdRef.current--,
+          targetMemberId: target.memberId,
+          targetMemberName: target.name,
+          targetAgentId: target.agentId,
+          body: route.agentBody,
+          displayText: route.displayText,
+        });
+        return {
+          rowId: row.id,
+          turnIntentId: delivery.turnIntentId,
+          targetMemberId: target.memberId,
+          targetMemberName: target.name,
+          createdAt: row.createdAt,
+          displayText: route.displayText,
+          text: route.agentBody,
+          inboxRow: row,
+        };
+      });
+      setGroupChatPendingMessages(optimistic);
+      // A rejected transport leaves the immutable envelope and optimistic
+      // rows untouched. The explicit Retry action below replays this exact
+      // request, including the original per-target Turn ids.
+      let response;
+      try {
+        const request = groupChatRetryRequest(envelope);
+        response = await sendAgentOrgGroupChatMessage(
+          sessionId,
+          request.deliveries,
+          request.content,
+          request.displayText,
+          request.images
+        );
+      } catch (err: unknown) {
+        const reason = err instanceof Error ? err.message : String(err);
+        if (!isDurableGroupDeliveryOutcomeUnknown(err)) {
+          groupChatRetryEnvelopeRef.current = null;
+          setGroupChatPendingMessages([]);
+          setGroupChatRetryError(null);
+          throw err;
+        }
+        setGroupChatRetryError(reason || "Group delivery outcome is unknown");
+        logger.warn(
+          "Agent Team group delivery outcome is unknown; preserving retry envelope:",
+          err
+        );
+        throw new SubmissionOutcomeUnknownError(
+          reason || "Group delivery outcome is unknown"
+        );
+      }
+      groupChatRetryEnvelopeRef.current = null;
+      setGroupChatRetryError(null);
+      setGroupChatPendingMessages(
+        response.deliveries.map((delivery) => ({
+          rowId: delivery.inboxRow.id,
+          turnIntentId: delivery.turnIntentId,
+          targetMemberId: delivery.targetMemberId,
+          targetMemberName: delivery.targetMemberName,
+          createdAt: delivery.inboxRow.createdAt,
+          displayText: route.displayText,
+          text: route.agentBody,
+          inboxRow: delivery.inboxRow,
+        }))
+      );
+      void refreshAgentOrgRunView().catch((err: unknown) => {
+        logger.error(
+          "Failed to refresh Agent Team run after group chat send:",
+          err
+        );
+      });
       return true;
     },
     [
       agentOrgRunView,
-      deliverPendingGroupChatMessage,
       directMemberView,
       groupChatViewActive,
+      refreshAgentOrgRunView,
+      sessionId,
+      groupChatPendingMessages,
     ]
   );
 
+  const handleRetryGroupChatMessage = useCallback(async () => {
+    const envelope = groupChatRetryEnvelopeRef.current;
+    if (!envelope || isRetryingGroupChat) return;
+    setIsRetryingGroupChat(true);
+    try {
+      const request = groupChatRetryRequest(envelope);
+      const response = await sendAgentOrgGroupChatMessage(
+        sessionId,
+        request.deliveries,
+        request.content,
+        request.displayText,
+        request.images
+      );
+      groupChatRetryEnvelopeRef.current = null;
+      setGroupChatRetryError(null);
+      setGroupChatPendingMessages(
+        response.deliveries.map((delivery) => ({
+          rowId: delivery.inboxRow.id,
+          turnIntentId: delivery.turnIntentId,
+          targetMemberId: delivery.targetMemberId,
+          targetMemberName: delivery.targetMemberName,
+          createdAt: delivery.inboxRow.createdAt,
+          displayText: envelope.displayText,
+          text: envelope.content,
+          inboxRow: delivery.inboxRow,
+        }))
+      );
+      await refreshAgentOrgRunView();
+    } catch (err: unknown) {
+      const reason = err instanceof Error ? err.message : String(err);
+      setGroupChatRetryError(reason || "Group delivery outcome is unknown");
+      logger.warn(
+        "Agent Team group delivery retry failed; preserving retry envelope:",
+        err
+      );
+    } finally {
+      setIsRetryingGroupChat(false);
+    }
+  }, [isRetryingGroupChat, refreshAgentOrgRunView, sessionId]);
+
+  const groupChatPendingMessage = useMemo(() => {
+    const retryEnvelope = groupChatRetryEnvelopeRef.current;
+    if (groupChatRetryError && retryEnvelope) {
+      return {
+        targetMemberName:
+          retryEnvelope.targetMemberNames.length > 1
+            ? `${retryEnvelope.targetMemberNames.length} Members`
+            : (retryEnvelope.targetMemberNames[0] ?? "Member"),
+        retryError: groupChatRetryError,
+        retrying: isRetryingGroupChat,
+        onRetry: handleRetryGroupChatMessage,
+      };
+    }
+    const pending = groupChatPendingMessages[0];
+    if (!pending) return null;
+    return {
+      ...pending,
+      targetMemberName:
+        groupChatPendingMessages.length > 1
+          ? `${groupChatPendingMessages.length} Members`
+          : pending.targetMemberName,
+      retryError: null,
+      retrying: false,
+      onRetry: handleRetryGroupChatMessage,
+    };
+  }, [
+    groupChatPendingMessages,
+    groupChatRetryError,
+    handleRetryGroupChatMessage,
+    isRetryingGroupChat,
+  ]);
+
+  // Compatibility for the history surface introduced on develop. Structured
+  // Group delivery restores known failures to the composer and owns unknown
+  // outcomes through the immutable envelope above, so any retained retry UI
+  // must replay that envelope rather than minting a new per-row identity.
   const retryFailedGroupChatMessage = useCallback(
-    async (rowId: number, editedDisplayText?: string): Promise<void> => {
-      const failed = groupChatPendingMessages.find(
-        (pending) =>
-          pending.rowId === rowId && pending.deliveryStatus === "failed"
-      );
-      if (!failed || !agentOrgRunView) return;
-      let next = failed;
-      if (editedDisplayText !== undefined) {
-        const route = resolveGroupChatOutgoing(
-          {
-            displayText: editedDisplayText,
-            agentContent: editedDisplayText,
-          },
-          agentOrgRunView.members
-        );
-        const targetMember = route.targetMemberId
-          ? agentOrgRunView.members.find(
-              (member) => member.memberId === route.targetMemberId
-            )
-          : agentOrgRunView.members.find((member) => member.isCoordinator);
-        if (!targetMember || !route.agentBody.trim()) return;
-        next = {
-          ...failed,
-          targetMemberId: targetMember.memberId,
-          targetMemberName: targetMember.name,
-          displayText: route.displayText,
-          text: route.agentBody,
-        };
-      }
-      next = { ...next, deliveryStatus: "pending", deliveryError: null };
-      setGroupChatPendingMessages((current) =>
-        current.map((pending) => (pending.rowId === rowId ? next : pending))
-      );
-      await deliverPendingGroupChatMessage(next).catch((err: unknown) => {
-        logger.error("Failed to retry Agent Team group chat message:", err);
-      });
+    async (_rowId: number, _editedDisplayText?: string): Promise<void> => {
+      await handleRetryGroupChatMessage();
     },
-    [agentOrgRunView, deliverPendingGroupChatMessage, groupChatPendingMessages]
+    [handleRetryGroupChatMessage]
   );
 
   return {
@@ -505,8 +585,7 @@ export function useAgentOrgGroupChatController({
     handleGroupChatTapEvents,
     groupChatMentionOptions,
     groupChatRunPaused,
-    groupChatPendingMessage:
-      groupChatPendingMessages[groupChatPendingMessages.length - 1] ?? null,
+    groupChatPendingMessage,
     groupChatHistoryHasMore,
     groupChatHistoryLoading,
     groupChatHistoryError,

--- a/src/engines/ChatPanel/hooks/useInputArea/__tests__/composerMemberPillSnapshot.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/__tests__/composerMemberPillSnapshot.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComposerSnapshot } from "@src/components/ComposerInput";
+
+import {
+  memberMentionsFromSnapshot,
+  serializeSubmissionSnapshot,
+} from "../useSubmitMessage";
+
+function memberPill(memberId: string, displayName: string) {
+  return {
+    kind: "pill" as const,
+    attrs: {
+      filePath: memberId,
+      fileName: displayName,
+      iconType: "member" as const,
+      isFolder: false,
+      lineStart: null,
+      lineEnd: null,
+    },
+  };
+}
+
+describe("structured Agent Team Member pill submission snapshot", () => {
+  it("preserves canonical pill order, deduplicates ids, and removes only Member pills", () => {
+    const snapshot: ComposerSnapshot = {
+      parts: [
+        memberPill("member://alice", "Same Name"),
+        { kind: "text", text: " " },
+        memberPill("member://bob", "Same Name"),
+        { kind: "text", text: " please inspect " },
+        memberPill("member://alice", "Renamed Alice"),
+        { kind: "newline" },
+        {
+          kind: "pill",
+          attrs: {
+            filePath: "/tmp/source.ts",
+            fileName: "source.ts",
+            iconType: "file",
+            isFolder: false,
+            lineStart: null,
+            lineEnd: null,
+          },
+        },
+      ],
+    };
+
+    expect(memberMentionsFromSnapshot(snapshot)).toEqual([
+      { memberId: "alice", displayName: "Same Name" },
+      { memberId: "bob", displayName: "Same Name" },
+    ]);
+    expect(serializeSubmissionSnapshot(snapshot, false)).toContain(
+      "@Same Name @Same Name"
+    );
+    const withoutMembers = serializeSubmissionSnapshot(snapshot, true);
+    expect(withoutMembers).not.toContain("@Same Name");
+    expect(withoutMembers).not.toContain("@Renamed Alice");
+    expect(withoutMembers).toContain("please inspect");
+    expect(withoutMembers).toContain("source.ts [file:/tmp/source.ts]");
+  });
+
+  it("rejects malformed Member pills instead of silently falling back to Root", () => {
+    const malformed: ComposerSnapshot = {
+      parts: [memberPill("legacy-member-id", "Legacy")],
+    };
+    expect(() => memberMentionsFromSnapshot(malformed)).toThrow(
+      "no canonical member:// id"
+    );
+  });
+});

--- a/src/engines/ChatPanel/hooks/useInputArea/__tests__/submissionErrors.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/__tests__/submissionErrors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SubmissionOutcomeUnknownError,
+  shouldRestoreSubmissionAfterDispatchError,
+} from "../submissionErrors";
+
+describe("submission dispatch error restoration", () => {
+  it("keeps a cleared composer when a durable Group outcome is unknown", () => {
+    expect(
+      shouldRestoreSubmissionAfterDispatchError(
+        new SubmissionOutcomeUnknownError("response lost after commit")
+      )
+    ).toBe(false);
+  });
+
+  it("restores the submission for known zero-write failures", () => {
+    expect(
+      shouldRestoreSubmissionAfterDispatchError(
+        new Error("group target limit exceeded")
+      )
+    ).toBe(true);
+  });
+});

--- a/src/engines/ChatPanel/hooks/useInputArea/__tests__/useSubmitMessage.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/__tests__/useSubmitMessage.test.ts
@@ -258,12 +258,17 @@ describe("useSubmitMessage composer boundary", () => {
       });
 
       if (path === "override") {
-        expect(onSubmitOverride).toHaveBeenCalledWith({
-          displayText: expected,
-          agentContent: undefined,
-          imageDataUrls: undefined,
-          composerSnapshot: editorHarness.editor.getSnapshot(),
-        });
+        expect(onSubmitOverride).toHaveBeenCalledWith(
+          expect.objectContaining({
+            displayText: expected,
+            agentContent: undefined,
+            imageDataUrls: undefined,
+            composerSnapshot: {
+              parts: [{ kind: "text", text: draft }],
+            },
+            memberMentions: [],
+          })
+        );
         expect(handleSessChatSubmit).not.toHaveBeenCalled();
       } else {
         expect(handleSessChatSubmit).toHaveBeenCalledWith(
@@ -398,12 +403,17 @@ describe("useSubmitMessage composer boundary", () => {
     });
 
     expect(mocks.messageWarning).not.toHaveBeenCalled();
-    expect(onSubmitOverride).toHaveBeenCalledWith({
-      displayText: "continue from this replay",
-      agentContent: "agent:continue from this replay",
-      imageDataUrls: undefined,
-      composerSnapshot: editorHarness.editor.getSnapshot(),
-    });
+    expect(onSubmitOverride).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayText: "continue from this replay",
+        agentContent: "agent:continue from this replay",
+        imageDataUrls: undefined,
+        composerSnapshot: {
+          parts: [{ kind: "text", text: "continue from this replay" }],
+        },
+        memberMentions: [],
+      })
+    );
     expect(handleSessChatSubmit).not.toHaveBeenCalled();
     expect(editorHarness.readText()).toBe("");
     expect(clearReplyTarget).toHaveBeenCalledOnce();

--- a/src/engines/ChatPanel/hooks/useInputArea/submissionErrors.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/submissionErrors.ts
@@ -1,0 +1,12 @@
+export class SubmissionOutcomeUnknownError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SubmissionOutcomeUnknownError";
+  }
+}
+
+export function shouldRestoreSubmissionAfterDispatchError(
+  error: unknown
+): boolean {
+  return !(error instanceof SubmissionOutcomeUnknownError);
+}

--- a/src/engines/ChatPanel/hooks/useInputArea/types.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/types.ts
@@ -33,6 +33,11 @@ export interface SubmitOverrideInput {
    * mutable display name after asynchronous preprocessing.
    */
   composerSnapshot?: ComposerSnapshot;
+  /** Ordered canonical Member pill identities from the same snapshot. */
+  memberMentions?: Array<{ memberId: string; displayName: string }>;
+  /** Display/agent copies with only Member pills removed. */
+  displayTextWithoutMemberMentions?: string;
+  agentContentWithoutMemberMentions?: string;
 }
 
 /** Rejected before any network/provider delivery was attempted. */

--- a/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
@@ -18,6 +18,8 @@ import { useAtomValue, useStore } from "jotai";
 import React, { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { ComposerSnapshot } from "@src/components/ComposerInput";
+import { serializePillNode } from "@src/components/ComposerInput/utils";
 import Message from "@src/components/Message";
 import { chatEventsAtom } from "@src/engines/SessionCore";
 import { createLogger } from "@src/hooks/logger";
@@ -37,6 +39,7 @@ import { resolveMcpSlashCommand } from "./mcpSlashCommand";
 import { expandSkillPills } from "./outgoingTextTransforms";
 import { projectOutgoingUserMessage } from "./projectOutgoingUserMessage";
 import { interceptPendingQuestionBatches } from "./questionIntercept";
+import { shouldRestoreSubmissionAfterDispatchError } from "./submissionErrors";
 import type {
   CiteCodeSnapshot,
   InputAreaRefs,
@@ -51,6 +54,43 @@ import { SubmitRetainedDeliveryError } from "./types";
 export { stripContextPillBase64 } from "./outgoingTextTransforms";
 
 const log = createLogger("useSubmitMessage");
+
+export function serializeSubmissionSnapshot(
+  snapshot: ComposerSnapshot,
+  omitMemberPills: boolean
+): string {
+  return snapshot.parts
+    .map((part) => {
+      if (part.kind === "text") return part.text;
+      if (part.kind === "newline") return "\n";
+      if (omitMemberPills && part.attrs.iconType === "member") return "";
+      return serializePillNode(part.attrs);
+    })
+    .join("")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/^[ \t]+|[ \t]+$/g, "");
+}
+
+export function memberMentionsFromSnapshot(
+  snapshot: ComposerSnapshot
+): Array<{ memberId: string; displayName: string }> {
+  const seen = new Set<string>();
+  const mentions: Array<{ memberId: string; displayName: string }> = [];
+  for (const part of snapshot.parts) {
+    if (part.kind !== "pill" || part.attrs.iconType !== "member") continue;
+    if (!part.attrs.filePath.startsWith("member://")) {
+      throw new Error("Agent Team Member pill has no canonical member:// id");
+    }
+    const memberId = part.attrs.filePath.slice("member://".length).trim();
+    if (!memberId) {
+      throw new Error("Agent Team Member pill has an empty canonical id");
+    }
+    if (seen.has(memberId)) continue;
+    seen.add(memberId);
+    mentions.push({ memberId, displayName: part.attrs.fileName });
+  }
+  return mentions;
+}
 
 // ============================================================================
 // Types
@@ -165,20 +205,22 @@ export function useSubmitMessage({
         return;
       }
 
-      const liveDisplayText = refs.composerInputRef.current.getTextWithPills();
+      const isExplicitAction = options.source === "explicit-action";
+      const submitComposerSnapshot = isExplicitAction
+        ? undefined
+        : refs.composerInputRef.current.getSnapshot();
+      const liveDisplayText = submitComposerSnapshot
+        ? serializeSubmissionSnapshot(submitComposerSnapshot, false)
+        : refs.composerInputRef.current.getTextWithPills();
       const resolvedInput = resolveSubmitInput(
         options,
         liveDisplayText,
         imageAttachment.hasImages
       );
-      const { isExplicitAction } = resolvedInput;
       // Capture typed mention identities before any async secret scan, MCP
       // expansion, or pending-pill load. Display text is not an identity
       // source: a roster rename while those awaits run must not retarget the
       // Team Chat message.
-      const submitComposerSnapshot = isExplicitAction
-        ? undefined
-        : refs.composerInputRef.current.getSnapshot();
       let { displayText } = resolvedInput;
       const hasText = displayText.trim().length > 0;
       const { hasAttachedImages } = resolvedInput;
@@ -370,6 +412,20 @@ export function useSubmitMessage({
           !hasAttachedImages && !isCliSession(draftSessionId || null),
       });
       displayText = displayContent;
+      const displayTextWithoutMemberMentions = submitComposerSnapshot
+        ? serializeSubmissionSnapshot(submitComposerSnapshot, true)
+        : displayText;
+      const { agentContent: agentContentWithoutMemberMentions } =
+        projectOutgoingUserMessage({
+          displayText: displayTextWithoutMemberMentions,
+          contextBlocks,
+          enableAgentInterceptors,
+          allowCanvasInterception:
+            !hasAttachedImages && !isCliSession(draftSessionId || null),
+        });
+      const memberMentions = submitComposerSnapshot
+        ? memberMentionsFromSnapshot(submitComposerSnapshot)
+        : [];
 
       const imageDataUrls = isExplicitAction
         ? []
@@ -378,6 +434,7 @@ export function useSubmitMessage({
         draftSessionId,
         displayText,
         agentContent,
+        memberIds: memberMentions.map((mention) => mention.memberId),
         imageDataUrls,
         composerSnapshot: submitComposerSnapshot,
       });
@@ -433,15 +490,25 @@ export function useSubmitMessage({
                 agentContent,
                 imageDataUrls: dispatchImages,
                 composerSnapshot: submitComposerSnapshot,
+                memberMentions,
+                displayTextWithoutMemberMentions,
+                agentContentWithoutMemberMentions:
+                  agentContentWithoutMemberMentions ??
+                  displayTextWithoutMemberMentions,
               })
             : false;
           if (!overrideHandled) {
+            const ordinaryAgentContent =
+              memberMentions.length > 0
+                ? (agentContentWithoutMemberMentions ??
+                  displayTextWithoutMemberMentions)
+                : agentContent;
             // Queue-vs-direct is decided inside handleSessChatSubmit against
             // the turn-lifecycle FSM — no composer-side heuristics.
             await handleSessChatSubmit(
               undefined,
               displayText || "(image)",
-              agentContent,
+              ordinaryAgentContent,
               dispatchImages
             );
           }
@@ -450,8 +517,13 @@ export function useSubmitMessage({
           // Until a transport has retained a visible failed row, the composer
           // remains the only recoverable copy of the user's text, images and
           // structured mention pills. Optimistic transports explicitly mark
-          // that ownership hand-off with SubmitRetainedDeliveryError.
-          if (!(err instanceof SubmitRetainedDeliveryError)) {
+          // that ownership hand-off with SubmitRetainedDeliveryError. A Group
+          // delivery with an unknown outcome similarly owns an immutable retry
+          // envelope and must not also repopulate the editor.
+          if (
+            !(err instanceof SubmitRetainedDeliveryError) &&
+            shouldRestoreSubmissionAfterDispatchError(err)
+          ) {
             const editor = refs.composerInputRef.current;
             if (editor && editorSnapshot) {
               try {

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "Ältere Nachrichten laden",
     "historyLoadFailed": "Verlauf nicht verfügbar",
-    "triggerLabel": "Gruppenchat"
+    "triggerLabel": "Gruppenchat",
+    "userMessageOutcomeUnknown": "Das Zustellungsergebnis ist unbekannt. Wiederhole die ursprüngliche Zustellung."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -2337,7 +2337,8 @@
       "otherTools_one": "{{count}} other tool call",
       "otherTools_other": "{{count}} other tool calls"
     },
-    "triggerLabel": "Group chat"
+    "triggerLabel": "Group chat",
+    "userMessageOutcomeUnknown": "Delivery outcome unknown. Retry the original delivery."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "Cargar mensajes anteriores",
     "historyLoadFailed": "Historial no disponible",
-    "triggerLabel": "Chat grupal"
+    "triggerLabel": "Chat grupal",
+    "userMessageOutcomeUnknown": "Se desconoce el resultado de la entrega. Reintenta la entrega original."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "Charger les messages précédents",
     "historyLoadFailed": "Historique indisponible",
-    "triggerLabel": "Chat de groupe"
+    "triggerLabel": "Chat de groupe",
+    "userMessageOutcomeUnknown": "Le résultat de l’envoi est inconnu. Réessayez l’envoi d’origine."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "古いメッセージを読み込む",
     "historyLoadFailed": "履歴を取得できません",
-    "triggerLabel": "グループチャット"
+    "triggerLabel": "グループチャット",
+    "userMessageOutcomeUnknown": "配信結果は不明です。元の配信を再試行してください。"
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "이전 메시지 불러오기",
     "historyLoadFailed": "기록을 사용할 수 없습니다",
-    "triggerLabel": "그룹 채팅"
+    "triggerLabel": "그룹 채팅",
+    "userMessageOutcomeUnknown": "전달 결과를 알 수 없습니다. 원래 전달을 다시 시도하세요."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "Wczytaj starsze wiadomości",
     "historyLoadFailed": "Historia niedostępna",
-    "triggerLabel": "Czat grupowy"
+    "triggerLabel": "Czat grupowy",
+    "userMessageOutcomeUnknown": "Wynik dostarczenia jest nieznany. Ponów pierwotne dostarczenie."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "Carregar mensagens anteriores",
     "historyLoadFailed": "Histórico indisponível",
-    "triggerLabel": "Chat de grupo"
+    "triggerLabel": "Chat de grupo",
+    "userMessageOutcomeUnknown": "O resultado da entrega é desconhecido. Tente novamente a entrega original."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "Загрузить более ранние сообщения",
     "historyLoadFailed": "История недоступна",
-    "triggerLabel": "Групповой чат"
+    "triggerLabel": "Групповой чат",
+    "userMessageOutcomeUnknown": "Результат доставки неизвестен. Повторите исходную доставку."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "Eski mesajları yükle",
     "historyLoadFailed": "Geçmiş kullanılamıyor",
-    "triggerLabel": "Grup sohbeti"
+    "triggerLabel": "Grup sohbeti",
+    "userMessageOutcomeUnknown": "Teslimat sonucu bilinmiyor. Özgün teslimatı yeniden deneyin."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "Tải tin nhắn cũ hơn",
     "historyLoadFailed": "Lịch sử không khả dụng",
-    "triggerLabel": "Trò chuyện nhóm"
+    "triggerLabel": "Trò chuyện nhóm",
+    "userMessageOutcomeUnknown": "Không xác định được kết quả gửi. Hãy thử lại lần gửi ban đầu."
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2338,7 +2338,8 @@
     },
     "loadOlder": "載入更早的訊息",
     "historyLoadFailed": "歷史訊息暫不可用",
-    "triggerLabel": "群組聊天"
+    "triggerLabel": "群組聊天",
+    "userMessageOutcomeUnknown": "訊息提交結果未知，請使用原請求重試。"
   },
   "orgTask": {
     "create": {

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2337,7 +2337,8 @@
       "otherTools_one": "{{count}} 次其他工具调用",
       "otherTools_other": "{{count}} 次其他工具调用"
     },
-    "triggerLabel": "群聊"
+    "triggerLabel": "群聊",
+    "userMessageOutcomeUnknown": "消息提交结果未知，请使用原请求重试。"
   },
   "orgTask": {
     "create": {


### PR DESCRIPTION
## Problem

Related to #764.

The stabilized Agent Org stack can preserve formal Task execution and Root FIFO ordering, but Group composer Member mentions still lack one atomic, durable user-directed-work ingress. A transport retry can therefore not rely on one immutable multi-target envelope, and Members cannot safely delegate linked side quests through `org_send_message` without mixing them into formal Task/work-episode authority.

PR9 must add that missing execution layer without replacing the PR8 Stabilization formal trigger, exact formal Inbox drain, work episode, completion, or Root queue behavior. The design document is the controlling specification; final Group-feed projection and default rollout remain PR10 work.

## Solution

- Add a source-neutral user-directed-work authority with canonical Inbox classification, frozen server-owned limits, root/parent causality, per-Member FIFO identity, exact lifecycle state, idempotency digests, and bounded startup recovery.
- Replace the old single-target Group write with an ordered multi-target transaction. Validation is all-or-nothing; each Member receives an independent Inbox row, Turn identity, FIFO sequence, receipt, runtime, and terminal result.
- Read recipients from structured `member://<canonical_member_id>` composer pills. The first send freezes the body, ordered targets, and per-target IDs; Retry after an unknown transport outcome reuses that envelope instead of creating duplicate work.
- Authorize Linked Inbox sends from persisted call context, not model-supplied claims. Linked peers are snapshot-checked, Coordinator remains reachable through the existing Root FIFO, and TaskExecution cannot use user-directed peer authority.
- Keep Direct Member work as the highest-priority intervention while Direct, Group, and Linked sources share one Member runtime lane. Paused user-directed work can answer without resuming the Team or mutating the formal graph.
- Delete user-directed causal rows from leaves to roots before deleting Team sessions, fixing the foreign-key failure found during packaged-app Delete acceptance.
- Add isolated test-only fault/evidence endpoints for response-loss and commit-before-kick validation. They cannot perform visible send, session switch, Pause/Resume, Archive, or Delete actions.

The rollout gate remains off by default. Zero-Member and Coordinator-only composer sends continue through the stabilized Root path; mixed Coordinator/Member selection is rejected. Final N-channel Group projection removal, localization sweep, default rollout, and PR10 feed performance work are deliberately excluded.

## Potential risks

- This stacked, unpublished schema is updated canonically and intentionally has no migration from intermediate PR-stack databases. Developers testing older stack states must reset/fresh-create Agent Org data. Rollback is to disable the rollout gate or revert these four commits and reset only unpublished test data.
- The PR must merge after PR #1079 (`codex/agent-org-pr8-stabilization`). If that base advances, this branch needs a deliberate rebase plus affected schema, formal-path, packaged-app, and recovery checks.
- Multi-target sends add bounded Provider concurrency and durable rows. Server-owned limits (10 Group targets, 32 pending roots per Member, 8 downstream deliveries per root, depth 2), one active Member runtime, and non-polling keyset recovery bound the exposure.
- Static screenshots are not attached: the important acceptance properties are ordering, retry identity, restart recovery, Pause/Resume state, and persisted causality, which a still image cannot establish. They were verified in one exact packaged Tauri artifact through visible UI actions plus SQLite/runtime evidence.
- Two repository-wide quality commands remain blocked by unchanged baseline files, documented below. PR9-scoped checks and the owning crate checks pass; this PR does not expand scope to repair unrelated Canvas runtime imports or workspace test layout.

## Verification

### Automated

- `pnpm exec vitest run src/engines/ChatPanel/hooks/groupChatRouting.test.ts src/engines/ChatPanel/hooks/useAgentOrgGroupChatController.test.ts src/engines/ChatPanel/hooks/useInputArea/__tests__/composerMemberPillSnapshot.test.ts src/engines/ChatPanel/hooks/useInputArea/__tests__/submissionErrors.test.ts` — 4 files, 17 tests passed.
- `pnpm typecheck` — passed.
- `pnpm run lint` — exited 0 with 0 errors and 5 pre-existing warnings in unchanged ProjectManager files.
- Targeted ESLint and Prettier checks over changed frontend files — passed; every commit hook ran without bypass.
- `cd src-tauri && cargo fmt --all --check` — passed.
- `cd src-tauri && cargo test -p agent_core --lib` — 3,413 passed, 0 failed, 2 ignored.
- `cd src-tauri && cargo clippy -p agent_core --all-targets -- -D warnings` — passed.
- `cd src-tauri && cargo check -p org2` — passed.
- `git diff --check 6ffddb8b1e3814ca8caf080915048a91e2322f10..HEAD` — passed.
- `pnpm run check:circular` — blocked before cycle analysis because Madge cannot resolve two existing `?raw` imports in unchanged `src/engines/ChatPanel/blocks/CanvasInlineCard/reactArtifactDocument.ts`.
- `cd src-tauri && cargo clippy --all-targets -- -D warnings` — PR9 owners passed, then the workspace test target stopped on pre-existing `clippy::items-after-test-module` in unchanged `src-tauri/src/api/agent/test/workspace.rs`.

### Packaged Tauri App and real Provider

- Built the frozen branch with `ORGII_AGENT_ORG_REDESIGN=1 pnpm run tauri:build:fast`.
- Verified artifact: `ORG2-PR9-BuildFast-Handoff-v2.app`; executable SHA-256 `e473c056c04618349f5b047841cfc12b018de87aae605f274ac3f52c57cf9cc0`.
- Used real `codexmaggie / gpt5.4mini` provider work in an isolated discount-calculator repository. Implementer and Reviewer received independent Group roots, edited/checked the real fixture, used real `org_send_message`, and produced persisted linked replies and test results.
- Verified Working queues Group work without interrupting the formal Task; Idle stays Idle; Paused accepts Member side work without auto-resume; Coordinator cannot mutate the formal graph while paused; Resume is explicit.
- Verified Direct Member work keeps priority while later Group work retains its FIFO position and completes after End Direct Work.
- Verified a real 10-Member burst produces 10 independent Inbox/Turn/root/FIFO/results with at most one active runtime per Member. An 11th target is rejected before write with zero Provider request.
- Injected response loss, used the visible Retry action, and verified the same immutable IDs with no duplicate Inbox, sequence, or wake.
- Injected commit-before-kick, quit and relaunched the packaged App, and verified pending-only recovery with no duplicate or replay of started side effects.
- Used Computer Use for all visible actions: Team open/create, structured pills, input/send/Retry, Member and Root A-to-B-to-A switching, Stop, Direct Member work, End Direct Work, Pause, paused send, Resume, Archive, archived read-only state, confirmation dialogs, and final Delete.
- Final Delete removed the isolated Team, all 11 sessions, Inbox/context/user-directed authority rows, and left 0 foreign-key violations; SQLite `quick_check` returned `ok`. Relaunch confirmed the deleted Team stayed absent.

### Lifecycle and performance

- Foreground 5 minutes: 60 samples, RSS 230,736–234,336 KiB, average 232,250 KiB, average CPU 1.512%.
- Ordinary New Session idle 5 minutes: RSS 234,912–234,944 KiB, average 234,925 KiB, average CPU 0.830%.
- Hidden/minimized 5 minutes: RSS 235,168–235,232 KiB, average 235,176 KiB, average CPU 0.163%.
- Durable row counts remained stable; no periodic scan, wake storm, retained listener/timer growth, or staircase memory growth was observed. Recovery is startup-only, single-flight, keyset-bounded to 100 rows with a 50 ms yield.

## Review structure

1. `feat(agent-core): add user-directed work authority`
2. `feat(agent-core): add atomic group member delivery`
3. `feat(agent-core): add linked inbox routing`
4. `feat(chat): wire structured group member delivery`

Architecture ownership/types/wire/persistence/lifecycle and the background-work lifecycle matrix were audited. Frontend design-system usage was reviewed manually because the configured `frontend-ui-audit` skill file was unavailable; no audit report is claimed.
