### PR TITLE
fix(sidebar): align workspace header controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,10 +180,14 @@ order:
 
 #### Draft, ready, and review lifecycle
 
-- Keep the PR in Draft while material design choices, known blockers, required
-  migrations, or risk-proportionate verification remain incomplete.
-- Mark the PR ready only when its acceptance criteria are met and the
-  description reflects the current implementation.
+- Open pull requests ready for review by default. Incomplete verification,
+  unverified paths, and missing visual evidence are not reasons to use Draft;
+  disclose them in `Potential risks` and `Verification`.
+- Use Draft only when the author asks for it, or when material design choices,
+  a known blocker, or an incomplete migration mean the change must not be
+  reviewed yet.
+- Mark a Draft ready once those resolve and the description reflects the
+  implementation.
 - If scope, behavior, or the chosen solution changes materially after review
   begins, update the description and notify reviewers instead of silently
   changing direction.

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuSectionBuilders.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuSectionBuilders.ts
@@ -4,7 +4,7 @@ import {
   type SessionGroupKey,
   getSessionGroupKey,
 } from "@src/config/sessionAgentGroups";
-import { Add01Icon, MoreHorizontalIcon } from "@src/icons";
+import { MessageAdd02Icon, MoreHorizontalIcon } from "@src/icons";
 import type {
   NavigationMenuItem,
   NavigationMenuRowAction,
@@ -178,9 +178,9 @@ interface BuildByWorkspaceMenuItemsParams {
 }
 
 /**
- * Hover actions on one workspace separator, `…` first then `+`.
+ * Hover actions on one workspace separator, more actions first then new session.
  *
- * `+` is omitted for the "No Workspace" bucket: it is not a directory, so
+ * New session is omitted for the "No Workspace" bucket: it is not a directory, so
  * there is nothing to source a new session at — but it can still be pinned or
  * hidden like any other group.
  */
@@ -199,7 +199,7 @@ function workspaceHeaderActions(
   ];
   if (key !== NO_WORKSPACE_KEY) {
     rowActions.push({
-      icon: Add01Icon,
+      icon: MessageAdd02Icon,
       label: actions.createSessionLabel,
       dataTestId: `sidebar-workspace-new-session-${key}`,
       onClick: () => actions.onCreateSession(key),

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -564,7 +564,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
                         role="button"
                         tabIndex={0}
                         aria-expanded={!isSectionCollapsed}
-                        className={`${isSectionCollapsed ? "" : "mb-px"} group/section-title flex h-7 cursor-pointer items-center gap-2 pl-2`}
+                        className={`${isSectionCollapsed ? "" : "mb-px"} group/section-title flex h-7 cursor-pointer items-center gap-1 pl-2`}
                         onClick={() => {
                           if (!hasSearchInput) toggleSection(section.id);
                         }}
@@ -579,22 +579,24 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
                           if (!hasSearchInput) toggleSection(section.id);
                         }}
                       >
-                        {section.titleIcon}
-                        <span className="min-w-0 truncate text-[11px] font-medium uppercase tracking-wider text-text-2">
-                          {section.title}
-                        </span>
-                        <span className="hidden flex-shrink-0 items-center leading-none text-text-2 group-hover/section-title:inline-flex">
-                          <NavigationMenuRowActionButton
-                            icon={
-                              isSectionCollapsed
-                                ? ArrowRight01Icon
-                                : ArrowDown01Icon
-                            }
-                            label={section.title ?? section.id}
-                            onClick={() => {
-                              if (!hasSearchInput) toggleSection(section.id);
-                            }}
-                          />
+                        <span className="flex min-w-0 items-center gap-2">
+                          {section.titleIcon}
+                          <span className="min-w-0 truncate text-[11px] font-medium uppercase tracking-wider text-text-2">
+                            {section.title}
+                          </span>
+                          <span className="hidden flex-shrink-0 items-center leading-none text-text-2 group-hover/section-title:inline-flex">
+                            <NavigationMenuRowActionButton
+                              icon={
+                                isSectionCollapsed
+                                  ? ArrowRight01Icon
+                                  : ArrowDown01Icon
+                              }
+                              label={section.title ?? section.id}
+                              onClick={() => {
+                                if (!hasSearchInput) toggleSection(section.id);
+                              }}
+                            />
+                          </span>
                         </span>
                         {section.headerActions && (
                           <span


### PR DESCRIPTION
## Problem

Workspace section headers used an 8px gap between the collapse control and overflow menu, while the overflow and create-session controls used 4px. This made the controls unevenly spaced when long titles were truncated. The create action also used a generic plus instead of the sidebar's New Session icon.

## Solution

- Use the existing 4px control gap on both sides of the overflow button, while preserving the title-to-chevron spacing and short-title trailing-action alignment.
- Reuse `MessageAdd02Icon` from the New Session entry for the workspace header's create-session action. Click handlers, hover visibility, and button sizes are unchanged.
- Synchronize the stale Draft/ready summary in `AGENTS.md` with `PR_RULES.md`, as the repository instructions require when the adapter conflicts with the source of truth.

## Potential risks

- The nested title layout could affect truncation at very narrow sidebar widths. A rendered desktop check and new screenshots were not captured because computer control is not authorized.
- Equal button gaps do not imply equal visible glyph spacing: the chevron is narrower than the other icons. This PR does not apply an optical icon offset, and short titles retain the existing auto spacing before the trailing actions.
- No dependencies, schemas, persistence, public APIs, background work, or session-creation behavior change. Rollback is a normal revert.

## Verification

- `pnpm exec eslint src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuSectionBuilders.ts --max-warnings 0` — passed.
- `pnpm exec prettier --check AGENTS.md src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuSectionBuilders.ts` — passed.
- `pnpm exec vitest run src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts src/scaffold/NavigationSidebar/connectors/__tests__/workstationSidebarMenuItems.test.ts` — passed, 24 tests across 3 files. These are existing tests; they do not measure rendered pixel spacing.
- `pnpm run typecheck` — passed.
- `git diff --check` and `git diff origin/develop...HEAD --check` — passed; final diff inspected for unrelated changes, credentials, personal paths, and generated files.
- Normal repository commit hooks completed successfully. Checks were rerun after rebasing the isolated branch onto the latest fetched `origin/develop`. The full test suite and desktop E2E checks were not run for this small presentation-only change. No post-change visual evidence is attached; the visual spacing limitation remains disclosed above.
