### PR TITLE
fix(search): update Rust lifetime scope query

### DIFF
--- a/src-tauri/crates/search/src/code/intelligence/language/rust.rs
+++ b/src-tauri/crates/search/src/code/intelligence/language/rust.rs
@@ -79,7 +79,9 @@ const RUST_SCOPES: &str = r#"
 
 (label (identifier) @local.definition.label)
 (lifetime (identifier) @local.definition.lifetime)
-(type_parameters (lifetime (identifier) @local.definition.lifetime))
+(type_parameters
+  (lifetime_parameter
+    name: (lifetime (identifier) @local.definition.lifetime)))
 
 ;; Imports
 
@@ -96,3 +98,35 @@ const RUST_SCOPES: &str = r#"
 (shorthand_field_identifier) @local.reference
 (lifetime (identifier) @local.reference)
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::code::intelligence::TreeSitterFile;
+
+    #[test]
+    fn rust_scope_query_compiles_against_the_bundled_grammar() {
+        RUST.scope_query
+            .query(RUST.grammar)
+            .expect("Rust scope query must match the bundled tree-sitter grammar");
+    }
+
+    #[test]
+    fn rust_scope_graph_extracts_symbols_with_lifetime_parameters() {
+        let source = b"fn borrow<'a>(value: &'a str) -> &'a str { value }\nstruct Widget;\n";
+        let graph = TreeSitterFile::try_build_from_extension(source, "rs")
+            .expect("parse Rust source")
+            .scope_graph()
+            .expect("build Rust scope graph");
+        let symbols = graph.symbols();
+
+        assert!(symbols.iter().any(|symbol| {
+            symbol.kind == "function"
+                && &source[symbol.range.start.byte..symbol.range.end.byte] == b"borrow"
+        }));
+        assert!(symbols.iter().any(|symbol| {
+            symbol.kind == "struct"
+                && &source[symbol.range.start.byte..symbol.range.end.byte] == b"Widget"
+        }));
+    }
+}


### PR DESCRIPTION
## Problem

The bundled tree-sitter-rust grammar represents generic lifetime declarations as `type_parameters -> lifetime_parameter -> lifetime`. The Rust scope query matched `lifetime` directly below `type_parameters`, so compiling the full query failed and API symbol extraction could not build a Rust scope graph for otherwise valid files.

## Solution

Update the query to follow the grammar's `lifetime_parameter` node and its named `lifetime` child. Add a regression that compiles the complete bundled Rust scope query plus an owning-boundary test that builds a scope graph from Rust source containing a lifetime parameter and verifies function/struct symbols remain available.

## Potential risks

The query is intentionally coupled to the bundled tree-sitter-rust grammar version. A future grammar upgrade may require another query adjustment; the new compile test will fail immediately instead of allowing a runtime parser failure. No wire format, persisted data, public Rust API, or non-Rust language query changes are involved, and rollback is the isolated one-line query change.

## Verification

- `cargo test -p app_utils -p inbox -p api_search -p search --features app_utils/testing --no-fail-fast` — passed; search reported 49 passed, 0 failed, including both new Rust query tests.
- `cargo fmt -p app_utils -p inbox -p api_search -p search -- --check` — passed.
- `cargo clippy -p app_utils -p inbox -p api_search -p search --tests --features app_utils/testing -- -D warnings` — passed.
- Commit hook scoped `cargo clippy` to `search` — passed.
- `pnpm run cargo:test` was not run because the shared checkout contains unrelated uncommitted work outside this PR; CI remains responsible for the clean full-workspace run.
- No visual verification was needed because this PR has no user-visible UI changes.
