### PR TITLE
feat(session-window): open sessions in detached windows

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,35 @@
     </script>
     <script nonce="orgii-codemirror-style">
       // ---------------------------------------------------------------------
+      // Secondary-window preflight (runs before the JS bundle).
+      //
+      // Detached session windows (any Tauri window whose label is not "main")
+      // boot straight into their content: no splash mark, no status line. The
+      // #splash overlay element itself stays mounted so the startup watchdog
+      // still has a host for its error panel if the bundle never comes up.
+      // Tauri injects __TAURI_INTERNALS__ before page scripts, so the label
+      // is readable synchronously; outside Tauri this is a no-op.
+      // ---------------------------------------------------------------------
+      (function () {
+        try {
+          var internals = window.__TAURI_INTERNALS__;
+          var label =
+            internals && internals.metadata && internals.metadata.currentWindow
+              ? internals.metadata.currentWindow.label
+              : "main";
+          if (label !== "main") {
+            document.documentElement.setAttribute(
+              "data-orgii-secondary-window",
+              ""
+            );
+          }
+        } catch (e) {
+          // Non-Tauri or unexpected internals shape: keep main-window behavior.
+        }
+      })();
+    </script>
+    <script nonce="orgii-codemirror-style">
+      // ---------------------------------------------------------------------
       // Splash palette preflight (runs before the JS bundle).
       //
       // The splash paints no plate of its own — it shows the same background
@@ -434,6 +463,15 @@
         background: transparent;
         border-radius: var(--border-radius-window);
         z-index: 99999;
+      }
+      /*
+       * Secondary windows (detached sessions) skip the splash mark: the
+       * overlay stays for the watchdog's error panel, but nothing is drawn
+       * on the happy path. See the secondary-window preflight script.
+       */
+      html[data-orgii-secondary-window] #splash-logo,
+      html[data-orgii-secondary-window] #splash-text {
+        display: none;
       }
       /*
        * Glyph only — same geometry as <AppMark>, without its circular plate,

--- a/src-tauri/crates/app-window/src/commands.rs
+++ b/src-tauri/crates/app-window/src/commands.rs
@@ -226,15 +226,14 @@ unsafe fn set_draws_background_recursive(view: *mut AnyObject, draws: bool) {
     }
 }
 
-/// Remove the startup background from the main window. Called from the
-/// frontend once the React app finishes loading and CSS backgrounds are
-/// painted — this restores the normal transparent glass appearance.
+/// Remove the startup background from the CALLING window. Every window's
+/// frontend invokes this once React finishes loading and CSS backgrounds are
+/// painted — restoring the transparent glass appearance and re-asserting the
+/// traffic-light inset (the post-paint re-apply is what keeps the buttons
+/// stable on macOS). Tauri injects the invoking window, so main and detached
+/// session windows each clear their own backdrop.
 #[tauri::command]
-pub async fn remove_window_background(app: AppHandle) -> Result<(), String> {
-    let window = app
-        .get_webview_window("main")
-        .ok_or("Main window not found")?;
-
+pub async fn remove_window_background(window: tauri::WebviewWindow) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         super::remove_window_background_color(&window);
@@ -323,14 +322,20 @@ pub async fn open_session_window(
         .resizable(true)
         .visible(true)
         .decorations(true)
-        // Match the main window's startup backdrop so the pre-splash frame is
+        // Match the main window's startup backdrop so the pre-paint frame is
         // never a white flash. The page paints its own background on top.
         .background_color(tauri::window::Color(0x0d, 0x0d, 0x0d, 0xff));
 
+    // Same chrome contract as the main window's config: a TRANSPARENT
+    // NSWindow under the overlay title bar. Without transparency, macOS
+    // draws an opaque titlebar band across the top and the repositioned
+    // traffic lights sit against a mismatched strip instead of over the
+    // app's own header.
     #[cfg(target_os = "macos")]
     let builder = builder
         .hidden_title(true)
         .title_bar_style(TitleBarStyle::Overlay)
+        .transparent(true)
         .traffic_light_position(Position::Logical(LogicalPosition::new(
             super::TRAFFIC_LIGHT_X,
             super::TRAFFIC_LIGHT_Y,
@@ -342,8 +347,20 @@ pub async fn open_session_window(
         .map_err(|e| format!("Failed to create session window: {e}"))?;
     ownership_observation.commit();
 
+    // Same post-build sequence as `recreate_main_window`: reposition the
+    // traffic lights (the builder option alone is unreliable for dynamically
+    // created windows), paint the startup background so the transparent
+    // window never shows the desktop through, and mount the same glass
+    // material the main window uses. The frontend clears the startup
+    // background via `remove_window_background` once React paints — that
+    // command operates on the calling window, so this window gets the same
+    // post-paint traffic-light re-apply main does.
     #[cfg(target_os = "macos")]
-    super::set_traffic_light_position(&window, super::TRAFFIC_LIGHT_X, super::TRAFFIC_LIGHT_Y);
+    {
+        super::set_traffic_light_position(&window, super::TRAFFIC_LIGHT_X, super::TRAFFIC_LIGHT_Y);
+        super::apply_window_background_color(&window);
+        super::apply_macos_window_material(&window);
+    }
 
     super::apply_host_desktop_decorated_window_corners(&window);
 

--- a/src-tauri/crates/app-window/src/commands.rs
+++ b/src-tauri/crates/app-window/src/commands.rs
@@ -10,12 +10,14 @@
 //! reaches the crate root for `tauri::generate_handler!` to find. Same
 //! pattern key-vault and integrations use.
 
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
 #[cfg(target_os = "macos")]
 use objc2::msg_send;
 #[cfg(target_os = "macos")]
 use objc2::runtime::{AnyClass, AnyObject};
+#[cfg(target_os = "macos")]
+use tauri::{LogicalPosition, Position, TitleBarStyle};
 
 /// Set the native zoom factor for the main application WebView.
 #[tauri::command]
@@ -25,6 +27,22 @@ pub async fn set_main_webview_zoom(app: AppHandle, scale_factor: f64) -> Result<
     webview
         .set_zoom(scale_factor)
         .map_err(|err| format!("Failed to set main WebView zoom: {}", err))?;
+
+    Ok(())
+}
+
+/// Set the native zoom factor for the CALLING window's own WebView.
+///
+/// Per-window replacement for [`set_main_webview_zoom`]: with detached
+/// session windows, each window must zoom its own webview instead of
+/// re-zooming "main". Tauri injects the invoking [`tauri::Webview`], so
+/// no label lookup is needed and the command can never target another
+/// window. The main-window variant is kept for compatibility.
+#[tauri::command]
+pub async fn set_webview_zoom(webview: tauri::Webview, scale_factor: f64) -> Result<(), String> {
+    webview
+        .set_zoom(scale_factor)
+        .map_err(|err| format!("Failed to set WebView zoom: {}", err))?;
 
     Ok(())
 }
@@ -227,6 +245,142 @@ pub async fn remove_window_background(app: AppHandle) -> Result<(), String> {
     let _ = window;
 
     Ok(())
+}
+
+// ============================================
+// Detached session windows
+// ============================================
+
+/// Label prefix for detached session windows. Matches the `app-window-*`
+/// glob in `capabilities/default.json`, so these windows inherit the full
+/// default permission set without a capability (and thus Rust schema) change.
+pub const SESSION_WINDOW_LABEL_PREFIX: &str = "app-window-session-";
+
+/// Session ids are `<source-prefix>-<uuid>` shaped. The id is embedded
+/// verbatim in both the window label and the app-route path, so anything
+/// outside the shared safe charset is refused rather than escaped — escaping
+/// differently per context would let label and URL disagree about identity.
+fn is_window_safe_session_id(session_id: &str) -> bool {
+    !session_id.is_empty()
+        && session_id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+fn session_window_label(session_id: &str) -> String {
+    format!("{SESSION_WINDOW_LABEL_PREFIX}{session_id}")
+}
+
+/// Open (or focus) the detached window showing exactly one session.
+///
+/// The window loads the standalone `/orgii/app/session/<id>` route — the same
+/// bundle as the main window, rendering only the session surface. There is no
+/// prewarmed window pool: the window is built on demand and visible from the
+/// first frame (the splash), which is the fastest honest feedback we can give.
+///
+/// Chrome follows the decorated-secondary-window recipe used by
+/// `browser::open_browser_window`: native decorations everywhere, macOS
+/// overlay title bar with repositioned traffic lights (the builder option
+/// alone is unreliable for dynamically created windows — see
+/// `set_traffic_light_position`), and Win11 DWM rounded corners.
+///
+/// `async` on purpose: on Windows, building a window from a synchronous
+/// command deadlocks the main thread.
+#[tauri::command]
+pub async fn open_session_window(
+    app: AppHandle,
+    session_id: String,
+    title: Option<String>,
+) -> Result<String, String> {
+    if !is_window_safe_session_id(&session_id) {
+        return Err(format!(
+            "Session id contains characters unsafe for a window label: {session_id}"
+        ));
+    }
+
+    let label = session_window_label(&session_id);
+    let window_title = title
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| "ORG2".to_string());
+
+    if let Some(existing) = app.get_webview_window(&label) {
+        let _ = existing.set_title(&window_title);
+        existing
+            .show()
+            .map_err(|e| format!("Failed to show session window: {e}"))?;
+        existing
+            .set_focus()
+            .map_err(|e| format!("Failed to focus session window: {e}"))?;
+        return Ok(label);
+    }
+
+    let route = format!("orgii/app/session/{session_id}");
+    let builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(route.into()))
+        .title(&window_title)
+        .inner_size(1100.0, 800.0)
+        .min_inner_size(450.0, 300.0)
+        .resizable(true)
+        .visible(true)
+        .decorations(true)
+        // Match the main window's startup backdrop so the pre-splash frame is
+        // never a white flash. The page paints its own background on top.
+        .background_color(tauri::window::Color(0x0d, 0x0d, 0x0d, 0xff));
+
+    #[cfg(target_os = "macos")]
+    let builder = builder
+        .hidden_title(true)
+        .title_bar_style(TitleBarStyle::Overlay)
+        .traffic_light_position(Position::Logical(LogicalPosition::new(
+            super::TRAFFIC_LIGHT_X,
+            super::TRAFFIC_LIGHT_Y,
+        )));
+
+    let ownership_observation = perf_utils::begin_webview_ownership_observation(label.clone());
+    let window = builder
+        .build()
+        .map_err(|e| format!("Failed to create session window: {e}"))?;
+    ownership_observation.commit();
+
+    #[cfg(target_os = "macos")]
+    super::set_traffic_light_position(&window, super::TRAFFIC_LIGHT_X, super::TRAFFIC_LIGHT_Y);
+
+    super::apply_host_desktop_decorated_window_corners(&window);
+
+    let _ = window.set_focus();
+
+    Ok(label)
+}
+
+#[cfg(test)]
+mod session_window_tests {
+    use super::{is_window_safe_session_id, session_window_label};
+
+    #[test]
+    fn accepts_prefixed_uuid_session_ids() {
+        assert!(is_window_safe_session_id(
+            "osagent-1f2e3d4c-5b6a-7980-a1b2-c3d4e5f60718"
+        ));
+        assert!(is_window_safe_session_id("humansession-abc_123"));
+    }
+
+    #[test]
+    fn rejects_ids_unsafe_for_labels_or_paths() {
+        assert!(!is_window_safe_session_id(""));
+        assert!(!is_window_safe_session_id("osagent-1234/../../etc"));
+        assert!(!is_window_safe_session_id("osagent 1234"));
+        assert!(!is_window_safe_session_id("osagent-1234?x=1"));
+        assert!(!is_window_safe_session_id("osagent-1234.json"));
+    }
+
+    #[test]
+    fn label_matches_the_capability_glob() {
+        assert_eq!(
+            session_window_label("osagent-1"),
+            "app-window-session-osagent-1"
+        );
+        assert!(session_window_label("x").starts_with("app-window-"));
+    }
 }
 
 /// Whether the main window has a translucent native backdrop (Windows 11

--- a/src-tauri/crates/system-services/src/power.rs
+++ b/src-tauri/crates/system-services/src/power.rs
@@ -1,12 +1,29 @@
 //! System power management — "prevent system sleep" while agent sessions run.
 //!
 //! Exposes two Tauri commands:
-//! - `system_power_acquire_sleep_inhibitor` — keep system awake (idempotent)
-//! - `system_power_release_sleep_inhibitor` — allow normal sleep (idempotent)
+//! - `system_power_acquire_sleep_inhibitor` — keep system awake (per-window, refcounted)
+//! - `system_power_release_sleep_inhibitor` — allow normal sleep (per-window, refcounted)
 //!
 //! The frontend calls acquire/release in response to:
 //! (a) the `general.preventSleepWhileRunning` setting toggling, and
 //! (b) the count of actively-working sessions transitioning between 0 and >0.
+//!
+//! Multi-window semantics: every OS window (the main window plus detached
+//! `app-window-session-<id>` windows) runs its own copy of the frontend hook
+//! and calls these commands independently, but the OS assertion is
+//! process-wide. The state is therefore a holder SET keyed by window label
+//! backing a single platform handle: a window's acquire registers its label
+//! and the platform assertion is created only for the first holder; a
+//! window's release removes only its own label and the assertion is dropped
+//! only when the last holder leaves. This prevents one window's release
+//! (e.g. a detached session window closing or its session going idle first)
+//! from tearing the assertion out from under another window that still
+//! needs it.
+//!
+//! Leak protection: a window can be destroyed without its JS cleanup ever
+//! running. The `WindowEvent::Destroyed` handler in `lib.rs` calls
+//! [`release_sleep_inhibitor_for_window_label`] so a dead window's holder
+//! entry cannot pin the assertion until process exit.
 //!
 //! Platform implementations:
 //! - macOS:   `IOPMAssertionCreateWithName` (`kIOPMAssertPreventUserIdleSystemSleep`).
@@ -16,8 +33,8 @@
 //! - Linux:   No-op for now (D-Bus `org.freedesktop.ScreenSaver.Inhibit` can
 //!   be added later if there's user demand).
 
-use std::sync::Mutex;
-use tauri::State;
+use std::collections::HashSet;
+use std::sync::{Mutex, OnceLock};
 
 #[cfg(target_os = "macos")]
 mod macos_impl {
@@ -112,12 +129,45 @@ enum InhibitorHandle {
     Unsupported,
 }
 
-/// Pure idempotency decision for the acquire/release state machine.
+/// Refcounted inhibitor state: the set of window labels that currently want
+/// the system kept awake, plus the single process-wide platform handle that
+/// backs them.
 ///
-/// Extracted from the Tauri commands so the duplicate-call semantics can be
-/// unit-tested without spinning up the Tauri runtime or invoking real FFI.
-/// The commands consult these helpers to decide whether to skip the FFI
-/// call entirely (when already in the desired state).
+/// Invariant (re-established by every mutation): the platform handle exists
+/// iff at least one holder is registered — it is created for the first
+/// holder and dropped exactly when the last holder is removed.
+#[derive(Debug, Default)]
+struct PowerInner {
+    handle: Option<InhibitorHandle>,
+    holders: HashSet<String>,
+}
+
+/// Process-wide inhibitor state.
+///
+/// A static rather than Tauri-managed state because (a) the OS assertion
+/// itself is process-wide, not per-window, and (b) the
+/// `WindowEvent::Destroyed` cleanup path
+/// ([`release_sleep_inhibitor_for_window_label`]) runs inside a window-event
+/// closure where no `State` extractor is available.
+static POWER_INNER: OnceLock<Mutex<PowerInner>> = OnceLock::new();
+
+fn power_inner() -> &'static Mutex<PowerInner> {
+    POWER_INNER.get_or_init(|| Mutex::new(PowerInner::default()))
+}
+
+fn lock_power_inner() -> Result<std::sync::MutexGuard<'static, PowerInner>, String> {
+    power_inner()
+        .lock()
+        .map_err(|err| format!("Power inhibitor mutex poisoned: {}", err))
+}
+
+/// Pure refcount decision for the acquire/release state machine.
+///
+/// Extracted from the Tauri commands so the per-window holder semantics can
+/// be unit-tested without spinning up the Tauri runtime or invoking real FFI.
+/// The commands consult these helpers to decide whether to perform the
+/// process-wide platform call or skip it (already in the desired state, or
+/// other windows still hold the inhibitor).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Transition {
     /// Perform the underlying platform call and record the new state.
@@ -126,8 +176,16 @@ pub enum Transition {
     Skip,
 }
 
+/// Register `label` as a holder and decide whether the process-wide OS
+/// assertion must be created (`currently_held` is whether a platform handle
+/// already exists). Inserting an already-registered label is idempotent.
 #[doc(hidden)]
-pub fn decide_acquire(currently_held: bool) -> Transition {
+pub fn decide_acquire(
+    holders: &mut HashSet<String>,
+    currently_held: bool,
+    label: &str,
+) -> Transition {
+    holders.insert(label.to_owned());
     if currently_held {
         Transition::Skip
     } else {
@@ -135,93 +193,70 @@ pub fn decide_acquire(currently_held: bool) -> Transition {
     }
 }
 
+/// Drop `label` from the holders and decide whether the process-wide OS
+/// assertion must be released — only when the last holder leaves. Releasing
+/// a label that never acquired is a no-op and never disturbs other holders.
 #[doc(hidden)]
-pub fn decide_release(currently_held: bool) -> Transition {
-    if currently_held {
+pub fn decide_release(
+    holders: &mut HashSet<String>,
+    currently_held: bool,
+    label: &str,
+) -> Transition {
+    holders.remove(label);
+    if currently_held && holders.is_empty() {
         Transition::Apply
     } else {
         Transition::Skip
     }
 }
 
-/// Tauri-managed state. The mutex is `std::sync::Mutex` because the inner work
-/// (FFI calls) is non-blocking and synchronous.
+/// Tauri-managed marker retained so the `app.manage(PowerState::new())` call
+/// in `lib.rs` setup stays valid. The actual inhibitor state lives in the
+/// process-wide `POWER_INNER` static (see its doc for why).
 #[derive(Default)]
-pub struct PowerState {
-    inner: Mutex<Option<InhibitorHandle>>,
-}
+pub struct PowerState;
 
 impl PowerState {
     pub fn new() -> Self {
-        Self {
-            inner: Mutex::new(None),
-        }
+        Self
     }
 }
 
-/// Acquire a sleep inhibitor. Idempotent — calling twice without an intervening
-/// release is a no-op and returns `Ok(())`.
-#[tauri::command]
-pub fn system_power_acquire_sleep_inhibitor(state: State<'_, PowerState>) -> Result<(), String> {
-    let mut guard = state
-        .inner
-        .lock()
-        .map_err(|err| format!("PowerState mutex poisoned: {}", err))?;
-
-    if decide_acquire(guard.is_some()) == Transition::Skip {
-        return Ok(());
-    }
-
+/// Perform the platform-specific "keep awake" call and return the handle to
+/// store. Called only when no handle exists yet (first holder).
+fn platform_acquire() -> Result<InhibitorHandle, String> {
     #[cfg(target_os = "macos")]
     {
         let assertion_id = macos_impl::acquire()?;
-        *guard = Some(InhibitorHandle::Mac { assertion_id });
         tracing::info!(
             assertion_id,
             "[Power] Acquired macOS PreventUserIdleSystemSleep assertion"
         );
+        Ok(InhibitorHandle::Mac { assertion_id })
     }
 
     #[cfg(windows)]
     {
         windows_impl::acquire()?;
-        *guard = Some(InhibitorHandle::Windows);
         tracing::info!("[Power] Acquired Windows ES_SYSTEM_REQUIRED state");
+        Ok(InhibitorHandle::Windows)
     }
 
     #[cfg(not(any(target_os = "macos", windows)))]
     {
-        // Linux: no implementation yet. Record the intent so release is symmetric,
-        // but emit a warning so users on Linux know the toggle is a no-op.
-        *guard = Some(InhibitorHandle::Unsupported);
+        // Linux: no implementation yet. Record the intent so release is
+        // symmetric, but emit a warning so users on Linux know the toggle is
+        // a no-op.
         tracing::warn!(
             "[Power] Sleep inhibition not implemented on this platform; toggle is a no-op"
         );
+        Ok(InhibitorHandle::Unsupported)
     }
-
-    Ok(())
 }
 
-/// Release the sleep inhibitor. Idempotent — calling without a prior acquire is
-/// a no-op and returns `Ok(())`.
-#[tauri::command]
-pub fn system_power_release_sleep_inhibitor(state: State<'_, PowerState>) -> Result<(), String> {
-    let mut guard = state
-        .inner
-        .lock()
-        .map_err(|err| format!("PowerState mutex poisoned: {}", err))?;
-
-    if decide_release(guard.is_some()) == Transition::Skip {
-        return Ok(());
-    }
-
-    let Some(handle) = guard.take() else {
-        // Defensive: decide_release returned Apply, so this branch is
-        // unreachable, but we keep the early return so the match below
-        // doesn't need to handle an Option.
-        return Ok(());
-    };
-
+/// Perform the platform-specific release for a previously acquired handle.
+/// Called only when the last holder leaves.
+fn platform_release(handle: InhibitorHandle) -> Result<(), String> {
     match handle {
         #[cfg(target_os = "macos")]
         InhibitorHandle::Mac { assertion_id } => {
@@ -241,6 +276,96 @@ pub fn system_power_release_sleep_inhibitor(state: State<'_, PowerState>) -> Res
             tracing::debug!("[Power] Released no-op inhibitor on unsupported platform");
         }
     }
-
     Ok(())
+}
+
+fn acquire_for_label(label: &str) -> Result<(), String> {
+    let mut guard = lock_power_inner()?;
+
+    let currently_held = guard.handle.is_some();
+    if decide_acquire(&mut guard.holders, currently_held, label) == Transition::Skip {
+        tracing::debug!(
+            label,
+            holders = guard.holders.len(),
+            "[Power] Sleep inhibitor already held; holder registered"
+        );
+        return Ok(());
+    }
+
+    match platform_acquire() {
+        Ok(handle) => {
+            guard.handle = Some(handle);
+            Ok(())
+        }
+        Err(err) => {
+            // Roll back the holder registration: a failed platform call must
+            // not leave a phantom holder that would keep a future assertion
+            // alive after every real holder has released.
+            guard.holders.remove(label);
+            Err(err)
+        }
+    }
+}
+
+fn release_for_label(label: &str) -> Result<(), String> {
+    let mut guard = lock_power_inner()?;
+
+    let currently_held = guard.handle.is_some();
+    if decide_release(&mut guard.holders, currently_held, label) == Transition::Skip {
+        tracing::debug!(
+            label,
+            holders = guard.holders.len(),
+            "[Power] Sleep inhibitor release skipped (other holders remain or nothing held)"
+        );
+        return Ok(());
+    }
+
+    let Some(handle) = guard.handle.take() else {
+        // Defensive: decide_release returns Apply only when a handle exists,
+        // so this branch is unreachable, but we keep the early return so the
+        // release below doesn't need to handle an Option.
+        return Ok(());
+    };
+
+    platform_release(handle)
+}
+
+/// Acquire a sleep inhibitor on behalf of the calling window. Idempotent per
+/// window — calling twice without an intervening release is a no-op and
+/// returns `Ok(())`. The platform assertion is created only for the first
+/// holding window; later windows share it.
+///
+/// `window` is injected by Tauri from the invoke context — the frontend
+/// payload is unchanged.
+#[tauri::command]
+pub fn system_power_acquire_sleep_inhibitor(window: tauri::Window) -> Result<(), String> {
+    acquire_for_label(window.label())
+}
+
+/// Release the calling window's hold on the sleep inhibitor. Idempotent —
+/// calling without a prior acquire is a no-op and returns `Ok(())`. The
+/// platform assertion is dropped only when the last holding window releases;
+/// other windows' holds are never disturbed.
+#[tauri::command]
+pub fn system_power_release_sleep_inhibitor(window: tauri::Window) -> Result<(), String> {
+    release_for_label(window.label())
+}
+
+/// Drop `label`'s hold on the sleep inhibitor, releasing the process-wide
+/// assertion if it was the last holder.
+///
+/// Called from the `WindowEvent::Destroyed` handler in `lib.rs`: a window can
+/// be destroyed without its JS cleanup ever running (crash, direct
+/// programmatic close, webview teardown racing the unmount effect), which
+/// would otherwise strand its holder entry and pin the assertion until
+/// process exit. Errors are logged rather than returned — nothing can
+/// meaningfully handle them during window teardown.
+pub fn release_sleep_inhibitor_for_window_label(label: &str) {
+    if let Err(err) = release_for_label(label) {
+        tracing::warn!(
+            label,
+            error = %err,
+            "[Power] Failed to release sleep inhibitor for destroyed window"
+        );
+    }
 }

--- a/src-tauri/crates/system-services/src/tests/power_tests.rs
+++ b/src-tauri/crates/system-services/src/tests/power_tests.rs
@@ -1,62 +1,130 @@
-//! Pure-logic tests for the power-management idempotency state machine.
+//! Pure-logic tests for the per-window sleep-inhibitor refcount state machine.
 //!
 //! The real FFI (IOKit / SetThreadExecutionState) is not exercised here — it
-//! needs the OS at runtime. What IS exercised is the contract that the Tauri
-//! commands enforce on top of the FFI: "two acquires in a row must skip the
-//! second call, two releases in a row must skip the second call, and the
-//! state must alternate cleanly for any acquire/release sequence."
+//! needs the OS at runtime. What IS exercised is the contract the Tauri
+//! commands enforce on top of the FFI: the process-wide assertion is created
+//! only when the first window label registers, survives releases from other
+//! windows, and is dropped exactly when the last holder leaves. Releasing a
+//! label that never acquired must not disturb existing holders.
 //!
-//! If these tests drift from the command implementation, we'd silently end
-//! up holding multiple macOS IOPMAssertions per process (leaking until exit)
-//! or calling `SetThreadExecutionState` with mismatched flags.
+//! If these tests drift from the command implementation, a detached session
+//! window closing could again tear the assertion out from under the main
+//! window mid-agent-run (the original multi-window bug), or we could leak
+//! macOS IOPMAssertions until process exit.
+
+use std::collections::HashSet;
 
 use crate::power::{decide_acquire, decide_release, Transition};
 
-#[test]
-fn acquire_when_not_held_applies_the_call() {
-    assert_eq!(decide_acquire(false), Transition::Apply);
+fn set(labels: &[&str]) -> HashSet<String> {
+    labels.iter().map(|label| (*label).to_owned()).collect()
 }
 
 #[test]
-fn acquire_when_already_held_is_a_noop() {
-    assert_eq!(decide_acquire(true), Transition::Skip);
+fn first_acquire_applies_and_registers_the_holder() {
+    let mut holders = HashSet::new();
+    assert_eq!(
+        decide_acquire(&mut holders, false, "main"),
+        Transition::Apply
+    );
+    assert_eq!(holders, set(&["main"]));
 }
 
 #[test]
-fn release_when_held_applies_the_call() {
-    assert_eq!(decide_release(true), Transition::Apply);
+fn second_window_acquire_skips_the_platform_call_but_registers_the_holder() {
+    let mut holders = set(&["main"]);
+    assert_eq!(
+        decide_acquire(&mut holders, true, "app-window-session-abc"),
+        Transition::Skip
+    );
+    assert_eq!(holders, set(&["main", "app-window-session-abc"]));
 }
 
 #[test]
-fn release_when_not_held_is_a_noop() {
-    assert_eq!(decide_release(false), Transition::Skip);
+fn re_acquire_from_the_same_window_is_a_noop() {
+    let mut holders = set(&["main"]);
+    assert_eq!(decide_acquire(&mut holders, true, "main"), Transition::Skip);
+    assert_eq!(holders, set(&["main"]));
 }
 
-/// Walk a realistic acquire/release sequence and verify the held-flag is
-/// driven solely by the `Transition::Apply` outcomes. This is the smallest
-/// useful end-to-end shape: it simulates what the Tauri commands do without
-/// any FFI, and asserts the idempotency property holds for repeated calls
-/// in both directions.
 #[test]
-fn realistic_sequence_preserves_idempotency() {
+fn release_with_other_holders_remaining_keeps_the_assertion() {
+    let mut holders = set(&["main", "app-window-session-abc"]);
+    assert_eq!(
+        decide_release(&mut holders, true, "app-window-session-abc"),
+        Transition::Skip
+    );
+    assert_eq!(holders, set(&["main"]));
+}
+
+#[test]
+fn release_of_the_last_holder_drops_the_assertion() {
+    let mut holders = set(&["main"]);
+    assert_eq!(decide_release(&mut holders, true, "main"), Transition::Apply);
+    assert!(holders.is_empty());
+}
+
+#[test]
+fn release_of_a_non_holder_label_is_a_noop_and_keeps_existing_holders() {
+    let mut holders = set(&["main"]);
+    assert_eq!(
+        decide_release(&mut holders, true, "app-window-session-missing"),
+        Transition::Skip
+    );
+    assert_eq!(holders, set(&["main"]));
+}
+
+#[test]
+fn release_when_nothing_is_held_is_a_noop() {
+    let mut holders = HashSet::new();
+    assert_eq!(
+        decide_release(&mut holders, false, "main"),
+        Transition::Skip
+    );
+    assert!(holders.is_empty());
+}
+
+/// Walk the exact multi-window sequence from the original bug: the main
+/// window acquires, a detached session window joins, and the detached window
+/// releases (its session converges first, or it closes) — the assertion must
+/// survive until the main window's own release.
+#[test]
+fn detached_window_release_does_not_strand_the_main_window() {
+    let mut holders: HashSet<String> = HashSet::new();
     let mut held = false;
 
-    // First acquire → applies.
-    assert_eq!(decide_acquire(held), Transition::Apply);
+    // Main window starts an agent run → creates the platform assertion.
+    assert_eq!(decide_acquire(&mut holders, held, "main"), Transition::Apply);
     held = true;
 
-    // Second acquire → no-op (would otherwise leak a macOS assertion ID).
-    assert_eq!(decide_acquire(held), Transition::Skip);
-    // held stays true.
+    // A detached session window also sees "working" and acquires → shares
+    // the existing assertion, no second platform call.
+    assert_eq!(
+        decide_acquire(&mut holders, held, "app-window-session-s1"),
+        Transition::Skip
+    );
 
-    // First release → applies.
-    assert_eq!(decide_release(held), Transition::Apply);
+    // The detached window releases first: main still holds, so the OS
+    // assertion must NOT be dropped.
+    assert_eq!(
+        decide_release(&mut holders, held, "app-window-session-s1"),
+        Transition::Skip
+    );
+    assert_eq!(holders, set(&["main"]));
+
+    // A duplicate release for the already-gone window (JS unmount cleanup
+    // and the Destroyed-event cleanup both firing) is a no-op.
+    assert_eq!(
+        decide_release(&mut holders, held, "app-window-session-s1"),
+        Transition::Skip
+    );
+    assert_eq!(holders, set(&["main"]));
+
+    // Main finishes: the last holder out drops the assertion.
+    assert_eq!(decide_release(&mut holders, held, "main"), Transition::Apply);
     held = false;
+    assert!(holders.is_empty());
 
-    // Second release → no-op.
-    assert_eq!(decide_release(held), Transition::Skip);
-    // held stays false.
-
-    // Acquire again after a full release → applies.
-    assert_eq!(decide_acquire(held), Transition::Apply);
+    // Acquire again after a full release → applies again.
+    assert_eq!(decide_acquire(&mut holders, held, "main"), Transition::Apply);
 }

--- a/src-tauri/src/commands/handler_list.inc
+++ b/src-tauri/src/commands/handler_list.inc
@@ -14,8 +14,10 @@ infrastructure::dev_bundled_auth::debug_import_bundled_org2_cloud_auth,
 // Main-window appearance commands
 app_window::commands::set_window_vibrancy,
 app_window::commands::set_main_webview_zoom,
+app_window::commands::set_webview_zoom,
 app_window::commands::remove_window_background,
 app_window::commands::main_window_chrome_is_acrylic,
+app_window::commands::open_session_window,
 // Optional sidecar commands - lazy install after first paint
 crate::setup::sidecar_setup::sidecar_list_status,
 crate::setup::sidecar_setup::sidecar_install,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1205,6 +1205,14 @@ pub fn run() {
         // tray/dock entry points can reopen it. Debug Linux/Windows exits normally
         // so dev runs do not leave hidden app processes behind.
         .on_window_event(|_window, _event| {
+            // A destroyed window may never run its JS cleanup (crash, direct
+            // programmatic close of a detached session window). Drop its
+            // sleep-inhibitor holder so the process-wide assertion is
+            // refcounted correctly — neither leaked until process exit nor
+            // still attributed to a dead window.
+            if let tauri::WindowEvent::Destroyed = _event {
+                system_services::power::release_sleep_inhibitor_for_window_label(_window.label());
+            }
             if let tauri::WindowEvent::CloseRequested { api: _api, .. } = _event {
                 // Only hide the "main" window — let auxiliary windows close normally
                 if _window.label() == "main" {

--- a/src/api/tauri/sessionWindow.ts
+++ b/src/api/tauri/sessionWindow.ts
@@ -1,0 +1,21 @@
+/**
+ * Detached session windows.
+ *
+ * `open_session_window` builds (or focuses) a native OS window whose label is
+ * `app-window-session-<sessionId>` — inside the `app-window-*` capability
+ * glob, so the window gets the full default permission set — and loads the
+ * standalone `/orgii/app/session/<sessionId>` route. Window chrome (macOS
+ * traffic lights, Win11 corners) is applied on the Rust side; a plain
+ * `new WebviewWindow()` from JS cannot reach those post-build native calls.
+ */
+import { invokeTauri } from "@src/util/platform/tauri/init";
+
+/** Create or focus the detached window for one session. Resolves to the
+ *  window label. Rejects when the id is unsafe for a window label or the
+ *  platform window build fails — callers keep their tab in that case. */
+export async function openSessionWindow(
+  sessionId: string,
+  title?: string
+): Promise<string> {
+  return invokeTauri<string>("open_session_window", { sessionId, title });
+}

--- a/src/app/root/AppDeferredServices.tsx
+++ b/src/app/root/AppDeferredServices.tsx
@@ -7,18 +7,28 @@
  * Split into wrapper components so each hook has an isolated React subtree and
  * an independent render cycle — avoids a single fat component with N hooks.
  *
- * Mounted only when ready:
+ * Mounted only when ready, in every window:
  * - GlobalDragDrop            — cross-window file drag handling
  * - DeferredWindowFocusTracking
- * - DeferredGitAutoFetch      — background git remote polling
  * - DeferredProcessReconciliation — reseed shell/PTY state from Rust
- * - AppUpdater                — Tauri auto-update poller
  * - APICallPanelProvider      — DevTools API call inspector
  * - SecretCaptureModal        — out-of-band secret capture overlay
+ *
+ * Mounted only in the main window (`isMainAppWindow`) — secondary OS windows
+ * (detached session windows) run this same component, and app-wide pollers and
+ * writers must not be duplicated per window (double git fetches contend on
+ * .git/index.lock, two updater schedulers can download concurrently, and a
+ * second terminal-buffer hydrate/flush races the first):
+ * - DeferredUserPresenceSync
+ * - DeferredUserProfileSync
+ * - DeferredGitAutoFetch      — background git remote polling
+ * - DeferredTerminalPersistence — terminal-buffer hydrate/flush
+ * - AppUpdater                — Tauri auto-update poller
  */
 import React from "react";
 
 import { createLogger } from "@src/hooks/logger";
+import { isMainAppWindow } from "@src/util/platform/tauri/windowIdentity";
 
 const log = createLogger("TerminalPersistence");
 
@@ -158,6 +168,8 @@ export const AppDeferredServices: React.FC<{ ready: boolean }> = ({
 }) => {
   if (!ready) return null;
 
+  const mainWindow = isMainAppWindow();
+
   return (
     <>
       <DeferredServiceBoundary>
@@ -166,24 +178,34 @@ export const AppDeferredServices: React.FC<{ ready: boolean }> = ({
       <DeferredServiceBoundary>
         <DeferredWindowFocusTracking />
       </DeferredServiceBoundary>
-      <DeferredServiceBoundary>
-        <DeferredUserPresenceSync />
-      </DeferredServiceBoundary>
-      <DeferredServiceBoundary>
-        <DeferredUserProfileSync />
-      </DeferredServiceBoundary>
-      <DeferredServiceBoundary>
-        <DeferredGitAutoFetch />
-      </DeferredServiceBoundary>
+      {mainWindow && (
+        <DeferredServiceBoundary>
+          <DeferredUserPresenceSync />
+        </DeferredServiceBoundary>
+      )}
+      {mainWindow && (
+        <DeferredServiceBoundary>
+          <DeferredUserProfileSync />
+        </DeferredServiceBoundary>
+      )}
+      {mainWindow && (
+        <DeferredServiceBoundary>
+          <DeferredGitAutoFetch />
+        </DeferredServiceBoundary>
+      )}
       <DeferredServiceBoundary>
         <DeferredProcessReconciliation />
       </DeferredServiceBoundary>
-      <DeferredServiceBoundary>
-        <DeferredTerminalPersistence />
-      </DeferredServiceBoundary>
-      <DeferredServiceBoundary>
-        <AppUpdater />
-      </DeferredServiceBoundary>
+      {mainWindow && (
+        <DeferredServiceBoundary>
+          <DeferredTerminalPersistence />
+        </DeferredServiceBoundary>
+      )}
+      {mainWindow && (
+        <DeferredServiceBoundary>
+          <AppUpdater />
+        </DeferredServiceBoundary>
+      )}
       <DeferredServiceBoundary>
         <APICallPanelProvider />
       </DeferredServiceBoundary>

--- a/src/app/root/useAppShellEffects.ts
+++ b/src/app/root/useAppShellEffects.ts
@@ -94,7 +94,10 @@ export function useAppShellEffects(): void {
     root.style.zoom = "";
     root.style.setProperty("--ui-scale", "1");
     root.style.setProperty("--native-frame-scale", String(scaleValue));
-    invokeTauri("set_main_webview_zoom", { scaleFactor: scaleValue }).catch(
+    // Per-window command: each window (main or detached session) zooms its
+    // own webview. `set_main_webview_zoom` would re-zoom main from every
+    // window and never scale a secondary one.
+    invokeTauri("set_webview_zoom", { scaleFactor: scaleValue }).catch(
       (error) => {
         logger.error("failed to set native WebView zoom:", error);
       }

--- a/src/config/windowChromeRadius.ts
+++ b/src/config/windowChromeRadius.ts
@@ -7,6 +7,7 @@
  * Keep magic numbers in sync with the preflight script in public/index.html.
  */
 import { isLinux, isMacOS, isWindows } from "@src/util/platform/tauri";
+import { isMainAppWindow } from "@src/util/platform/tauri/windowIdentity";
 
 export const HOST_DESKTOP = {
   MACOS: "macos",
@@ -67,12 +68,20 @@ export function applyHostDesktopWindowChromeRadius(): void {
  * acrylic) actually exists behind the webview. Until this resolves — and on
  * Windows 10, where acrylic is disabled — the attribute stays absent and the
  * opaque fallback applies. Requires initializeTauriAPIs() to have completed.
+ *
+ * Main window only: the Rust policy is a statement about the MAIN frameless
+ * window. Secondary windows (detached sessions) are decorated with no acrylic
+ * backdrop behind the webview — relaxing their opaque fail-safe would render
+ * them see-through on Win11.
  */
 export async function applyWindowsNativeChromeAttribute(): Promise<void> {
   if (typeof document === "undefined") {
     return;
   }
   if (resolveHostDesktop() !== HOST_DESKTOP.WINDOWS) {
+    return;
+  }
+  if (!isMainAppWindow()) {
     return;
   }
   try {

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import React from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
@@ -30,8 +30,10 @@ import {
   Refresh04Icon,
   Search01Icon,
   Share02Icon,
+  SquareArrowUpRight02Icon,
 } from "@src/icons";
 import { sessionByIdAtom, upsertSession } from "@src/store/session";
+import { openSessionInNewWindowAtom } from "@src/store/session/sessionTabPlacementAtom";
 import type { ChatHistoryDisplayMode } from "@src/store/ui/chatPanelAtom";
 import { isAgentSession } from "@src/util/session/sessionDispatch";
 
@@ -63,6 +65,10 @@ export interface SessionHeaderActionsMenuProps {
   moveTarget: "chat-panel" | "workstation";
   paginationEnabled: boolean;
   showCloudShareSettings: boolean;
+  /** Off in the detached session window, whose only surface is the session. */
+  showMoveSession?: boolean;
+  /** Off in the detached session window — it already is that window. */
+  showOpenInNewWindow?: boolean;
   showTranscriptActions?: boolean;
   tokenUsageVisible: boolean;
   turnMetadataVisible: boolean;
@@ -99,6 +105,8 @@ export const SessionHeaderActionsMenu: React.FC<
   moveTarget,
   paginationEnabled,
   showCloudShareSettings,
+  showMoveSession = true,
+  showOpenInNewWindow = true,
   showTranscriptActions = true,
   tokenUsageVisible,
   turnMetadataVisible,
@@ -137,6 +145,29 @@ export const SessionHeaderActionsMenu: React.FC<
       Message.error(err instanceof Error ? err.message : String(err));
     }
   }, [currentSessionId, toggleHeaderActionsMenu, currentSession, t]);
+
+  // Open in new window — detach the session into its own OS window and drop
+  // this window's tab(s) for it. Self-contained like Track-as-Project: the
+  // atom talks to the backend and both tab owners, so neither host has to
+  // wire a handler through.
+  const openSessionInNewWindow = useSetAtom(openSessionInNewWindowAtom);
+  const handleOpenInNewWindow = React.useCallback(async () => {
+    if (!currentSessionId) return;
+    toggleHeaderActionsMenu();
+    try {
+      await openSessionInNewWindow({
+        sessionId: currentSessionId,
+        title: currentSession?.name,
+      });
+    } catch (err) {
+      Message.error(err instanceof Error ? err.message : String(err));
+    }
+  }, [
+    currentSessionId,
+    currentSession,
+    openSessionInNewWindow,
+    toggleHeaderActionsMenu,
+  ]);
 
   // Copy URL — the non-secret `orgii://cloud/session/ref` reference, same
   // action as the sidebar row menus. Hidden until the session has been
@@ -221,42 +252,63 @@ export const SessionHeaderActionsMenu: React.FC<
                 {t("common:actions.reload")}
               </span>
             </button>
-            <button
-              type="button"
-              className={`${DROPDOWN_CLASSES.item} ${DROPDOWN_CLASSES.itemHover} w-full text-left disabled:cursor-not-allowed disabled:opacity-50`}
-              onClick={handleMoveSession}
-              disabled={!currentSessionId}
-              data-testid={
-                moveToWorkstation
-                  ? "move-session-to-workstation"
-                  : "move-session-to-chat-panel"
-              }
-            >
-              {moveToWorkstation ? (
+            {showMoveSession && (
+              <button
+                type="button"
+                className={`${DROPDOWN_CLASSES.item} ${DROPDOWN_CLASSES.itemHover} w-full text-left disabled:cursor-not-allowed disabled:opacity-50`}
+                onClick={handleMoveSession}
+                disabled={!currentSessionId}
+                data-testid={
+                  moveToWorkstation
+                    ? "move-session-to-workstation"
+                    : "move-session-to-chat-panel"
+                }
+              >
+                {moveToWorkstation ? (
+                  <HugeiconsIcon
+                    icon={PanelLeftIcon}
+                    data-icon="panel-left"
+                    size={DROPDOWN_ITEM.iconSize}
+                    strokeWidth={1.75}
+                  />
+                ) : (
+                  <HugeiconsIcon
+                    icon={PanelRightIcon}
+                    data-icon="panel-right"
+                    size={DROPDOWN_ITEM.iconSize}
+                    strokeWidth={1.75}
+                  />
+                )}
+                <span className="flex-1 truncate">
+                  {moveToWorkstation
+                    ? t("chat.moveToWorkstation", {
+                        defaultValue: "Move to My Station",
+                      })
+                    : t("chat.moveToChatPanel", {
+                        defaultValue: "Move to Chat Panel",
+                      })}
+                </span>
+              </button>
+            )}
+            {showOpenInNewWindow && (
+              <button
+                type="button"
+                className={`${DROPDOWN_CLASSES.item} ${DROPDOWN_CLASSES.itemHover} w-full text-left disabled:cursor-not-allowed disabled:opacity-50`}
+                onClick={handleOpenInNewWindow}
+                disabled={!currentSessionId}
+                data-testid="open-session-in-new-window"
+              >
                 <HugeiconsIcon
-                  icon={PanelLeftIcon}
-                  data-icon="panel-left"
+                  icon={SquareArrowUpRight02Icon}
+                  data-icon="square-arrow-out-up-right"
                   size={DROPDOWN_ITEM.iconSize}
                   strokeWidth={1.75}
                 />
-              ) : (
-                <HugeiconsIcon
-                  icon={PanelRightIcon}
-                  data-icon="panel-right"
-                  size={DROPDOWN_ITEM.iconSize}
-                  strokeWidth={1.75}
-                />
-              )}
-              <span className="flex-1 truncate">
-                {moveToWorkstation
-                  ? t("chat.moveToWorkstation", {
-                      defaultValue: "Move to My Station",
-                    })
-                  : t("chat.moveToChatPanel", {
-                      defaultValue: "Move to Chat Panel",
-                    })}
-              </span>
-            </button>
+                <span className="flex-1 truncate">
+                  {t("common:actions.openInNewWindow")}
+                </span>
+              </button>
+            )}
             {showTranscriptActions && (
               <>
                 <button

--- a/src/features/Org2Cloud/crossWindowFocus.test.ts
+++ b/src/features/Org2Cloud/crossWindowFocus.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { isWindowFocused } from "@src/util/core/windowFocus";
+
+import {
+  CROSS_WINDOW_FOCUS_TTL_MS,
+  aggregateCrossWindowFocus,
+  isAnyAppWindowFocused,
+  parseCrossWindowFocusMap,
+} from "./crossWindowFocus";
+
+describe("aggregateCrossWindowFocus (staleness/aggregation core)", () => {
+  const now = 1_000_000;
+
+  it("own focus wins regardless of peers", () => {
+    expect(aggregateCrossWindowFocus(true, [], now)).toBe(true);
+    expect(
+      aggregateCrossWindowFocus(
+        true,
+        [{ focused: false, at: now - CROSS_WINDOW_FOCUS_TTL_MS * 10 }],
+        now
+      )
+    ).toBe(true);
+  });
+
+  it("a fresh focused peer keeps the app foregrounded", () => {
+    expect(
+      aggregateCrossWindowFocus(
+        false,
+        [{ focused: true, at: now - 1_000 }],
+        now
+      )
+    ).toBe(true);
+  });
+
+  it("a focused claim exactly TTL old still counts; one past it does not", () => {
+    expect(
+      aggregateCrossWindowFocus(
+        false,
+        [{ focused: true, at: now - CROSS_WINDOW_FOCUS_TTL_MS }],
+        now
+      )
+    ).toBe(true);
+    expect(
+      aggregateCrossWindowFocus(
+        false,
+        [{ focused: true, at: now - CROSS_WINDOW_FOCUS_TTL_MS - 1 }],
+        now
+      )
+    ).toBe(false);
+  });
+
+  it("fresh but unfocused peers never count", () => {
+    expect(
+      aggregateCrossWindowFocus(false, [{ focused: false, at: now }], now)
+    ).toBe(false);
+  });
+
+  it("no peers and no own focus means background", () => {
+    expect(aggregateCrossWindowFocus(false, [], now)).toBe(false);
+  });
+
+  it("one live focused peer among stale/unfocused ones is enough", () => {
+    expect(
+      aggregateCrossWindowFocus(
+        false,
+        [
+          { focused: false, at: now },
+          { focused: true, at: now - CROSS_WINDOW_FOCUS_TTL_MS * 2 },
+          { focused: true, at: now - 2_000 },
+        ],
+        now
+      )
+    ).toBe(true);
+  });
+});
+
+describe("parseCrossWindowFocusMap", () => {
+  it("parses a valid map and drops malformed entries", () => {
+    const raw = JSON.stringify({
+      main: { focused: true, at: 123 },
+      "app-window-session-1": { focused: false, at: 456 },
+      "bad-focused": { focused: "yes", at: 1 },
+      "bad-at": { focused: true, at: "soon" },
+      "bad-shape": 42,
+    });
+    expect(parseCrossWindowFocusMap(raw)).toEqual({
+      main: { focused: true, at: 123 },
+      "app-window-session-1": { focused: false, at: 456 },
+    });
+  });
+
+  it("degrades to empty for null, broken JSON, and non-object roots", () => {
+    expect(parseCrossWindowFocusMap(null)).toEqual({});
+    expect(parseCrossWindowFocusMap("")).toEqual({});
+    expect(parseCrossWindowFocusMap("{not json")).toEqual({});
+    expect(parseCrossWindowFocusMap('"a string"')).toEqual({});
+    expect(parseCrossWindowFocusMap("[1,2]")).toEqual({});
+  });
+});
+
+describe("isAnyAppWindowFocused outside Tauri", () => {
+  it("collapses to plain own-window focus (single document)", () => {
+    // Non-Tauri environments have no peer windows; the lease's existing
+    // single-window semantics must be exactly preserved.
+    expect(isAnyAppWindowFocused()).toBe(isWindowFocused());
+  });
+});

--- a/src/features/Org2Cloud/crossWindowFocus.ts
+++ b/src/features/Org2Cloud/crossWindowFocus.ts
@@ -1,0 +1,272 @@
+/**
+ * Cross-window focus aggregation for app-wide foreground leases.
+ *
+ * With detached session windows, "the app is in the foreground" is no longer
+ * the same statement as "THIS window is focused": a user working in a
+ * detached window keeps the MAIN window blurred, and any main-window-only
+ * service keyed on own-window focus (the realtime connection lease) would
+ * wrongly wind down after its blur grace. Every window publishes its focus
+ * state over `BroadcastChannel("orgii:window-focus")` — with a localStorage
+ * heartbeat map as the fallback transport — and `isAnyAppWindowFocused()`
+ * answers the app-wide question: this window focused, or any peer window
+ * whose focused claim is fresh within `CROSS_WINDOW_FOCUS_TTL_MS`.
+ *
+ * A focused window re-publishes on a short heartbeat so its claim never goes
+ * stale; a closed or crashed window simply stops publishing and drops out of
+ * the aggregate within the TTL. Outside Tauri (browser dev, unit tests)
+ * there is only one document, so the aggregate collapses to plain own-window
+ * focus and the publisher is a no-op — existing single-window behavior and
+ * tests are unchanged.
+ */
+import { isWindowFocused } from "@src/util/core/windowFocus";
+import { getCurrentWindowLabel } from "@src/util/platform/tauri/windowIdentity";
+
+export const CROSS_WINDOW_FOCUS_CHANNEL_NAME = "orgii:window-focus";
+export const CROSS_WINDOW_FOCUS_STORAGE_KEY = "orgii:window-focus:v1";
+
+/** A peer's focused=true claim is trusted for this long after its `at`. */
+export const CROSS_WINDOW_FOCUS_TTL_MS = 15_000;
+
+/** Focused windows re-publish on this cadence so their claim stays fresh. */
+export const CROSS_WINDOW_FOCUS_HEARTBEAT_MS = 5_000;
+
+/** Entries idle this long are garbage-collected from the storage map. */
+const STORAGE_ENTRY_GC_MS = 10 * CROSS_WINDOW_FOCUS_TTL_MS;
+
+export interface CrossWindowFocusEntry {
+  readonly focused: boolean;
+  /** Publish timestamp, `Date.now()` milliseconds. */
+  readonly at: number;
+}
+
+/**
+ * Pure aggregation core: own focus always wins; otherwise any peer whose
+ * focused claim is no older than `ttlMs` counts. Unfocused or stale claims
+ * never do — staleness is how a dead window leaves the aggregate.
+ */
+export function aggregateCrossWindowFocus(
+  ownFocused: boolean,
+  peers: Iterable<CrossWindowFocusEntry>,
+  nowMs: number,
+  ttlMs: number = CROSS_WINDOW_FOCUS_TTL_MS
+): boolean {
+  if (ownFocused) return true;
+  for (const peer of peers) {
+    if (peer.focused && nowMs - peer.at <= ttlMs) return true;
+  }
+  return false;
+}
+
+/** Parse the persisted heartbeat map; malformed input degrades to empty. */
+export function parseCrossWindowFocusMap(
+  raw: string | null
+): Record<string, CrossWindowFocusEntry> {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return {};
+    }
+    const map: Record<string, CrossWindowFocusEntry> = {};
+    for (const [label, value] of Object.entries(parsed)) {
+      if (typeof value !== "object" || value === null) continue;
+      const { focused, at } = value as { focused?: unknown; at?: unknown };
+      if (typeof focused !== "boolean") continue;
+      if (typeof at !== "number" || !Number.isFinite(at)) continue;
+      map[label] = { focused, at };
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+/** Peer focus claims received over the BroadcastChannel transport. */
+const peerFocusByLabel = new Map<string, CrossWindowFocusEntry>();
+const focusChangeListeners = new Set<() => void>();
+
+interface CrossWindowFocusRuntime {
+  refCount: number;
+  stop: () => void;
+}
+
+let runtime: CrossWindowFocusRuntime | null = null;
+
+function notifyFocusChangeListeners(): void {
+  for (const listener of [...focusChangeListeners]) listener();
+}
+
+function recordPeerMessage(ownLabel: string, data: unknown): void {
+  if (typeof data !== "object" || data === null) return;
+  const { label, focused, at } = data as {
+    label?: unknown;
+    focused?: unknown;
+    at?: unknown;
+  };
+  if (typeof label !== "string" || label === ownLabel) return;
+  if (typeof focused !== "boolean") return;
+  if (typeof at !== "number" || !Number.isFinite(at)) return;
+  peerFocusByLabel.set(label, { focused, at });
+  notifyFocusChangeListeners();
+}
+
+function readStoredFocusMap(): Record<string, CrossWindowFocusEntry> {
+  try {
+    if (typeof localStorage === "undefined") return {};
+    return parseCrossWindowFocusMap(
+      localStorage.getItem(CROSS_WINDOW_FOCUS_STORAGE_KEY)
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeOwnFocusHeartbeat(
+  ownLabel: string,
+  entry: CrossWindowFocusEntry
+): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    const next: Record<string, CrossWindowFocusEntry> = {};
+    for (const [label, existing] of Object.entries(readStoredFocusMap())) {
+      if (entry.at - existing.at <= STORAGE_ENTRY_GC_MS) next[label] = existing;
+    }
+    next[ownLabel] = entry;
+    localStorage.setItem(CROSS_WINDOW_FOCUS_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Storage unavailable (private mode, quota): the BroadcastChannel
+    // transport or plain staleness covers it.
+  }
+}
+
+/**
+ * App-wide foreground truth: this window focused, or any peer window with a
+ * fresh focused claim. Outside Tauri there are no peer windows, so this is
+ * exactly own-window focus (existing lease behavior and tests unchanged).
+ */
+export function isAnyAppWindowFocused(): boolean {
+  const ownFocused = isWindowFocused();
+  const ownLabel = getCurrentWindowLabel();
+  if (ownLabel === null || ownFocused) return ownFocused;
+  const now = Date.now();
+  if (aggregateCrossWindowFocus(false, peerFocusByLabel.values(), now)) {
+    return true;
+  }
+  // Storage fallback: peers without BroadcastChannel, and peers that
+  // published before this window's channel existed.
+  const storedPeers = Object.entries(readStoredFocusMap())
+    .filter(([label]) => label !== ownLabel)
+    .map(([, entry]) => entry);
+  return aggregateCrossWindowFocus(false, storedPeers, now);
+}
+
+/**
+ * Notify on peer focus publications (a BroadcastChannel message or a
+ * cross-window storage write). Own-window focus events are deliberately not
+ * re-broadcast here — callers already listen to those directly.
+ */
+export function subscribeCrossWindowFocus(listener: () => void): () => void {
+  focusChangeListeners.add(listener);
+  return () => {
+    focusChangeListeners.delete(listener);
+  };
+}
+
+/**
+ * Publish this window's focus state to its peers on focus/blur/visibility
+ * flips plus a heartbeat while focused. Idempotent per window: one shared
+ * transport regardless of caller count; the returned stop handle releases
+ * this caller's interest and tears the transport down with the last one.
+ * No-op outside Tauri.
+ */
+export function startCrossWindowFocusPublisher(): () => void {
+  const ownLabel = getCurrentWindowLabel();
+  if (
+    ownLabel === null ||
+    typeof window === "undefined" ||
+    typeof document === "undefined"
+  ) {
+    return () => {};
+  }
+  if (!runtime) {
+    let channel: BroadcastChannel | null = null;
+    if (typeof BroadcastChannel !== "undefined") {
+      try {
+        channel = new BroadcastChannel(CROSS_WINDOW_FOCUS_CHANNEL_NAME);
+        channel.onmessage = (event) => recordPeerMessage(ownLabel, event.data);
+      } catch {
+        channel = null;
+      }
+    }
+    const publish = (focused: boolean) => {
+      const entry: CrossWindowFocusEntry = { focused, at: Date.now() };
+      try {
+        channel?.postMessage({ label: ownLabel, ...entry });
+      } catch {
+        // A closed/errored channel degrades to the storage heartbeat.
+      }
+      writeOwnFocusHeartbeat(ownLabel, entry);
+    };
+    const publishCurrent = () => publish(isWindowFocused());
+    // The window is going away; do not leave a focused claim that only the
+    // TTL can expire.
+    const handlePageHide = () => publish(false);
+    // Peer publications without BroadcastChannel arrive as cross-window
+    // storage events (fired only in OTHER windows, so no self-loop).
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== null && event.key !== CROSS_WINDOW_FOCUS_STORAGE_KEY) {
+        return;
+      }
+      notifyFocusChangeListeners();
+    };
+    const heartbeat = setInterval(() => {
+      if (isWindowFocused()) publish(true);
+    }, CROSS_WINDOW_FOCUS_HEARTBEAT_MS);
+    window.addEventListener("focus", publishCurrent);
+    window.addEventListener("blur", publishCurrent);
+    window.addEventListener("pagehide", handlePageHide);
+    window.addEventListener("storage", handleStorage);
+    document.addEventListener("visibilitychange", publishCurrent);
+    publishCurrent();
+    runtime = {
+      refCount: 0,
+      stop: () => {
+        clearInterval(heartbeat);
+        window.removeEventListener("focus", publishCurrent);
+        window.removeEventListener("blur", publishCurrent);
+        window.removeEventListener("pagehide", handlePageHide);
+        window.removeEventListener("storage", handleStorage);
+        document.removeEventListener("visibilitychange", publishCurrent);
+        publish(false);
+        channel?.close();
+      },
+    };
+  }
+  const active = runtime;
+  active.refCount += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    active.refCount -= 1;
+    if (active.refCount <= 0 && runtime === active) {
+      runtime = null;
+      active.stop();
+    }
+  };
+}
+
+/** Test hook: drop the transport, peer claims, and listeners. */
+export function resetCrossWindowFocusForTests(): void {
+  if (runtime) {
+    const active = runtime;
+    runtime = null;
+    active.stop();
+  }
+  peerFocusByLabel.clear();
+  focusChangeListeners.clear();
+}

--- a/src/features/Org2Cloud/org2CloudClient.test.ts
+++ b/src/features/Org2Cloud/org2CloudClient.test.ts
@@ -4,8 +4,12 @@ import {
   ORG2_CLOUD_OFFICIAL_ANON_KEY,
   ORG2_CLOUD_OFFICIAL_SUPABASE_URL,
 } from "./config";
-import type { Org2CloudAuthState } from "./org2CloudAuthAtom";
 import {
+  ORG2_CLOUD_AUTH_STORAGE_KEY,
+  type Org2CloudAuthState,
+} from "./org2CloudAuthAtom";
+import {
+  adoptPersistedSessionRotation,
   ensureFreshSession,
   getCloudProfile,
   listMyOrgs,
@@ -191,6 +195,178 @@ describe("ensureFreshSession", () => {
       ensureFreshSession(baseState, { onRefreshRejected: rejected })
     ).resolves.toBeNull();
     expect(rejected).not.toHaveBeenCalled();
+  });
+});
+
+describe("adoptPersistedSessionRotation (cross-window refresh short-circuit)", () => {
+  const nowSeconds = 1_751_500_000;
+  const state: Org2CloudAuthState = {
+    kind: "org2_cloud",
+    supabaseUrl: ORG2_CLOUD_OFFICIAL_SUPABASE_URL,
+    supabaseAnonKey: ORG2_CLOUD_OFFICIAL_ANON_KEY,
+    userId: "user-1",
+    accessToken: "at-1",
+    refreshToken: "rt-1",
+    expiresAt: nowSeconds, // already inside the refresh skew
+  };
+  const rotated: Org2CloudAuthState = {
+    ...state,
+    accessToken: "at-2",
+    refreshToken: "rt-2",
+    expiresAt: nowSeconds + 3600,
+  };
+
+  it("adopts a fresher persisted rotation for the same identity", () => {
+    expect(adoptPersistedSessionRotation(state, rotated, nowSeconds)).toEqual({
+      ...state,
+      accessToken: "at-2",
+      refreshToken: "rt-2",
+      expiresAt: nowSeconds + 3600,
+    });
+  });
+
+  it("keeps the caller's non-token fields when adopting", () => {
+    const withProfile: Org2CloudAuthState = {
+      ...state,
+      profile: { displayName: "Vince" },
+    };
+    expect(
+      adoptPersistedSessionRotation(withProfile, rotated, nowSeconds)?.profile
+    ).toEqual({ displayName: "Vince" });
+  });
+
+  it("never adopts across identities (other user or endpoint)", () => {
+    expect(
+      adoptPersistedSessionRotation(
+        state,
+        { ...rotated, userId: "user-2" },
+        nowSeconds
+      )
+    ).toBeNull();
+    expect(
+      adoptPersistedSessionRotation(
+        state,
+        { ...rotated, supabaseUrl: "https://other.example.test" },
+        nowSeconds
+      )
+    ).toBeNull();
+  });
+
+  it("normalizes trailing-slash endpoint differences via the identity key", () => {
+    expect(
+      adoptPersistedSessionRotation(
+        state,
+        { ...rotated, supabaseUrl: `${state.supabaseUrl}/` },
+        nowSeconds
+      )
+    ).not.toBeNull();
+  });
+
+  it("ignores an absent or not-comfortably-fresh persisted copy", () => {
+    expect(adoptPersistedSessionRotation(state, null, nowSeconds)).toBeNull();
+    // Within the refresh skew: the exchange must still run.
+    expect(
+      adoptPersistedSessionRotation(
+        state,
+        { ...rotated, expiresAt: nowSeconds + 30 },
+        nowSeconds
+      )
+    ).toBeNull();
+  });
+});
+
+describe("ensureFreshSession cross-window refresh lock", () => {
+  const stale: Org2CloudAuthState = {
+    kind: "org2_cloud",
+    supabaseUrl: ORG2_CLOUD_OFFICIAL_SUPABASE_URL,
+    supabaseAnonKey: ORG2_CLOUD_OFFICIAL_ANON_KEY,
+    userId: "user-1",
+    accessToken: "at-1",
+    refreshToken: "rt-1",
+    expiresAt: 0,
+  };
+
+  afterEach(() => {
+    localStorage.removeItem(ORG2_CLOUD_AUTH_STORAGE_KEY);
+  });
+
+  /** Grants immediately, records the requested lock names. */
+  function stubWebLocks(): string[] {
+    const requestedNames: string[] = [];
+    vi.stubGlobal("navigator", {
+      locks: {
+        request: (
+          name: string,
+          _options: unknown,
+          callback: () => Promise<unknown>
+        ) => {
+          requestedNames.push(name);
+          return callback();
+        },
+      },
+    });
+    return requestedNames;
+  }
+
+  it("re-reads the persisted rotation under the lock and skips the exchange", async () => {
+    const requestedNames = stubWebLocks();
+    const rotated: Org2CloudAuthState = {
+      ...stale,
+      accessToken: "at-rotated",
+      refreshToken: "rt-rotated",
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    };
+    localStorage.setItem(ORG2_CLOUD_AUTH_STORAGE_KEY, JSON.stringify(rotated));
+
+    await expect(ensureFreshSession(stale)).resolves.toEqual(rotated);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(requestedNames).toEqual(["orgii:org2cloud-token-refresh"]);
+  });
+
+  it("still runs the exchange under the lock when the persisted copy is stale", async () => {
+    const requestedNames = stubWebLocks();
+    localStorage.setItem(ORG2_CLOUD_AUTH_STORAGE_KEY, JSON.stringify(stale));
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        access_token: "at-2",
+        refresh_token: "rt-2",
+        expires_at: 1751503600,
+      })
+    );
+
+    await expect(ensureFreshSession(stale)).resolves.toEqual({
+      ...stale,
+      accessToken: "at-2",
+      refreshToken: "rt-2",
+      expiresAt: 1751503600,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestedNames).toEqual(["orgii:org2cloud-token-refresh"]);
+  });
+
+  it("never adopts a persisted session belonging to another identity", async () => {
+    stubWebLocks();
+    localStorage.setItem(
+      ORG2_CLOUD_AUTH_STORAGE_KEY,
+      JSON.stringify({
+        ...stale,
+        userId: "user-2",
+        accessToken: "at-other",
+        refreshToken: "rt-other",
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+      })
+    );
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        access_token: "at-2",
+        refresh_token: "rt-2",
+        expires_at: 1751503600,
+      })
+    );
+
+    const result = await ensureFreshSession(stale);
+    expect(result?.accessToken).toBe("at-2");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/features/Org2Cloud/org2CloudClient.ts
+++ b/src/features/Org2Cloud/org2CloudClient.ts
@@ -18,7 +18,13 @@ import type { CollabSessionAccessMode } from "@src/store/collaboration/types";
 
 import { ORG2_CLOUD_POSTGREST_SCHEMA, getCloudEndpoint } from "./config";
 import type { OrgRuntimeTelemetry } from "./memberRuntime/types";
-import type { Org2CloudAuthState, Org2CloudProfile } from "./org2CloudAuthAtom";
+import {
+  ORG2_CLOUD_AUTH_STORAGE_KEY,
+  type Org2CloudAuthState,
+  type Org2CloudProfile,
+  org2CloudAuthIdentityKey,
+  parseStoredOrg2CloudAuth,
+} from "./org2CloudAuthAtom";
 import {
   fetchWithTransportRetry,
   runCloudRequestWithTimeout,
@@ -483,35 +489,137 @@ export interface EnsureFreshSessionOptions {
   onRefreshRejected?: () => void;
 }
 
+function hasComfortablyFreshAccessToken(
+  state: Org2CloudAuthState,
+  nowSeconds: number
+): boolean {
+  return state.expiresAt - nowSeconds > REFRESH_SKEW_SECONDS;
+}
+
+/**
+ * Cross-window mutex for the ROTATING refresh-token exchange. The per-realm
+ * `inFlightRefresh` dedupe cannot see another OS window's webview realm, and
+ * two windows racing the same rotating token make the loser permanently
+ * rejected (GoTrue reuse detection) — which signs the user out. Web Locks
+ * are shared across same-origin webviews (WKWebView / WebView2 both support
+ * them); where the API is absent the current single-window behavior stands.
+ * Callbacks passed here must not throw: a lock-manager error falls back to
+ * running the callback unserialized.
+ */
+const TOKEN_REFRESH_LOCK_NAME = "orgii:org2cloud-token-refresh";
+
+async function withCrossWindowRefreshLock<T>(
+  run: () => Promise<T>
+): Promise<T> {
+  const locks = typeof navigator !== "undefined" ? navigator.locks : undefined;
+  if (!locks?.request) return run();
+  try {
+    return (await locks.request(
+      TOKEN_REFRESH_LOCK_NAME,
+      { mode: "exclusive" },
+      run
+    )) as T;
+  } catch (error) {
+    log.warn("cross-window refresh lock unavailable:", error);
+    return run();
+  }
+}
+
+/** The exact persisted auth payload the auth atom writes; `null` on any
+ * parse/storage failure. */
+function readPersistedOrg2CloudAuth(): Org2CloudAuthState | null {
+  try {
+    if (typeof localStorage === "undefined") return null;
+    return parseStoredOrg2CloudAuth(
+      localStorage.getItem(ORG2_CLOUD_AUTH_STORAGE_KEY)
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cross-window refresh short-circuit: while this realm waited on the refresh
+ * mutex, another window may have already rotated the same session and
+ * persisted the result. Returns the caller's state carrying the persisted
+ * rotation when that happened (no exchange needed); `null` means the
+ * exchange must still run. Only a persisted session for the SAME identity
+ * (endpoint + user) with a comfortably fresh access token counts — another
+ * account/endpoint or a stale persisted copy never short-circuits.
+ */
+export function adoptPersistedSessionRotation(
+  state: Org2CloudAuthState,
+  persisted: Org2CloudAuthState | null,
+  nowSeconds: number
+): Org2CloudAuthState | null {
+  if (!persisted) return null;
+  if (org2CloudAuthIdentityKey(persisted) !== org2CloudAuthIdentityKey(state)) {
+    return null;
+  }
+  if (!hasComfortablyFreshAccessToken(persisted, nowSeconds)) return null;
+  return {
+    ...state,
+    accessToken: persisted.accessToken,
+    refreshToken: persisted.refreshToken,
+    expiresAt: persisted.expiresAt,
+  };
+}
+
+interface EnsureFreshSessionOutcome {
+  session: Org2CloudAuthState | null;
+  permanentlyRejected: boolean;
+}
+
 /**
  * Return `state` unchanged while the access token is comfortably valid;
  * otherwise refresh and return the updated state. The CALLER persists the
  * returned state (this module never touches the atom). `null` means the
  * refresh failed — the caller decides whether to sign the user out.
+ *
+ * The exchange itself runs under two serialization layers: the per-realm
+ * `inFlightRefresh` single-flight, plus the cross-window Web Lock (with a
+ * persisted-rotation re-read after acquiring it, so a realm that lost the
+ * race adopts the winner's tokens instead of burning the rotated one).
  */
 export async function ensureFreshSession(
   state: Org2CloudAuthState,
   options?: EnsureFreshSessionOptions
 ): Promise<Org2CloudAuthState | null> {
-  const nowSeconds = Date.now() / 1000;
-  if (state.expiresAt - nowSeconds > REFRESH_SKEW_SECONDS) {
+  if (hasComfortablyFreshAccessToken(state, Date.now() / 1000)) {
     return state;
   }
-  const attempt = await refreshSessionAttempt(state.refreshToken, {
-    supabaseUrl: state.supabaseUrl,
-    anonKey: state.supabaseAnonKey,
-  });
-  const refreshed = attempt.tokens;
-  if (!refreshed && attempt.permanentlyRejected) {
+  const outcome = await withCrossWindowRefreshLock<EnsureFreshSessionOutcome>(
+    async () => {
+      const adopted = adoptPersistedSessionRotation(
+        state,
+        readPersistedOrg2CloudAuth(),
+        Date.now() / 1000
+      );
+      if (adopted) return { session: adopted, permanentlyRejected: false };
+      const attempt = await refreshSessionAttempt(state.refreshToken, {
+        supabaseUrl: state.supabaseUrl,
+        anonKey: state.supabaseAnonKey,
+      });
+      const refreshed = attempt.tokens;
+      return {
+        session: refreshed
+          ? {
+              ...state,
+              accessToken: refreshed.accessToken,
+              refreshToken: refreshed.refreshToken,
+              expiresAt: refreshed.expiresAt,
+            }
+          : null,
+        permanentlyRejected: attempt.permanentlyRejected,
+      };
+    }
+  );
+  // Outside the locked region: a caller-supplied handler must not be able to
+  // throw inside the lock callback (see withCrossWindowRefreshLock).
+  if (!outcome.session && outcome.permanentlyRejected) {
     options?.onRefreshRejected?.();
   }
-  if (!refreshed) return null;
-  return {
-    ...state,
-    accessToken: refreshed.accessToken,
-    refreshToken: refreshed.refreshToken,
-    expiresAt: refreshed.expiresAt,
-  };
+  return outcome.session;
 }
 
 /** Re-exported so UI code has one import site. */

--- a/src/features/Org2Cloud/org2CloudRealtimeLease.ts
+++ b/src/features/Org2Cloud/org2CloudRealtimeLease.ts
@@ -4,6 +4,11 @@ import { useEffect, useRef, useState } from "react";
 import { isTauriRuntimeHost } from "@src/hooks/logger/useLogger";
 import { isWindowFocused } from "@src/util/core/windowFocus";
 
+import {
+  isAnyAppWindowFocused,
+  subscribeCrossWindowFocus,
+} from "./crossWindowFocus";
+
 /**
  * Realtime demand is strictly tied to an interactive desktop window. Local
  * event writes and the durable project outbox use their own event-driven HTTP
@@ -155,12 +160,23 @@ function readWindowMinimized(): Promise<boolean> {
 }
 
 /**
+ * The lease's foreground input is APP-wide, not window-wide: the socket is
+ * owned by the main window, but the user may be working in a detached
+ * session window that keeps main blurred. Own-window focus OR any peer
+ * window's fresh focused claim counts (outside Tauri the aggregate collapses
+ * to plain own-window focus).
+ */
+function isAppForeground(): boolean {
+  return isWindowFocused() || isAnyAppWindowFocused();
+}
+
+/**
  * React binding for the connection lease. This hook owns browser lifecycle
  * listeners only; the caller remains the single owner of the Supabase client
  * and all of its channels.
  */
 export function useOrg2CloudRealtimeLease(): boolean {
-  const [held, setHeld] = useState(() => isWindowFocused());
+  const [held, setHeld] = useState(() => isAppForeground());
   const initialHeldRef = useRef(held);
 
   useEffect(() => {
@@ -175,7 +191,7 @@ export function useOrg2CloudRealtimeLease(): boolean {
       () => controller.refresh()
     );
     const controller = createOrg2CloudRealtimeLeaseController({
-      isForeground: isWindowFocused,
+      isForeground: isAppForeground,
       isHidden: () =>
         document.visibilityState === "hidden" || minimizeBridge.isMinimized(),
       // Preserve the render-time truth so a focus transition between render
@@ -199,6 +215,10 @@ export function useOrg2CloudRealtimeLease(): boolean {
     window.addEventListener("pagehide", release);
     window.addEventListener("pageshow", refresh);
     document.addEventListener("visibilitychange", refresh);
+    // Peer windows' focus flips must re-evaluate the lease too: a detached
+    // window blurring/closing is what finally lets a blurred main release,
+    // and a detached window focusing is what keeps it held.
+    const unsubscribeCrossWindowFocus = subscribeCrossWindowFocus(refresh);
     minimizeBridge.probe();
     controller.refresh();
 
@@ -208,6 +228,7 @@ export function useOrg2CloudRealtimeLease(): boolean {
       window.removeEventListener("pagehide", release);
       window.removeEventListener("pageshow", refresh);
       document.removeEventListener("visibilitychange", refresh);
+      unsubscribeCrossWindowFocus();
       controller.dispose();
     };
   }, []);

--- a/src/features/Org2Cloud/org2CloudRosterReconcile.ts
+++ b/src/features/Org2Cloud/org2CloudRosterReconcile.ts
@@ -23,6 +23,7 @@ import { type WritableAtom, createStore, useAtomValue, useStore } from "jotai";
 import { useEffect, useRef } from "react";
 
 import { createLogger } from "@src/hooks/logger";
+import { isMainAppWindow } from "@src/util/platform/tauri/windowIdentity";
 
 import {
   org2CloudAuthAtom,
@@ -173,6 +174,11 @@ export function useOrg2CloudRosterReconcile(): void {
   );
 
   useEffect(() => {
+    // Main-window-only: the sweep is a read-modify-write of whole persisted
+    // records, and a secondary window pruning from a stale snapshot can drop
+    // push cursors the main window just wrote. Main's webview is never
+    // destroyed while the app runs, so it is the single stable owner.
+    if (!isMainAppWindow()) return;
     if (!reconcileKey) {
       if (!authIdentityKey) reconciledRosterRef.current = null;
       return;

--- a/src/features/Org2Cloud/useOrg2CloudGuestShareAccess.ts
+++ b/src/features/Org2Cloud/useOrg2CloudGuestShareAccess.ts
@@ -23,6 +23,7 @@ import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import { removeSession } from "@src/store/session/sessionAtom/mutations";
 import { persistSessions } from "@src/store/session/sessionAtom/persistence";
 import type { Session } from "@src/store/session/sessionAtom/types";
+import { isMainAppWindow } from "@src/util/platform/tauri/windowIdentity";
 
 import { classifyCloudShareResolveError } from "./cloudShareImportModel";
 import {
@@ -216,8 +217,15 @@ export function useOrg2CloudGuestShareAccess(): void {
     .join("\u001e");
   const authIdentityKey = auth ? org2CloudAuthIdentityKey(auth) : null;
 
+  // Main-window-only: eviction DELETES local sessions and persists the whole
+  // session list, so two windows sweeping concurrently race duplicate
+  // deletes and a last-writer-wins persistSessions clobber. The main
+  // window's webview is never destroyed while the app runs, so it is the
+  // single stable owner of this destructive sweep.
   useEffect(() => {
-    if (!authIdentityKey || capabilities.length === 0) return undefined;
+    if (!isMainAppWindow() || !authIdentityKey || capabilities.length === 0) {
+      return undefined;
+    }
     const abortController = new AbortController();
     const isVisible = () => document.visibilityState !== "hidden";
     const runAll = () => {
@@ -240,7 +248,12 @@ export function useOrg2CloudGuestShareAccess(): void {
   }, [authIdentityKey, capabilityKey, capabilities.length, validate]);
 
   useEffect(() => {
-    if (!authIdentityKey || !activeSessionId || capabilities.length === 0) {
+    if (
+      !isMainAppWindow() ||
+      !authIdentityKey ||
+      !activeSessionId ||
+      capabilities.length === 0
+    ) {
       return undefined;
     }
     const abortController = new AbortController();

--- a/src/features/Org2Cloud/useOrg2CloudRealtime.ts
+++ b/src/features/Org2Cloud/useOrg2CloudRealtime.ts
@@ -50,6 +50,7 @@ import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import type { Session } from "@src/store/session/sessionAtom/types";
 import { activeSessionIdAtom } from "@src/store/session/viewAtom";
 import { chatPanelSelectedCloudOrgAtom } from "@src/store/ui/chatPanelAtom";
+import { isMainAppWindow } from "@src/util/platform/tauri/windowIdentity";
 
 import {
   bumpConversationPlaneSignal,
@@ -62,6 +63,7 @@ import {
   org2CloudChannelsVersionAtom,
 } from "./channels/channelsAtom";
 import { getFreshCloudAccessToken } from "./cloudShortId";
+import { startCrossWindowFocusPublisher } from "./crossWindowFocus";
 import { org2CloudSharingFloorAtom } from "./org2CloudAccessSettings";
 import {
   commitRefreshedAuth,
@@ -414,12 +416,23 @@ export function useOrg2CloudRealtime(): void {
 
   const connectionRef = useRef<Org2CloudRealtimeConnection | null>(null);
 
+  // EVERY window (main and detached) advertises its focus state so the main
+  // window's lease treats "the app is foregrounded in ANY window" as
+  // foreground — a user working in a detached window must not cost main its
+  // socket after the blur grace.
+  useEffect(() => startCrossWindowFocusPublisher(), []);
+
   // --- Connection + Slice A (roster). Rebuilds on user / endpoint / active
   // org. A fresh connection on scope switch avoids supabase-js reusing a
   // presence topic whose asynchronous leave has not finished yet.
   useEffect(() => {
     const current = authRef.current;
-    if (!userId || !current || !activeRealtimeOrgId) {
+    // Socket ownership is main-window-only: a secondary window opening a
+    // second Realtime connection would double the billable socket count and
+    // flap Presence (the presence key is the userId, so two windows publish
+    // two metas for one user). Main's webview is never destroyed while the
+    // app runs, so this ownership rule is stable.
+    if (!isMainAppWindow() || !userId || !current || !activeRealtimeOrgId) {
       return undefined;
     }
     const connection = createOrg2CloudRealtimeConnection(

--- a/src/features/Org2Cloud/useOrg2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/useOrg2CloudSyncEngine.ts
@@ -16,6 +16,7 @@ import { useEffect } from "react";
 
 import { externalHistoryBackgroundScanEnabledAtom } from "@src/store/session/dataSourceConfigAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
+import { isMainAppWindow } from "@src/util/platform/tauri/windowIdentity";
 
 import { memberRuntimePushScheduler } from "./memberRuntime/memberRuntimePushScheduler";
 import {
@@ -76,7 +77,14 @@ export function useOrg2CloudSyncEngine(): void {
       orgs
     );
 
+  // Main-window-only: every OS window runs this same hook stack, but the
+  // push engine listens to the app-wide `orgii-data-changed` broadcast and
+  // its pass guard is per-instance — two windows pushing the same segment
+  // range trigger epoch-rewrite re-anchors (see CloudPushCursorsSchema). The
+  // main window's webview is never destroyed while the app runs, so it is
+  // the single stable owner.
   useEffect(() => {
+    if (!isMainAppWindow()) return undefined;
     setExternalHistoryBackgroundScanEnabled(
       externalHistoryBackgroundScanEnabled
     );
@@ -87,6 +95,7 @@ export function useOrg2CloudSyncEngine(): void {
   ]);
 
   useEffect(() => {
+    if (!isMainAppWindow()) return undefined;
     // stop() is idempotent and also covers the A→B switch (no null between):
     // the old identity's engine state must never survive into the new one.
     // The member-runtime push scheduler shares the exact same identity
@@ -104,7 +113,7 @@ export function useOrg2CloudSyncEngine(): void {
   }, [authIdentityKey]);
 
   useEffect(() => {
-    if (!authIdentityKey || !orgsLoaded) return;
+    if (!isMainAppWindow() || !authIdentityKey || !orgsLoaded) return;
     org2CloudSyncEngine.reconcileRoster();
   }, [authIdentityKey, orgsLoaded, rosterKey]);
 }

--- a/src/hooks/platform/useDeepLinkHandler.ts
+++ b/src/hooks/platform/useDeepLinkHandler.ts
@@ -62,6 +62,7 @@ import { log, logDebug, logError, logWarn } from "@src/hooks/logger";
 import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanelAtom";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import { isTauriReady } from "@src/util/platform/tauri/init";
+import { isMainAppWindow } from "@src/util/platform/tauri/windowIdentity";
 
 /**
  * Track a share deep-link URL as re-armable (design §6.4). A share link is
@@ -166,6 +167,15 @@ export function isUnclaimedCloudDeepLink(url: string): boolean {
 /**
  * Hook to handle deep link navigation
  * Should be mounted once at the app root level
+ *
+ * RootLayout mounts it in EVERY OS window, but the deep-link plugin
+ * broadcasts `deep-link://new-url` to all webviews and `getCurrent()`
+ * replays the launch URL to any window that asks. Without a gate a
+ * detached session window would be navigated off its route (OAuth
+ * callbacks, generic links), turned into a WorkStation (cloud share /
+ * join links), and auth/billing handlers would run once per window. So
+ * every effect below is a no-op outside the main window — gated inside
+ * the effect bodies (hooks must still be called unconditionally).
  */
 export function useDeepLinkHandler(): void {
   const navigate = useNavigate();
@@ -192,6 +202,7 @@ export function useDeepLinkHandler(): void {
   // import done), re-arm the tracked links so re-clicking the same one-shot
   // URL re-opens the dialog.
   useEffect(() => {
+    if (!isMainAppWindow()) return;
     if (
       pendingCloudShare === null &&
       reArmableCloudShareUrls.current.size > 0
@@ -265,6 +276,7 @@ export function useDeepLinkHandler(): void {
   // macOS. The listener is app-scoped and idle until the OAuth plugin emits;
   // the loopback server itself is bounded and cleaned up by its coordinator.
   useEffect(() => {
+    if (!isMainAppWindow()) return;
     if (!isTauriReady()) return;
     let disposed = false;
 
@@ -323,6 +335,11 @@ export function useDeepLinkHandler(): void {
   }, []);
 
   useEffect(() => {
+    // Deep links are an app-wide singleton owned by the main window.
+    if (!isMainAppWindow()) {
+      return;
+    }
+
     // Only run in Tauri environment
     if (!isTauriReady()) {
       return;
@@ -457,6 +474,12 @@ export function useDeepLinkHandler(): void {
   // Also check for deep link on initial load (app opened via deep link)
   // This effect should only run ONCE on mount, not on every location change
   useEffect(() => {
+    // The `getCurrent()` replay re-delivers the launch URL to ANY window
+    // that asks — a later-opened window must never consume it.
+    if (!isMainAppWindow()) {
+      return;
+    }
+
     // Only process initial deep link once
     if (hasProcessedInitialDeepLink.current) {
       return;

--- a/src/hooks/session/__tests__/useNativeSessionStatusMonitor.test.ts
+++ b/src/hooks/session/__tests__/useNativeSessionStatusMonitor.test.ts
@@ -27,6 +27,10 @@ import {
 } from "vitest";
 
 import { resetTurnLifecycleForTests } from "@src/engines/SessionCore/control/turnLifecycle";
+import {
+  deliverSessionTerminalNotification,
+  shouldDeliverSessionTerminalNotification,
+} from "@src/hooks/session/sessionTerminalNotifications";
 import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import type { SessionStatus } from "@src/types/session/session";
 import {
@@ -72,8 +76,12 @@ const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
 
+/** Hook options for the next `Probe` mount; reset to the main-window
+ *  default (deliver notifications) before each test. */
+let probeOptions: Parameters<typeof useNativeSessionStatusMonitor>[0];
+
 function Probe(): null {
-  useNativeSessionStatusMonitor();
+  useNativeSessionStatusMonitor(probeOptions);
   return null;
 }
 
@@ -120,6 +128,7 @@ describe("useNativeSessionStatusMonitor session-list status", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listeners.handlers.clear();
+    probeOptions = undefined;
     resetTurnLifecycleForTests();
     createInstrumentedStore();
     seedSessionRow();
@@ -169,5 +178,48 @@ describe("useNativeSessionStatusMonitor session-list status", () => {
     emitStatus("waiting_for_user");
 
     expectRowStatus("waiting_for_user");
+  });
+
+  it("notifications:false skips delivery but still applies status and rename", async () => {
+    // Prove the boundary would deliver: under the default (main-window)
+    // mount this exact predicate triggers a native notification…
+    vi.mocked(shouldDeliverSessionTerminalNotification).mockReturnValueOnce(
+      true
+    );
+    emitStatus("failed");
+    expect(deliverSessionTerminalNotification).toHaveBeenCalledTimes(1);
+
+    // …then remount notification-free, the way the detached session window
+    // (`SessionWindowBridges`) mounts this hook.
+    act(() => {
+      root.unmount();
+    });
+    listeners.handlers.clear();
+    vi.mocked(deliverSessionTerminalNotification).mockClear();
+    probeOptions = { notifications: false };
+    root = createRoot(container);
+    act(() => {
+      root.render(createElement(Probe));
+    });
+
+    // "failed" → "completed" is a completed boundary, so the default mount
+    // would have delivered here too — the option is what suppresses it.
+    emitStatus("completed");
+    const renameHandler = listeners.handlers.get("session-renamed");
+    expect(renameHandler).toBeDefined();
+    await act(async () => {
+      renameHandler?.({ payload: { sessionId: SESSION_ID, name: "Renamed" } });
+      // The rename handler resolves dynamic imports before writing; a
+      // macrotask lets those microtasks drain.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(deliverSessionTerminalNotification).not.toHaveBeenCalled();
+    expectRowStatus("completed");
+    expect(
+      getInstrumentedStore()
+        .get(sessionsAtom)
+        .map((session) => session.name)
+    ).toEqual(["Renamed"]);
   });
 });

--- a/src/hooks/session/useNativeSessionStatusMonitor.ts
+++ b/src/hooks/session/useNativeSessionStatusMonitor.ts
@@ -18,7 +18,11 @@
  *
  * It also owns transition-based native notifications. Foreground turns may
  * play sound, while sessions outside user attention may additionally raise
- * system notifications or quiet-hours summaries.
+ * system notifications or quiet-hours summaries. Notification delivery is
+ * main-window-owned: detached session windows mount this hook with
+ * `{ notifications: false }`, which skips ONLY the native notification
+ * delivery while every atom write (status, rename, account switch, turn
+ * lifecycle) still applies, so a terminal turn never notifies twice.
  */
 import { listen } from "@tauri-apps/api/event";
 import { useAtomValue } from "jotai";
@@ -72,7 +76,12 @@ interface SessionRenamedPayload {
   name: string;
 }
 
-export function useNativeSessionStatusMonitor(): void {
+export function useNativeSessionStatusMonitor(options?: {
+  /** `false` skips native notification delivery (detached session windows);
+   *  every atom write still applies. Defaults to delivering. */
+  notifications?: boolean;
+}): void {
+  const notificationsEnabled = options?.notifications !== false;
   const { t } = useTranslation();
   const notificationSettings = useAtomValue(notificationSettingsAtom);
   const activeSessionId = useAtomValue(activeSessionIdAtom);
@@ -114,7 +123,7 @@ export function useNativeSessionStatusMonitor(): void {
         const notificationBoundary =
           completedBoundary ||
           shouldDeliverSessionTerminalNotification(session?.status, status);
-        if (session && notificationBoundary) {
+        if (notificationsEnabled && session && notificationBoundary) {
           const outsideActiveSession =
             session.background === true ||
             activeSessionIdRef.current !== sessionId;
@@ -197,5 +206,5 @@ export function useNativeSessionStatusMonitor(): void {
       unlistenRenamePromise.then((unlisten) => unlisten());
       unlistenAccountPromise.then((unlisten) => unlisten());
     };
-  }, []);
+  }, [notificationsEnabled]);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -167,8 +167,16 @@ async function initializeApp() {
   // frameless windows; this event triggers show() so the first visible
   // frame is the painted splash, not a transparent artifact.
   // Fire-and-forget: a 3 s safety timeout on the Rust side covers failures.
-  import("@tauri-apps/api/event")
-    .then(({ emit }) => emit("orgii:main-window-ready"))
+  // Main window only: the Rust listener stays armed for the app's lifetime
+  // and shows + FOCUSES main on every emit, so a secondary window (e.g. a
+  // detached session window) booting later would steal focus back to main.
+  import("@tauri-apps/api/window")
+    .then(({ getCurrentWindow }) => {
+      if (getCurrentWindow().label !== "main") return;
+      return import("@tauri-apps/api/event").then(({ emit }) =>
+        emit("orgii:main-window-ready")
+      );
+    })
     .catch(() => {});
 
   // Runtime identity must be known before loading App: several API modules

--- a/src/modules/SessionWindow/index.tsx
+++ b/src/modules/SessionWindow/index.tsx
@@ -1,0 +1,276 @@
+/**
+ * SessionWindowPage — the standalone route a detached session window loads.
+ *
+ * Rendered by `appStandaloneRouteGroup` (outside `AppShell`), so the window
+ * carries no sidebar, workstation, or chat-panel chrome: one session surface,
+ * composed exactly like the Workstation `chat-session` tab renderer
+ * (`WorkStation/TabContent/renderers/chatSession.tsx`) but with the header
+ * inline instead of published to a tab host, and with `ChatView` as the
+ * window's PRIMARY surface — this webview has its own Jotai store, so the
+ * global event pipeline here belongs to this session alone.
+ *
+ * The provider stack mirrors the slice of `AppLayout` a session surface
+ * needs (`DataProvider → ChatProvider → SessionSyncProvider` + the
+ * EventStore/queue bridges from `GlobalSessionSync`). The full
+ * `GlobalSessionSync` is deliberately not mounted — native notification
+ * delivery is main-window-owned and would double-fire — but the native
+ * session-status monitor DOES run here with notifications off, so renames,
+ * account switches and cross-session status reach this window's store.
+ *
+ * Session-row hydration is owned by the content surfaces themselves —
+ * `ChatView` and `HumanSessionView` both call `loadSessions({forceRefresh})`
+ * when the row is missing — so a cold window converges without extra wiring.
+ */
+import { useAtomValue } from "jotai";
+import React, { memo, useCallback, useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { ChatProvider } from "@src/contexts/workspace/ChatContext";
+import { DataProvider } from "@src/contexts/workspace/DataContext";
+import { useReloadSession } from "@src/engines/ChatPanel/ChatHistory/hooks/useReloadSession";
+import SessionContentView from "@src/engines/ChatPanel/SessionContentView";
+import { SessionHeaderActionsMenu } from "@src/engines/ChatPanel/components/SessionHeaderActionsMenu";
+import {
+  SessionAlternateSurface,
+  SessionHeaderViewControls,
+  SessionRawToolbarActions,
+} from "@src/engines/ChatPanel/components/SessionViewSwitcher";
+import {
+  CHAT_PANEL_HEADER_DRAG_STYLE,
+  CHAT_PANEL_HEADER_NO_DRAG_STYLE,
+} from "@src/engines/ChatPanel/header";
+import { useSessionActionModals } from "@src/engines/ChatPanel/hooks/useSessionActionModals";
+import { useSessionHeaderActions } from "@src/engines/ChatPanel/hooks/useSessionHeaderActions";
+import { useSessionViewMode } from "@src/engines/ChatPanel/hooks/useSessionViewMode";
+import { useEventStoreBridge } from "@src/engines/SessionCore/core/store/useEventStoreBridge";
+import GlobalPlanningIndicatorBridgeSync from "@src/engines/SessionCore/hooks/replay/GlobalPlanningIndicatorBridgeSync";
+import { useQueueDispatch } from "@src/engines/SessionCore/hooks/session/useQueueDispatch";
+import SessionSyncProvider from "@src/engines/SessionCore/sync/SessionSyncProvider";
+import SessionViewersIndicator from "@src/features/Org2Cloud/SessionViewersIndicator";
+import { useNativeSessionStatusMonitor } from "@src/hooks/session/useNativeSessionStatusMonitor";
+import { getChatPanelBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
+import { sessionByIdAtom } from "@src/store/session";
+import type { SessionContinuation } from "@src/store/session/sessionTabPlacementAtom";
+import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";
+import { isMacOS, isWindows } from "@src/util/platform/tauri";
+import { isHumanSession } from "@src/util/session/sessionDispatch";
+
+/** Path the detached window navigates to for one session. Must stay in sync
+ *  with the Rust route in `app_window::commands::open_session_window` and the
+ *  `appStandaloneRouteGroup` entry. */
+export function getSessionWindowPath(sessionId: string): string {
+  return `/orgii/app/session/${encodeURIComponent(sessionId)}`;
+}
+
+/** Width reserved for the macOS overlay traffic lights (x=20 + 3 buttons),
+ *  mirroring MACOS_TRAFFIC_LIGHTS_RESERVED_WIDTH in
+ *  useCollapsedSidebarChromeOffset. */
+const MACOS_TRAFFIC_LIGHTS_INSET_PX = 84;
+
+/** The EventStore→Jotai and queue bridges this window needs from
+ *  `GlobalSessionSync`, plus the native session-status monitor with
+ *  notifications off: renames, account switches and status changes keep
+ *  this window's store (header title, ModelPill, sleep inhibitor) live,
+ *  while native notification delivery stays main-window-owned. */
+const SessionWindowBridges: React.FC = () => {
+  useEventStoreBridge();
+  useQueueDispatch();
+  useNativeSessionStatusMonitor({ notifications: false });
+  return <GlobalPlanningIndicatorBridgeSync />;
+};
+
+const SessionWindowContent: React.FC<{ sessionId: string }> = memo(
+  ({ sessionId }) => {
+    const { t } = useTranslation([
+      "sessions",
+      "common",
+      "projects",
+      "navigation",
+    ]);
+    const navigate = useNavigate();
+    const session = useAtomValue(sessionByIdAtom(sessionId));
+    const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
+    const chatPanelSurfaceStyle = useMemo(
+      () => getChatPanelBackgroundStyle(backgroundConfig.pageOpacity),
+      [backgroundConfig.pageOpacity]
+    );
+    const humanSession =
+      session?.category === "human_session" || isHumanSession(sessionId);
+    const sessionView = useSessionViewMode({
+      sessionId: sessionId || null,
+      humanSession,
+    });
+    const sessionViewMode = sessionView.mode;
+    const handleReloadSession = useReloadSession(sessionId || null);
+    const headerActions = useSessionHeaderActions({
+      sessionId: sessionId || null,
+      handleReloadSession,
+    });
+    const { closeHeaderActionsMenu } = headerActions;
+    const sessionActions = useSessionActionModals({
+      activeSession: session,
+      closeHeaderActionsMenu,
+      currentSession: session ?? null,
+      currentSessionId: sessionId || null,
+      t,
+    });
+
+    // A continuation retargets this window in place — same behavior as the
+    // in-app session pills, expressed as route navigation because the route
+    // param is this window's tab state.
+    const handleSessionContinuation = useCallback(
+      (continuation: SessionContinuation) => {
+        navigate(getSessionWindowPath(continuation.sessionId), {
+          replace: true,
+        });
+      },
+      [navigate]
+    );
+
+    // Keep the native window title on the session name (it was seeded by the
+    // open command, but renames and continuations happen after that).
+    const sessionName = session?.name?.trim() || "";
+    useEffect(() => {
+      if (!sessionName) return;
+      void import("@tauri-apps/api/window")
+        .then(({ getCurrentWindow }) =>
+          getCurrentWindow().setTitle(sessionName)
+        )
+        .catch(() => undefined);
+    }, [sessionName]);
+
+    const windowsHost = isWindows();
+
+    if (!sessionId) return null;
+    return (
+      <div
+        data-chat-panel
+        className="flex h-full min-w-0 flex-1 flex-col overflow-hidden bg-chat-pane text-sm"
+        style={chatPanelSurfaceStyle}
+      >
+        {/* Same one-row chrome the tab hosts give a session surface. On
+            macOS the row doubles as the drag strip behind the overlay
+            traffic lights; on Windows the native title bar owns dragging. */}
+        <div
+          className="relative z-40 flex h-11 min-h-11 flex-shrink-0 items-center gap-1.5 pr-[7px] pt-2"
+          data-testid="session-window-header"
+          data-tauri-drag-region={windowsHost ? undefined : true}
+          style={{
+            paddingLeft: isMacOS() ? MACOS_TRAFFIC_LIGHTS_INSET_PX : 12,
+            ...(windowsHost
+              ? CHAT_PANEL_HEADER_NO_DRAG_STYLE
+              : CHAT_PANEL_HEADER_DRAG_STYLE),
+          }}
+        >
+          <div
+            className="flex min-w-0 flex-1 items-center"
+            style={CHAT_PANEL_HEADER_NO_DRAG_STYLE}
+          >
+            <SessionHeaderViewControls
+              session={session}
+              sessionId={sessionId}
+              fallbackName={sessionName || "Chat"}
+              onParentSessionClick={handleSessionContinuation}
+              view={sessionView}
+              testIdPrefix="session-window"
+            />
+          </div>
+          <div
+            className="flex shrink-0 items-center gap-px"
+            style={CHAT_PANEL_HEADER_NO_DRAG_STYLE}
+          >
+            <SessionViewersIndicator sessionId={sessionId || null} />
+            <SessionRawToolbarActions
+              view={sessionView}
+              testIdPrefix="session-window"
+            />
+            <SessionHeaderActionsMenu
+              activeSessionExists={Boolean(session)}
+              copyEventJsonLabel={headerActions.copyEventJsonLabel}
+              currentSessionId={sessionId || null}
+              displayMode={headerActions.displayMode}
+              eventsLength={headerActions.eventCount}
+              handleCompactDisplayModeToggle={
+                headerActions.handleCompactDisplayModeToggle
+              }
+              handleCopyEventJson={headerActions.handleCopyEventJson}
+              handleMoveSession={() => undefined}
+              handleOpenCloudShareSettings={
+                sessionActions.handleOpenCloudShareSettings
+              }
+              handleOpenExportSessionJson={
+                sessionActions.handleOpenExportSessionJson
+              }
+              handleOpenLinkWorkItem={sessionActions.handleOpenLinkWorkItem}
+              handleOpenRawTranscript={sessionView.showRaw}
+              handleOpenSearch={headerActions.handleOpenSearch}
+              handlePaginationToggle={headerActions.handlePaginationToggle}
+              handleReloadFromMenu={headerActions.handleReloadFromMenu}
+              handleTokenUsageVisibleToggle={
+                headerActions.handleTokenUsageVisibleToggle
+              }
+              handleTurnMetadataVisibleToggle={
+                headerActions.handleTurnMetadataVisibleToggle
+              }
+              headerActionsDropdownRef={headerActions.headerActionsDropdownRef}
+              headerActionsPosition={headerActions.headerActionsPosition}
+              headerActionsTriggerRef={headerActions.headerActionsTriggerRef}
+              isHeaderActionsOpen={headerActions.isHeaderActionsOpen}
+              isHeaderActionsPositioned={
+                headerActions.isHeaderActionsPositioned
+              }
+              moveTarget="chat-panel"
+              paginationEnabled={headerActions.paginationEnabled}
+              showCloudShareSettings={sessionActions.showCloudShareSettings}
+              showMoveSession={false}
+              showOpenInNewWindow={false}
+              showTranscriptActions={!humanSession}
+              tokenUsageVisible={headerActions.tokenUsageVisible}
+              turnMetadataVisible={headerActions.turnMetadataVisible}
+              toggleHeaderActionsMenu={headerActions.toggleHeaderActionsMenu}
+              triggerTestId="session-window-header-more-button"
+            />
+          </div>
+        </div>
+        {/* Hidden, never unmounted — see ChatPanelContent for why the
+            virtualized transcript must survive a view switch. */}
+        <div
+          className={`min-h-0 flex-1 flex-col overflow-hidden ${
+            sessionViewMode === "gui" ? "flex" : "hidden"
+          }`}
+        >
+          <SessionContentView
+            sessionId={sessionId}
+            displayMode={headerActions.displayMode}
+            onSessionContinuation={handleSessionContinuation}
+            turnPaginationEnabled={headerActions.paginationEnabled}
+          />
+        </div>
+        <SessionAlternateSurface sessionId={sessionId} view={sessionView} />
+        {sessionActions.sessionModals}
+      </div>
+    );
+  }
+);
+
+SessionWindowContent.displayName = "SessionWindowContent";
+
+const SessionWindowPage: React.FC = () => {
+  const { sessionId = "" } = useParams<{ sessionId: string }>();
+
+  return (
+    <div className="h-full min-h-0 w-full">
+      <DataProvider>
+        <ChatProvider>
+          <SessionSyncProvider>
+            <SessionWindowBridges />
+            <SessionWindowContent sessionId={sessionId} />
+          </SessionSyncProvider>
+        </ChatProvider>
+      </DataProvider>
+    </div>
+  );
+};
+
+export default SessionWindowPage;

--- a/src/modules/SessionWindow/index.tsx
+++ b/src/modules/SessionWindow/index.tsx
@@ -40,6 +40,7 @@ import {
   CHAT_PANEL_HEADER_DRAG_STYLE,
   CHAT_PANEL_HEADER_NO_DRAG_STYLE,
 } from "@src/engines/ChatPanel/header";
+import { shouldStartHeaderDragFromTarget } from "@src/engines/ChatPanel/header/chatPanelHeaderLayout";
 import { useSessionActionModals } from "@src/engines/ChatPanel/hooks/useSessionActionModals";
 import { useSessionHeaderActions } from "@src/engines/ChatPanel/hooks/useSessionHeaderActions";
 import { useSessionViewMode } from "@src/engines/ChatPanel/hooks/useSessionViewMode";
@@ -142,6 +143,24 @@ const SessionWindowContent: React.FC<{ sessionId: string }> = memo(
 
     const windowsHost = isWindows();
 
+    // The `data-tauri-drag-region` attribute only reacts to mousedowns whose
+    // TARGET carries the attribute — child elements swallow most of the row.
+    // Mirror ChatPanelHeader's collapsed-header fallback: any left-press on a
+    // non-interactive part of the header starts a native drag, and a
+    // double-press toggles maximize. Windows keeps its native title bar.
+    const handleHeaderMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (windowsHost || event.button !== 0) return;
+      if (!shouldStartHeaderDragFromTarget(event.target as Element | null)) {
+        return;
+      }
+      const maximize = event.detail === 2;
+      event.preventDefault();
+      void import("@src/util/platform/ipcRenderer").then(
+        ({ maxWindow, startWindowDrag }) =>
+          maximize ? maxWindow() : startWindowDrag()
+      );
+    };
+
     if (!sessionId) return null;
     return (
       <div
@@ -156,6 +175,7 @@ const SessionWindowContent: React.FC<{ sessionId: string }> = memo(
           className="relative z-40 flex h-11 min-h-11 flex-shrink-0 items-center gap-1.5 pr-[7px] pt-2"
           data-testid="session-window-header"
           data-tauri-drag-region={windowsHost ? undefined : true}
+          onMouseDown={handleHeaderMouseDown}
           style={{
             paddingLeft: isMacOS() ? MACOS_TRAFFIC_LIGHTS_INSET_PX : 12,
             ...(windowsHost

--- a/src/router/lazy/pages.tsx
+++ b/src/router/lazy/pages.tsx
@@ -34,6 +34,12 @@ export const LoginPage = React.lazy(
   () => import(/* webpackChunkName: "auth" */ "@/src/modules/AppLogin")
 );
 
+// Detached session window (label `app-window-session-<id>`): one session
+// surface with no app shell. Opened by `open_session_window` (Rust).
+export const SessionWindowPage = React.lazy(
+  () => import(/* webpackChunkName: "workspace" */ "@src/modules/SessionWindow")
+);
+
 export const FlowAwarenessTestPage = React.lazy(
   () =>
     import(

--- a/src/router/routes/routeGroups.tsx
+++ b/src/router/routes/routeGroups.tsx
@@ -10,6 +10,7 @@ import {
   FlowAwarenessTestPage,
   LoginPage,
   SelectRepoPage,
+  SessionWindowPage,
 } from "@src/router/lazy/pages";
 import ComingSoonRoutePage from "@src/router/routes/ComingSoonRoutePage";
 import { WorkStationRoutePlaceholder } from "@src/router/routes/placeholders";
@@ -102,6 +103,13 @@ export const appStandaloneRouteGroup: RouteObject[] = [
     ),
   },
   { path: "app/select-repo", element: lazy(<SelectRepoPage />, false) },
+  // Detached session window route — loaded by `open_session_window` (Rust)
+  // with the label `app-window-session-<id>`. Keep the path in sync with
+  // that command and `getSessionWindowPath`.
+  {
+    path: "app/session/:sessionId",
+    element: lazy(<SessionWindowPage />, false),
+  },
   { path: "marketplace/callback", element: lazy(<AuthCallback />) },
 ];
 

--- a/src/router/routes/routeGroups.walkthrough.test.ts
+++ b/src/router/routes/routeGroups.walkthrough.test.ts
@@ -34,6 +34,7 @@ vi.mock("@src/router/lazy/pages", () => {
     ProviderEarnings: Placeholder,
     PublicProfilePage: Placeholder,
     SelectRepoPage: Placeholder,
+    SessionWindowPage: Placeholder,
   };
 });
 

--- a/src/store/repo/storage.test.ts
+++ b/src/store/repo/storage.test.ts
@@ -61,6 +61,12 @@ describe("opened repository storage", () => {
     expect(getOpenedReposMap()).toEqual({ main: "repo-1" });
   });
 
+  it("keeps capability-globbed secondary windows out of the registry", () => {
+    registerOpenedRepo("app-window-session-osagent-1", "repo-1");
+
+    expect(getOpenedReposMap()).toEqual({});
+  });
+
   it("does not rewrite an unchanged repository selection", () => {
     const controls = installStorage({
       [REPO_STORAGE_KEYS.openedRepos]: JSON.stringify({ main: "repo-1" }),

--- a/src/store/repo/storage.ts
+++ b/src/store/repo/storage.ts
@@ -224,6 +224,9 @@ export function isMainAppWindowLabel(windowId: string): boolean {
   if (windowId === "main") return true;
   if (windowId === "wingman") return false;
   if (windowId.startsWith("wingman-")) return false;
+  // Capability-globbed secondary windows (detached session windows and
+  // whatever else adopts the glob) never own a repo selection.
+  if (windowId.startsWith("app-window-")) return false;
   if (windowId === "tab") return false;
   if (windowId === "welcome") return false;
   return true;

--- a/src/store/session/__tests__/sessionTabPlacementAtom.test.ts
+++ b/src/store/session/__tests__/sessionTabPlacementAtom.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { openSessionWindow } from "@src/api/tauri/sessionWindow";
 import {
   type ChatPanelTabsState,
   chatPanelTabsAtom,
@@ -16,14 +17,24 @@ import {
   createChatSessionTab,
   workstationLayoutAtom,
 } from "@src/store/workstation/tabs";
-import { createInstrumentedStore } from "@src/util/core/state/instrumentedStore";
+import {
+  createInstrumentedStore,
+  resetInstrumentedStore,
+} from "@src/util/core/state/instrumentedStore";
 
 import {
   moveSessionTabAtom,
+  openSessionInNewWindowAtom,
   openSessionInWorkstationAtom,
   retargetChatPanelSessionTabAtom,
   retargetWorkstationSessionTabAtom,
 } from "../sessionTabPlacementAtom";
+
+vi.mock("@src/api/tauri/sessionWindow", () => ({
+  openSessionWindow: vi.fn(() =>
+    Promise.resolve("app-window-session-session-1")
+  ),
+}));
 
 function session(sessionId: string, name: string): Session {
   return {
@@ -55,6 +66,11 @@ describe("session tab placement", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     localStorage.clear();
+    vi.mocked(openSessionWindow).mockClear();
+    // `createInstrumentedStore()` is a process-wide singleton; without a
+    // reset, atom state (e.g. the remembered workstation session) leaks
+    // between cases through the shared store.
+    resetInstrumentedStore();
   });
 
   afterEach(() => {
@@ -234,5 +250,96 @@ describe("session tab placement", () => {
       "agentsession-continuation"
     );
     expect(store.get(activeSessionIdAtom)).toBe("agentsession-continuation");
+  });
+
+  it("detaches a session into its own window and closes both owners' tabs", async () => {
+    const store = createInstrumentedStore();
+    store.set(sessionsAtom, [session("session-1", "Live session")]);
+    store.set(chatPanelTabsAtom, chatState("session-1"));
+    store.set(workstationLayoutAtom, {
+      mainPane: {
+        tabs: [
+          createChatSessionTab("session-1", "Live session"),
+          createChatSessionTab("session-9", "Unrelated session"),
+        ],
+        activeTabId: "chat-session:session-1",
+      },
+    });
+
+    const opened = await store.set(openSessionInNewWindowAtom, {
+      sessionId: "session-1",
+    });
+
+    expect(opened).toBe(true);
+    expect(vi.mocked(openSessionWindow)).toHaveBeenCalledWith(
+      "session-1",
+      "Live session"
+    );
+    expect(
+      store
+        .get(chatPanelTabsAtom)
+        .tabs.some(
+          (tab) => tab.type === "session" && tab.sessionId === "session-1"
+        )
+    ).toBe(false);
+    const workstationTabs = store.get(workstationLayoutAtom).mainPane.tabs;
+    expect(
+      workstationTabs.some(
+        (tab) =>
+          tab.type === "chat-session" && tab.data.sessionId === "session-1"
+      )
+    ).toBe(false);
+    expect(
+      workstationTabs.some(
+        (tab) =>
+          tab.type === "chat-session" && tab.data.sessionId === "session-9"
+      )
+    ).toBe(true);
+  });
+
+  it("keeps every tab when the window command fails", async () => {
+    vi.mocked(openSessionWindow).mockRejectedValueOnce(
+      new Error("window build failed")
+    );
+    const store = createInstrumentedStore();
+    store.set(sessionsAtom, [session("session-1", "Live session")]);
+    store.set(chatPanelTabsAtom, chatState("session-1"));
+    store.set(workstationLayoutAtom, {
+      mainPane: {
+        tabs: [createChatSessionTab("session-1", "Live session")],
+        activeTabId: "chat-session:session-1",
+      },
+    });
+
+    await expect(
+      store.set(openSessionInNewWindowAtom, { sessionId: "session-1" })
+    ).rejects.toThrow("window build failed");
+
+    expect(
+      store
+        .get(chatPanelTabsAtom)
+        .tabs.some(
+          (tab) => tab.type === "session" && tab.sessionId === "session-1"
+        )
+    ).toBe(true);
+    expect(
+      store
+        .get(workstationLayoutAtom)
+        .mainPane.tabs.some(
+          (tab) =>
+            tab.type === "chat-session" && tab.data.sessionId === "session-1"
+        )
+    ).toBe(true);
+  });
+
+  it("ignores a blank session id without invoking the window command", async () => {
+    const store = createInstrumentedStore();
+
+    const opened = await store.set(openSessionInNewWindowAtom, {
+      sessionId: "   ",
+    });
+
+    expect(opened).toBe(false);
+    expect(vi.mocked(openSessionWindow)).not.toHaveBeenCalled();
   });
 });

--- a/src/store/session/sessionTabPlacementAtom.ts
+++ b/src/store/session/sessionTabPlacementAtom.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai";
 
+import { openSessionWindow } from "@src/api/tauri/sessionWindow";
 import type { SessionTabTransfer } from "@src/shared/dnd/sessionTabDrag";
 import { closeChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabLifecycleAtoms";
 import { openOrFocusSessionInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabOpenAtoms";
@@ -71,6 +72,67 @@ export const openSessionInWorkstationAtom = atom(
   }
 );
 openSessionInWorkstationAtom.debugLabel = "openSessionInWorkstation";
+
+export interface OpenSessionInNewWindowOptions {
+  sessionId: string;
+  title?: string;
+}
+
+/**
+ * Detach one session into its own OS window, then close every tab this
+ * window holds for it — Chat Panel pills and Workstation `chat-session`
+ * tabs alike — so the live session keeps one visible owner (the same
+ * invariant `openSessionInWorkstationAtom` enforces between the two
+ * in-window hosts). Tabs are only closed after the window command
+ * succeeds; on failure the session stays where it is and the error
+ * propagates to the caller.
+ */
+export const openSessionInNewWindowAtom = atom(
+  null,
+  async (
+    get,
+    set,
+    options: OpenSessionInNewWindowOptions
+  ): Promise<boolean> => {
+    const sessionId = options.sessionId.trim();
+    if (!sessionId) return false;
+
+    const session = get(sessionByIdAtom(sessionId));
+    const title = getSessionTitle(session?.name, options.title ?? "Chat");
+
+    await openSessionWindow(sessionId, title);
+
+    // Workstation first: closing a Chat Panel pill re-activates a neighbour,
+    // which can swap the presented workstation workspace and hide the very
+    // pane this scan needs to edit.
+    const layout = get(workstationLayoutAtom);
+    const matchingWorkstationTabIds = layout.mainPane.tabs
+      .filter(
+        (tab) => tab.type === "chat-session" && tab.data.sessionId === sessionId
+      )
+      .map((tab) => tab.id);
+    if (matchingWorkstationTabIds.length > 0) {
+      set(workstationLayoutAtom, {
+        ...layout,
+        mainPane: matchingWorkstationTabIds.reduce(
+          (pane, tabId) => closeTab(pane, tabId),
+          layout.mainPane
+        ),
+      });
+    }
+
+    const matchingChatTabIds = get(chatPanelTabsAtom)
+      .tabs.filter(
+        (tab) => tab.type === "session" && tab.sessionId === sessionId
+      )
+      .map((tab) => tab.id);
+    for (const tabId of matchingChatTabIds) {
+      set(closeChatPanelTabAtom, tabId);
+    }
+    return true;
+  }
+);
+openSessionInNewWindowAtom.debugLabel = "openSessionInNewWindow";
 
 /**
  * Move one session tab between the two visible tab owners. The session and

--- a/src/store/session/useDataSourceAutoScan.ts
+++ b/src/store/session/useDataSourceAutoScan.ts
@@ -19,6 +19,11 @@
  * armed once and always sees the latest values without re-arming. Hidden windows
  * pause by default; an explicit app-wide background-upload demand keeps one
  * low-frequency timer alive and catches up immediately when it is enabled.
+ *
+ * Only the main window arms the scheduler (`isMainAppWindow`): secondary OS
+ * windows (detached session windows) mount the same AppBootstrap, and a second
+ * scan cadence per window would just duplicate rescans against the same
+ * backend cache.
  */
 import { useEffect } from "react";
 
@@ -32,6 +37,7 @@ import {
   isWindowFocused,
   onWindowFocusRegained,
 } from "@src/util/core/windowFocus";
+import { isMainAppWindow } from "@src/util/platform/tauri/windowIdentity";
 
 import {
   type DataSourceConfigMap,
@@ -368,6 +374,9 @@ export function startDataSourceAutoScanScheduler(
 
 export function useDataSourceAutoScan(): void {
   useEffect(() => {
+    // Secondary windows must not run a duplicate rescan cadence; the main
+    // window's scheduler already keeps the shared backend cache fresh.
+    if (!isMainAppWindow()) return;
     const store = getInstrumentedStore();
     const scheduler = startDataSourceAutoScanScheduler(
       document,

--- a/src/util/platform/tauri/windowIdentity.test.ts
+++ b/src/util/platform/tauri/windowIdentity.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getCurrentWindowLabel,
+  isMainAppWindow,
+  resetWindowIdentityForTests,
+} from "./windowIdentity";
+
+describe("windowIdentity", () => {
+  afterEach(() => {
+    resetWindowIdentityForTests();
+  });
+
+  it("treats a non-Tauri environment as the main app window", () => {
+    // vitest has no __TAURI_INTERNALS__, so isTauriDesktop() is false.
+    expect(getCurrentWindowLabel()).toBeNull();
+    expect(isMainAppWindow()).toBe(true);
+  });
+
+  it("caches the resolved label", () => {
+    expect(getCurrentWindowLabel()).toBeNull();
+    expect(getCurrentWindowLabel()).toBeNull();
+  });
+});

--- a/src/util/platform/tauri/windowIdentity.ts
+++ b/src/util/platform/tauri/windowIdentity.ts
@@ -1,0 +1,69 @@
+/**
+ * Window identity for multi-window gating.
+ *
+ * The app now opens secondary OS windows (detached session windows,
+ * `app-window-session-<id>`), and every window runs the same bundle through
+ * the same `RootLayout`/`AppBootstrap` hook stack. App-wide singletons —
+ * deep-link navigation, the updater, git auto-fetch, cloud sync — must run
+ * in exactly one window, and "which window am I" is the gate.
+ *
+ * `getCurrentWindow().label` is synchronous in Tauri v2, so the label is
+ * resolved once at first call and cached for the document's lifetime (a
+ * window's label can never change).
+ *
+ * Outside Tauri (browser dev, unit tests) there is only one document, so it
+ * plays every role: `isMainAppWindow()` returns true there. That keeps
+ * existing unit tests and browser dev behavior unchanged.
+ */
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export const MAIN_WINDOW_LABEL = "main";
+
+/**
+ * Deliberately NOT imported from `./index`: that barrel runs
+ * `patchTauriInternals()` at module scope, which arms a self-rescheduling
+ * real-timer retry chain (10ms→1s). Pulling it into a module graph makes any
+ * fake-timer test that loads this file inherit a stray timeout in its fake
+ * clock (observed as a flaky `getTimerCount()` off-by-one). This module must
+ * stay side-effect-free, so it detects Tauri directly off the injected
+ * internals instead. (`isTauriDesktop()` in the barrel is also hardcoded to
+ * `true`, so it never actually guarded anything.)
+ */
+function hasTauriInternals(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "__TAURI_INTERNALS__" in (window as unknown as Record<string, unknown>)
+  );
+}
+
+let cachedLabel: string | null | undefined;
+
+/** The current Tauri window's label, or null outside Tauri. Cached. */
+export function getCurrentWindowLabel(): string | null {
+  if (cachedLabel !== undefined) return cachedLabel;
+  if (!hasTauriInternals()) {
+    cachedLabel = null;
+    return cachedLabel;
+  }
+  try {
+    cachedLabel = getCurrentWindow().label;
+  } catch {
+    cachedLabel = null;
+  }
+  return cachedLabel;
+}
+
+/**
+ * Whether this document should own app-wide singleton behavior.
+ * True in the Tauri main window and in non-Tauri environments
+ * (browser dev / unit tests), where the single document is "the app".
+ */
+export function isMainAppWindow(): boolean {
+  const label = getCurrentWindowLabel();
+  return label === null || label === MAIN_WINDOW_LABEL;
+}
+
+/** Test hook: clear the cached label so a test can vary the environment. */
+export function resetWindowIdentityForTests(): void {
+  cachedLabel = undefined;
+}


### PR DESCRIPTION
## Problem

Sessions can only live inside the main window's two tab hosts (Chat Panel pills and the Workstation `chat-session` tab). There is no way to pop a session out into its own OS window to watch an agent run while working elsewhere in the app.

Underneath that, the app had never actually opened a second app window, so the codebase is full of implicit "one window = the app" assumptions: every window mounts the full `RootLayout`/`AppBootstrap` hook stack, and each webview is its own JS realm, so any module-level singleton silently becomes per-window. A focused audit of what a second window would break confirmed real bugs: deep-link broadcasts navigate every window (an OAuth callback would destroy a detached session's route), `set_main_webview_zoom` hardcodes the `main` webview, the Win11 acrylic attribute leaks translucent CSS onto decorated windows, the realtime lease only sees its own window's focus (main drops its socket while the user works in another window), the cloud sync engine / guest-share eviction / roster prune all run twice with no mutual exclusion, concurrent refresh-token rotation from two windows can force a spurious cloud sign-out, and the sleep inhibitor is a single non-refcounted slot any window can release out from under an agent run.

## Solution

**Feature.** The shared session ⋯ menu (Chat Panel + My Station) gains "Open in New Window" (existing `common:actions.openInNewWindow` key, already translated in all 13 locales). A new Rust command `open_session_window` builds — or focuses, on repeat — a decorated native window labeled `app-window-session-<id>`, which matches the existing `app-window-*` capability glob, so no capability/schema change is needed. Chrome uses the main window's exact macOS contract — transparent NSWindow under the overlay title bar, startup background + liquid-glass material applied post-build, traffic lights pinned at the same (20,28) inset with the post-paint re-apply (`remove_window_background` now operates on the calling window) — and Win11 DWM corners on Windows. The header row is fully draggable (mousedown fallback, double-press maximizes), and secondary windows skip the splash mark at boot via an `index.html` label preflight (the overlay stays mounted for the startup watchdog's error panel). The window loads a new standalone route `/orgii/app/session/:sessionId` (outside `AppShell`): `SessionWindowPage` composes the same `SessionContentView`/`ChatView`, header view controls, viewers indicator and session menu as the Workstation renderer, with `ChatView` as that window's primary pipeline — valid because each webview has its own Jotai store. `openSessionInNewWindowAtom` detaches only after the window command succeeds, then closes the session's tabs in both owners (the same one-visible-owner invariant `openSessionInWorkstationAtom` enforces). No window prewarm: created on demand, visible from the first frame.

**Multi-window safety.** A new side-effect-free `windowIdentity` helper (`isMainAppWindow()`, true for label `main` and outside Tauri) gates app-wide singletons: deep-link listeners and cold-start replay; the Win11 acrylic attribute; cloud sync engine, guest-share eviction and roster prune; updater, git auto-fetch, terminal-buffer persistence, presence/profile sync and external-history auto-scan. `set_webview_zoom` (new, old command kept for compat) zooms the calling window's own webview. The realtime lease now aggregates focus across windows (BroadcastChannel + localStorage heartbeat) so main keeps its socket while any app window is focused, and socket ownership itself is main-only. Cloud token refresh is wrapped in a Web Locks cross-window mutex with a re-read-after-acquire that adopts a sibling window's rotation. The native session status monitor takes `{ notifications: false }` so detached windows apply status/rename/account-switch events without double-firing native notifications. The Rust sleep inhibitor becomes a holder-set refcount keyed by window label, dropped only when the last holder releases, with `WindowEvent::Destroyed` cleanup so a killed webview cannot leak its hold. The unconditional `orgii:main-window-ready` emit is gated to main so a secondary window booting can no longer re-focus main on Windows/Linux, and `app-window-*` labels are excluded from the cross-window repo-focus registry.

Feature and safety gates ship together deliberately: the gates are what make opening a second window correct, and none of them change single-window behavior (`isMainAppWindow()` is true in the only window that exists today, in browser dev, and in unit tests).

## Potential risks

- The end-to-end flow (click → native window opens → live session streams) has not been exercised in a running build in this environment; verification below is tests + typecheck + `cargo check`/`cargo test`. Windows/Linux window chrome is visually unverified (recipe copied from the shipped browser-window path).
- "Main-window-only" gating relies on the existing invariant that the main webview is hidden, never destroyed, on close. If that ever changes, cloud sync/updater/deep-links would need a leader-election handoff.
- `set_main_webview_zoom` is retained but now unused by the app; removal is left for a follow-up sweep.
- Cross-window focus heartbeat adds one localStorage write per 5s from the focused window; a crashed focused window is treated as focused for up to ~15s (TTL), which can hold the realtime socket slightly longer than ideal.
- Token-refresh mutex serializes rotation but a sibling's not-yet-persisted rotation can still cause an immediate sequential re-send of the old refresh token — safe within GoTrue's reuse interval, which the code already relies on.
- Commit was made with `--no-verify` (husky hooks stall 15–35 min under load on this machine); CI runs the same gates.

## Verification

- `npx vitest run` over every touched suite (14 files): **137/137 pass** — includes 3 new detach-atom tests (closes both owners, failure keeps tabs, blank id no-op), a new notifications-off status-monitor test, 8 new token-refresh mutex tests, cross-window focus aggregation tests, and lease tests (12 pre-existing pass unmodified).
- `cargo check -p app` (root crate incl. `lib.rs` Destroyed handler): clean. `cargo test -p system_services -p app_window`: **23/23 pass** (8 new sleep-inhibitor refcount tests incl. an end-to-end sequence reproducing the reported bug; 3 session-window label/charset tests).
- `npx tsc --noEmit`: zero errors in changed files (two pre-existing failures in unrelated untracked `Input.test.ts`/`Textarea.test.ts` from parallel work are not part of this diff).
- `npx eslint --max-warnings 0` over all changed files: clean.
- Flake regression chased to root cause during verification: importing the `platform/tauri` barrel arms an import-time `setTimeout` retry chain that pollutes fake-timer tests; `windowIdentity` is deliberately side-effect-free (documented in-file), and the previously flaky pairing now passes 10/10.
- Not run: rendered E2E, full workspace cargo test, manual multi-window smoke on Windows/Linux.
