### PR TITLE
fix(chat-history): stop the tail collapse bar from flickering away

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx
@@ -128,7 +128,6 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
   } = historyState;
   const {
     activeProjectionHistory,
-    collapseTailWhenIdle,
     currentPageIndex,
     currentTurnPageLabel,
     currentTurnPageTimeLabel,
@@ -155,8 +154,7 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
     selectTurnPage,
     setTurnPageListOpen,
     setTurnPageSortAscending,
-    tailTurnComplete,
-    tailTurnStale,
+    tailTurnPhase,
     turnMetadataReloadKey,
     turnPageListOpen,
     turnPageSortAscending,
@@ -222,9 +220,7 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
     displayGroupCount: displayGroupCounts.length,
     collapseLabelVariant: groupChatEnabled ? "agents" : "agent",
     turnPaginationEnabled,
-    collapseTailWhenIdle,
-    tailTurnComplete,
-    tailTurnStale,
+    tailTurnPhase,
     hideUserMessage: hideGroupUserMessage,
     defaultTurnCollapsed,
     turnCollapseInteractionAtRef,
@@ -299,9 +295,7 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
       header={activePinnedHeader}
       meta={activePinnedMeta}
       collapseLabelVariant={groupChatEnabled ? "agents" : "agent"}
-      collapseTailWhenIdle={collapseTailWhenIdle}
-      tailTurnComplete={tailTurnComplete}
-      tailTurnStale={tailTurnStale}
+      tailTurnPhase={tailTurnPhase}
       hideUserMessage={hideGroupUserMessage}
       defaultTurnCollapsed={defaultTurnCollapsed}
       turnCollapseInteractionAtRef={turnCollapseInteractionAtRef}

--- a/src/engines/ChatPanel/ChatHistory/components/ChatPinnedHeaderLayer.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatPinnedHeaderLayer.tsx
@@ -41,9 +41,7 @@ interface ChatPinnedHeaderLayerProps {
   header: OptimizedChatItem | null | undefined;
   meta: ChatGroupMeta | undefined;
   collapseLabelVariant?: GroupHeaderRendererProps["collapseLabelVariant"];
-  collapseTailWhenIdle: boolean;
-  tailTurnComplete: boolean;
-  tailTurnStale: boolean;
+  tailTurnPhase: GroupHeaderRendererProps["tailTurnPhase"];
   hideUserMessage: boolean;
   defaultTurnCollapsed: boolean;
   turnCollapseInteractionAtRef: React.MutableRefObject<number>;
@@ -85,9 +83,7 @@ const ChatPinnedHeaderLayer: React.FC<ChatPinnedHeaderLayerProps> = memo(
     header,
     meta,
     collapseLabelVariant,
-    collapseTailWhenIdle,
-    tailTurnComplete,
-    tailTurnStale,
+    tailTurnPhase,
     hideUserMessage,
     defaultTurnCollapsed,
     turnCollapseInteractionAtRef,
@@ -137,9 +133,7 @@ const ChatPinnedHeaderLayer: React.FC<ChatPinnedHeaderLayerProps> = memo(
           header={header}
           meta={meta}
           collapseLabelVariant={collapseLabelVariant}
-          collapseTailWhenIdle={collapseTailWhenIdle}
-          tailTurnComplete={tailTurnComplete}
-          tailTurnStale={tailTurnStale}
+          tailTurnPhase={tailTurnPhase}
           hideUserMessage={hideUserMessage}
           defaultTurnCollapsed={defaultTurnCollapsed}
           turnCollapseInteractionAtRef={turnCollapseInteractionAtRef}

--- a/src/engines/ChatPanel/ChatHistory/components/PinnedTurnHeader.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/PinnedTurnHeader.tsx
@@ -14,9 +14,7 @@ interface PinnedTurnHeaderProps {
   header: OptimizedChatItem | null | undefined;
   meta: ChatGroupMeta | undefined;
   collapseLabelVariant?: GroupHeaderRendererProps["collapseLabelVariant"];
-  collapseTailWhenIdle: boolean;
-  tailTurnComplete: boolean;
-  tailTurnStale: boolean;
+  tailTurnPhase: GroupHeaderRendererProps["tailTurnPhase"];
   hideUserMessage: boolean;
   defaultTurnCollapsed: boolean;
   turnCollapseInteractionAtRef: React.MutableRefObject<number>;
@@ -65,9 +63,7 @@ function samePinnedTurnHeaderProps(
     previous.sourceGroupIndex === next.sourceGroupIndex &&
     previous.sourceGroupCount === next.sourceGroupCount &&
     previous.collapseLabelVariant === next.collapseLabelVariant &&
-    previous.collapseTailWhenIdle === next.collapseTailWhenIdle &&
-    previous.tailTurnComplete === next.tailTurnComplete &&
-    previous.tailTurnStale === next.tailTurnStale &&
+    previous.tailTurnPhase === next.tailTurnPhase &&
     previous.hideUserMessage === next.hideUserMessage &&
     previous.defaultTurnCollapsed === next.defaultTurnCollapsed &&
     previous.turnCollapseInteractionAtRef ===
@@ -86,9 +82,7 @@ const PinnedTurnHeaderComponent: React.FC<PinnedTurnHeaderProps> = ({
   header,
   meta,
   collapseLabelVariant = "agent",
-  collapseTailWhenIdle,
-  tailTurnComplete,
-  tailTurnStale,
+  tailTurnPhase,
   hideUserMessage,
   defaultTurnCollapsed,
   turnCollapseInteractionAtRef,
@@ -107,9 +101,7 @@ const PinnedTurnHeaderComponent: React.FC<PinnedTurnHeaderProps> = ({
         groupMeta={meta ? [meta] : []}
         groupCount={1}
         collapseLabelVariant={collapseLabelVariant}
-        collapseTailWhenIdle={collapseTailWhenIdle}
-        tailTurnComplete={tailTurnComplete}
-        tailTurnStale={tailTurnStale}
+        tailTurnPhase={tailTurnPhase}
         hideUserMessage={hideUserMessage}
         defaultTurnCollapsed={defaultTurnCollapsed}
         suppressRoundGap

--- a/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
@@ -22,6 +22,7 @@ import {
   isTurnCollapseEligible,
   isTurnPreviewItem,
   projectChatGroups,
+  resolveTurnDefaultCollapsed,
 } from "../useChatGroupsProjection";
 
 vi.mock("react", () => ({
@@ -243,7 +244,7 @@ describe("useChatGroups collapse — terminal error survival", () => {
     const result = useChatGroups(history);
 
     // The prior turn defaults to the compact summary, while the live tail
-    // remains expanded until it becomes eligible after the idle delay.
+    // remains expanded while its round is still running.
     expect(result.groupCounts).toEqual([1, 2]);
     expect(flatTexts(result.flatItems)).toEqual([
       "first reply",
@@ -537,33 +538,48 @@ describe("isTurnCollapseEligible — unloaded placeholder affordance", () => {
     expect(isTurnCollapseEligible(empty, 0, 3, {})).toBe(false);
   });
 
-  it("shows the tail bar as soon as the round ends, with no idle wait or size threshold", () => {
+  it("shows the tail bar as soon as the round ends, with no wait or size threshold", () => {
     const smallTail = meta({ itemCount: 2 });
-    // Without the completion signal the old gating still applies.
+    // A running tail is never collapsible.
     expect(isTurnCollapseEligible(smallTail, 2, 3, {})).toBe(false);
     expect(
-      isTurnCollapseEligible(smallTail, 2, 3, { collapseTailWhenIdle: true })
+      isTurnCollapseEligible(smallTail, 2, 3, { tailTurnPhase: "running" })
     ).toBe(false);
-    // With it, the completed tail is eligible regardless of size/idle.
+    // A completed tail is eligible regardless of size.
     expect(
-      isTurnCollapseEligible(smallTail, 2, 3, { tailTurnComplete: true })
+      isTurnCollapseEligible(smallTail, 2, 3, { tailTurnPhase: "complete" })
+    ).toBe(true);
+    expect(
+      isTurnCollapseEligible(smallTail, 2, 3, { tailTurnPhase: "stale" })
     ).toBe(true);
   });
 
   it("still hides the bar for a trivial completed tail", () => {
     expect(
       isTurnCollapseEligible(meta({ itemCount: 1 }), 2, 3, {
-        tailTurnComplete: true,
+        tailTurnPhase: "complete",
       })
     ).toBe(false);
   });
 
-  it("treats a stale tail as eligible on its own (stale implies finished)", () => {
+  it("resolves the shared default-collapse decision per phase", () => {
+    // Non-tail turns default to collapsed.
+    expect(resolveTurnDefaultCollapsed(false, {})).toBe(true);
+    // A fresh completed tail stays expanded…
+    expect(resolveTurnDefaultCollapsed(true, { tailTurnPhase: "complete" })).toBe(
+      false
+    );
+    // …until the session goes stale.
+    expect(resolveTurnDefaultCollapsed(true, { tailTurnPhase: "stale" })).toBe(
+      true
+    );
+    // An explicit expanded-by-default surface wins over everything.
     expect(
-      isTurnCollapseEligible(meta({ itemCount: 2 }), 2, 3, {
-        tailTurnStale: true,
+      resolveTurnDefaultCollapsed(true, {
+        defaultTurnCollapsed: false,
+        tailTurnPhase: "stale",
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 
@@ -580,10 +596,10 @@ describe("projectChatGroups — completed tail turn", () => {
   }
 
   it("keeps the completed tail expanded by default", () => {
-    const result = projectChatGroups(history(), { tailTurnComplete: true });
+    const result = projectChatGroups(history(), { tailTurnPhase: "complete" });
 
-    // Bar-eligible, but the tail's default stays expanded: the idle rule
-    // (collapseTailWhenIdle + size threshold) still governs auto-collapse.
+    // Bar-eligible, but the tail's default stays expanded until the session
+    // goes stale.
     expect(result.groupCounts).toEqual([1, 2]);
     expect(flatTexts(result.flatItems)).toEqual([
       "first reply",
@@ -597,7 +613,7 @@ describe("projectChatGroups — completed tail turn", () => {
     const tailTurnId = items[3].event!.id;
 
     const result = projectChatGroups(items, {
-      tailTurnComplete: true,
+      tailTurnPhase: "complete",
       collapseOverrides: new Map([[tailTurnId, true]]),
     });
 
@@ -616,15 +632,12 @@ describe("projectChatGroups — completed tail turn", () => {
       collapseOverrides: new Map([[tailTurnId, true]]),
     });
 
-    // Not complete and not idle-eligible -> not collapse-eligible at all.
+    // A running tail is not collapse-eligible at all.
     expect(result.groupCounts).toEqual([1, 2]);
   });
 
   it("defaults a stale tail to collapsed regardless of size", () => {
-    const result = projectChatGroups(history(), {
-      tailTurnComplete: true,
-      tailTurnStale: true,
-    });
+    const result = projectChatGroups(history(), { tailTurnPhase: "stale" });
 
     expect(result.groupCounts).toEqual([1, 1]);
     expect(flatTexts(result.flatItems)).toEqual([
@@ -638,8 +651,7 @@ describe("projectChatGroups — completed tail turn", () => {
     const tailTurnId = items[3].event!.id;
 
     const result = projectChatGroups(items, {
-      tailTurnComplete: true,
-      tailTurnStale: true,
+      tailTurnPhase: "stale",
       collapseOverrides: new Map([[tailTurnId, false]]),
     });
 
@@ -651,19 +663,4 @@ describe("projectChatGroups — completed tail turn", () => {
     ]);
   });
 
-  it("still auto-collapses the tail under the pre-existing idle rule", () => {
-    const items = [
-      userItem("only turn"),
-      ...Array.from({ length: 10 }, () => toolItem()),
-      assistantItem("final reply"),
-    ];
-
-    const result = projectChatGroups(items, {
-      tailTurnComplete: true,
-      collapseTailWhenIdle: true,
-    });
-
-    expect(result.groupCounts).toEqual([1]);
-    expect(flatTexts(result.flatItems)).toEqual(["final reply"]);
-  });
 });

--- a/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
@@ -566,9 +566,9 @@ describe("isTurnCollapseEligible — unloaded placeholder affordance", () => {
     // Non-tail turns default to collapsed.
     expect(resolveTurnDefaultCollapsed(false, {})).toBe(true);
     // A fresh completed tail stays expanded…
-    expect(resolveTurnDefaultCollapsed(true, { tailTurnPhase: "complete" })).toBe(
-      false
-    );
+    expect(
+      resolveTurnDefaultCollapsed(true, { tailTurnPhase: "complete" })
+    ).toBe(false);
     // …until the session goes stale.
     expect(resolveTurnDefaultCollapsed(true, { tailTurnPhase: "stale" })).toBe(
       true
@@ -662,5 +662,4 @@ describe("projectChatGroups — completed tail turn", () => {
       "current reply",
     ]);
   });
-
 });

--- a/src/engines/ChatPanel/ChatHistory/hooks/index.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/index.ts
@@ -67,10 +67,8 @@ export { useGroupHeaderRenderer } from "./useGroupHeaderRenderer";
 export { useReloadSession } from "./useReloadSession";
 export {
   findTailTurnId,
-  TAIL_TURN_COLLAPSE_IDLE_MS,
   TAIL_TURN_STALE_MS,
-  useTailTurnCollapse,
-  useTailTurnStale,
+  useTailTurnPhase,
 } from "./useTailTurnCollapse";
 export {
   useTurnPageNavigation,

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatGroups.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatGroups.ts
@@ -15,12 +15,13 @@ import {
 
 export {
   getUnloadedTurnMeta,
-  isTailTurnIdleCollapsible,
   isTurnCollapseEligible,
   isTurnPreviewItem,
+  resolveTurnDefaultCollapsed,
 } from "./useChatGroupsProjection";
 export type {
   ChatGroupMeta,
+  TailTurnPhase,
   UnloadedTurnMeta,
   UseChatGroupsOptions,
   UseChatGroupsReturn,
@@ -33,9 +34,7 @@ export function useChatGroups(
   const {
     collapseOverrides,
     isAgentWorking,
-    collapseTailWhenIdle,
-    tailTurnComplete,
-    tailTurnStale,
+    tailTurnPhase,
     forceCollapseAllTurns,
     disableTurnCollapse,
     allTurnsCollapsed,
@@ -49,9 +48,7 @@ export function useChatGroups(
     () => ({
       collapseOverrides,
       isAgentWorking,
-      collapseTailWhenIdle,
-      tailTurnComplete,
-      tailTurnStale,
+      tailTurnPhase,
       forceCollapseAllTurns,
       disableTurnCollapse,
       allTurnsCollapsed,
@@ -63,9 +60,7 @@ export function useChatGroups(
     [
       collapseOverrides,
       isAgentWorking,
-      collapseTailWhenIdle,
-      tailTurnComplete,
-      tailTurnStale,
+      tailTurnPhase,
       forceCollapseAllTurns,
       disableTurnCollapse,
       allTurnsCollapsed,

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatGroupsProjection.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatGroupsProjection.ts
@@ -45,22 +45,21 @@ export type TurnGroupingPolicy =
   | { mode: "standard" }
   | { mode: "agent-org"; coordinatorSessionId: string };
 
+/**
+ * Lifecycle phase of the tail (latest) turn, produced by `useTailTurnPhase`:
+ * `"running"` while the round is in flight (no collapse bar, no folding);
+ * `"complete"` once it ends (bar renders immediately, turn stays expanded by
+ * default); `"stale"` once the session's newest event is older than the
+ * stale window (the turn also DEFAULTS to collapsed like a historical one).
+ * Stale implies complete, so the illegal combination cannot exist.
+ */
+export type TailTurnPhase = "running" | "complete" | "stale";
+
 export interface ChatGroupsProjectionOptions {
   collapseOverrides?: ReadonlyMap<string, boolean>;
   isAgentWorking?: boolean;
-  collapseTailWhenIdle?: boolean;
-  /**
-   * The tail round has ended (agent no longer working). Shows the tail's
-   * collapse bar immediately — wall-clock start→end, no idle wait, no
-   * item-count threshold — without changing its default collapse state.
-   */
-  tailTurnComplete?: boolean;
-  /**
-   * The session's last event is older than the stale window (most likely
-   * finished): the tail turn DEFAULTS to collapsed like a historical turn,
-   * with no size threshold. Explicit overrides still win.
-   */
-  tailTurnStale?: boolean;
+  /** Defaults to `"running"` (tail not collapsible) when omitted. */
+  tailTurnPhase?: TailTurnPhase;
   forceCollapseAllTurns?: boolean;
   disableTurnCollapse?: boolean;
   allTurnsCollapsed?: boolean;
@@ -195,31 +194,12 @@ function parseEpochMs(iso: string | undefined): number | null {
   return Number.isFinite(ms) ? ms : null;
 }
 
-const TURN_COLLAPSE_ITEM_COUNT_THRESHOLD = 10;
-
-/**
- * Idle rule for AUTO-collapsing the tail turn: only after the session idles,
- * and only for turns large enough that folding them reads as a relief. The
- * bar's visibility no longer waits for this (`isTurnCollapseEligible` accepts
- * `tailTurnComplete`); the tail's DEFAULT collapse state still does.
- */
-export function isTailTurnIdleCollapsible(
-  meta: ChatGroupMeta,
-  collapseTailWhenIdle: boolean
-): boolean {
-  if (!collapseTailWhenIdle) return false;
-  if (meta.unloadedTurn) return true;
-  return meta.itemCount + 1 > TURN_COLLAPSE_ITEM_COUNT_THRESHOLD;
-}
-
 export function isTurnCollapseEligible(
   meta: ChatGroupMeta | undefined,
   groupIndex: number,
   groupCount: number,
   options: {
-    collapseTailWhenIdle?: boolean;
-    tailTurnComplete?: boolean;
-    tailTurnStale?: boolean;
+    tailTurnPhase?: TailTurnPhase;
     forceCollapseAllTurns?: boolean;
   } = {}
 ): boolean {
@@ -233,13 +213,31 @@ export function isTurnCollapseEligible(
   if (meta.unloadedTurn ? bodyItemCount < 1 : bodyItemCount <= 1) return false;
   if (options.forceCollapseAllTurns === true) return true;
   if (groupIndex < groupCount - 1) return true;
-  // A completed (or stale — stale implies finished) tail round shows its bar
-  // right away; whether it defaults to collapsed is decided separately in
-  // projectChatGroups.
-  if (options.tailTurnComplete === true || options.tailTurnStale === true) {
-    return true;
-  }
-  return isTailTurnIdleCollapsible(meta, options.collapseTailWhenIdle === true);
+  // The tail round shows its bar as soon as it ends; whether it defaults to
+  // collapsed is decided separately (resolveTurnDefaultCollapsed).
+  return (options.tailTurnPhase ?? "running") !== "running";
+}
+
+/**
+ * Default collapse state for one turn group. Shared by `projectChatGroups`
+ * and the pin bar's chevron mirror in `GroupHeaderRenderer` so the two can
+ * never drift: a completed tail turn is collapse-ELIGIBLE (bar renders,
+ * manual toggles and collapse-all work) before it is collapse-DEFAULTED —
+ * it only folds on its own once the session goes stale, so finishing a
+ * round never hides its content abruptly.
+ */
+export function resolveTurnDefaultCollapsed(
+  isTailGroup: boolean,
+  options: {
+    defaultTurnCollapsed?: boolean;
+    tailTurnPhase?: TailTurnPhase;
+    forceCollapseAllTurns?: boolean;
+  } = {}
+): boolean {
+  if (options.defaultTurnCollapsed === false) return false;
+  if (!isTailGroup) return true;
+  if (options.forceCollapseAllTurns === true) return true;
+  return options.tailTurnPhase === "stale";
 }
 
 /** Pure grouping/collapse projection. It has no React, Jotai, or DOM dependency. */
@@ -250,9 +248,7 @@ export function projectChatGroups(
   const {
     collapseOverrides,
     isAgentWorking = false,
-    collapseTailWhenIdle = false,
-    tailTurnComplete = false,
-    tailTurnStale = false,
+    tailTurnPhase = "running",
     forceCollapseAllTurns = false,
     disableTurnCollapse = false,
     allTurnsCollapsed,
@@ -324,29 +320,22 @@ export function projectChatGroups(
     const eligible =
       !disableTurnCollapse &&
       isTurnCollapseEligible(meta, groupIndex, groups.length, {
-        collapseTailWhenIdle,
-        tailTurnComplete,
-        tailTurnStale,
+        tailTurnPhase,
         forceCollapseAllTurns,
       });
     const override =
       meta.turnId && collapseOverrides
         ? collapseOverrides.get(meta.turnId)
         : undefined;
-    // A completed tail turn is collapse-ELIGIBLE (bar renders, manual toggles
-    // and collapse-all work) before it is collapse-DEFAULTED: it only folds on
-    // its own under the idle rule, or once the whole session goes stale
-    // (last event older than TAIL_TURN_STALE_MS — most likely finished), so
-    // finishing a round never hides its content abruptly.
-    const isTailGroup = groupIndex === groups.length - 1;
-    const groupDefaultCollapsed =
-      defaultTurnCollapsed &&
-      (!isTailGroup ||
-        forceCollapseAllTurns ||
-        tailTurnStale ||
-        isTailTurnIdleCollapsible(meta, collapseTailWhenIdle));
     const isCollapsed =
-      eligible && (override ?? allTurnsCollapsed ?? groupDefaultCollapsed);
+      eligible &&
+      (override ??
+        allTurnsCollapsed ??
+        resolveTurnDefaultCollapsed(groupIndex === groups.length - 1, {
+          defaultTurnCollapsed,
+          tailTurnPhase,
+          forceCollapseAllTurns,
+        }));
 
     if (!isCollapsed) {
       const keepStructuralPlaceholder = meta.unloadedTurn !== null;

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatHistoryProjectionModel.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatHistoryProjectionModel.ts
@@ -22,11 +22,7 @@ import { useChatProjection } from "../projection/useChatProjection";
 import { formatAssistantTurnCopyContent } from "../turnCopyContent";
 import type { ChatGroupsProjectionOptions } from "./useChatGroupsProjection";
 import { useChatTurnPagination } from "./useChatTurnPagination";
-import {
-  resolveTailTurnAgentWorking,
-  useTailTurnCollapse,
-  useTailTurnStale,
-} from "./useTailTurnCollapse";
+import { useTailTurnPhase } from "./useTailTurnCollapse";
 import {
   useTurnPageNavigation,
   useTurnPageSelectionState,
@@ -46,7 +42,6 @@ interface UseChatHistoryProjectionModelOptions {
   groupChat: GroupChatContextValue | null;
   hideGroupUserMessage: boolean;
   isAgentWorking: boolean;
-  isCursorIde: boolean;
   planningIndicatorCount: 0 | 1;
   sessionStatus: string | undefined;
   sessionLoadStatus: SessionLoadStatus;
@@ -69,7 +64,6 @@ export function useChatHistoryProjectionModel({
   groupChat,
   hideGroupUserMessage,
   isAgentWorking,
-  isCursorIde,
   planningIndicatorCount,
   sessionStatus,
   sessionLoadStatus,
@@ -87,32 +81,16 @@ export function useChatHistoryProjectionModel({
   const turnCollapseOverrides = useAtomValue(turnCollapseOverrideAtom);
   const collapseAllCommand = useAtomValue(collapseAllCommandAtom);
   const selectedThreadId = useAtomValue(selectedExecutionThreadAtom);
-  const collapseTailWhenIdle = useTailTurnCollapse({
+  // Drives bar visibility ("complete") and the stale default-collapse;
+  // see useTailTurnPhase for the rules and the anti-flicker latch.
+  const tailTurnPhase = useTailTurnPhase({
     activeId,
     chatHistory,
     disableTailCollapse,
     groupChat,
     isAgentWorking,
-    isCursorIde,
     sessionStatus,
   });
-  // The "Agent worked for X" bar shows on the tail turn as soon as its round
-  // ends — no idle wait, no size threshold. Auto-collapse still waits for
-  // `collapseTailWhenIdle`. Surfaces that opt out of tail collapse entirely
-  // (subagent cells) keep their unchanged layout.
-  const tailTurnComplete =
-    !disableTailCollapse &&
-    !resolveTailTurnAgentWorking({ activeId, isAgentWorking, sessionStatus });
-  // Once the last session event is older than TAIL_TURN_STALE_MS the session
-  // most likely finished, so the tail turn DEFAULTS to collapsed like any
-  // historical turn. Gated on tailTurnComplete so a hung-but-working agent
-  // never folds its own in-flight round.
-  const tailTurnStaleByClock = useTailTurnStale({
-    activeId,
-    chatHistory,
-    disableTailCollapse,
-  });
-  const tailTurnStale = tailTurnComplete && tailTurnStaleByClock;
 
   const projectionSource = resolveChatHistoryProjectionSource({
     activeSessionId: activeId,
@@ -125,9 +103,7 @@ export function useChatHistoryProjectionModel({
     () => ({
       collapseOverrides: turnCollapseOverrides,
       isAgentWorking,
-      collapseTailWhenIdle,
-      tailTurnComplete,
-      tailTurnStale,
+      tailTurnPhase,
       forceCollapseAllTurns,
       defaultTurnCollapsed: DEFAULT_TURN_COLLAPSED,
       allTurnsCollapsed:
@@ -143,9 +119,7 @@ export function useChatHistoryProjectionModel({
     }),
     [
       collapseAllCommand,
-      collapseTailWhenIdle,
-      tailTurnComplete,
-      tailTurnStale,
+      tailTurnPhase,
       forceCollapseAllTurns,
       groupChat,
       isAgentWorking,
@@ -325,9 +299,7 @@ export function useChatHistoryProjectionModel({
 
   return {
     activeProjectionHistory,
-    collapseTailWhenIdle,
-    tailTurnComplete,
-    tailTurnStale,
+    tailTurnPhase,
     defaultTurnCollapsed: DEFAULT_TURN_COLLAPSED,
     displayTurnIds,
     flatItems,

--- a/src/engines/ChatPanel/ChatHistory/hooks/useGroupHeaderRenderer.tsx
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useGroupHeaderRenderer.tsx
@@ -23,9 +23,7 @@ interface UseGroupHeaderRendererOptions {
   displayGroupCount: number;
   collapseLabelVariant?: GroupHeaderRendererProps["collapseLabelVariant"];
   turnPaginationEnabled: boolean;
-  collapseTailWhenIdle: boolean;
-  tailTurnComplete: boolean;
-  tailTurnStale: boolean;
+  tailTurnPhase: GroupHeaderRendererProps["tailTurnPhase"];
   hideUserMessage: boolean;
   defaultTurnCollapsed: boolean;
   turnCollapseInteractionAtRef: React.MutableRefObject<number>;
@@ -41,9 +39,7 @@ export function useGroupHeaderRenderer({
   displayGroupCount,
   collapseLabelVariant,
   turnPaginationEnabled,
-  collapseTailWhenIdle,
-  tailTurnComplete,
-  tailTurnStale,
+  tailTurnPhase,
   hideUserMessage,
   defaultTurnCollapsed,
   turnCollapseInteractionAtRef,
@@ -71,9 +67,7 @@ export function useGroupHeaderRenderer({
           groupCount={displayGroupCount}
           collapseLabelVariant={collapseLabelVariant}
           hideCollapseTimeRange={turnPaginationEnabled}
-          collapseTailWhenIdle={collapseTailWhenIdle}
-          tailTurnComplete={tailTurnComplete}
-          tailTurnStale={tailTurnStale}
+          tailTurnPhase={tailTurnPhase}
           hideUserMessage={hideUserMessage}
           defaultTurnCollapsed={defaultTurnCollapsed}
           renderPart={renderPart}
@@ -91,9 +85,7 @@ export function useGroupHeaderRenderer({
       displayGroupCount,
       collapseLabelVariant,
       turnPaginationEnabled,
-      collapseTailWhenIdle,
-      tailTurnComplete,
-      tailTurnStale,
+      tailTurnPhase,
       hideUserMessage,
       defaultTurnCollapsed,
       turnCollapseInteractionAtRef,

--- a/src/engines/ChatPanel/ChatHistory/hooks/useTailTurnCollapse.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useTailTurnCollapse.ts
@@ -142,7 +142,19 @@ export function useTailTurnPhase({
   const completeNow = turnKey !== null && !agentWorking;
 
   useEffect(() => {
-    if (completeNow) setCompleteLatchKey(turnKey);
+    if (!completeNow || turnKey === null) return;
+
+    // Routed through a zero-delay timer for the same reason the stale effect
+    // below is: a synchronous set from an effect body is a cascading render
+    // (react-hooks/set-state-in-effect). The latch lands one macrotask after
+    // the "complete" render commits; a complete→running flip inside that
+    // same macrotask loses the latch, but a bar that never survived a single
+    // frame has nothing visible to preserve.
+    const timeoutId = window.setTimeout(() => {
+      setCompleteLatchKey(turnKey);
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
   }, [completeNow, turnKey]);
 
   useEffect(() => {

--- a/src/engines/ChatPanel/ChatHistory/hooks/useTailTurnCollapse.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useTailTurnCollapse.ts
@@ -6,13 +6,12 @@ import { isSessionInProgress } from "@src/util/session/sessionInProgress";
 
 import type { GroupChatContextValue } from "../GroupChatView/GroupChatContext";
 import { isAgentOrgInboxTranscriptEvent } from "../GroupChatView/groupChatUtils";
-
-export const TAIL_TURN_COLLAPSE_IDLE_MS = 60_000;
+import type { TailTurnPhase } from "./useChatGroupsProjection";
 
 /**
  * A session whose last event is older than this is treated as finished: its
- * tail turn DEFAULTS to collapsed (no size threshold), matching historical
- * turns. Explicit per-turn overrides still win.
+ * tail turn DEFAULTS to collapsed, matching historical turns. Explicit
+ * per-turn overrides still win.
  */
 export const TAIL_TURN_STALE_MS = 10 * 60_000;
 
@@ -32,16 +31,6 @@ export function findTailTurnId(
     }
   }
   return null;
-}
-
-interface UseTailTurnCollapseOptions {
-  activeId: string | null;
-  chatHistory: SessionEvent[];
-  disableTailCollapse: boolean;
-  groupChat: GroupChatContextValue | null;
-  isAgentWorking: boolean;
-  isCursorIde: boolean;
-  sessionStatus: string | undefined;
 }
 
 interface ResolveTailTurnAgentWorkingOptions {
@@ -65,53 +54,6 @@ export function resolveTailTurnAgentWorking({
   return isSessionInProgress(sessionStatus);
 }
 
-export function useTailTurnCollapse({
-  activeId,
-  chatHistory,
-  disableTailCollapse,
-  groupChat,
-  isAgentWorking,
-  isCursorIde,
-  sessionStatus,
-}: UseTailTurnCollapseOptions): boolean {
-  const [tailIdleReadyKey, setTailIdleReadyKey] = useState<string | null>(null);
-  const tailTurnId = useMemo(
-    () => findTailTurnId(chatHistory, groupChat),
-    [chatHistory, groupChat]
-  );
-  const tailTurnAgentWorking = resolveTailTurnAgentWorking({
-    activeId,
-    isAgentWorking,
-    sessionStatus,
-  });
-  const tailIdleKey =
-    !tailTurnAgentWorking && !isCursorIde && activeId && tailTurnId
-      ? `${activeId}:${tailTurnId}`
-      : null;
-
-  useEffect(() => {
-    if (!tailIdleKey) return;
-
-    const timeoutId = window.setTimeout(() => {
-      setTailIdleReadyKey(tailIdleKey);
-    }, TAIL_TURN_COLLAPSE_IDLE_MS);
-
-    return () => window.clearTimeout(timeoutId);
-  }, [tailIdleKey]);
-
-  return (
-    !disableTailCollapse &&
-    tailIdleKey !== null &&
-    tailIdleReadyKey === tailIdleKey
-  );
-}
-
-interface UseTailTurnStaleOptions {
-  activeId: string | null;
-  chatHistory: SessionEvent[];
-  disableTailCollapse: boolean;
-}
-
 /**
  * How long until the tail turn goes stale, floored at zero.
  *
@@ -127,18 +69,53 @@ export function resolveTailTurnStaleDelayMs(
   return Math.max(lastEventMs + TAIL_TURN_STALE_MS - nowMs, 0);
 }
 
+interface UseTailTurnPhaseOptions {
+  activeId: string | null;
+  chatHistory: SessionEvent[];
+  disableTailCollapse: boolean;
+  groupChat: GroupChatContextValue | null;
+  isAgentWorking: boolean;
+  sessionStatus: string | undefined;
+}
+
 /**
- * True once the session's newest event is older than `TAIL_TURN_STALE_MS`.
- * Live sessions arm a timer for the remaining window, and any new event
- * re-arms it; already-stale sessions arm a zero-delay one. Wall-clock based
- * on the event's own timestamp, no exclusions.
+ * The tail turn's lifecycle phase, driving exactly two collapse rules:
+ *
+ * - `"complete"` — the round ended: the "Agent worked for X" bar may render
+ *   (no wait, no size threshold) while the turn stays expanded by default.
+ *   LATCHED per `${activeId}:${tailTurnId}`: a raw `!agentWorking` read
+ *   flickers, because every dispatch writes an optimistic `running` status
+ *   BEFORE the user-message event lands (`optimisticTurnStatus.ts` ordering
+ *   invariant), so the finished round is briefly still the tail group when
+ *   the signal flips false and its bar would unmount until the projection
+ *   regroups. Watched external CLI sessions have the same
+ *   status-before-transcript gap; session-switch status resets and
+ *   background-subagent signal edges add more. Once a tail turn is observed
+ *   complete it stays complete until the tail moves to a new turn, which
+ *   always starts unlatched.
+ * - `"stale"` — the newest event is older than `TAIL_TURN_STALE_MS`: the
+ *   session most likely finished, so the tail also DEFAULTS to collapsed
+ *   like a historical turn. Requires completion first, so a hung-but-working
+ *   agent never folds its own in-flight round; any new event re-arms the
+ *   clock.
+ *
+ * Always `"running"` under `disableTailCollapse` (subagent cells).
  */
-export function useTailTurnStale({
+export function useTailTurnPhase({
   activeId,
   chatHistory,
   disableTailCollapse,
-}: UseTailTurnStaleOptions): boolean {
+  groupChat,
+  isAgentWorking,
+  sessionStatus,
+}: UseTailTurnPhaseOptions): TailTurnPhase {
+  const [completeLatchKey, setCompleteLatchKey] = useState<string | null>(null);
   const [staleReadyKey, setStaleReadyKey] = useState<string | null>(null);
+
+  const tailTurnId = useMemo(
+    () => findTailTurnId(chatHistory, groupChat),
+    [chatHistory, groupChat]
+  );
   const lastEventMs = useMemo(() => {
     for (let index = chatHistory.length - 1; index >= 0; index--) {
       const iso = chatHistory[index]?.createdAt;
@@ -148,10 +125,25 @@ export function useTailTurnStale({
     }
     return null;
   }, [chatHistory]);
+  const agentWorking = resolveTailTurnAgentWorking({
+    activeId,
+    isAgentWorking,
+    sessionStatus,
+  });
+
+  const turnKey =
+    !disableTailCollapse && activeId && tailTurnId
+      ? `${activeId}:${tailTurnId}`
+      : null;
   const staleKey =
     !disableTailCollapse && activeId && lastEventMs !== null
       ? `${activeId}:${lastEventMs}`
       : null;
+  const completeNow = turnKey !== null && !agentWorking;
+
+  useEffect(() => {
+    if (completeNow) setCompleteLatchKey(turnKey);
+  }, [completeNow, turnKey]);
 
   useEffect(() => {
     if (!staleKey || lastEventMs === null) return;
@@ -166,5 +158,8 @@ export function useTailTurnStale({
     return () => window.clearTimeout(timeoutId);
   }, [staleKey, lastEventMs]);
 
-  return staleKey !== null && staleReadyKey === staleKey;
+  const complete =
+    completeNow || (turnKey !== null && completeLatchKey === turnKey);
+  if (!complete) return "running";
+  return staleKey !== null && staleReadyKey === staleKey ? "stale" : "complete";
 }

--- a/src/engines/ChatPanel/ChatHistory/index.tsx
+++ b/src/engines/ChatPanel/ChatHistory/index.tsx
@@ -161,7 +161,6 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
     groupChat,
     hideGroupUserMessage,
     isAgentWorking,
-    isCursorIde,
     planningIndicatorCount,
     sessionStatus: activeSession?.status,
     sessionLoadStatus: historyState.sessionLoadStatus,

--- a/src/engines/ChatPanel/ChatHistory/renderers/GroupHeaderRenderer.tsx
+++ b/src/engines/ChatPanel/ChatHistory/renderers/GroupHeaderRenderer.tsx
@@ -16,8 +16,9 @@ import type { OptimizedChatItem } from "../chatItemPipeline/types";
 import { CHAT_FOOTER_SPACER } from "../config/chatFooterSpacer";
 import {
   type ChatGroupMeta,
-  isTailTurnIdleCollapsible,
+  type TailTurnPhase,
   isTurnCollapseEligible,
+  resolveTurnDefaultCollapsed,
 } from "../hooks/useChatGroups";
 
 const log = createLogger("GroupHeaderRenderer");
@@ -83,9 +84,7 @@ function sameGroupHeaderProps(
     previous.collapseLabelVariant === next.collapseLabelVariant &&
     previous.hideCollapseTimeRange === next.hideCollapseTimeRange &&
     previous.suppressRoundGap === next.suppressRoundGap &&
-    previous.collapseTailWhenIdle === next.collapseTailWhenIdle &&
-    previous.tailTurnComplete === next.tailTurnComplete &&
-    previous.tailTurnStale === next.tailTurnStale &&
+    previous.tailTurnPhase === next.tailTurnPhase &&
     previous.hideUserMessage === next.hideUserMessage &&
     previous.defaultTurnCollapsed === next.defaultTurnCollapsed &&
     previous.renderPart === next.renderPart &&
@@ -113,19 +112,12 @@ export interface GroupHeaderRendererProps {
   hideCollapseTimeRange?: boolean;
   /** Suppresses the inter-round top gap for headers rendered outside the list. */
   suppressRoundGap?: boolean;
-  /** Allows the latest turn to AUTO-collapse after the session idles. */
-  collapseTailWhenIdle?: boolean;
   /**
-   * The tail round has ended — its "Agent worked for X" bar renders
-   * immediately (no idle wait, no size threshold) while its default collapse
-   * state still follows the idle rule.
+   * Lifecycle phase of the tail turn: "complete" renders its "Agent worked
+   * for X" bar immediately (still expanded by default); "stale" also
+   * defaults it to collapsed like a historical turn.
    */
-  tailTurnComplete?: boolean;
-  /**
-   * The session's last event is older than the stale window — the tail turn
-   * defaults to collapsed like a historical turn.
-   */
-  tailTurnStale?: boolean;
+  tailTurnPhase?: TailTurnPhase;
   /**
    * Skip rendering the per-turn user-message card. The `TurnCollapsePinBar`
    * ("Agent worked for X") still renders. Subagent cells use this so each
@@ -163,9 +155,7 @@ export const GroupHeaderRenderer: React.FC<GroupHeaderRendererProps> = memo(
     collapseLabelVariant = "agent",
     hideCollapseTimeRange = false,
     suppressRoundGap = false,
-    collapseTailWhenIdle = false,
-    tailTurnComplete = false,
-    tailTurnStale = false,
+    tailTurnPhase = "running",
     hideUserMessage = false,
     defaultTurnCollapsed = false,
     renderPart = "all",
@@ -230,26 +220,19 @@ export const GroupHeaderRenderer: React.FC<GroupHeaderRendererProps> = memo(
     if (!header) return <div />;
 
     // Show the "Agent worked for …" pin bar on collapse-eligible turns.
-    // The latest turn joins as soon as its round ends (`tailTurnComplete`).
+    // The latest turn joins as soon as its round ends (phase "complete").
     const showCollapseBar = isTurnCollapseEligible(
       meta,
       collapseGroupIndex,
       collapseGroupCount,
-      {
-        collapseTailWhenIdle,
-        tailTurnComplete,
-        tailTurnStale,
-      }
+      { tailTurnPhase }
     );
-    // Mirror projectChatGroups: a completed tail turn renders its bar
-    // immediately but stays expanded until the idle rule folds it or the
-    // session goes stale.
-    const isTailGroup = collapseGroupIndex === collapseGroupCount - 1;
-    const turnDefaultCollapsed =
-      defaultTurnCollapsed &&
-      (!isTailGroup ||
-        tailTurnStale ||
-        (meta ? isTailTurnIdleCollapsible(meta, collapseTailWhenIdle) : false));
+    // Same helper as projectChatGroups, so the chevron's default always
+    // matches what the projection actually folded.
+    const turnDefaultCollapsed = resolveTurnDefaultCollapsed(
+      collapseGroupIndex === collapseGroupCount - 1,
+      { defaultTurnCollapsed, tailTurnPhase }
+    );
 
     const showUserPart = renderPart !== "collapse" && !hideUserMessage;
     const showCollapsePart = renderPart !== "user" && showCollapseBar && turnId;

--- a/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx
+++ b/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx
@@ -20,11 +20,11 @@
  * Completed turns are collapsed by default; the override atom only
  * records explicit user toggles. The currently active (tail) turn is
  * never collapsed while the agent is still streaming; once its round ends
- * the bar renders immediately (wall-clock start→end duration, no idle wait
- * or size threshold) but the turn stays expanded until the idle rule —
- * see `isTailTurnIdleCollapsible` — folds it, or the session goes stale
- * (last event older than `TAIL_TURN_STALE_MS`, most likely finished), which
- * defaults it to collapsed like a historical turn.
+ * (tail phase "complete") the bar renders immediately — wall-clock
+ * start→end duration, no wait, no size threshold — with the turn still
+ * expanded, and once the session goes stale (phase "stale": last event
+ * older than `TAIL_TURN_STALE_MS`, most likely finished) the turn defaults
+ * to collapsed like a historical one.
  *
  * Hover reveals a navigate icon that jumps to this turn in WorkStation replay.
  * Hidden inside the Simulator Messages replay surface (no-op jump).


### PR DESCRIPTION
## Problem

Follow-up to #1100. The "Agent worked for X" bar on the latest round would show and then disappear. Root cause: bar visibility keyed off the **live** agent-working signal, and that signal deliberately flips before the transcript catches up — every dispatch writes an optimistic `running` status BEFORE the user-message event lands (`optimisticTurnStatus.ts` documents this ordering as an invariant), so the finished round is still the tail group at that instant, loses eligibility, and its bar unmounts until the projection regroups. Watched external CLI sessions hit a larger version of the same gap (lifecycle-hook status flips to running before the transcript ingests the new user event); session-switch status resets and background-subagent signal edges add more.

Separately, #1100 left the tail-collapse logic with three tiers (bar at completion, 60s-idle auto-fold for >10-item turns, 10-minute stale fold), three sibling hooks computing overlapping inputs, two booleans where one implied the other, and a hand-mirrored default-collapse computation in `GroupHeaderRenderer` that had to be kept in sync with `projectChatGroups` by comment.

## Solution

- **Latch the completion signal per tail turn.** Once a tail turn (keyed `${activeId}:${tailTurnId}`) is observed complete it stays complete until the tail moves to a new turn, which always starts unlatched. Transient flips of the working signal can no longer unmount a shown bar.
- **Collapse the flow to one value and two rules.** A single `tailTurnPhase: "running" | "complete" | "stale"` (stale implies complete — the illegal combination is unrepresentable) replaces `collapseTailWhenIdle` + `tailTurnComplete` + `tailTurnStale` everywhere: bar renders at `"complete"`, turn defaults to collapsed at `"stale"` (last event older than `TAIL_TURN_STALE_MS` = 10 min). The 60-second idle auto-fold tier is removed along with its 10-item threshold, `TAIL_TURN_COLLAPSE_IDLE_MS`, `isTailTurnIdleCollapsible`, and the cursor-IDE carve-out that existed only to serve it.
- **One hook, one shared default.** The three per-signal hooks merge into `useTailTurnPhase` (tail turn id and working state computed once, stale gated on completion internally); `resolveTurnDefaultCollapsed` is now the single owner of the default-collapse decision, used by both the projection and the pin bar's chevron so they cannot drift. `isCursorIde` leaves the projection model's inputs.

Net −100 lines. Invariant: for the tail turn, *eligibility* = phase ≠ running; *default state* = expanded unless phase = stale. Explicit per-turn overrides and collapse-all still win over defaults; historical (non-tail) turns are untouched.

## Potential risks

- **Behavior change:** large turns no longer auto-fold after 60s of idling — the tail now folds only at the 10-minute stale mark (or by hand). Anyone used to the idle fold will see turns stay open longer.
- **Behavior change:** cursor-IDE sessions lose their tail-collapse exemption; their tail now shows the bar on completion and folds at stale like every other session. Their working state is coarse, so `"complete"` may occasionally arrive late rather than flicker (the latch absorbs the flip).
- The projection options field is renamed (`tailTurnComplete`/`tailTurnStale`/`collapseTailWhenIdle` → `tailTurnPhase`) and the hooks barrel drops `useTailTurnCollapse`/`TAIL_TURN_COLLAPSE_IDLE_MS`. All consumers are in-repo and updated; out-of-tree callers of these internals (none known) would break at typecheck.
- A genuinely hung agent (working, no events for 10+ minutes) still never folds its own round — stale requires completion first — but its bar also won't show until the working signal clears.
- No screenshots/recordings: Tauri-only desktop app, timing-based behavior; verified with unit tests at the projection boundary instead.
- The commit was built via a temporary index from a shared checkout carrying unrelated in-flight work (kept out of this diff), so pre-commit hooks did not run and the "Pre-commit hook ran." trailer is absent. All checks below ran against this exact tree in a clean worktree.

## Verification

Run in a clean `git worktree` of this branch's exact tree (base = current origin/develop, post-#1100/#1107):

- `npx tsc --noEmit --pretty false` — exit 0.
- `npx vitest run` over the affected suites — all pass: `useChatGroups.test.ts` (27 — reworked for the phase enum: completed-tail eligibility with no wait or size gate, stale default regardless of size, expand override beating the stale default, overrides ignored while running, per-phase default decision), `useChatTurnPagination.test.ts` (7), `useCellReplayState.test.ts` (10), `TurnCollapsePinBar.test.ts` (1), `ConversationMinimap.test.ts`.
- Not run: full vitest suite (CI covers it), cargo tests (no Rust changes), E2E, manual visual pass of the flicker scenario in the running app.
- Second commit (lint): CI's Frontend job flagged `react-hooks/set-state-in-effect` on the latch effect plus two prettier fixups in the test file. The latch now arms through a zero-delay timer (the same idiom the stale effect uses; a complete→running flip inside that single macrotask has nothing visible to preserve). Re-verified against that exact tree in a clean worktree: `tsc --noEmit` exit 0, CI-equivalent `eslint --max-warnings 0` exit 0, affected suites 45/45.
