### PR TITLE
feat(workstation-trail): resizable trail with a docked terminal

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx
@@ -257,6 +257,12 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
       }) as React.CSSProperties,
     [chatFontSize, chatCodeFontSize, chatLineHeight]
   );
+  const conversationMinimapOpen =
+    !turnPaginationEnabled && !turnPageListOpen && !agentOrgOverviewOpen;
+  // The scrollport reserves nothing for the minimap rail. While the rail has
+  // no space of its own it floats as an inset pill over the transcript, and
+  // it only goes flush against the edge once the pane is wide enough that it
+  // covers nothing (see `ConversationMinimap`'s placement classes).
   const showTurnContextRow =
     turnPaginationEnabled ||
     Boolean(agentOrgCurrentMemberName) ||
@@ -394,23 +400,21 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
             style={VIRTUALIZED_BODY_STYLE}
             data-chat-virtualized-body-layer
           >
-            {!turnPaginationEnabled &&
-              !turnPageListOpen &&
-              !agentOrgOverviewOpen && (
-                <ConversationMinimap
-                  groupHeaders={displayGroupHeaders}
-                  groupMeta={displayGroupMeta}
-                  groupCounts={displayGroupCounts}
-                  flatItems={displayFlatItems}
-                  chatPanelPosition={chatPanelPosition}
-                  activeGroupIndex={activeGroupIndex}
-                  visibleGroupIndices={visibleGroupIndices}
-                  isAtBottom={historyState.atBottom}
-                  isScrolling={conversationMinimapScrolling}
-                  labelVariant={groupChatEnabled ? "agents" : "agent"}
-                  onNavigate={handleConversationMinimapNavigate}
-                />
-              )}
+            {conversationMinimapOpen && (
+              <ConversationMinimap
+                groupHeaders={displayGroupHeaders}
+                groupMeta={displayGroupMeta}
+                groupCounts={displayGroupCounts}
+                flatItems={displayFlatItems}
+                chatPanelPosition={chatPanelPosition}
+                activeGroupIndex={activeGroupIndex}
+                visibleGroupIndices={visibleGroupIndices}
+                isAtBottom={historyState.atBottom}
+                isScrolling={conversationMinimapScrolling}
+                labelVariant={groupChatEnabled ? "agents" : "agent"}
+                onNavigate={handleConversationMinimapNavigate}
+              />
+            )}
 
             {turnPageListOpen &&
               (turnPaginationEnabled

--- a/src/engines/ChatPanel/ChatHistory/components/ConversationMinimap.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ConversationMinimap.tsx
@@ -99,6 +99,30 @@ export function getNavigableConversationGroupIndices(
   );
 }
 
+/**
+ * Width at which the chat body's centered `max-w-[800px]` content clears the
+ * rail on its own, so the rail can sit flush in the outer gutter without
+ * touching a message. The tight crossover is 856px ((856 − 800) / 2 + 8px of
+ * row padding ≥ 36px); this stays at the roomier 960px the 900px column
+ * needed, so a flush rail never sits shoulder-to-shoulder with the text.
+ *
+ * Below it the rail has nowhere of its own to stand, and the scrollport
+ * deliberately does NOT reserve space for it — it floats as an inset pill
+ * over the transcript instead. Same rule in the trail-hosted variant, where
+ * the crossover is the 1100px at which the trail column becomes real.
+ */
+export const CONVERSATION_MINIMAP_FLUSH_CONTAINER_PX = 960;
+
+/** Whether the conversation has enough navigable rounds to show the rail. */
+export function hasConversationMinimapRail(
+  groupHeaders: readonly unknown[],
+  groupCounts: readonly number[]
+): boolean {
+  return (
+    getNavigableConversationGroupIndices(groupHeaders, groupCounts).length >= 2
+  );
+}
+
 export function getConversationMarkerWidthClass(
   markerIndex: number,
   previewMarkerIndex: number
@@ -111,23 +135,84 @@ export function getConversationMarkerWidthClass(
   return "w-2";
 }
 
+/**
+ * The floating pill — one literal, shared by both panes so they cannot drift
+ * apart. Compact markers hugging the right edge, on a bordered blurred
+ * surface inset from the edge, because nothing reserves space for it here.
+ */
+const MINIMAP_FLOATING_NAV_CLASS =
+  "pointer-events-auto absolute right-3 top-1/2 z-40 -translate-y-1/2 flex-col overflow-visible rounded-xl border border-border-2/60 bg-bg-1/90 px-1 py-2 shadow-lg backdrop-blur-sm transition-opacity motion-reduce:transition-none";
+const MINIMAP_FLOATING_MARKER_CLASS =
+  "relative flex h-3 w-2 shrink-0 items-center justify-end";
+const MINIMAP_FLOATING_MARKER_BUTTON_CLASS =
+  "group flex h-3 w-2 cursor-pointer items-center justify-end border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/30";
+
+/**
+ * Overrides that turn the pill into a bare flush rail once the pane gives it
+ * a column of its own. Same set in both panes; only the container query
+ * differs, and each has to be written out in full because Tailwind reads
+ * class names literally out of the source.
+ *
+ * Maximized chat crosses over at 850px, where the trail track starts
+ * reserving the rail's 36px. The side pane crosses over at 960px, where the
+ * centered content clears the outer gutter by itself.
+ */
+const MINIMAP_FLUSH_OVERRIDES = {
+  maximized: {
+    nav: "@[850px]/focusedchat:right-0 @[850px]/focusedchat:w-9 @[850px]/focusedchat:items-center @[850px]/focusedchat:rounded-none @[850px]/focusedchat:border-0 @[850px]/focusedchat:bg-transparent @[850px]/focusedchat:p-0 @[850px]/focusedchat:shadow-none @[850px]/focusedchat:backdrop-blur-none @[1100px]/focusedchat:top-2 @[1100px]/focusedchat:translate-y-0",
+    marker: "@[850px]/focusedchat:w-9 @[850px]/focusedchat:justify-center",
+    markerButton:
+      "@[850px]/focusedchat:w-9 @[850px]/focusedchat:justify-center",
+  },
+  side: {
+    nav: "@[960px]/chatbody:right-0 @[960px]/chatbody:w-9 @[960px]/chatbody:items-center @[960px]/chatbody:rounded-none @[960px]/chatbody:border-0 @[960px]/chatbody:bg-transparent @[960px]/chatbody:p-0 @[960px]/chatbody:shadow-none @[960px]/chatbody:backdrop-blur-none",
+    marker: "@[960px]/chatbody:w-9 @[960px]/chatbody:justify-center",
+    markerButton: "@[960px]/chatbody:w-9 @[960px]/chatbody:justify-center",
+  },
+} as const;
+
+/**
+ * When the rail is on screen.
+ *
+ * While it floats it follows the side pane's rule in both panes: it appears
+ * on scroll or hover, and otherwise only once the body is wide enough to
+ * carry it. Once a maximized pane gives it a column of its own it is always
+ * up — worth stating separately, because a wide trail can leave the body
+ * under 640px while the pane itself is well past 850px.
+ *
+ * The two container queries set the same declaration, so whichever Tailwind
+ * emits last is irrelevant: the rail shows if either matches.
+ */
+export function resolveConversationMinimapVisibilityClass({
+  showFloatingMinimap,
+  inWorkstationRail,
+}: {
+  showFloatingMinimap: boolean;
+  inWorkstationRail: boolean;
+}): string {
+  if (showFloatingMinimap) return "flex";
+  return inWorkstationRail
+    ? "hidden @[640px]/chatbody:flex @[850px]/focusedchat:flex"
+    : "hidden @[640px]/chatbody:flex";
+}
+
+/**
+ * One rail in two arrangements: a floating pill while it would cover the
+ * transcript, a bare flush rail once it has space of its own. The floating
+ * half is identical in both panes — they differ only in the width at which
+ * they cross over.
+ */
 export function getConversationMinimapPlacementClasses(
   inWorkstationRail: boolean
 ) {
-  return inWorkstationRail
-    ? {
-        nav: "pointer-events-auto absolute left-1/2 top-1/2 z-40 w-9 -translate-x-1/2 -translate-y-1/2 flex-col items-center overflow-visible @[1100px]/focusedchat:top-2 @[1100px]/focusedchat:translate-y-0",
-        marker: "relative flex h-3 w-9 shrink-0 items-center justify-center",
-        markerButton:
-          "group flex h-3 w-9 cursor-pointer items-center justify-center border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/30",
-      }
-    : {
-        nav: "pointer-events-auto absolute right-3 top-1/2 z-40 -translate-y-1/2 flex-col overflow-visible rounded-xl border border-border-2/60 bg-bg-1/90 px-1 py-2 shadow-lg backdrop-blur-sm transition-opacity @[640px]/chatbody:right-0 @[640px]/chatbody:w-9 @[640px]/chatbody:items-center @[640px]/chatbody:rounded-none @[640px]/chatbody:border-0 @[640px]/chatbody:bg-transparent @[640px]/chatbody:p-0 @[640px]/chatbody:shadow-none @[640px]/chatbody:backdrop-blur-none motion-reduce:transition-none",
-        marker:
-          "relative flex h-3 w-2 shrink-0 items-center justify-end @[640px]/chatbody:w-9 @[640px]/chatbody:justify-center",
-        markerButton:
-          "group flex h-3 w-2 cursor-pointer items-center justify-end border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/30 @[640px]/chatbody:w-9 @[640px]/chatbody:justify-center",
-      };
+  const flush = inWorkstationRail
+    ? MINIMAP_FLUSH_OVERRIDES.maximized
+    : MINIMAP_FLUSH_OVERRIDES.side;
+  return {
+    nav: `${MINIMAP_FLOATING_NAV_CLASS} ${flush.nav}`,
+    marker: `${MINIMAP_FLOATING_MARKER_CLASS} ${flush.marker}`,
+    markerButton: `${MINIMAP_FLOATING_MARKER_BUTTON_CLASS} ${flush.markerButton}`,
+  };
 }
 
 function getUserPreview(header: OptimizedChatItem | null): string {
@@ -272,11 +357,10 @@ const ConversationMinimap: React.FC<ConversationMinimapProps> = memo(
     const inWorkstationRail = workstationRailHost !== null;
     const placementClasses =
       getConversationMinimapPlacementClasses(inWorkstationRail);
-    const visibilityClass = showFloatingMinimap
-      ? "flex"
-      : inWorkstationRail
-        ? "hidden @[640px]/focusedchat:flex"
-        : "hidden @[640px]/chatbody:flex";
+    const visibilityClass = resolveConversationMinimapVisibilityClass({
+      showFloatingMinimap,
+      inWorkstationRail,
+    });
     const previewPositionClass =
       getConversationPreviewPositionClass(chatPanelPosition);
     if (markerGroupIndices.length < 2) return null;
@@ -332,11 +416,14 @@ const ConversationMinimap: React.FC<ConversationMinimapProps> = memo(
                 onMouseEnter={() => setPreviewGroupIndex(groupIndex)}
                 onFocus={() => setPreviewGroupIndex(groupIndex)}
               >
+                {/* Hover/focus is a pointing affordance, not a state the
+                    rail is in, so it darkens to text-2 rather than borrowing
+                    the accent that marks the turns actually on screen. */}
                 <span
                   className={`h-[3px] shrink-0 ${widthClass} transition-[width,background-color] duration-150 motion-reduce:transition-none ${
                     isHighlighted
                       ? "bg-primary-6"
-                      : "bg-text-3/40 group-hover:bg-primary-6 group-focus-visible:bg-primary-6"
+                      : "bg-text-3/40 group-hover:bg-text-2 group-focus-visible:bg-text-2"
                   }`}
                 />
               </button>

--- a/src/engines/ChatPanel/ChatHistory/components/__tests__/ConversationMinimap.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/__tests__/ConversationMinimap.test.ts
@@ -1,32 +1,100 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CONVERSATION_MINIMAP_FLUSH_CONTAINER_PX,
   findNearestConversationMarker,
   getConversationMarkerWidthClass,
   getConversationMinimapPlacementClasses,
   getConversationPreviewPositionClass,
   getNavigableConversationGroupIndices,
+  hasConversationMinimapRail,
   resolveActiveConversationMarker,
+  resolveConversationMinimapVisibilityClass,
   resolveHighlightedConversationMarkers,
   sampleConversationGroupIndices,
 } from "../ConversationMinimap";
 
 describe("getConversationMinimapPlacementClasses", () => {
-  it("centers the navigator in the workstation rail host", () => {
-    const classes = getConversationMinimapPlacementClasses(true);
+  const railed = getConversationMinimapPlacementClasses(true);
+  const side = getConversationMinimapPlacementClasses(false);
 
-    expect(classes.nav).toContain("left-1/2");
-    expect(classes.nav).toContain("-translate-x-1/2");
-    expect(classes.nav).toContain("@[1100px]/focusedchat:top-2");
-    expect(classes.marker).toContain("w-9");
-    expect(classes.marker).toContain("justify-center");
+  it("floats the identical pill in both panes", () => {
+    // The floating half is one shared literal: a maximized pane that is too
+    // narrow for a column must look exactly like the side pane, not like a
+    // wider variant of itself.
+    const floatingHalf = (classes: string) =>
+      classes
+        .split(" ")
+        .filter((token) => !token.startsWith("@["))
+        .join(" ");
+
+    expect(floatingHalf(railed.nav)).toBe(floatingHalf(side.nav));
+    expect(floatingHalf(railed.marker)).toBe(floatingHalf(side.marker));
+    expect(floatingHalf(railed.markerButton)).toBe(
+      floatingHalf(side.markerButton)
+    );
   });
 
-  it("keeps the standalone navigator anchored to the chat edge", () => {
-    const classes = getConversationMinimapPlacementClasses(false);
+  it("gives the floating pill compact right-hugging markers", () => {
+    for (const classes of [railed, side]) {
+      expect(classes.nav).toContain("right-3");
+      expect(classes.nav).toContain("rounded-xl");
+      expect(classes.marker).toContain("w-2");
+      expect(classes.marker).toContain("justify-end");
+    }
+  });
 
-    expect(classes.nav).toContain("right-3");
-    expect(classes.nav).not.toContain("left-1/2");
+  it("crosses over to a flush rail at each pane's own width", () => {
+    expect(railed.nav).toContain("@[850px]/focusedchat:right-0");
+    expect(railed.nav).toContain("@[850px]/focusedchat:shadow-none");
+    expect(railed.marker).toContain("@[850px]/focusedchat:w-9");
+    expect(railed.nav).toContain("@[1100px]/focusedchat:top-2");
+
+    expect(side.nav).toContain(
+      `@[${CONVERSATION_MINIMAP_FLUSH_CONTAINER_PX}px]/chatbody:right-0`
+    );
+    expect(side.nav).toContain("@[960px]/chatbody:shadow-none");
+    expect(side.marker).toContain("@[960px]/chatbody:w-9");
+  });
+});
+
+describe("resolveConversationMinimapVisibilityClass", () => {
+  it("shows the rail outright while scrolling or hovering, in either pane", () => {
+    for (const inWorkstationRail of [true, false]) {
+      expect(
+        resolveConversationMinimapVisibilityClass({
+          showFloatingMinimap: true,
+          inWorkstationRail,
+        })
+      ).toBe("flex");
+    }
+  });
+
+  it("uses the side pane's idle rule while the maximized rail floats", () => {
+    // Floating is floating: a narrow maximized pane must not keep the rail
+    // up when the side pane would have hidden it.
+    const maximized = resolveConversationMinimapVisibilityClass({
+      showFloatingMinimap: false,
+      inWorkstationRail: true,
+    });
+    const side = resolveConversationMinimapVisibilityClass({
+      showFloatingMinimap: false,
+      inWorkstationRail: false,
+    });
+
+    expect(side).toBe("hidden @[640px]/chatbody:flex");
+    expect(maximized.startsWith(side)).toBe(true);
+  });
+
+  it("keeps the rail up once a maximized pane gives it a column", () => {
+    // A wide trail can leave the body under 640px, so the column state has
+    // to say so itself rather than relying on the body-width rule.
+    expect(
+      resolveConversationMinimapVisibilityClass({
+        showFloatingMinimap: false,
+        inWorkstationRail: true,
+      })
+    ).toContain("@[850px]/focusedchat:flex");
   });
 });
 
@@ -77,6 +145,21 @@ describe("getConversationMarkerWidthClass", () => {
 
   it("keeps resting handles at eight pixels", () => {
     expect(getConversationMarkerWidthClass(3, -1)).toBe("w-2");
+  });
+});
+
+describe("hasConversationMinimapRail", () => {
+  it("shows the rail once two rounds are navigable", () => {
+    expect(hasConversationMinimapRail([{}, {}], [1, 1])).toBe(true);
+  });
+
+  it("keeps the rail hidden for empty and single-round conversations", () => {
+    expect(hasConversationMinimapRail([], [])).toBe(false);
+    expect(hasConversationMinimapRail([{}], [3])).toBe(false);
+  });
+
+  it("ignores fully empty groups when counting navigable rounds", () => {
+    expect(hasConversationMinimapRail([{}, null], [2, 0])).toBe(false);
   });
 });
 

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  FOCUSED_CHAT_MINIMAP_COLUMN_CONTAINER_PX,
   FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS,
   isSameFocusedChatGitEnvironment,
   resolveFocusedChatWorkstationRailInsetStyle,
@@ -76,13 +77,28 @@ describe("shouldReserveFocusedChatWorkstationPlaceholder", () => {
 });
 
 describe("resolveFocusedChatWorkstationRailTrackClass", () => {
-  it("uses fixed expanded and collapsed tracks without resize geometry", () => {
+  it("drives the expanded column from the resizable track-width variable", () => {
     expect(resolveFocusedChatWorkstationRailTrackClass(false)).toBe(
-      "w-0 @[1100px]/focusedchat:w-64 @[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2"
+      "w-0 @[850px]/focusedchat:w-9 @[1100px]/focusedchat:w-[var(--workstation-trail-track-width)] @[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2"
     );
+  });
+
+  it("keeps the collapsed track at the fixed button-controlled width", () => {
     expect(resolveFocusedChatWorkstationRailTrackClass(true)).toBe(
-      "w-0 @[1100px]/focusedchat:w-11 @[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2"
+      "w-0 @[850px]/focusedchat:w-9 @[1100px]/focusedchat:w-11 @[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2"
     );
+  });
+
+  it("reserves the minimap rail's column only once the pane can spare it", () => {
+    // Under 850px a maximized pane is as tight as a side pane: the column is
+    // zero and the rail floats, rather than taking 36px off the transcript.
+    for (const collapsed of [false, true]) {
+      const track = resolveFocusedChatWorkstationRailTrackClass(collapsed);
+      expect(track).toContain("w-0");
+      expect(track).toContain(
+        `@[${FOCUSED_CHAT_MINIMAP_COLUMN_CONTAINER_PX}px]/focusedchat:w-9`
+      );
+    }
   });
 });
 
@@ -104,14 +120,27 @@ describe("resolveFocusedChatWorkstationRailInsetStyle", () => {
 });
 
 describe("FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS", () => {
+  it("floats over the transcript while the pane is too tight for a column", () => {
+    // Pinned flush at the pane edge and 36px wide — the same box the side
+    // pane's rail floats in, so the pill's own `right-3` lands on the
+    // identical spot in both panes.
+    expect(FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS).toContain("absolute");
+    expect(FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS).toContain("right-0");
+    expect(FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS).toContain("w-9");
+  });
+
+  it("joins the flow at the width where the track reserves its column", () => {
+    expect(FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS).toContain(
+      `@[${FOCUSED_CHAT_MINIMAP_COLUMN_CONTAINER_PX}px]/focusedchat:relative`
+    );
+  });
+
   it("stays centered on the fixed trailing rail column when expanded", () => {
     expect(FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS).toContain("w-9");
     expect(FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS).toContain(
-      "@[1100px]/focusedchat:ml-auto"
+      `@[${FOCUSED_CHAT_MINIMAP_COLUMN_CONTAINER_PX}px]/focusedchat:ml-auto`
     );
-    expect(FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS).not.toContain(
-      "@[1100px]/focusedchat:w-full"
-    );
+    expect(FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS).not.toContain("w-full");
   });
 });
 

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
@@ -4,8 +4,25 @@ import {
 } from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
 import type { ChatPanelTab } from "@src/store/chatPanel/chatPanelTabsAtom";
 
+/**
+ * Width at which a maximized chat pane is wide enough to give the
+ * conversation minimap a column of its own. Below it the pane is as tight as
+ * a side pane, so the rail floats over the transcript there instead of
+ * taking 36px the transcript cannot spare.
+ */
+export const FOCUSED_CHAT_MINIMAP_COLUMN_CONTAINER_PX = 850;
+
+/**
+ * Host for the conversation minimap inside the trail column.
+ *
+ * In-flow from 850px up, where the track reserves the rail's 36px (see
+ * `resolveFocusedChatWorkstationRailTrackClass`). Below that the track is
+ * zero-width and the host is a 36px box pinned to the pane's right edge —
+ * the same box the side pane's rail floats in, so the pill inside lands on
+ * the identical spot in both.
+ */
 export const FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS =
-  "pointer-events-none absolute right-0 top-0 h-full w-9 @[1100px]/focusedchat:relative @[1100px]/focusedchat:ml-auto @[1100px]/focusedchat:h-auto @[1100px]/focusedchat:min-h-0 @[1100px]/focusedchat:flex-1";
+  "pointer-events-none absolute right-0 top-0 h-full w-9 @[850px]/focusedchat:relative @[850px]/focusedchat:ml-auto @[850px]/focusedchat:h-auto @[850px]/focusedchat:min-h-0 @[850px]/focusedchat:flex-1";
 
 export function resolveFocusedChatWorkstationSectionOrder(
   hasOpenTabs: boolean,
@@ -80,12 +97,20 @@ export function shouldReserveFocusedChatWorkstationPlaceholder({
   return isChatFocus && activeTabType === "start-page" && startPageOpen;
 }
 
+/**
+ * Width of the trail column, in three steps.
+ *
+ * Under 850px the pane is too tight to spend 36px on chrome, so the column
+ * is zero and the minimap floats over the transcript exactly as it does in a
+ * non-maximized pane. From 850px the column reserves the minimap's rail. At
+ * 1100px the trail surface itself arrives and takes over the width.
+ */
 export function resolveFocusedChatWorkstationRailTrackClass(
   collapsed: boolean
 ): string {
   return collapsed
-    ? `w-0 ${WORKSTATION_TRAIL_WIDTH.collapsedResponsiveClass} ${FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS}`
-    : `w-0 ${WORKSTATION_TRAIL_WIDTH.expandedResponsiveClass} ${FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS}`;
+    ? `w-0 @[850px]/focusedchat:w-9 ${WORKSTATION_TRAIL_WIDTH.collapsedResponsiveClass} ${FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS}`
+    : `w-0 @[850px]/focusedchat:w-9 ${WORKSTATION_TRAIL_WIDTH.resizableResponsiveClass} ${FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS}`;
 }
 
 /** Keep the rail below overlaid chat chrome while the transcript scrolls behind it. */

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -78,7 +78,8 @@ import {
   ChatPanelTabBar,
   useChatPanelTabShortcuts,
 } from "./ChatPanelTabBar";
-import SessionContinueCliHeaderExtras from "./SessionContinueCliHeaderExtras";
+// Parked with its header button below.
+// import SessionContinueCliHeaderExtras from "./SessionContinueCliHeaderExtras";
 import SessionOpenInAppHeaderExtras from "./SessionOpenInAppHeaderExtras";
 import {
   SessionAlternateSurface,
@@ -641,11 +642,15 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
             <ConversationParticipantsChip
               sessionId={currentSessionId ?? null}
             />
-            <SessionContinueCliHeaderExtras
+            {/* "Continue in <agent>" is parked: it hands the session to a
+                CLI in a Workstation terminal tab, which leaves the focused
+                chat — the same reason the trail's Workstation-navigating
+                rows were parked. */}
+            {/* <SessionContinueCliHeaderExtras
               session={currentSession ?? null}
               sessionId={currentSessionId ?? null}
               onOpenCliTerminal={handleOpenCliTerminal}
-            />
+            /> */}
             <SessionOpenInAppHeaderExtras
               sessionId={currentSessionId ?? null}
             />

--- a/src/engines/TerminalCore/__tests__/terminalMountWindow.test.ts
+++ b/src/engines/TerminalCore/__tests__/terminalMountWindow.test.ts
@@ -56,4 +56,19 @@ describe("selectMountedTerminalSessions", () => {
       ]).map((s) => s.id)
     ).toEqual(["a"]);
   });
+
+  it("never mounts a session another host has claimed", () => {
+    const initialized = new Set(["a", "b", "c", "d"]);
+    // "a" is both active and warm; the mini terminal holding it still wins,
+    // otherwise one PTY would have two xterm writers.
+    expect(
+      selectMountedTerminalSessions(
+        sessions,
+        "a",
+        initialized,
+        ["a", "c"],
+        new Set(["a"])
+      ).map((s) => s.id)
+    ).toEqual(["c"]);
+  });
 });

--- a/src/engines/TerminalCore/index.tsx
+++ b/src/engines/TerminalCore/index.tsx
@@ -68,6 +68,17 @@ export interface TerminalCoreProps {
   visible?: boolean;
   /** Host-owned renderer for SessionCore read-only terminal sessions. */
   renderReadOnlySession?: (agentSessionId: string) => React.ReactNode;
+  /**
+   * Sessions another host currently mounts (today: the terminal docked
+   * under the Workstation trail). A PTY is bound to one xterm through
+   * `TerminalView`'s `sessionKey`, so mounting it here as well would give
+   * one PTY two writers and two competing resizes. Suppressed sessions stay in
+   * `terminalState.sessions` — only their mount is skipped — and remount
+   * through the normal PTY attach/restore path once released.
+   */
+  suppressedSessionIds?: ReadonlySet<string>;
+  /** Host-owned placeholder shown when the active session is suppressed. */
+  renderSuppressedSession?: (sessionId: string) => React.ReactNode;
 }
 
 // ============================================
@@ -82,6 +93,8 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
   onOpenFileLink,
   visible = true,
   renderReadOnlySession,
+  suppressedSessionIds,
+  renderSuppressedSession,
 }) => {
   const { sessions, activeSessionId, initializedSessions, updateSessionInfo } =
     terminalState;
@@ -325,11 +338,14 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
 
   const bgColor = backgroundColor || "var(--cm-editor-background)";
 
+  const activeSessionSuppressed =
+    suppressedSessionIds?.has(activeSessionId) === true;
   const visibleSessions = selectMountedTerminalSessions(
     sessions,
     activeSessionId,
     initializedSessions,
-    recentTerminalIds
+    recentTerminalIds,
+    suppressedSessionIds
   );
 
   return (
@@ -347,9 +363,13 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
         className="terminal-content-area relative flex flex-1 flex-col overflow-hidden"
         style={{ backgroundColor: bgColor }}
       >
-        {visibleSessions.length === 0 && (
+        {activeSessionSuppressed ? (
+          (renderSuppressedSession?.(activeSessionId) ?? (
+            <Placeholder variant="empty" fillParentHeight />
+          ))
+        ) : visibleSessions.length === 0 ? (
           <Placeholder variant="empty" fillParentHeight />
-        )}
+        ) : null}
         {visibleSessions.map((session) => (
           <div
             key={session.id}

--- a/src/engines/TerminalCore/terminalMountWindow.ts
+++ b/src/engines/TerminalCore/terminalMountWindow.ts
@@ -34,17 +34,24 @@ export function pushRecentTerminalId(
 /**
  * Select which sessions should be mounted: the active one always, plus
  * initialized sessions that are still inside the recent window.
+ *
+ * `suppressedSessionIds` wins over everything, including the active slot: a
+ * PTY is bound to one xterm through `TerminalView`'s `sessionKey`, so a
+ * session another host currently mounts (the terminal docked under the
+ * Workstation trail) must not be mounted here as well.
  */
 export function selectMountedTerminalSessions<T extends { id: string }>(
   sessions: readonly T[],
   activeSessionId: string,
   initializedSessionIds: ReadonlySet<string>,
-  recentTerminalIds: readonly string[]
+  recentTerminalIds: readonly string[],
+  suppressedSessionIds?: ReadonlySet<string>
 ): T[] {
   const warm = new Set(recentTerminalIds);
   return sessions.filter(
     (session) =>
-      session.id === activeSessionId ||
-      (initializedSessionIds.has(session.id) && warm.has(session.id))
+      !suppressedSessionIds?.has(session.id) &&
+      (session.id === activeSessionId ||
+        (initializedSessionIds.has(session.id) && warm.has(session.id)))
   );
 }

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1255,7 +1255,17 @@
       "openTabs": "Geöffnete Tabs",
       "closeItem": "{{label}} schließen",
       "expand": "Arbeitsbereichsinformationen erweitern",
-      "collapse": "Arbeitsbereichsinformationen einklappen"
+      "collapse": "Arbeitsbereichsinformationen einklappen",
+      "restoreWidth": "Ursprüngliche Breite wiederherstellen ({{width}} px)",
+      "setMinimumWidth": "Aktuelle Breite als Minimum festlegen ({{width}} px)",
+      "widerWidth": "Breiter ({{width}} px)",
+      "resizeTrail": "Breite der Workstation-Leiste ändern",
+      "openMiniTerminal": "Mini-Terminal öffnen",
+      "hideMiniTerminal": "Mini-Terminal ausblenden",
+      "newMiniTerminal": "Neues Mini-Terminal",
+      "showMiniTerminals": "Mini-Terminals",
+      "sessionInMiniTerminal": "Läuft im Mini-Terminal",
+      "returnFromMiniTerminal": "Hier anzeigen"
     },
     "pr": {
       "title": "Pull Request",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1143,7 +1143,17 @@
       "openTabs": "Open Tabs",
       "closeItem": "Close {{label}}",
       "expand": "Expand workstation info",
-      "collapse": "Collapse workstation info"
+      "collapse": "Collapse workstation info",
+      "restoreWidth": "Restore original width ({{width}}px)",
+      "setMinimumWidth": "Set current width as minimum ({{width}}px)",
+      "widerWidth": "Wider ({{width}}px)",
+      "resizeTrail": "Resize workstation trail",
+      "openMiniTerminal": "Open mini terminal",
+      "hideMiniTerminal": "Hide mini terminal",
+      "newMiniTerminal": "New mini terminal",
+      "showMiniTerminals": "Mini terminals",
+      "sessionInMiniTerminal": "Running in the mini terminal",
+      "returnFromMiniTerminal": "Show it here"
     },
     "messages": {
       "pushSuccess": "Successfully pushed changes to remote",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1255,7 +1255,17 @@
       "openTabs": "Pestañas abiertas",
       "closeItem": "Cerrar {{label}}",
       "expand": "Expandir la información del espacio de trabajo",
-      "collapse": "Contraer la información del espacio de trabajo"
+      "collapse": "Contraer la información del espacio de trabajo",
+      "restoreWidth": "Restaurar ancho original ({{width}} px)",
+      "setMinimumWidth": "Fijar el ancho actual como mínimo ({{width}} px)",
+      "widerWidth": "Más ancho ({{width}} px)",
+      "resizeTrail": "Redimensionar la barra de la estación",
+      "openMiniTerminal": "Abrir miniterminal",
+      "hideMiniTerminal": "Ocultar miniterminal",
+      "newMiniTerminal": "Nuevo miniterminal",
+      "showMiniTerminals": "Miniterminales",
+      "sessionInMiniTerminal": "En ejecución en el miniterminal",
+      "returnFromMiniTerminal": "Mostrar aquí"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1255,7 +1255,17 @@
       "openTabs": "Onglets ouverts",
       "closeItem": "Fermer {{label}}",
       "expand": "Développer les informations de l’espace de travail",
-      "collapse": "Réduire les informations de l’espace de travail"
+      "collapse": "Réduire les informations de l’espace de travail",
+      "restoreWidth": "Rétablir la largeur d'origine ({{width}} px)",
+      "setMinimumWidth": "Définir la largeur actuelle comme minimum ({{width}} px)",
+      "widerWidth": "Plus large ({{width}} px)",
+      "resizeTrail": "Redimensionner la barre de la station",
+      "openMiniTerminal": "Ouvrir le mini-terminal",
+      "hideMiniTerminal": "Masquer le mini-terminal",
+      "newMiniTerminal": "Nouveau mini-terminal",
+      "showMiniTerminals": "Mini-terminaux",
+      "sessionInMiniTerminal": "En cours d'exécution dans le mini-terminal",
+      "returnFromMiniTerminal": "Afficher ici"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1254,7 +1254,17 @@
       "openTabs": "開いているタブ",
       "closeItem": "{{label}} を閉じる",
       "expand": "ワークステーション情報を展開",
-      "collapse": "ワークステーション情報を折りたたむ"
+      "collapse": "ワークステーション情報を折りたたむ",
+      "restoreWidth": "元の幅に戻す（{{width}}px）",
+      "setMinimumWidth": "現在の幅を最小値に設定（{{width}}px）",
+      "widerWidth": "広げる（{{width}}px）",
+      "resizeTrail": "ワークステーションバーの幅を変更",
+      "openMiniTerminal": "ミニターミナルを開く",
+      "hideMiniTerminal": "ミニターミナルを隠す",
+      "newMiniTerminal": "新しいミニターミナル",
+      "showMiniTerminals": "ミニターミナル",
+      "sessionInMiniTerminal": "ミニターミナルで実行中",
+      "returnFromMiniTerminal": "ここに表示"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1254,7 +1254,17 @@
       "openTabs": "열린 탭",
       "closeItem": "{{label}} 닫기",
       "expand": "워크스테이션 정보 펼치기",
-      "collapse": "워크스테이션 정보 접기"
+      "collapse": "워크스테이션 정보 접기",
+      "restoreWidth": "원래 너비로 복원({{width}}px)",
+      "setMinimumWidth": "현재 너비를 최소값으로 설정({{width}}px)",
+      "widerWidth": "넓게({{width}}px)",
+      "resizeTrail": "워크스테이션 바 너비 조정",
+      "openMiniTerminal": "미니 터미널 열기",
+      "hideMiniTerminal": "미니 터미널 숨기기",
+      "newMiniTerminal": "새 미니 터미널",
+      "showMiniTerminals": "미니 터미널",
+      "sessionInMiniTerminal": "미니 터미널에서 실행 중",
+      "returnFromMiniTerminal": "여기에 표시"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1259,7 +1259,17 @@
       "openTabs": "Otwarte karty",
       "closeItem": "Zamknij {{label}}",
       "expand": "Rozwiń informacje o obszarze roboczym",
-      "collapse": "Zwiń informacje o obszarze roboczym"
+      "collapse": "Zwiń informacje o obszarze roboczym",
+      "restoreWidth": "Przywróć pierwotną szerokość ({{width}} px)",
+      "setMinimumWidth": "Ustaw bieżącą szerokość jako minimalną ({{width}} px)",
+      "widerWidth": "Szerzej ({{width}} px)",
+      "resizeTrail": "Zmień szerokość paska stacji roboczej",
+      "openMiniTerminal": "Otwórz miniterminal",
+      "hideMiniTerminal": "Ukryj miniterminal",
+      "newMiniTerminal": "Nowy miniterminal",
+      "showMiniTerminals": "Miniterminale",
+      "sessionInMiniTerminal": "Działa w miniterminalu",
+      "returnFromMiniTerminal": "Pokaż tutaj"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1255,7 +1255,17 @@
       "openTabs": "Abas abertas",
       "closeItem": "Fechar {{label}}",
       "expand": "Expandir informações da área de trabalho",
-      "collapse": "Recolher informações da área de trabalho"
+      "collapse": "Recolher informações da área de trabalho",
+      "restoreWidth": "Restaurar largura original ({{width}} px)",
+      "setMinimumWidth": "Definir a largura atual como mínima ({{width}} px)",
+      "widerWidth": "Mais largo ({{width}} px)",
+      "resizeTrail": "Redimensionar a barra da estação",
+      "openMiniTerminal": "Abrir miniterminal",
+      "hideMiniTerminal": "Ocultar miniterminal",
+      "newMiniTerminal": "Novo miniterminal",
+      "showMiniTerminals": "Miniterminais",
+      "sessionInMiniTerminal": "Em execução no miniterminal",
+      "returnFromMiniTerminal": "Mostrar aqui"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1259,7 +1259,17 @@
       "openTabs": "Открытые вкладки",
       "closeItem": "Закрыть {{label}}",
       "expand": "Развернуть сведения о рабочей области",
-      "collapse": "Свернуть сведения о рабочей области"
+      "collapse": "Свернуть сведения о рабочей области",
+      "restoreWidth": "Восстановить исходную ширину ({{width}} px)",
+      "setMinimumWidth": "Сделать текущую ширину минимальной ({{width}} px)",
+      "widerWidth": "Шире ({{width}} px)",
+      "resizeTrail": "Изменить ширину панели рабочей станции",
+      "openMiniTerminal": "Открыть мини-терминал",
+      "hideMiniTerminal": "Скрыть мини-терминал",
+      "newMiniTerminal": "Новый мини-терминал",
+      "showMiniTerminals": "Мини-терминалы",
+      "sessionInMiniTerminal": "Выполняется в мини-терминале",
+      "returnFromMiniTerminal": "Показать здесь"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1256,7 +1256,17 @@
       "openTabs": "Açık sekmeler",
       "closeItem": "{{label}} öğesini kapat",
       "expand": "Çalışma alanı bilgilerini genişlet",
-      "collapse": "Çalışma alanı bilgilerini daralt"
+      "collapse": "Çalışma alanı bilgilerini daralt",
+      "restoreWidth": "Özgün genişliği geri yükle ({{width}} px)",
+      "setMinimumWidth": "Geçerli genişliği en küçük değer yap ({{width}} px)",
+      "widerWidth": "Daha geniş ({{width}} px)",
+      "resizeTrail": "İstasyon çubuğunu yeniden boyutlandır",
+      "openMiniTerminal": "Mini terminali aç",
+      "hideMiniTerminal": "Mini terminali gizle",
+      "newMiniTerminal": "Yeni mini terminal",
+      "showMiniTerminals": "Mini terminaller",
+      "sessionInMiniTerminal": "Mini terminalde çalışıyor",
+      "returnFromMiniTerminal": "Burada göster"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1254,7 +1254,17 @@
       "openTabs": "Các tab đang mở",
       "closeItem": "Đóng {{label}}",
       "expand": "Mở rộng thông tin không gian làm việc",
-      "collapse": "Thu gọn thông tin không gian làm việc"
+      "collapse": "Thu gọn thông tin không gian làm việc",
+      "restoreWidth": "Khôi phục chiều rộng ban đầu ({{width}} px)",
+      "setMinimumWidth": "Đặt chiều rộng hiện tại làm mức tối thiểu ({{width}} px)",
+      "widerWidth": "Rộng hơn ({{width}} px)",
+      "resizeTrail": "Đổi chiều rộng thanh workstation",
+      "openMiniTerminal": "Mở terminal thu nhỏ",
+      "hideMiniTerminal": "Ẩn terminal thu nhỏ",
+      "newMiniTerminal": "Terminal thu nhỏ mới",
+      "showMiniTerminals": "Terminal thu nhỏ",
+      "sessionInMiniTerminal": "Đang chạy trong terminal thu nhỏ",
+      "returnFromMiniTerminal": "Hiển thị tại đây"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1267,7 +1267,17 @@
       "openTabs": "開啟的分頁",
       "closeItem": "關閉 {{label}}",
       "expand": "展開工作區資訊",
-      "collapse": "收合工作區資訊"
+      "collapse": "收合工作區資訊",
+      "restoreWidth": "恢復原始寬度（{{width}}px）",
+      "setMinimumWidth": "將目前寬度設為最小值（{{width}}px）",
+      "widerWidth": "加寬（{{width}}px）",
+      "resizeTrail": "調整工作站列寬度",
+      "openMiniTerminal": "開啟迷你終端機",
+      "hideMiniTerminal": "隱藏迷你終端機",
+      "newMiniTerminal": "新增迷你終端機",
+      "showMiniTerminals": "迷你終端機",
+      "sessionInMiniTerminal": "正在迷你終端機中執行",
+      "returnFromMiniTerminal": "在此處顯示"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1131,7 +1131,17 @@
       "openTabs": "打开的标签页",
       "closeItem": "关闭 {{label}}",
       "expand": "展开工作区信息",
-      "collapse": "折叠工作区信息"
+      "collapse": "折叠工作区信息",
+      "restoreWidth": "恢复原始宽度（{{width}}px）",
+      "setMinimumWidth": "将当前宽度设为最小值（{{width}}px）",
+      "widerWidth": "加宽（{{width}}px）",
+      "resizeTrail": "调整工作站栏宽度",
+      "openMiniTerminal": "打开迷你终端",
+      "hideMiniTerminal": "隐藏迷你终端",
+      "newMiniTerminal": "新建迷你终端",
+      "showMiniTerminals": "迷你终端",
+      "sessionInMiniTerminal": "正在迷你终端中运行",
+      "returnFromMiniTerminal": "在此处显示"
     },
     "pr": {
       "title": "Pull request",

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx
@@ -19,6 +19,10 @@ import {
   TerminalNewSessionSplitButton,
 } from "@src/modules/WorkStation/shared";
 import {
+  miniTerminalSuppressedIdsAtom,
+  releaseMiniTerminalSessionAtom,
+} from "@src/store/ui/miniTerminalAtom";
+import {
   clearTerminalTargetReferencesAtom,
   codeEditorTerminalTargetAtom,
 } from "@src/store/workstation/codeEditor";
@@ -48,6 +52,25 @@ const TerminalMainContent: React.FC<TerminalMainContentProps> = ({
   const setTerminalTarget = useSetAtom(codeEditorTerminalTargetAtom);
   const clearTerminalTargetReferences = useSetAtom(
     clearTerminalTargetReferencesAtom
+  );
+  // Sessions the trail's docked terminal currently mounts. One PTY can only
+  // have one xterm, so this pane skips their mount and offers to take them
+  // back instead.
+  const suppressedSessionIds = useAtomValue(miniTerminalSuppressedIdsAtom);
+  const releaseMiniTerminalSession = useSetAtom(releaseMiniTerminalSessionAtom);
+  const renderSuppressedSession = useCallback(
+    (sessionId: string) => (
+      <Placeholder
+        variant="empty"
+        fillParentHeight
+        title={t("common:git.rail.sessionInMiniTerminal")}
+        action={{
+          label: t("common:git.rail.returnFromMiniTerminal"),
+          onClick: () => releaseMiniTerminalSession(sessionId),
+        }}
+      />
+    ),
+    [releaseMiniTerminalSession, t]
   );
 
   const activePtySession = terminalState.activeSession;
@@ -193,6 +216,8 @@ const TerminalMainContent: React.FC<TerminalMainContentProps> = ({
         backgroundColor="var(--cm-editor-background)"
         onOpenFileLink={handleOpenFileLink}
         renderReadOnlySession={renderReadOnlySession}
+        suppressedSessionIds={suppressedSessionIds}
+        renderSuppressedSession={renderSuppressedSession}
       />
     );
 

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.tsx
@@ -1,0 +1,281 @@
+/**
+ * WorkstationTrailTerminal
+ *
+ * The trail's terminal: a short panel docked directly under the trail
+ * surface, in the trail's own column and on an identical surface. It is not
+ * a floating window — it cannot be dragged, it collapses to its header row,
+ * and it widens the trail track to `MINI_TERMINAL_TRAIL_WIDTH` when opened.
+ *
+ * # Reuses the Workstation terminal, does not clone it
+ *
+ * The panel renders the same `TerminalCore` / `TerminalView` / PTY pipeline
+ * the Workstation terminal pane uses, over the same
+ * `store/workstation/codeEditor/terminal` sessions. It scopes a synthetic
+ * `UseTerminalStateReturn` down to the sessions it has claimed — the shape
+ * `ChatPanelTerminalContent` already uses for chat pane terminal tabs.
+ *
+ * While a session is claimed the Workstation pane suppresses its mount, so a
+ * PTY never has two xterm writers. The terminal is therefore only rendered
+ * once suppression is actually in force for the active session, and stays
+ * mounted behind `display: none` while collapsed so the PTY keeps its view.
+ */
+import { useAtomValue, useSetAtom } from "jotai";
+import React, { Suspense, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  type AddSessionOptions,
+  type UseTerminalStateReturn,
+  getTerminalDisplayTitle,
+} from "@src/engines/TerminalCore/types";
+import {
+  Add01Icon,
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  Cancel01Icon,
+  Delete02Icon,
+  HugeiconsIcon,
+} from "@src/icons";
+import { selectedRepoPathAtom } from "@src/store/repo";
+import {
+  closeMiniTerminalAtom,
+  closeMiniTerminalSessionAtom,
+  miniTerminalActiveIdAtom,
+  miniTerminalClaimedIdsAtom,
+  miniTerminalCollapsedAtom,
+  miniTerminalSuppressedIdsAtom,
+  openMiniTerminalAtom,
+  setMiniTerminalActiveIdAtom,
+} from "@src/store/ui/miniTerminalAtom";
+import {
+  editorAddTerminalSessionAtom,
+  initializedTerminalIdsAtom,
+  markTerminalInitializedAtom,
+  renameTerminalSessionAtom,
+  terminalSessionsAtom,
+  updateTerminalSessionInfoAtom,
+} from "@src/store/workstation/codeEditor/terminal";
+
+import {
+  DetailTabStrip,
+  type DetailTabStripItem,
+  WorkstationTrailHeader,
+  WorkstationTrailIconButton,
+  WorkstationTrailSurface,
+} from "../blocks";
+
+// Lazy: pulls TerminalCore (xterm + addons) only once the trail terminal is
+// actually opened, so the focused chat does not pay for it by default.
+const TerminalCore = React.lazy(() => import("@src/engines/TerminalCore"));
+
+/** Expanded panel height. Collapsed, the surface is just its header row. */
+export const WORKSTATION_TRAIL_TERMINAL_HEIGHT_PX = 260;
+
+export function WorkstationTrailTerminal() {
+  const { t } = useTranslation();
+  const claimedIds = useAtomValue(miniTerminalClaimedIdsAtom);
+  const activeId = useAtomValue(miniTerminalActiveIdAtom);
+  const suppressedIds = useAtomValue(miniTerminalSuppressedIdsAtom);
+  const collapsed = useAtomValue(miniTerminalCollapsedAtom);
+  const allSessions = useAtomValue(terminalSessionsAtom);
+  const initializedIds = useAtomValue(initializedTerminalIdsAtom);
+  const repoPath = useAtomValue(selectedRepoPathAtom);
+
+  const setCollapsed = useSetAtom(miniTerminalCollapsedAtom);
+  const setActiveId = useSetAtom(setMiniTerminalActiveIdAtom);
+  const markInitialized = useSetAtom(markTerminalInitializedAtom);
+  const updateInfo = useSetAtom(updateTerminalSessionInfoAtom);
+  const renameSession = useSetAtom(renameTerminalSessionAtom);
+  const addWorkstationSession = useSetAtom(editorAddTerminalSessionAtom);
+  const openMiniTerminal = useSetAtom(openMiniTerminalAtom);
+  const closeMiniTerminal = useSetAtom(closeMiniTerminalAtom);
+  const closeMiniTerminalSession = useSetAtom(closeMiniTerminalSessionAtom);
+
+  const sessions = useMemo(
+    () => allSessions.filter((session) => claimedIds.includes(session.id)),
+    [allSessions, claimedIds]
+  );
+
+  const handleAddSession = useCallback(
+    (options?: AddSessionOptions) => {
+      const sessionId = addWorkstationSession({
+        cwd: repoPath || undefined,
+        ...options,
+      });
+      if (sessionId) openMiniTerminal(sessionId);
+      return sessionId;
+    },
+    [addWorkstationSession, openMiniTerminal, repoPath]
+  );
+
+  // Scoped runtime: the real Workstation sessions, narrowed to this panel's
+  // claims and its own active tab, so `TerminalCore` mounts exactly the
+  // sessions the Workstation pane is currently suppressing.
+  const terminalState = useMemo<UseTerminalStateReturn>(
+    () => ({
+      sessions,
+      activeSessionId: activeId ?? "",
+      activeSession: sessions.find((session) => session.id === activeId),
+      initializedSessions: initializedIds,
+      addSession: handleAddSession,
+      closeSession: (sessionId: string) => closeMiniTerminalSession(sessionId),
+      setActiveSession: (sessionId: string) => setActiveId(sessionId),
+      markSessionInitialized: (sessionId: string) => markInitialized(sessionId),
+      updateSessionInfo: (sessionId, info) => updateInfo({ sessionId, info }),
+      renameSession: (sessionId: string, title: string) =>
+        renameSession({ sessionId, title }),
+    }),
+    [
+      activeId,
+      closeMiniTerminalSession,
+      handleAddSession,
+      initializedIds,
+      markInitialized,
+      renameSession,
+      sessions,
+      setActiveId,
+      updateInfo,
+    ]
+  );
+
+  const terminalTabs = useMemo<DetailTabStripItem[]>(
+    () =>
+      sessions.map((session) => ({
+        key: session.id,
+        label: getTerminalDisplayTitle(session),
+      })),
+    [sessions]
+  );
+
+  const activeSession = terminalState.activeSession;
+  const activeTitle = activeSession
+    ? getTerminalDisplayTitle(activeSession)
+    : t("common:tabs.terminal");
+  const showTabs = !collapsed && sessions.length > 1;
+  // The strip already names every terminal; repeating the active one in the
+  // header title would say it twice.
+  const title = showTabs ? t("common:tabs.terminal") : activeTitle;
+  // Only mount once the Workstation pane has actually let go of the session.
+  const terminalMountable = activeId != null && suppressedIds.has(activeId);
+
+  return (
+    <WorkstationTrailSurface
+      as="aside"
+      aria-label={t("common:git.rail.showMiniTerminals")}
+      className="group/workstation-trail-terminal mt-1 hidden shrink-0 @[1100px]/focusedchat:flex"
+      style={
+        collapsed
+          ? undefined
+          : {
+              height: WORKSTATION_TRAIL_TERMINAL_HEIGHT_PX,
+              // Never let the terminal swallow the whole trail column on a
+              // short window — the trail above it stays readable.
+              maxHeight: "60%",
+            }
+      }
+      data-workstation-trail-terminal
+    >
+      <WorkstationTrailHeader
+        title={title}
+        titleActions={
+          <WorkstationTrailIconButton
+            onClick={() => setCollapsed(!collapsed)}
+            aria-label={t(
+              collapsed ? "common:actions.expand" : "common:actions.collapse"
+            )}
+            aria-expanded={!collapsed}
+          >
+            <HugeiconsIcon
+              icon={collapsed ? ArrowRight01Icon : ArrowDown01Icon}
+              data-icon={collapsed ? "chevron-right" : "chevron-down"}
+              size={14}
+              strokeWidth={1.75}
+            />
+          </WorkstationTrailIconButton>
+        }
+        actions={
+          <div className="flex items-center">
+            <WorkstationTrailIconButton
+              onClick={() => handleAddSession()}
+              aria-label={t("common:git.rail.newMiniTerminal")}
+              title={t("common:git.rail.newMiniTerminal")}
+            >
+              <HugeiconsIcon
+                icon={Add01Icon}
+                data-icon="plus"
+                size={14}
+                strokeWidth={1.75}
+              />
+            </WorkstationTrailIconButton>
+            <WorkstationTrailIconButton
+              onClick={closeMiniTerminal}
+              aria-label={t("common:git.rail.hideMiniTerminal")}
+              title={t("common:git.rail.hideMiniTerminal")}
+            >
+              <HugeiconsIcon
+                icon={Cancel01Icon}
+                data-icon="x"
+                size={14}
+                strokeWidth={1.75}
+              />
+            </WorkstationTrailIconButton>
+          </div>
+        }
+      />
+      {showTabs ? (
+        // Same strip the pull-request detail header uses, in its compact
+        // header variant: one tab per claimed terminal, and a trailing
+        // control that kills the terminal the strip is showing.
+        <DetailTabStrip
+          activeTab={activeId ?? ""}
+          ariaLabel={t("common:git.rail.showMiniTerminals")}
+          className="mb-1 px-1"
+          idPrefix="workstation-trail-terminal"
+          onChange={setActiveId}
+          tabs={terminalTabs}
+          variant="header"
+          trailing={
+            activeId ? (
+              <WorkstationTrailIconButton
+                onClick={() => closeMiniTerminalSession(activeId)}
+                aria-label={t("common:git.rail.closeItem", {
+                  label: activeTitle,
+                })}
+                title={t("common:git.rail.closeItem", { label: activeTitle })}
+              >
+                <HugeiconsIcon
+                  icon={Delete02Icon}
+                  data-icon="trash"
+                  size={14}
+                  strokeWidth={1.75}
+                />
+              </WorkstationTrailIconButton>
+            ) : null
+          }
+        />
+      ) : null}
+      {/* Kept mounted while collapsed: unmounting would drop the xterm this
+          panel is the only host for, leaving the claimed PTY unattached. */}
+      <div
+        className={
+          collapsed
+            ? "hidden"
+            : "flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg"
+        }
+      >
+        <Suspense fallback={null}>
+          {terminalMountable ? (
+            <TerminalCore
+              terminalState={terminalState}
+              repoPath={repoPath || undefined}
+              backgroundColor="var(--cm-editor-background)"
+              visible={!collapsed}
+            />
+          ) : null}
+        </Suspense>
+      </div>
+    </WorkstationTrailSurface>
+  );
+}
+
+WorkstationTrailTerminal.displayName = "WorkstationTrailTerminal";

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/index.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/index.tsx
@@ -1,5 +1,11 @@
 import { useAtomValue, useSetAtom } from "jotai";
-import React, { useCallback, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -24,6 +30,7 @@ import { useBranchPullRequestStatus } from "@src/hooks/git/useBranchPullRequestS
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { useWorkingTreeDiffTotals } from "@src/hooks/git/useWorkingTreeDiffTotals";
 import { useCloseTabWithGuard } from "@src/hooks/tabHost/useCloseTabWithGuard";
+import { useResizeHandle } from "@src/hooks/ui";
 import {
   ArrowLeftDoubleIcon,
   ArrowRightDoubleIcon,
@@ -37,8 +44,15 @@ import {
   SquareTerminalIcon,
 } from "@src/icons";
 import { openBranchSpotlight } from "@src/scaffold/GlobalSpotlight/openSpotlight";
+import { VerticalResizeHandle } from "@src/scaffold/Resize";
 import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
+import {
+  closeMiniTerminalAtom,
+  miniTerminalHostMountedAtom,
+  miniTerminalVisibleAtom,
+  openMiniTerminalAtom,
+} from "@src/store/ui/miniTerminalAtom";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import { spotlightOpenAtom } from "@src/store/ui/uiAtom";
 import { activeWorkspaceRootAtom } from "@src/store/workspace";
@@ -46,13 +60,9 @@ import { requestNewBrowserSessionAtom } from "@src/store/workstation";
 import {
   closeTerminalSessionAtom,
   initializedTerminalIdsAtom,
-  setActiveTerminalAtom,
   terminalSessionsAtom,
 } from "@src/store/workstation/codeEditor/terminal";
-import {
-  clearTerminalTargetReferencesAtom,
-  codeEditorTerminalTargetAtom,
-} from "@src/store/workstation/codeEditor/terminalTargetAtom";
+import { clearTerminalTargetReferencesAtom } from "@src/store/workstation/codeEditor/terminalTargetAtom";
 import {
   type WorkstationTabHost,
   tabToHost,
@@ -66,6 +76,7 @@ import { openExternalLink } from "@src/util/platform/ipcRenderer";
 
 import {
   WORKSTATION_TRAIL_ICON_BUTTON_CLASS,
+  WORKSTATION_TRAIL_WIDTH,
   WorkstationTrailBody,
   WorkstationTrailHeader,
   WorkstationTrailIconButton,
@@ -73,17 +84,29 @@ import {
 } from "../blocks";
 import { WorkstationGroupToggle } from "./WorkstationGroupToggle";
 import { WorkstationSections } from "./WorkstationSections";
+import { WorkstationTrailTerminal } from "./WorkstationTrailTerminal";
 import {
   getStoredRailCollapsed,
+  getStoredRailMinWidth,
+  getStoredRailWidth,
   persistRailCollapsed,
+  persistRailMinWidth,
+  persistRailWidth,
   resolveRailStatusDotClass,
 } from "./railStorage";
+import {
+  WORKSTATION_TRAIL_WIDTH_LIMITS,
+  clampTrailWidth,
+  resolveTrailMinWidth,
+  resolveTrailWidthVariables,
+} from "./trailWidth";
 import type {
   FocusedChatRailItem,
   FocusedChatRailSection,
   FocusedChatSessionContext,
   FocusedChatWorkstationRailProps,
 } from "./types";
+import { useWorkstationTrailMenu } from "./useWorkstationTrailMenu";
 
 export type { FocusedChatSessionContext } from "./types";
 
@@ -131,6 +154,73 @@ export function FocusedChatWorkstationRail({
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(getStoredRailCollapsed);
+  // Expanded width and the user's own floor. `minWidth` only ever gates the
+  // width the user is actively changing — "set current width as minimum"
+  // pins the trail where it stands and never resizes it.
+  const [minWidth, setMinWidth] = useState(() =>
+    resolveTrailMinWidth(getStoredRailMinWidth())
+  );
+  const [width, setWidth] = useState(() =>
+    clampTrailWidth(
+      getStoredRailWidth(),
+      resolveTrailMinWidth(getStoredRailMinWidth())
+    )
+  );
+  // Latest width for `onResizeEnd`, which must persist without re-subscribing
+  // the drag listeners on every RAF-throttled width update.
+  const widthRef = useRef(width);
+
+  // Drag: state only, so the RAF-throttled stream never touches storage.
+  const handleWidthChange = useCallback((next: number) => {
+    widthRef.current = next;
+    setWidth(next);
+  }, []);
+  const handleResizeEnd = useCallback(() => {
+    persistRailWidth(widthRef.current);
+  }, []);
+  const { handleMouseDown: handleResizeMouseDown, isResizing } =
+    useResizeHandle(width, handleWidthChange, {
+      direction: "horizontal",
+      minSize: minWidth,
+      maxSize: WORKSTATION_TRAIL_WIDTH_LIMITS.max,
+      // The trail sits at the pane's right edge: dragging left grows it.
+      isReversed: true,
+      onResizeEnd: handleResizeEnd,
+    });
+
+  /** Menu-driven width change: clamp and persist immediately. */
+  const applyWidth = useCallback(
+    (next: number) => {
+      const clamped = clampTrailWidth(next, minWidth);
+      widthRef.current = clamped;
+      setWidth(clamped);
+      persistRailWidth(clamped);
+    },
+    [minWidth]
+  );
+
+  /** Pin the current width as the floor. Deliberately does not resize. */
+  const setCurrentWidthAsMinimum = useCallback(() => {
+    const nextMinimum = resolveTrailMinWidth(width);
+    setMinWidth(nextMinimum);
+    persistRailMinWidth(nextMinimum);
+  }, [width]);
+
+  /**
+   * Restore the shipped width. The user-set floor is cleared with it — a
+   * floor above 256px would otherwise leave this command a no-op with no
+   * way back from the menu.
+   */
+  const restoreDefaultWidth = useCallback(() => {
+    const nextMinimum = WORKSTATION_TRAIL_WIDTH_LIMITS.floor;
+    const nextWidth = WORKSTATION_TRAIL_WIDTH_LIMITS.default;
+    widthRef.current = nextWidth;
+    setMinWidth(nextMinimum);
+    setWidth(nextWidth);
+    persistRailMinWidth(nextMinimum);
+    persistRailWidth(nextWidth);
+  }, []);
+
   const [collapsedGroupKeys, setCollapsedGroupKeys] = useState<Set<string>>(
     () => new Set()
   );
@@ -199,8 +289,6 @@ export function FocusedChatWorkstationRail({
   const initializedTerminalIds = useAtomValue(initializedTerminalIdsAtom);
   const closeTab = useCloseTabWithGuard();
   const setFocusedTab = useSetAtom(focusTabAtom);
-  const setActiveTerminal = useSetAtom(setActiveTerminalAtom);
-  const setTerminalTarget = useSetAtom(codeEditorTerminalTargetAtom);
   const clearTerminalTargetReferences = useSetAtom(
     clearTerminalTargetReferencesAtom
   );
@@ -208,6 +296,29 @@ export function FocusedChatWorkstationRail({
   const setStationMode = useSetAtom(stationModeAtom);
   const setChatPanelMaximized = useSetAtom(chatPanelMaximizedAtom);
   const requestNewBrowserSession = useSetAtom(requestNewBrowserSessionAtom);
+  const miniTerminalVisible = useAtomValue(miniTerminalVisibleAtom);
+  const openMiniTerminal = useSetAtom(openMiniTerminalAtom);
+  const closeMiniTerminal = useSetAtom(closeMiniTerminalAtom);
+  const setMiniTerminalHostMounted = useSetAtom(miniTerminalHostMountedAtom);
+
+  // Claimed sessions are only suppressed in the Workstation pane while this
+  // trail — the panel's only host — is actually mounted.
+  useEffect(() => {
+    setMiniTerminalHostMounted(true);
+    return () => setMiniTerminalHostMounted(false);
+  }, [setMiniTerminalHostMounted]);
+
+  /**
+   * Show the docked terminal. The terminal carries its own width, so the
+   * trail above it keeps whatever width the user gave it — only the column
+   * grows, and only when the terminal is the wider of the two.
+   */
+  const showMiniTerminal = useCallback(
+    (sessionId: string | null) => {
+      openMiniTerminal(sessionId);
+    },
+    [openMiniTerminal]
+  );
 
   const visibleTabs = useMemo(
     () => tabEntries.filter(({ tab }) => !tab.hideWhenOthersExist),
@@ -235,15 +346,24 @@ export function FocusedChatWorkstationRail({
     [openWorkstationHost, setFocusedTab]
   );
 
+  /**
+   * Terminal rows stay in the chat pane now: the session is claimed by the
+   * trail's docked terminal instead of navigating to the Workstation.
+   */
   const openTerminalSession = useCallback(
     (sessionId: string) => {
-      setActiveTerminal(sessionId);
-      setTerminalTarget({ kind: "pty", ptySessionId: sessionId });
-      setFocusedTab({ tabId: "terminal:main" });
-      openWorkstationHost("code");
+      showMiniTerminal(sessionId);
     },
-    [openWorkstationHost, setActiveTerminal, setFocusedTab, setTerminalTarget]
+    [showMiniTerminal]
   );
+
+  const toggleMiniTerminal = useCallback(() => {
+    if (miniTerminalVisible) {
+      closeMiniTerminal();
+      return;
+    }
+    showMiniTerminal(null);
+  }, [closeMiniTerminal, miniTerminalVisible, showMiniTerminal]);
 
   const closePtySession = useCallback(
     (sessionId: string) => {
@@ -369,6 +489,31 @@ export function FocusedChatWorkstationRail({
             },
           ]
         : []),
+      // Terminal / Files / Browser rows are parked in the expanded list:
+      // each of them left the focused chat for the Workstation, which is the
+      // opposite of what the trail is for. The terminal now stays in the
+      // pane — the header's terminal control and the trail's native
+      // right-click menu open `WorkstationTrailTerminal` instead.
+    ],
+    [
+      t,
+      reviewAdditions,
+      reviewDeletions,
+      branchCompareUrl,
+      branchPullRequest,
+      branchPullRequestStatus,
+    ]
+  );
+
+  /**
+   * Collapsed rail keeps the original icon set. The parked rows are only
+   * parked from the labelled list: in the 44px column these are pure icon
+   * shortcuts with nothing to replace them — the docked terminal cannot open
+   * in a column that narrow either.
+   */
+  const collapsedWorkspaceItems = useMemo<FocusedChatRailItem[]>(
+    () => [
+      ...workspaceItems,
       {
         key: "terminal",
         label: t("common:tabs.terminal"),
@@ -396,16 +541,12 @@ export function FocusedChatWorkstationRail({
       },
     ],
     [
-      t,
       browserTab,
       openWorkstationHost,
       openWorkstationTab,
       requestNewBrowserSession,
-      reviewAdditions,
-      reviewDeletions,
-      branchCompareUrl,
-      branchPullRequest,
-      branchPullRequestStatus,
+      t,
+      workspaceItems,
     ]
   );
 
@@ -530,6 +671,20 @@ export function FocusedChatWorkstationRail({
       return next;
     });
   };
+
+  // The collapsed 44px track has no room for the terminal panel.
+  const showTrailTerminal = miniTerminalVisible && !collapsed;
+
+  const handleTrailContextMenu = useWorkstationTrailMenu({
+    width,
+    minWidth,
+    onWidthChange: applyWidth,
+    onSetMinimum: setCurrentWidthAsMinimum,
+    onRestoreDefault: restoreDefaultWidth,
+    miniTerminalVisible,
+    onOpenMiniTerminal: () => showMiniTerminal(null),
+    onHideMiniTerminal: closeMiniTerminal,
+  });
   const toggleGroup = useCallback((groupKey: string) => {
     setCollapsedGroupKeys((current) => {
       const next = new Set(current);
@@ -589,105 +744,171 @@ export function FocusedChatWorkstationRail({
   return (
     <>
       {compactMenu}
-      {/* Button-controlled 256px/44px tracks only: the trail intentionally
-          has no drag handle or continuously resizable width. */}
+      {/* Expanded column is continuously resizable (drag its leading edge, or
+          right-click the trail for the native width menu); the collapsed
+          column stays the fixed 44px button-controlled rail. */}
       <div
         data-workstation-pane-control
         data-workstation-trail-track
-        className={`relative flex h-full shrink-0 flex-col items-start transition-[width] duration-200 ease-out motion-reduce:transition-none ${resolveFocusedChatWorkstationRailTrackClass(
-          collapsed
-        )}`}
-        style={resolveFocusedChatWorkstationRailInsetStyle(topInset)}
+        className={`relative flex h-full shrink-0 flex-col items-start ${
+          isResizing
+            ? ""
+            : "transition-[width] duration-200 ease-out motion-reduce:transition-none"
+        } ${resolveFocusedChatWorkstationRailTrackClass(collapsed)}`}
+        style={{
+          ...resolveFocusedChatWorkstationRailInsetStyle(topInset),
+          ...resolveTrailWidthVariables(width, {
+            collapsed,
+            terminalShown: showTrailTerminal,
+          }),
+        }}
       >
-        <WorkstationTrailSurface
-          as="aside"
-          aria-label={environmentLabel}
-          className="group/workstation-trail hidden @[1100px]/focusedchat:flex"
-        >
-          <WorkstationTrailHeader
-            title={environmentLabel}
-            collapsed={collapsed}
-            titleActions={
-              !collapsed && hasSessionEnvironment ? (
-                <WorkstationGroupToggle
-                  collapseLabel={t("common:actions.collapse")}
-                  collapsed={collapsedGroupKeys.has("session")}
-                  expandLabel={t("common:actions.expand")}
-                  groupKey="session"
-                  onToggle={() => toggleGroup("session")}
-                />
-              ) : null
-            }
-            actions={
-              <WorkstationTrailIconButton
-                onClick={toggleCollapsed}
-                aria-label={t(
-                  collapsed
-                    ? "common:git.rail.expand"
-                    : "common:git.rail.collapse"
-                )}
-                aria-expanded={!collapsed}
-              >
-                {collapsed ? (
-                  <HugeiconsIcon
-                    icon={ArrowLeftDoubleIcon}
-                    data-icon="chevrons-left"
-                    size={14}
-                    strokeWidth={1.75}
-                  />
-                ) : (
-                  <HugeiconsIcon
-                    icon={ArrowRightDoubleIcon}
-                    data-icon="chevrons-right"
-                    size={14}
-                    strokeWidth={1.75}
-                  />
-                )}
-              </WorkstationTrailIconButton>
-            }
-          />
-          {collapsed ? (
-            <div className="flex flex-col items-center gap-2">
-              {workspaceItems.map((item) => {
-                const icon = item.icon;
-                return (
-                  <button
-                    key={item.key}
-                    type="button"
-                    className={`${WORKSTATION_TRAIL_ICON_BUTTON_CLASS} relative`}
-                    onClick={item.onClick}
-                    aria-label={
-                      item.status
-                        ? `${item.label}, ${item.status.label}`
-                        : item.label
-                    }
-                    title={item.status?.title ?? item.label}
-                  >
-                    <AnyIcon icon={icon} size={16} strokeWidth={1.75} />
-                    {item.status ? (
-                      <span
-                        aria-hidden
-                        className={`absolute bottom-1 right-1 h-1.5 w-1.5 rounded-full ring-1 ring-bg-1 ${resolveRailStatusDotClass(
-                          item.status.state
-                        )}`}
-                      />
-                    ) : null}
-                  </button>
-                );
-              })}
-            </div>
-          ) : (
-            <WorkstationTrailBody>
-              <WorkstationSections
-                collapseGroupLabel={t("common:actions.collapse")}
-                collapsedGroupKeys={collapsedGroupKeys}
-                expandGroupLabel={t("common:actions.expand")}
-                onToggleGroup={toggleGroup}
-                sections={sections}
+        {/* Trail + terminal, grouped so the resize edge spans exactly them
+            and stops where they stop — the minimap track below is not part
+            of the resizable surface. */}
+        {/* The trail's own `max-h-full` is inert here — it resolves against
+            this group, whose height is content-driven — so the group carries
+            the cap instead: `max-h-full` against the full-height column plus
+            `min-h-0` so it can actually shrink into it. Without both, a long
+            trail outgrows the column and starves the minimap track below.
+            No `overflow-hidden`: it would clip the resize edge's hit area,
+            which reaches 6px past this box. */}
+        <div className="relative hidden max-h-full min-h-0 w-full flex-col @[1100px]/focusedchat:flex">
+          {!collapsed ? (
+            <div className="absolute inset-y-0 left-0 z-30 flex">
+              <VerticalResizeHandle
+                className="h-full"
+                isResizing={isResizing}
+                onMouseDown={handleResizeMouseDown}
+                onContextMenu={handleTrailContextMenu}
+                tooltipLabel={t("common:git.rail.resizeTrail")}
+                variant="transparent"
               />
-            </WorkstationTrailBody>
-          )}
-        </WorkstationTrailSurface>
+            </div>
+          ) : null}
+          <WorkstationTrailSurface
+            as="aside"
+            aria-label={environmentLabel}
+            // Right-click anywhere on the trail opens the same native width
+            // menu as its resize edge — the edge alone is a 13px target.
+            onContextMenu={handleTrailContextMenu}
+            // `min-h-0` unconditionally: inside the capped group the trail
+            // has to be able to shrink past its content height, whether what
+            // it would push out is the terminal or the minimap track.
+            className={`group/workstation-trail ml-auto flex min-h-0 ${WORKSTATION_TRAIL_WIDTH.surfaceResponsiveClass}`}
+          >
+            <WorkstationTrailHeader
+              title={environmentLabel}
+              collapsed={collapsed}
+              titleActions={
+                !collapsed && hasSessionEnvironment ? (
+                  <WorkstationGroupToggle
+                    collapseLabel={t("common:actions.collapse")}
+                    collapsed={collapsedGroupKeys.has("session")}
+                    expandLabel={t("common:actions.expand")}
+                    groupKey="session"
+                    onToggle={() => toggleGroup("session")}
+                  />
+                ) : null
+              }
+              actions={
+                <div className="flex items-center">
+                  {!collapsed ? (
+                    <WorkstationTrailIconButton
+                      onClick={toggleMiniTerminal}
+                      aria-label={t(
+                        miniTerminalVisible
+                          ? "common:git.rail.hideMiniTerminal"
+                          : "common:git.rail.openMiniTerminal"
+                      )}
+                      aria-pressed={miniTerminalVisible}
+                      title={t(
+                        miniTerminalVisible
+                          ? "common:git.rail.hideMiniTerminal"
+                          : "common:git.rail.openMiniTerminal"
+                      )}
+                      className={miniTerminalVisible ? "bg-fill-2" : ""}
+                    >
+                      <HugeiconsIcon
+                        icon={SquareTerminalIcon}
+                        data-icon="square-terminal"
+                        size={14}
+                        strokeWidth={1.75}
+                      />
+                    </WorkstationTrailIconButton>
+                  ) : null}
+                  <WorkstationTrailIconButton
+                    onClick={toggleCollapsed}
+                    aria-label={t(
+                      collapsed
+                        ? "common:git.rail.expand"
+                        : "common:git.rail.collapse"
+                    )}
+                    aria-expanded={!collapsed}
+                  >
+                    {collapsed ? (
+                      <HugeiconsIcon
+                        icon={ArrowLeftDoubleIcon}
+                        data-icon="chevrons-left"
+                        size={14}
+                        strokeWidth={1.75}
+                      />
+                    ) : (
+                      <HugeiconsIcon
+                        icon={ArrowRightDoubleIcon}
+                        data-icon="chevrons-right"
+                        size={14}
+                        strokeWidth={1.75}
+                      />
+                    )}
+                  </WorkstationTrailIconButton>
+                </div>
+              }
+            />
+            {collapsed ? (
+              <div className="flex flex-col items-center gap-2">
+                {collapsedWorkspaceItems.map((item) => {
+                  const icon = item.icon;
+                  return (
+                    <button
+                      key={item.key}
+                      type="button"
+                      className={`${WORKSTATION_TRAIL_ICON_BUTTON_CLASS} relative`}
+                      onClick={item.onClick}
+                      aria-label={
+                        item.status
+                          ? `${item.label}, ${item.status.label}`
+                          : item.label
+                      }
+                      title={item.status?.title ?? item.label}
+                    >
+                      <AnyIcon icon={icon} size={16} strokeWidth={1.75} />
+                      {item.status ? (
+                        <span
+                          aria-hidden
+                          className={`absolute bottom-1 right-1 h-1.5 w-1.5 rounded-full ring-1 ring-bg-1 ${resolveRailStatusDotClass(
+                            item.status.state
+                          )}`}
+                        />
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <WorkstationTrailBody>
+                <WorkstationSections
+                  collapseGroupLabel={t("common:actions.collapse")}
+                  collapsedGroupKeys={collapsedGroupKeys}
+                  expandGroupLabel={t("common:actions.expand")}
+                  onToggleGroup={toggleGroup}
+                  sections={sections}
+                />
+              </WorkstationTrailBody>
+            )}
+          </WorkstationTrailSurface>
+          {showTrailTerminal ? <WorkstationTrailTerminal /> : null}
+        </div>
         <div
           ref={conversationMinimapHostRef}
           data-focused-chat-conversation-minimap-host

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/railStorage.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/railStorage.ts
@@ -1,13 +1,54 @@
 /**
- * Rail collapse persistence and CI status-dot mapping.
+ * Rail collapse / width persistence and CI status-dot mapping.
  *
  * Storage is best-effort: the responsive control still works when
- * localStorage is unavailable.
+ * localStorage is unavailable, and every reader falls back to the shipped
+ * defaults in `./trailWidth`.
  */
 import type { BranchCiStatus } from "@src/services/git/branchPullRequestStatus";
 
 const FOCUSED_CHAT_RAIL_COLLAPSED_KEY =
   "orgii:focusedChatWorkstationRailCollapsed";
+const FOCUSED_CHAT_RAIL_WIDTH_KEY = "orgii:focusedChatWorkstationRailWidth";
+const FOCUSED_CHAT_RAIL_MIN_WIDTH_KEY =
+  "orgii:focusedChatWorkstationRailMinWidth";
+
+function readStoredNumber(key: string): number | null {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw == null) return null;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredNumber(key: string, value: number): void {
+  try {
+    localStorage.setItem(key, String(Math.round(value)));
+  } catch {
+    // The trail still resizes for this session when storage is unavailable.
+  }
+}
+
+/** Persisted expanded width, or `null` when never set / unreadable. */
+export function getStoredRailWidth(): number | null {
+  return readStoredNumber(FOCUSED_CHAT_RAIL_WIDTH_KEY);
+}
+
+export function persistRailWidth(width: number): void {
+  writeStoredNumber(FOCUSED_CHAT_RAIL_WIDTH_KEY, width);
+}
+
+/** Persisted user-set minimum width, or `null` when never set. */
+export function getStoredRailMinWidth(): number | null {
+  return readStoredNumber(FOCUSED_CHAT_RAIL_MIN_WIDTH_KEY);
+}
+
+export function persistRailMinWidth(minWidth: number): void {
+  writeStoredNumber(FOCUSED_CHAT_RAIL_MIN_WIDTH_KEY, minWidth);
+}
 
 export function getStoredRailCollapsed(): boolean {
   try {

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WORKSTATION_TRAIL_TERMINAL_WIDTH,
+  WORKSTATION_TRAIL_TRACK_PADDING_X,
+  WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE,
+  WORKSTATION_TRAIL_WIDTH_LIMITS,
+  WORKSTATION_TRAIL_WIDTH_VARIABLE,
+  clampTrailWidth,
+  resolveNextWiderTrailWidth,
+  resolveTrailMinWidth,
+  resolveTrailWidthVariables,
+} from "./trailWidth";
+
+const {
+  default: DEFAULT_WIDTH,
+  floor,
+  max,
+  step,
+} = WORKSTATION_TRAIL_WIDTH_LIMITS;
+
+describe("resolveTrailMinWidth", () => {
+  it("falls back to the floor when nothing is stored", () => {
+    expect(resolveTrailMinWidth(null)).toBe(floor);
+    expect(resolveTrailMinWidth(Number.NaN)).toBe(floor);
+  });
+
+  it("keeps a user-set minimum wider than the shipped default", () => {
+    // "Set current width as minimum" pins whatever the trail is at, which
+    // may be a width the user dragged well past 256px.
+    expect(resolveTrailMinWidth(DEFAULT_WIDTH + step)).toBe(
+      DEFAULT_WIDTH + step
+    );
+  });
+
+  it("clamps a stored minimum into the hard bounds", () => {
+    expect(floor).toBe(220);
+    expect(resolveTrailMinWidth(10)).toBe(floor);
+    expect(resolveTrailMinWidth(max + 400)).toBe(max);
+  });
+});
+
+describe("clampTrailWidth", () => {
+  it("defaults to the shipped width when nothing is stored", () => {
+    expect(clampTrailWidth(null, floor)).toBe(DEFAULT_WIDTH);
+  });
+
+  it("never returns a width below the user-set minimum", () => {
+    expect(clampTrailWidth(200, 320)).toBe(320);
+  });
+
+  it("respects a minimum above the shipped default", () => {
+    expect(clampTrailWidth(null, 400)).toBe(400);
+  });
+
+  it("caps at the maximum", () => {
+    expect(clampTrailWidth(max + 100, floor)).toBe(max);
+  });
+});
+
+describe("resolveNextWiderTrailWidth", () => {
+  it("grows by one step", () => {
+    expect(resolveNextWiderTrailWidth(DEFAULT_WIDTH, floor)).toBe(
+      DEFAULT_WIDTH + step
+    );
+  });
+
+  it("returns the same width at the maximum, so the menu can disable it", () => {
+    expect(resolveNextWiderTrailWidth(max, floor)).toBe(max);
+  });
+});
+
+describe("resolveTrailWidthVariables", () => {
+  it("keeps the trail box inside the column's edge inset", () => {
+    // The measured width is the *column*, the same thing the old `w-64`
+    // track was, so the trail box inside it is one inset narrower and never
+    // reaches the pane edge.
+    expect(resolveTrailWidthVariables(288)).toEqual({
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: `${
+        288 - WORKSTATION_TRAIL_TRACK_PADDING_X
+      }px`,
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "288px",
+    });
+  });
+
+  it("reproduces the shipped track the trail had before it could resize", () => {
+    expect(resolveTrailWidthVariables(DEFAULT_WIDTH)).toEqual({
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "248px",
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "256px",
+    });
+  });
+
+  it("widens only the column when the terminal is the wider of the two", () => {
+    // Opening the terminal must not resize the trail itself, and the
+    // terminal still gets its full width inside the inset.
+    expect(resolveTrailWidthVariables(256, { terminalShown: true })).toEqual({
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "248px",
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: `${
+        WORKSTATION_TRAIL_TERMINAL_WIDTH + WORKSTATION_TRAIL_TRACK_PADDING_X
+      }px`,
+    });
+  });
+
+  it("leaves a trail wider than the terminal owning the column", () => {
+    const wide = WORKSTATION_TRAIL_TERMINAL_WIDTH + 60;
+    expect(resolveTrailWidthVariables(wide, { terminalShown: true })).toEqual({
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: `${
+        wide - WORKSTATION_TRAIL_TRACK_PADDING_X
+      }px`,
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: `${wide}px`,
+    });
+  });
+
+  it("lets the collapsed rail's own class own the column", () => {
+    expect(
+      resolveTrailWidthVariables(288, { collapsed: true, terminalShown: true })
+    ).toEqual({
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "100%",
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "100%",
+    });
+  });
+});

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.ts
@@ -1,0 +1,137 @@
+/**
+ * Workstation trail width model.
+ *
+ * The trail used to be a two-state track (256px expanded / 44px collapsed)
+ * driven purely by responsive Tailwind classes. It is now continuously
+ * resizable while expanded, so the expanded track reads its width from the
+ * `--workstation-trail-width` custom property this module produces.
+ *
+ * Two persisted numbers drive it:
+ *   - `width`     — the current expanded width.
+ *   - `minWidth`  — the user's own floor, set from the context menu's
+ *                   "set current width as minimum". Drag and the width
+ *                   clamp both respect it, so a trail the user decided is
+ *                   as narrow as it should get can never be dragged past
+ *                   that point.
+ *
+ * `FLOOR` is the hard lower bound a user-set minimum itself is clamped to:
+ * below it the trail rows stop being readable and the collapsed track is
+ * the better control.
+ */
+import type { CSSProperties } from "react";
+
+export const WORKSTATION_TRAIL_WIDTH_LIMITS = {
+  /** Shipped width, and the target of "restore original width". */
+  default: 256,
+  /** Hard lower bound for both the width and a user-set minimum. */
+  floor: 220,
+  /** Hard upper bound; the chat column keeps its own min width on top. */
+  max: 520,
+  /** How much one "wider" step grows the trail. */
+  step: 48,
+} as const;
+
+/** Width of the trail surface itself. */
+export const WORKSTATION_TRAIL_WIDTH_VARIABLE = "--workstation-trail-width";
+/** Width of the whole trail column, which the terminal can widen on its own. */
+export const WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE =
+  "--workstation-trail-track-width";
+
+/**
+ * Width of the docked terminal. It is the terminal's own width, not the
+ * trail's: a 256px trail is fine to read but too narrow for a shell, so the
+ * terminal takes this width and the trail above it keeps whatever width the
+ * user gave it. The column is as wide as the wider of the two.
+ */
+export const WORKSTATION_TRAIL_TERMINAL_WIDTH = 400;
+
+/**
+ * Horizontal inset the column reserves so neither box touches the pane edge
+ * — `FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS`'s `px-1`, 4px a side.
+ *
+ * Widths in this module are *column* widths, matching the `w-64` the track
+ * used to carry: the boxes inside are that much narrower, because the column
+ * is `box-sizing: border-box` and the padding comes out of its width.
+ */
+export const WORKSTATION_TRAIL_TRACK_PADDING_X = 8;
+
+/**
+ * Clamp a user-set minimum into `[floor, max]`.
+ *
+ * The minimum is allowed above the shipped default: "set current width as
+ * minimum" pins whatever the trail is at right now, including a width the
+ * user dragged past 256px. It never moves the current width — see
+ * `clampTrailWidth`, which is only applied to widths the user is actively
+ * changing.
+ */
+export function resolveTrailMinWidth(storedMinWidth: number | null): number {
+  if (storedMinWidth == null || !Number.isFinite(storedMinWidth)) {
+    return WORKSTATION_TRAIL_WIDTH_LIMITS.floor;
+  }
+  return Math.min(
+    WORKSTATION_TRAIL_WIDTH_LIMITS.max,
+    Math.max(WORKSTATION_TRAIL_WIDTH_LIMITS.floor, Math.round(storedMinWidth))
+  );
+}
+
+/** Clamp a width into `[minWidth, max]`, falling back to the default. */
+export function clampTrailWidth(
+  width: number | null,
+  minWidth: number
+): number {
+  if (width == null || !Number.isFinite(width)) {
+    return Math.max(minWidth, WORKSTATION_TRAIL_WIDTH_LIMITS.default);
+  }
+  return Math.min(
+    WORKSTATION_TRAIL_WIDTH_LIMITS.max,
+    Math.max(minWidth, Math.round(width))
+  );
+}
+
+/**
+ * Next width one "wider" step up, clamped to the maximum. Returns the same
+ * width when the trail is already at the maximum, which the menu reads as
+ * "disable this item".
+ */
+export function resolveNextWiderTrailWidth(
+  width: number,
+  minWidth: number
+): number {
+  return clampTrailWidth(width + WORKSTATION_TRAIL_WIDTH_LIMITS.step, minWidth);
+}
+
+/**
+ * Style payload for the trail column: the trail surface's own width, and the
+ * column width that has to contain both it and the terminal.
+ *
+ * Widths live in custom properties rather than `style.width` because the
+ * column only takes a width inside the `@[1100px]/focusedchat` container
+ * query — an inline width would also apply below that breakpoint, where the
+ * trail must stay at zero and the compact dropdown takes over. Collapsed,
+ * the shipped `w-11` class owns the column and both boxes just fill it.
+ */
+export function resolveTrailWidthVariables(
+  width: number,
+  options?: { collapsed?: boolean; terminalShown?: boolean }
+): CSSProperties {
+  if (options?.collapsed) {
+    return {
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "100%",
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "100%",
+    } as CSSProperties;
+  }
+  const trackWidth = options?.terminalShown
+    ? Math.max(
+        width,
+        WORKSTATION_TRAIL_TERMINAL_WIDTH + WORKSTATION_TRAIL_TRACK_PADDING_X
+      )
+    : width;
+  return {
+    // The trail box itself sits inside the column's inset, exactly as it did
+    // when the track was a plain `w-64`.
+    [WORKSTATION_TRAIL_WIDTH_VARIABLE]: `${
+      width - WORKSTATION_TRAIL_TRACK_PADDING_X
+    }px`,
+    [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: `${trackWidth}px`,
+  } as CSSProperties;
+}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/useWorkstationTrailMenu.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/useWorkstationTrailMenu.ts
@@ -1,0 +1,118 @@
+/**
+ * Right-click menu for the Workstation trail's resize handle.
+ *
+ * Width commands:
+ *   - "Restore original width" — back to the shipped 256px. It also clears a
+ *     user-set minimum, because a minimum above 256px would otherwise make
+ *     the command a no-op with no way back from the menu.
+ *   - "Set current width as minimum" — pins the trail's *current* width as
+ *     the floor for dragging. It never resizes the trail.
+ *   - "Wider" — one `step` up, disabled at the maximum.
+ *
+ * Terminal commands open / hide the terminal docked under the trail, which
+ * is the trail's terminal entry point now that the Workstation-navigating
+ * terminal, files and browser rows are gone.
+ */
+import i18next from "i18next";
+import { type MouseEvent, useCallback } from "react";
+
+import { createLogger } from "@src/hooks/logger";
+import {
+  type NativeMenuItemOptions,
+  popupNativeMenu,
+} from "@src/util/platform/tauri/nativeMenuPopup";
+
+import {
+  WORKSTATION_TRAIL_WIDTH_LIMITS,
+  resolveNextWiderTrailWidth,
+} from "./trailWidth";
+
+const log = createLogger("useWorkstationTrailMenu");
+
+export interface UseWorkstationTrailMenuOptions {
+  /** Current expanded width in px. */
+  width: number;
+  /** Effective minimum width in px (user-set or the shipped floor). */
+  minWidth: number;
+  onWidthChange: (width: number) => void;
+  /** Persist `width` as the new minimum without resizing the trail. */
+  onSetMinimum: () => void;
+  /** Restore the shipped width and clear a user-set minimum. */
+  onRestoreDefault: () => void;
+  /** Mini terminal currently on screen. */
+  miniTerminalVisible: boolean;
+  onOpenMiniTerminal: () => void;
+  onHideMiniTerminal: () => void;
+}
+
+export function useWorkstationTrailMenu({
+  width,
+  minWidth,
+  onWidthChange,
+  onSetMinimum,
+  onRestoreDefault,
+  miniTerminalVisible,
+  onOpenMiniTerminal,
+  onHideMiniTerminal,
+}: UseWorkstationTrailMenuOptions) {
+  return useCallback(
+    (event: MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const isDefaultWidth = width === WORKSTATION_TRAIL_WIDTH_LIMITS.default;
+      const nextWider = resolveNextWiderTrailWidth(width, minWidth);
+      const isAlreadyMinimum = minWidth === width;
+
+      void popupNativeMenu({
+        source: "workstation-trail",
+        buildItems: () => {
+          const items: NativeMenuItemOptions[] = [
+            {
+              text: i18next.t("common:git.rail.restoreWidth", {
+                width: WORKSTATION_TRAIL_WIDTH_LIMITS.default,
+              }),
+              enabled: !isDefaultWidth,
+              action: onRestoreDefault,
+            },
+            {
+              text: i18next.t("common:git.rail.setMinimumWidth", { width }),
+              enabled: !isAlreadyMinimum,
+              action: onSetMinimum,
+            },
+            {
+              text: i18next.t("common:git.rail.widerWidth", {
+                width: nextWider,
+              }),
+              enabled: nextWider !== width,
+              action: () => onWidthChange(nextWider),
+            },
+            { item: "Separator" },
+            miniTerminalVisible
+              ? {
+                  text: i18next.t("common:git.rail.hideMiniTerminal"),
+                  action: onHideMiniTerminal,
+                }
+              : {
+                  text: i18next.t("common:git.rail.openMiniTerminal"),
+                  action: onOpenMiniTerminal,
+                },
+          ];
+          return items;
+        },
+      }).catch((error) => {
+        log.error("Failed to show workstation trail menu:", error);
+      });
+    },
+    [
+      miniTerminalVisible,
+      minWidth,
+      onHideMiniTerminal,
+      onOpenMiniTerminal,
+      onRestoreDefault,
+      onSetMinimum,
+      onWidthChange,
+      width,
+    ]
+  );
+}

--- a/src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts
+++ b/src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts
@@ -14,7 +14,16 @@ import WorkstationTrailSurface, {
 describe("WorkstationTrailSurface", () => {
   it("owns the expanded Workstation trail width", () => {
     expect(WORKSTATION_TRAIL_WIDTH.expandedPx).toBe(256);
-    expect(WORKSTATION_TRAIL_WIDTH.expandedResponsiveClass).toContain("w-64");
+    // The focused-chat column is resizable, so its width and the trail
+    // surface's own width come from custom properties instead of fixed
+    // Tailwind widths — and they are separate, because the docked terminal
+    // can widen the column without widening the trail.
+    expect(WORKSTATION_TRAIL_WIDTH.resizableResponsiveClass).toContain(
+      "var(--workstation-trail-track-width)"
+    );
+    expect(WORKSTATION_TRAIL_WIDTH.surfaceResponsiveClass).toContain(
+      "var(--workstation-trail-width)"
+    );
   });
 
   it("owns the exact focused-chat environment trail surface", () => {

--- a/src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx
+++ b/src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx
@@ -20,7 +20,19 @@ export interface WorkstationTrailSurfaceProps extends HTMLAttributes<HTMLElement
 export const WORKSTATION_TRAIL_SURFACE_CLASS = `max-h-full w-full flex-col overflow-hidden rounded-xl border border-border-1 p-1 ${DROPDOWN_PANEL.shadowClass} ${EDITOR_TAB_CANVAS_BG_CLASS}`;
 export const WORKSTATION_TRAIL_WIDTH = {
   expandedPx: 256,
-  expandedResponsiveClass: "@[1100px]/focusedchat:w-64",
+  /**
+   * Expanded focused-chat column. Its width comes from the
+   * `--workstation-trail-track-width` custom property the trail sets inline
+   * (see `FocusedChatWorkstationRail/trailWidth.ts`) — the column has to
+   * contain both the trail surface and the wider docked terminal. The
+   * container query keeps it at zero below 1100px, where the compact
+   * dropdown takes over.
+   */
+  resizableResponsiveClass:
+    "@[1100px]/focusedchat:w-[var(--workstation-trail-track-width)]",
+  /** Trail surface's own width inside that column. */
+  surfaceResponsiveClass:
+    "@[1100px]/focusedchat:w-[var(--workstation-trail-width)]",
   collapsedResponsiveClass: "@[1100px]/focusedchat:w-11",
 } as const;
 export const WORKSTATION_TRAIL_RAIL_PADDING_CLASS = "px-1 pb-1 pt-2";

--- a/src/store/ui/__tests__/miniTerminalAtom.test.ts
+++ b/src/store/ui/__tests__/miniTerminalAtom.test.ts
@@ -13,7 +13,7 @@ import {
   openMiniTerminalAtom,
   releaseMiniTerminalSessionAtom,
   setMiniTerminalActiveIdAtom,
-} from "./miniTerminalAtom";
+} from "../miniTerminalAtom";
 
 function seedStore(sessionIds: string[]) {
   const store = createStore();

--- a/src/store/ui/miniTerminalAtom.test.ts
+++ b/src/store/ui/miniTerminalAtom.test.ts
@@ -1,0 +1,109 @@
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import { terminalSessionsAtom } from "@src/store/workstation/codeEditor/terminal";
+
+import {
+  closeMiniTerminalAtom,
+  miniTerminalActiveIdAtom,
+  miniTerminalClaimedIdsAtom,
+  miniTerminalHostMountedAtom,
+  miniTerminalSuppressedIdsAtom,
+  miniTerminalVisibleAtom,
+  openMiniTerminalAtom,
+  releaseMiniTerminalSessionAtom,
+  setMiniTerminalActiveIdAtom,
+} from "./miniTerminalAtom";
+
+function seedStore(sessionIds: string[]) {
+  const store = createStore();
+  store.set(
+    terminalSessionsAtom,
+    sessionIds.map((id) => ({ id, name: id, isActive: false }))
+  );
+  // The trail registers itself as the panel's host on mount.
+  store.set(miniTerminalHostMountedAtom, true);
+  return store;
+}
+
+describe("mini terminal claims", () => {
+  it("claims a session and suppresses it in the Workstation pane", () => {
+    const store = seedStore(["a", "b"]);
+    store.set(openMiniTerminalAtom, "a");
+
+    expect(store.get(miniTerminalVisibleAtom)).toBe(true);
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual(["a"]);
+    expect([...store.get(miniTerminalSuppressedIdsAtom)]).toEqual(["a"]);
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("a");
+  });
+
+  it("re-opening an already claimed session only refocuses it", () => {
+    const store = seedStore(["a", "b"]);
+    store.set(openMiniTerminalAtom, "a");
+    store.set(openMiniTerminalAtom, "b");
+    store.set(openMiniTerminalAtom, "a");
+
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual(["a", "b"]);
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("a");
+  });
+
+  it("suppresses nothing while the panel is hidden", () => {
+    const store = seedStore(["a"]);
+    store.set(openMiniTerminalAtom, "a");
+    store.set(miniTerminalVisibleAtom, false);
+
+    // The Workstation pane must remount a session the panel is not showing,
+    // otherwise a hidden panel would strand the PTY with no xterm at all.
+    expect(store.get(miniTerminalSuppressedIdsAtom).size).toBe(0);
+  });
+
+  it("suppresses nothing while the trail that hosts the panel is unmounted", () => {
+    const store = seedStore(["a"]);
+    store.set(openMiniTerminalAtom, "a");
+    store.set(miniTerminalHostMountedAtom, false);
+
+    expect(store.get(miniTerminalVisibleAtom)).toBe(true);
+    expect(store.get(miniTerminalSuppressedIdsAtom).size).toBe(0);
+  });
+
+  it("prunes a claim whose PTY was closed elsewhere", () => {
+    const store = seedStore(["a", "b"]);
+    store.set(openMiniTerminalAtom, "a");
+    store.set(openMiniTerminalAtom, "b");
+    store.set(terminalSessionsAtom, [{ id: "b", name: "b", isActive: false }]);
+
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual(["b"]);
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("b");
+  });
+
+  it("moves the active tab off a released session", () => {
+    const store = seedStore(["a", "b"]);
+    store.set(openMiniTerminalAtom, "a");
+    store.set(openMiniTerminalAtom, "b");
+    store.set(setMiniTerminalActiveIdAtom, "a");
+    store.set(releaseMiniTerminalSessionAtom, "a");
+
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual(["b"]);
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("b");
+    expect(store.get(miniTerminalVisibleAtom)).toBe(true);
+  });
+
+  it("hides the panel once its last claim is released", () => {
+    const store = seedStore(["a"]);
+    store.set(openMiniTerminalAtom, "a");
+    store.set(releaseMiniTerminalSessionAtom, "a");
+
+    expect(store.get(miniTerminalVisibleAtom)).toBe(false);
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual([]);
+  });
+
+  it("releases every claim when the panel closes", () => {
+    const store = seedStore(["a", "b"]);
+    store.set(openMiniTerminalAtom, "a");
+    store.set(openMiniTerminalAtom, "b");
+    store.set(closeMiniTerminalAtom);
+
+    expect(store.get(miniTerminalVisibleAtom)).toBe(false);
+    expect(store.get(miniTerminalSuppressedIdsAtom).size).toBe(0);
+  });
+});

--- a/src/store/ui/miniTerminalAtom.ts
+++ b/src/store/ui/miniTerminalAtom.ts
@@ -1,0 +1,185 @@
+/**
+ * Mini terminal docked under the Workstation trail.
+ *
+ * A short terminal panel that sits directly below the trail surface, in the
+ * trail's own column and on its own surface. It does NOT own a terminal
+ * runtime of its own: it *claims* Workstation PTY sessions out of
+ * `store/workstation/codeEditor/terminal` and mounts them itself.
+ *
+ * # Why a claim rather than a second view
+ *
+ * A PTY session is bound to exactly one xterm instance through
+ * `TerminalView`'s `sessionKey`. Mounting the same session twice would give
+ * one PTY two writers and two competing `resize` calls, so a claimed session
+ * is suppressed in the Workstation terminal pane (`TerminalCore`'s
+ * `suppressedSessionIds`) for as long as the mini window holds it, and is
+ * remounted there through the normal PTY attach/restore path once released.
+ */
+import { atom } from "jotai";
+
+import { selectedRepoPathAtom } from "@src/store/repo";
+import {
+  activeTerminalIdAtom,
+  closeTerminalSessionAtom,
+  editorAddTerminalSessionAtom,
+  terminalSessionsAtom,
+} from "@src/store/workstation/codeEditor/terminal";
+
+/** Panel shown. Suppression lifts whenever it hides. */
+export const miniTerminalVisibleAtom = atom<boolean>(false);
+miniTerminalVisibleAtom.debugLabel = "chatPanel/miniTerminal/visible";
+
+/**
+ * The trail is only mounted for a maximized session, so the panel that
+ * mounts the claimed PTYs comes and goes with it. Suppression has to follow
+ * that mount, or an unmounted trail would leave a claimed session with no
+ * xterm anywhere. The host sets this from an effect; the panel mounts its
+ * terminal only once suppression is actually in force, so the handover never
+ * has a frame with two xterms on one PTY.
+ */
+export const miniTerminalHostMountedAtom = atom<boolean>(false);
+miniTerminalHostMountedAtom.debugLabel = "chatPanel/miniTerminal/hostMounted";
+
+const miniTerminalClaimedIdsStateAtom = atom<readonly string[]>([]);
+miniTerminalClaimedIdsStateAtom.debugLabel =
+  "chatPanel/miniTerminal/claimedIds/state";
+
+/**
+ * Workstation session ids the mini window currently mounts, pruned against
+ * the live session list so a PTY killed elsewhere cannot strand a claim
+ * that keeps suppressing a session id the store no longer has.
+ */
+export const miniTerminalClaimedIdsAtom = atom<readonly string[]>((get) => {
+  const claimed = get(miniTerminalClaimedIdsStateAtom);
+  if (claimed.length === 0) return claimed;
+  const live = new Set(get(terminalSessionsAtom).map((session) => session.id));
+  const pruned = claimed.filter((id) => live.has(id));
+  return pruned.length === claimed.length ? claimed : pruned;
+});
+miniTerminalClaimedIdsAtom.debugLabel = "chatPanel/miniTerminal/claimedIds";
+
+/**
+ * Suppression set read by the Workstation terminal pane. Empty while the
+ * panel is hidden or unmounted, so either one hands every session straight
+ * back to the Workstation.
+ */
+export const miniTerminalSuppressedIdsAtom = atom<ReadonlySet<string>>(
+  (get) =>
+    new Set(
+      get(miniTerminalVisibleAtom) && get(miniTerminalHostMountedAtom)
+        ? get(miniTerminalClaimedIdsAtom)
+        : []
+    )
+);
+miniTerminalSuppressedIdsAtom.debugLabel =
+  "chatPanel/miniTerminal/suppressedIds";
+
+const miniTerminalActiveIdStateAtom = atom<string | null>(null);
+miniTerminalActiveIdStateAtom.debugLabel =
+  "chatPanel/miniTerminal/activeId/state";
+
+/** Active tab inside the mini window, defaulted to the first live claim. */
+export const miniTerminalActiveIdAtom = atom<string | null>((get) => {
+  const claimed = get(miniTerminalClaimedIdsAtom);
+  const active = get(miniTerminalActiveIdStateAtom);
+  if (active && claimed.includes(active)) return active;
+  return claimed[0] ?? null;
+});
+miniTerminalActiveIdAtom.debugLabel = "chatPanel/miniTerminal/activeId";
+
+export const setMiniTerminalActiveIdAtom = atom(
+  null,
+  (_get, set, sessionId: string) => {
+    set(miniTerminalActiveIdStateAtom, sessionId);
+  }
+);
+setMiniTerminalActiveIdAtom.debugLabel = "chatPanel/miniTerminal/setActiveId";
+
+/**
+ * Show the panel on `sessionId`, or on a brand-new Workstation PTY when
+ * called with `null`. Claiming an already-claimed session just focuses it.
+ */
+export const openMiniTerminalAtom = atom(
+  null,
+  (get, set, sessionId: string | null) => {
+    const targetId =
+      sessionId ??
+      set(editorAddTerminalSessionAtom, {
+        cwd: get(selectedRepoPathAtom) || undefined,
+      });
+    if (!targetId) return null;
+    const claimed = get(miniTerminalClaimedIdsAtom);
+    if (!claimed.includes(targetId)) {
+      set(miniTerminalClaimedIdsStateAtom, [...claimed, targetId]);
+    }
+    set(miniTerminalActiveIdStateAtom, targetId);
+    set(miniTerminalVisibleAtom, true);
+    return targetId;
+  }
+);
+openMiniTerminalAtom.debugLabel = "chatPanel/miniTerminal/open";
+
+/**
+ * Hand one session back to the Workstation pane. The panel closes once its
+ * last claim is released, and the Workstation regains focus of the session
+ * it had been showing.
+ */
+export const releaseMiniTerminalSessionAtom = atom(
+  null,
+  (get, set, sessionId: string) => {
+    const remaining = get(miniTerminalClaimedIdsAtom).filter(
+      (id) => id !== sessionId
+    );
+    set(miniTerminalClaimedIdsStateAtom, remaining);
+    if (remaining.length === 0) {
+      set(miniTerminalVisibleAtom, false);
+      set(miniTerminalActiveIdStateAtom, null);
+      return;
+    }
+    if (get(miniTerminalActiveIdStateAtom) === sessionId) {
+      set(miniTerminalActiveIdStateAtom, remaining[0] ?? null);
+    }
+  }
+);
+releaseMiniTerminalSessionAtom.debugLabel = "chatPanel/miniTerminal/release";
+
+/** Kill a claimed PTY outright (the panel's per-tab close control). */
+export const closeMiniTerminalSessionAtom = atom(
+  null,
+  (get, set, sessionId: string) => {
+    set(releaseMiniTerminalSessionAtom, sessionId);
+    void set(closeTerminalSessionAtom, sessionId);
+  }
+);
+closeMiniTerminalSessionAtom.debugLabel = "chatPanel/miniTerminal/closeSession";
+
+/**
+ * Hide the panel and release every claim. The Workstation terminal pane
+ * remounts the sessions it had been showing; the PTYs keep running.
+ */
+export const closeMiniTerminalAtom = atom(null, (get, set) => {
+  // Read before clearing: the active id is derived from the claim list.
+  const lastActive = get(miniTerminalActiveIdAtom);
+  set(miniTerminalVisibleAtom, false);
+  set(miniTerminalClaimedIdsStateAtom, []);
+  set(miniTerminalActiveIdStateAtom, null);
+  // Hand focus of the released session to the Workstation pane, so the tab
+  // the user was just looking at is the one waiting for them there.
+  if (lastActive && get(activeTerminalIdAtom) !== lastActive) {
+    set(activeTerminalIdAtom, lastActive);
+  }
+});
+closeMiniTerminalAtom.debugLabel = "chatPanel/miniTerminal/close";
+
+/** Panel folded to just its header row; the PTY stays mounted behind it. */
+export const miniTerminalCollapsedAtom = atom<boolean>(false);
+miniTerminalCollapsedAtom.debugLabel = "chatPanel/miniTerminal/collapsed";
+
+export const toggleMiniTerminalAtom = atom(null, (get, set) => {
+  if (get(miniTerminalVisibleAtom)) {
+    set(closeMiniTerminalAtom);
+    return;
+  }
+  set(openMiniTerminalAtom, get(miniTerminalClaimedIdsAtom)[0] ?? null);
+});
+toggleMiniTerminalAtom.debugLabel = "chatPanel/miniTerminal/toggle";


### PR DESCRIPTION
## Problem

The focused-chat Workstation trail was a two-state track — 256px expanded or
a 44px rail — with an explicit *"Button-controlled 256px/44px tracks only:
the trail intentionally has no drag handle or continuously resizable width"*
note in its markup. There was no way to widen it for a long branch name, no
way to narrow it to give the transcript more room, and no memory of a
preference between sessions.

Its rows also all led **out** of the focused chat: Terminal, Files and
Browser each navigated to the Workstation, as did every terminal-session row
and the `Continue in <agent>` header button. Wanting a shell meant leaving
the conversation you were reading.

## Solution

**Width.** The expanded track reads its width from a
`--workstation-trail-width` custom property rather than a fixed `w-64`. The
property is the mechanism, not a flourish: the track must stay at zero below
the `@[1100px]/focusedchat` container query where the compact dropdown takes
over, which an inline `style.width` cannot express. Drag the column's leading
edge, or right-click the trail for the native width menu — *restore original
width*, *set current width as minimum* (pins the floor without resizing),
*wider*. Width and floor both persist; the floor is 220px.

Widths in `trailWidth.ts` are **column** widths, matching what `w-64` was, so
the boxes inside sit one 8px inset narrower and never touch the pane edge.

**Terminal.** A short panel docked under the trail, on the same surface,
collapsible, not draggable. It carries its own 400px width, so opening it
never resizes the trail above — the column is simply the wider of the two.
It renders the real `TerminalCore` / `TerminalView` / PTY pipeline over the
real Workstation sessions, scoping a synthetic `UseTerminalStateReturn` to
the sessions it claims (the shape `ChatPanelTerminalContent` already uses).
Tabs are `DetailTabStrip`, the same component the pull-request detail header
renders.

**The invariant that needed care:** a PTY binds to exactly one xterm through
`TerminalView`'s `sessionKey`. A session shown in the panel is therefore
*claimed* and suppressed in the Workstation terminal pane
(`suppressedSessionIds`, folded into `selectMountedTerminalSessions`), which
shows "Running in the mini terminal / Show it here" in its place. Suppression
lifts when the panel hides **or** when the trail unmounts, so a claim can
never strand a PTY with no view; and the panel mounts its terminal only once
suppression is actually in force, so the handover never has a frame with two
xterms writing one PTY.

**Minimap.** The trail column now owns the conversation rail's space, so the
two had to be reconciled. The rail is one shape in two arrangements: an inset
floating pill while it would cover the transcript, a bare flush rail once it
has space of its own. The floating half is a single shared literal, so the
maximized and side panes cannot drift apart — a test strips every
container-query token and asserts the remainders are byte-identical.
Maximized chat crosses over at 850px, where the track starts reserving the
rail's column; the side pane at 960px, where the centered content clears the
outer gutter by itself. No scrollport gutter is reserved anywhere any more.

**Parked**, all for one reason — they left the focused chat for the
Workstation: the trail's Terminal / Files / Browser rows and the
`Continue in <agent>` header button. The three rows stay in the **collapsed**
rail, where they are pure icon shortcuts with nothing to replace them and the
docked terminal cannot open in a 44px column anyway.

## Potential risks

- **Scope.** This is deliberately one PR for one surface rather than one
  responsibility, at the author's request. Trail resize, the docked terminal,
  and the minimap rework are separable in principle, but the minimap is not
  separable in practice: the track width change is what took its space away.
- **No visual verification.** None of this was run in the app — it is
  reviewed, typechecked, linted and unit-tested only. The geometry claims
  (the 8px edge inset, the 400px terminal, the resize edge spanning
  trail+terminal, the three-step column) rest on reasoning about the flex and
  container-query cascade, not on a screenshot. A layout regression of
  exactly this kind was caught and fixed during development: nesting the
  trail one level deeper made its `max-h-full` resolve against a
  content-height parent, silently starving the minimap of its space. Please
  look at it running before merging.
- **Parked, not deleted.** The four entry points are commented out with their
  reason inline, so they read as a decision rather than dead code. If the
  intent is permanent they should be removed, along with
  `SessionContinueCliHeaderExtras` and the `browserTab` lookup.
- **Terminal claim.** Both sides of the handover are covered at the pure
  boundary (`selectMountedTerminalSessions`, the claim atoms), but the actual
  two-host mount/unmount sequence is not exercised by a test — this repo has
  no hook-rendering harness, and adding one means a new dependency.
- **Persistence.** New `localStorage` keys (`…RailWidth`, `…RailMinWidth`).
  Unreadable or absent values fall back to the shipped defaults; no
  migration, no server state, nothing to roll back.
- **i18n.** 10 new keys across all 13 locales; the non-English strings are
  machine-written and worth a native check.

## Verification

Run on the branch in a clean worktree, base `7435f2d6b`, using the same
commands as CI's `Frontend (typecheck · lint · test)` job:

- `pnpm typecheck` (`tsc --noEmit --pretty false`) — exit 0.
- `pnpm lint` (`eslint src/ --max-warnings 0 --report-unused-disable-directives`,
  full tree) — exit 0.
- `eslint` over the changed `.ts`/`.tsx` files, the changed-files invocation —
  exit 0.
- `pnpm run check:test-placement` — consistent across 434 directories.
- `pnpm run test` (`vitest run`, full suite) — **1263 files, 9916 tests, all
  pass**.
- Pre-commit hooks ran on both commits (lint-staged, scoped tsc, stats
  trailer).

New coverage: `trailWidth.test.ts` (10 cases — clamping, a user-set floor
above the default, the column-vs-box inset, the terminal widening only the
column), `__tests__/miniTerminalAtom.test.ts` (8 — claim, prune on external
close, release, suppression lifting with the panel and with its host), plus
the suppression case in `terminalMountWindow.test.ts` and the
shared-floating-half and visibility cases in `ConversationMinimap.test.ts`.

**Not run:** the app itself, E2E, cargo (no Rust changes), and any visual or
manual pass. No screenshots — see `Potential risks`.

The first push failed CI on `check:test-placement`: `src/store/ui` keeps its
tests in `__tests__/` and the new store test was colocated, mixing both
conventions in one directory. Fixed in 8887ba3, and the full-suite and
full-tree-lint runs above were added to close the gap that let it through —
the first round had only been verified with scoped `vitest` invocations.
