### PR TITLE
fix(tabs): align drag highlights and insertion markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,10 +180,13 @@ order:
 
 #### Draft, ready, and review lifecycle
 
-- Keep the PR in Draft while material design choices, known blockers, required
-  migrations, or risk-proportionate verification remain incomplete.
-- Mark the PR ready only when its acceptance criteria are met and the
-  description reflects the current implementation.
+- Open PRs ready for review by default. Disclose incomplete verification,
+  unverified paths, and missing visual evidence in `Potential risks` and
+  `Verification`; these gaps alone do not require Draft.
+- Use Draft only when the author asks for it or material design choices, a
+  known blocker, or an incomplete migration make the change unready for review.
+- Mark a Draft ready once those conditions resolve and the description
+  reflects the current implementation.
 - If scope, behavior, or the chosen solution changes materially after review
   begins, update the description and notify reviewers instead of silently
   changing direction.

--- a/docs/org2-performance-guard-2026-08-31/TabDragFeedback.md
+++ b/docs/org2-performance-guard-2026-08-31/TabDragFeedback.md
@@ -1,0 +1,60 @@
+# Tab drag feedback verification
+
+The insertion line now measures the same 32px content band as the rectangular
+drop highlight in My Station and Chat Panel. My Station's band includes unused
+tab space but excludes the leading and trailing header buttons. The previous
+line used `TAB_BAR_HEIGHT - 8` and header/pane bounds, ignoring the window-edge
+gap. It also updated its transform only when the horizontal position changed.
+
+`src/shared/dnd/useTabInsertionIndicator.ts` owns the indicator for both hosts.
+The old implementation was removed from `useTabDrag`. Reorder callbacks and
+session-transfer payloads are unchanged. This is presentation geometry; there
+is no persisted data or historical cleanup.
+
+## Performance guard
+
+| Area               | Verdict | Evidence                                                                                                             | Change or reason kept                                                                                 | Verification                                                                            |
+| ------------------ | ------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Background work    | fix     | One effect owns drag-only pointer, scroll, resize, and visibility listeners plus at most one pending animation frame | No idle polling; cancel frames while hidden; remove listeners on drag end/cancel/unmount              | Idle, coalescing, visibility, and repeated cleanup tests                                |
+| Memory             | fix     | One DOM indicator and one pointer position per active drag                                                           | Remove the owned indicator in cleanup; no module-global registry                                      | Three drag cycles and unmount tests                                                     |
+| Scope/isolation    | fix     | Each host passes its own content-band ref                                                                            | No document-wide pane lookup or removal of another host's indicator; clip insertion x within the band | Button-area clipping tests and call-site inspection; no identity/network state involved |
+| Rendering/hot path | fix     | Pointer events schedule DOM positioning without React state updates                                                  | Coalesce into one frame and remeasure on scrolling/resizing; no recurring frame loop                  | Coalescing, scroll, and vertical-only movement tests                                    |
+
+Lifecycle coverage is limited to the shared hook in jsdom with mocked DOM
+geometry. Active and idle behavior, hide/return, repeated drag end/cancel, and
+unmount are covered. Real Tauri visual alignment, CPU/RSS, and native window
+interaction were not exercised because desktop control was not authorized.
+Network, account, provider-history, and transport matrices do not apply.
+
+## Architecture scope
+
+- Layer 1: Full TypeScript compilation and changed-file lint pass in the
+  isolated PR worktree based on the latest `origin/develop`.
+- Layers 2–7: Reviewed shared ownership, removed the old marker implementation
+  and unused pane-id option, kept names specific, used measured geometry without
+  header-height fallbacks, and kept session/business state out of the hook.
+- Layer 9: Both production tab bars invoke the same hook with their own refs
+  and expose tab ids for positioning.
+- Layers 8 and 10: Not applicable; no wire serialization or multi-source
+  resolver changes.
+
+## Commands and results
+
+```sh
+pnpm exec vitest run src/shared/dnd/useTabInsertionIndicator.test.ts src/shared/dnd/sessionTabDrag.test.ts src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts src/engines/ChatPanel/ChatPanelTabBar/ChatPanelTabBar.test.ts src/modules/WorkStation/shared/TabBar/components/SortableTab/__tests__/index.test.ts
+pnpm exec eslint src/shared/dnd/useTabInsertionIndicator.ts src/shared/dnd/useTabInsertionIndicator.test.ts src/modules/WorkStation/shared/TabBar/hooks/useTabDrag.ts src/modules/WorkStation/shared/TabBar/index.tsx src/engines/ChatPanel/ChatPanelTabBar/index.tsx src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx --max-warnings 0 --report-unused-disable-directives
+pnpm run check:test-placement
+pnpm run typecheck
+git diff --check
+```
+
+- Focused tests: 45 passed across five files, including 12 marker tests.
+- ESLint, test placement, and whitespace checks: passed.
+- Full typecheck: passed in the isolated PR worktree. The unrelated
+  Input/Textarea test edits from the original working directory are not part
+  of this branch.
+- Existing Vite/Sass deprecation and i18next test warnings remain.
+
+Performance verdict: blocked for full runtime sign-off by unexecuted Tauri
+visual/CPU/RSS checks. The scoped automated lifecycle checks pass; no measured
+performance improvement is claimed.

--- a/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
@@ -338,6 +338,7 @@ export const TabPill = memo(function TabPill({
       isActive={isActive}
       variant="session"
       role="tab"
+      data-tab-id={tab.id}
       aria-selected={isActive}
       title={displayTitle}
       onClick={() => onActivate(tab.id)}

--- a/src/engines/ChatPanel/ChatPanelTabBar/index.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/index.tsx
@@ -33,7 +33,13 @@ import {
   horizontalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { useAtomValue, useSetAtom } from "jotai";
-import React, { Fragment, useCallback, useRef, useState } from "react";
+import React, {
+  Fragment,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
@@ -50,6 +56,7 @@ import {
   dispatchSessionTabDragStart,
 } from "@src/shared/dnd/sessionTabDrag";
 import { useSessionTabDropTarget } from "@src/shared/dnd/useSessionTabDropTarget";
+import { useTabInsertionIndicator } from "@src/shared/dnd/useTabInsertionIndicator";
 import { openTeamInboxInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabOpenAtoms";
 import {
   activateChatPanelTabAtom,
@@ -90,6 +97,7 @@ export function ChatPanelTabBar(): React.ReactNode {
     null
   );
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
+  useTabInsertionIndicator({ containerRef: barRef, draggingTabId });
   const [contextMenuTabId, setContextMenuTabId] = useState<string | null>(null);
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
@@ -113,6 +121,7 @@ export function ChatPanelTabBar(): React.ReactNode {
     window.removeEventListener("pointermove", pointerTrackerRef.current);
     pointerTrackerRef.current = null;
   }, []);
+  useEffect(() => removePointerTracker, [removePointerTracker]);
 
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
@@ -249,7 +258,7 @@ export function ChatPanelTabBar(): React.ReactNode {
         >
           <div
             ref={barRef}
-            className="relative flex min-w-0 flex-1 items-center overflow-x-auto overflow-y-hidden scrollbar-hide"
+            className="relative flex h-8 min-w-0 flex-1 items-center overflow-x-auto overflow-y-hidden scrollbar-hide"
             data-session-tab-drop-target="chat-panel"
             data-tauri-drag-region
             style={CHAT_PANEL_HEADER_DRAG_STYLE}

--- a/src/modules/WorkStation/shared/TabBar/hooks/useTabDrag.ts
+++ b/src/modules/WorkStation/shared/TabBar/hooks/useTabDrag.ts
@@ -3,7 +3,6 @@
  *
  * Handles all drag-and-drop logic for tabs including:
  * - Drag start/end events
- * - Insertion indicator positioning
  * - Tab reordering within a single pane
  */
 import type {
@@ -24,23 +23,14 @@ import {
   dispatchSessionTabDragStart,
 } from "@src/shared/dnd/sessionTabDrag";
 
-import { TAB_BAR_HEIGHT } from "../config";
 import type { TabDragEventDetail, TabDragPillPayload } from "../tabDragTypes";
 import type { WorkStationTab } from "../types";
-
-/**
- * Drop line height; centered in the actual tab bar strip (the `.work-station-tab-bar`
- * row), not the full pane column — same vertical math as 32px pills in a 40px bar.
- */
-const INSERTION_INDICATOR_HEIGHT = TAB_BAR_HEIGHT - 8;
 
 // ============================================
 // Types
 // ============================================
 
 export interface UseTabDragOptions {
-  /** Current pane ID */
-  paneId: string;
   /** List of tabs */
   tabs: WorkStationTab[];
   /** Callback when tabs are reordered */
@@ -167,7 +157,6 @@ function getSessionTabTransfer(
 // ============================================
 
 export function useTabDrag({
-  paneId,
   tabs,
   onTabReorder,
 }: UseTabDragOptions): UseTabDragReturn {
@@ -240,172 +229,8 @@ export function useTabDrag({
     [tabs]
   );
 
-  // Track pointer position during drag move, and show insertion indicator
-  useEffect(() => {
-    if (!draggingTabId) {
-      document.querySelectorAll(".drop-target-highlight").forEach((el) => {
-        el.classList.remove("drop-target-highlight");
-      });
-      document.querySelector(".tab-insertion-indicator")?.remove();
-      return;
-    }
-
-    let indicator = document.querySelector(
-      ".tab-insertion-indicator"
-    ) as HTMLDivElement | null;
-    if (!indicator) {
-      indicator = document.createElement("div");
-      indicator.className = "tab-insertion-indicator";
-      indicator.style.cssText = `
-        position: fixed;
-        left: 0;
-        top: 0;
-        width: 2px;
-        height: ${INSERTION_INDICATOR_HEIGHT}px;
-        background: var(--color-primary-6);
-        border-radius: 1px;
-        z-index: 10000;
-        pointer-events: none;
-        display: none;
-        box-shadow: 0 0 4px color-mix(in srgb, var(--color-primary-6) 50%, transparent);
-        will-change: transform;
-        contain: layout style;
-      `;
-      document.body.appendChild(indicator);
-    }
-
-    const allPanes = Array.from(
-      document.querySelectorAll("[data-pane-id]")
-    ) as HTMLElement[];
-
-    const currentPane = allPanes.find((pane) => pane.dataset.paneId === paneId);
-
-    let lastIndicatorX = -1;
-    let rafId: number | null = null;
-    let lastX = 0;
-    let lastY = 0;
-
-    const updateIndicator = () => {
-      rafId = null;
-      if (!indicator) return;
-
-      // Re-read layout on every frame so stale cached bounds don't cause
-      // wrong indicator positions after the tab strip has scrolled or the
-      // panel has been resized since drag-start.
-      let currentPaneBounds: DOMRect | null = null;
-      let currentTabBarBounds: DOMRect | null = null;
-      let currentPaneTabBounds: Array<{
-        left: number;
-        right: number;
-        midpoint: number;
-        id: string;
-      }> = [];
-      if (currentPane) {
-        currentPaneBounds = currentPane.getBoundingClientRect();
-        const currentTabBar = currentPane.querySelector(
-          ".work-station-tab-bar"
-        );
-        currentTabBarBounds = currentTabBar
-          ? currentTabBar.getBoundingClientRect()
-          : null;
-        const currentTabs = currentPane.querySelectorAll("[data-tab-id]");
-        currentPaneTabBounds = Array.from(currentTabs).map((tab) => {
-          const tabEl = tab as HTMLElement;
-          const rect = tabEl.getBoundingClientRect();
-          return {
-            left: rect.left,
-            right: rect.right,
-            midpoint: rect.left + rect.width / 2,
-            id: tabEl.dataset.tabId || "",
-          };
-        });
-      }
-
-      const overCurrent =
-        currentPaneBounds &&
-        lastX >= currentPaneBounds.left &&
-        lastX <= currentPaneBounds.right &&
-        lastY >= currentPaneBounds.top &&
-        lastY <= currentPaneBounds.bottom;
-
-      if (!overCurrent) {
-        indicator.style.display = "none";
-        return;
-      }
-
-      let indicatorX = 0;
-      const tabBounds = currentPaneTabBounds;
-      const paneBounds = currentPaneBounds;
-      if (!paneBounds) return;
-
-      const tabStripBounds = currentTabBarBounds;
-      const top = tabStripBounds?.top ?? paneBounds.top;
-      const stripH = tabStripBounds?.height ?? TAB_BAR_HEIGHT;
-      const lineH = Math.min(
-        INSERTION_INDICATOR_HEIGHT,
-        Math.max(1, stripH - 2)
-      );
-      const indicatorY = top + (stripH - lineH) / 2;
-      if (indicator) {
-        indicator.style.height = `${lineH}px`;
-      }
-
-      if (tabBounds.length > 0) {
-        let foundPosition = false;
-
-        for (let tabIdx = 0; tabIdx < tabBounds.length; tabIdx++) {
-          const tabBound = tabBounds[tabIdx];
-          if (tabBound.id === draggingTabId) {
-            continue;
-          }
-          if (lastX < tabBound.midpoint) {
-            indicatorX = tabBound.left - 1;
-            foundPosition = true;
-            break;
-          }
-        }
-
-        if (!foundPosition) {
-          const lastTab = tabBounds[tabBounds.length - 1];
-          if (lastTab) {
-            indicatorX = lastTab.right - 1;
-          }
-        }
-      } else {
-        indicatorX = paneBounds.left + 8;
-      }
-
-      if (Math.abs(indicatorX - lastIndicatorX) > 1) {
-        lastIndicatorX = indicatorX;
-        indicator.style.transform = `translate3d(${indicatorX}px, ${indicatorY}px, 0)`;
-        indicator.style.display = "block";
-      }
-    };
-
-    const handlePointerMove = (event: PointerEvent) => {
-      lastX = event.clientX;
-      lastY = event.clientY;
-
-      if (rafId === null) {
-        rafId = requestAnimationFrame(updateIndicator);
-      }
-    };
-
-    document.addEventListener("pointermove", handlePointerMove, {
-      passive: true,
-    });
-
-    return () => {
-      document.removeEventListener("pointermove", handlePointerMove);
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-      }
-      indicator?.remove();
-    };
-  }, [draggingTabId, paneId]);
-
   const handleDragMove = useCallback((_event: DragMoveEvent) => {
-    // Position tracking handled by pointermove listener above
+    // Position tracking is owned by the drag-start pointer listener.
   }, []);
 
   const removePointerTracker = useCallback(() => {
@@ -414,6 +239,8 @@ export function useTabDrag({
       pointerMoveHandlerRef.current = null;
     }
   }, []);
+
+  useEffect(() => removePointerTracker, [removePointerTracker]);
 
   const clearTabDragGlobals = useCallback(() => {
     clearWorkstationTabDrag();

--- a/src/modules/WorkStation/shared/TabBar/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/index.tsx
@@ -55,6 +55,7 @@ import {
   type SessionTabTransfer,
 } from "@src/shared/dnd/sessionTabDrag";
 import { useSessionTabDropTarget } from "@src/shared/dnd/useSessionTabDropTarget";
+import { useTabInsertionIndicator } from "@src/shared/dnd/useTabInsertionIndicator";
 import { openTeamInboxInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabOpenAtoms";
 import {
   canMoveWorkstationPrTabToChatPanel,
@@ -226,6 +227,7 @@ export const TabBar: React.FC<TabBarProps> = memo(
     const tabGitInfoMap = useTabGitInfoMap(tabs, repoPath, gitStatusMap);
 
     const tabsContainerRef = useRef<HTMLDivElement>(null);
+    const tabBandRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const moveSessionTab = useSetAtom(moveSessionTabAtom);
     const moveWorkstationPrTabToChatPanel = useSetAtom(
@@ -279,10 +281,10 @@ export const TabBar: React.FC<TabBarProps> = memo(
       handleDragEnd,
       handleDragCancel,
     } = useTabDrag({
-      paneId,
       tabs,
       onTabReorder,
     });
+    useTabInsertionIndicator({ containerRef: tabBandRef, draggingTabId });
 
     const [contextMenu, setContextMenu] = useState<{
       position: { x: number; y: number };
@@ -388,12 +390,6 @@ export const TabBar: React.FC<TabBarProps> = memo(
           } as React.CSSProperties
         }
       >
-        {isSessionDragOver ? (
-          <div
-            className={`${SESSION_TAB_DROP_TARGET_HIGHLIGHT_CLASS} inset-1`}
-            aria-hidden
-          />
-        ) : null}
         <div className="mt-2 flex h-9 min-w-0 flex-1 items-center">
           {shouldOffsetLeftChrome ? <CollapsedSidebarButton /> : null}
           {leadingSlot ? (
@@ -407,69 +403,82 @@ export const TabBar: React.FC<TabBarProps> = memo(
           ) : null}
 
           <div
-            ref={tabsContainerRef}
-            className="relative flex h-full min-w-0 max-w-full shrink items-center overflow-x-auto overflow-y-hidden scrollbar-hide"
-            style={{ scrollBehavior: "smooth" } as React.CSSProperties}
+            ref={tabBandRef}
+            className="relative flex h-8 min-w-0 flex-1 items-center"
           >
-            {tabRowPrefix ? (
-              <NoDragRegion className="flex h-full shrink-0 items-center gap-1">
-                {tabRowPrefix}
-              </NoDragRegion>
+            {isSessionDragOver ? (
+              <div
+                // Fill the tab band and empty space, excluding header buttons.
+                className={`${SESSION_TAB_DROP_TARGET_HIGHLIGHT_CLASS} inset-0`}
+                aria-hidden
+              />
             ) : null}
-            {tabRowPrefix && hasTabs ? (
-              <span className={TAB_STRIP_SECTION_RULE_CLASS} aria-hidden />
-            ) : null}
-            {hasTabs ? (
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragStart={handleDragStart}
-                onDragMove={handleDragMove}
-                onDragEnd={handleDragEnd}
-                onDragCancel={handleDragCancel}
-              >
-                <SortableTabList
-                  tabs={tabs}
-                  tabIds={tabIds}
-                  activeTabId={activeTabId}
-                  tabGitInfoMap={tabGitInfoMap}
-                  hideInactiveTabLabels={
-                    collapseInactiveTabLabelsOnOverflow && hideInactiveTabLabels
-                  }
-                  onTabClick={handleTabClick}
-                  onCloseClick={handleCloseClick}
-                  onContextMenu={handleContextMenu}
-                />
+            <div
+              ref={tabsContainerRef}
+              className="relative flex h-full min-w-0 max-w-full shrink items-center overflow-x-auto overflow-y-hidden scrollbar-hide"
+              style={{ scrollBehavior: "smooth" } as React.CSSProperties}
+            >
+              {tabRowPrefix ? (
+                <NoDragRegion className="flex h-full shrink-0 items-center gap-1">
+                  {tabRowPrefix}
+                </NoDragRegion>
+              ) : null}
+              {tabRowPrefix && hasTabs ? (
+                <span className={TAB_STRIP_SECTION_RULE_CLASS} aria-hidden />
+              ) : null}
+              {hasTabs ? (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragStart={handleDragStart}
+                  onDragMove={handleDragMove}
+                  onDragEnd={handleDragEnd}
+                  onDragCancel={handleDragCancel}
+                >
+                  <SortableTabList
+                    tabs={tabs}
+                    tabIds={tabIds}
+                    activeTabId={activeTabId}
+                    tabGitInfoMap={tabGitInfoMap}
+                    hideInactiveTabLabels={
+                      collapseInactiveTabLabelsOnOverflow &&
+                      hideInactiveTabLabels
+                    }
+                    onTabClick={handleTabClick}
+                    onCloseClick={handleCloseClick}
+                    onContextMenu={handleContextMenu}
+                  />
 
-                {createPortal(
-                  <DragOverlay dropAnimation={null}>
-                    {draggingTab && (
-                      <div
-                        className={TAB_PILL_DRAG_OVERLAY_CLASS}
-                        style={{ zIndex: 9999 }}
-                      >
-                        <FileTypeIcon
-                          fileName={draggingTab.title}
-                          size="small"
-                        />
-                        <span className="max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
-                          {draggingTab.title}
-                        </span>
-                      </div>
-                    )}
-                  </DragOverlay>,
-                  document.body
-                )}
-              </DndContext>
-            ) : null}
+                  {createPortal(
+                    <DragOverlay dropAnimation={null}>
+                      {draggingTab && (
+                        <div
+                          className={TAB_PILL_DRAG_OVERLAY_CLASS}
+                          style={{ zIndex: 9999 }}
+                        >
+                          <FileTypeIcon
+                            fileName={draggingTab.title}
+                            size="small"
+                          />
+                          <span className="max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
+                            {draggingTab.title}
+                          </span>
+                        </div>
+                      )}
+                    </DragOverlay>,
+                    document.body
+                  )}
+                </DndContext>
+              ) : null}
+            </div>
+
+            <div
+              className="h-8 min-w-px flex-1"
+              data-tauri-drag-region
+              style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+              aria-hidden
+            />
           </div>
-
-          <div
-            className="h-8 min-w-px flex-1"
-            data-tauri-drag-region
-            style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
-            aria-hidden
-          />
 
           <NoDragRegion>
             <TabBarControls

--- a/src/shared/dnd/useTabInsertionIndicator.test.ts
+++ b/src/shared/dnd/useTabInsertionIndicator.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { type RefObject, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTabInsertionIndicator } from "./useTabInsertionIndicator";
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function Harness({
+  containerRef,
+  draggingTabId,
+}: {
+  containerRef: RefObject<HTMLDivElement | null>;
+  draggingTabId: string | null;
+}) {
+  useTabInsertionIndicator({ containerRef, draggingTabId });
+  return null;
+}
+
+describe("useTabInsertionIndicator", () => {
+  let host: HTMLDivElement;
+  let band: HTMLDivElement;
+  let bandRef: RefObject<HTMLDivElement | null>;
+  let root: Root;
+  let bandTop: number;
+  let targetLeft: number;
+  let nextFrameId: number;
+  let frames: Map<number, FrameRequestCallback>;
+  let visibility: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+    band = document.createElement("div");
+    band.dataset.tabBand = "true";
+    const scrollStrip = document.createElement("div");
+    scrollStrip.dataset.scrollStrip = "true";
+    for (const tabId of ["source", "target"]) {
+      const tab = document.createElement("div");
+      tab.dataset.tabId = tabId;
+      scrollStrip.appendChild(tab);
+    }
+    band.appendChild(scrollStrip);
+    document.body.appendChild(band);
+    bandRef = { current: band };
+    bandTop = 10;
+    targetLeft = 190;
+    nextFrameId = 0;
+    frames = new Map();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      const frameId = ++nextFrameId;
+      frames.set(frameId, callback);
+      return frameId;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frameId) => {
+      frames.delete(frameId);
+    });
+    visibility = vi.spyOn(document, "visibilityState", "get");
+    visibility.mockReturnValue("visible");
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        const left = this.dataset.tabId === "target" ? targetLeft : 100;
+        const width = this.hasAttribute("data-tab-band") ? 400 : 80;
+        return new DOMRect(left, bandTop, width, 32);
+      }
+    );
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    band.remove();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  function renderDrag(draggingTabId: string | null = "source") {
+    act(() =>
+      root.render(
+        createElement(Harness, { containerRef: bandRef, draggingTabId })
+      )
+    );
+  }
+
+  function movePointer(clientX = 210, clientY = bandTop + 12) {
+    document.dispatchEvent(new MouseEvent("pointermove", { clientX, clientY }));
+  }
+
+  function flushFrame() {
+    const pending = [...frames.values()];
+    frames.clear();
+    for (const callback of pending) callback(0);
+  }
+
+  function indicator() {
+    return document.querySelector<HTMLDivElement>(".tab-insertion-indicator")!;
+  }
+
+  it.each([
+    ["Workstation", 10],
+    ["Chat Panel", 130],
+  ])("matches the %s highlight band's top and height", (_surface, top) => {
+    bandTop = top;
+    renderDrag();
+    movePointer();
+    flushFrame();
+
+    expect(indicator().style.height).toBe("32px");
+    expect(indicator().style.transform).toBe(`translate3d(189px, ${top}px, 0)`);
+    expect(indicator().style.display).toBe("block");
+    expect(indicator().getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("updates vertical geometry when the insertion x position is unchanged", () => {
+    renderDrag();
+    movePointer();
+    flushFrame();
+
+    bandTop = 20;
+    window.dispatchEvent(new Event("resize"));
+    flushFrame();
+    expect(indicator().style.transform).toBe("translate3d(189px, 20px, 0)");
+  });
+
+  it("reappears at the same insertion position after leaving the tab band", () => {
+    renderDrag();
+    movePointer();
+    flushFrame();
+    movePointer(50);
+    flushFrame();
+    expect(indicator().style.display).toBe("none");
+
+    movePointer();
+    flushFrame();
+    expect(indicator().style.display).toBe("block");
+  });
+
+  it("tracks scrolling without waiting for another pointer movement", () => {
+    renderDrag();
+    movePointer();
+    flushFrame();
+    targetLeft = 200;
+    band
+      .querySelector("[data-scroll-strip]")!
+      .dispatchEvent(new Event("scroll"));
+    flushFrame();
+    expect(indicator().style.transform).toBe("translate3d(199px, 10px, 0)");
+  });
+
+  it.each([
+    [10, 100],
+    [590, 498],
+  ])(
+    "keeps a scrolled edge at %ipx out of the button areas",
+    (left, expected) => {
+      targetLeft = left;
+      renderDrag();
+      movePointer();
+      flushFrame();
+      expect(indicator().style.transform).toBe(
+        `translate3d(${expected}px, 10px, 0)`
+      );
+    }
+  );
+
+  it("coalesces pointer bursts into one frame and does no continuous work", () => {
+    renderDrag();
+    movePointer(200);
+    movePointer(205);
+    movePointer();
+    expect(frames.size).toBe(1);
+    flushFrame();
+    expect(frames.size).toBe(0);
+    expect(indicator().style.transform).toBe("translate3d(189px, 10px, 0)");
+  });
+
+  it("creates no indicator or pointer listener while idle", () => {
+    const addListener = vi.spyOn(document, "addEventListener");
+    renderDrag(null);
+    movePointer();
+    expect(indicator()).toBeNull();
+    expect(frames.size).toBe(0);
+    expect(
+      addListener.mock.calls.filter(([type]) => type === "pointermove")
+    ).toHaveLength(0);
+  });
+
+  it("cancels pending work while hidden and refreshes once on return", () => {
+    renderDrag();
+    movePointer();
+    visibility.mockReturnValue("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(frames.size).toBe(0);
+    expect(indicator().style.display).toBe("none");
+    movePointer();
+    expect(frames.size).toBe(0);
+
+    visibility.mockReturnValue("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(frames.size).toBe(1);
+    flushFrame();
+    expect(indicator().style.display).toBe("block");
+    expect(frames.size).toBe(0);
+  });
+
+  it("removes listeners, pending frames, and DOM on repeated drag end or cancel", () => {
+    const addListener = vi.spyOn(document, "addEventListener");
+    const removeListener = vi.spyOn(document, "removeEventListener");
+    for (let cycle = 0; cycle < 3; cycle++) {
+      renderDrag();
+      movePointer();
+      expect(
+        document.querySelectorAll(".tab-insertion-indicator")
+      ).toHaveLength(1);
+      renderDrag(null);
+      expect(indicator()).toBeNull();
+      expect(frames.size).toBe(0);
+      movePointer();
+      expect(frames.size).toBe(0);
+    }
+    for (const type of ["pointermove", "visibilitychange"]) {
+      const added = addListener.mock.calls.filter(([event]) => event === type);
+      const removed = removeListener.mock.calls.filter(
+        ([event]) => event === type
+      );
+      expect(added).toHaveLength(3);
+      expect(removed.map(([, listener]) => listener)).toEqual(
+        added.map(([, listener]) => listener)
+      );
+    }
+  });
+
+  it("cleans up when the tab strip unmounts during a drag", () => {
+    renderDrag();
+    movePointer();
+    act(() => root.render(null));
+    expect(indicator()).toBeNull();
+    expect(frames.size).toBe(0);
+    movePointer();
+    window.dispatchEvent(new Event("resize"));
+    expect(frames.size).toBe(0);
+  });
+});

--- a/src/shared/dnd/useTabInsertionIndicator.ts
+++ b/src/shared/dnd/useTabInsertionIndicator.ts
@@ -1,0 +1,126 @@
+import { type RefObject, useEffect } from "react";
+
+interface UseTabInsertionIndicatorOptions {
+  /** The same content band filled by the rectangular drop highlight. */
+  containerRef: RefObject<HTMLElement | null>;
+  draggingTabId: string | null;
+}
+
+/** Drag-only insertion feedback shared by the Workstation and Chat Panel. */
+export function useTabInsertionIndicator({
+  containerRef,
+  draggingTabId,
+}: UseTabInsertionIndicatorOptions): void {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!draggingTabId || !container) return;
+
+    const indicator = document.createElement("div");
+    indicator.className = "tab-insertion-indicator";
+    indicator.setAttribute("aria-hidden", "true");
+    indicator.style.cssText = `
+      position: fixed;
+      left: 0;
+      top: 0;
+      width: 2px;
+      background: var(--color-primary-6);
+      border-radius: 1px;
+      z-index: 10000;
+      pointer-events: none;
+      display: none;
+      box-shadow: 0 0 4px color-mix(in srgb, var(--color-primary-6) 50%, transparent);
+      will-change: transform;
+      contain: layout style;
+    `;
+    document.body.appendChild(indicator);
+
+    let frameId: number | null = null;
+    let pointer: { x: number; y: number } | null = null;
+
+    const hideIndicator = () => {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId);
+        frameId = null;
+      }
+      indicator.style.display = "none";
+    };
+
+    const updateIndicator = () => {
+      frameId = null;
+      if (!pointer || document.visibilityState === "hidden") return;
+
+      // Measure the content band, not the header's window-edge padding.
+      const bounds = container.getBoundingClientRect();
+      if (
+        bounds.width <= 0 ||
+        bounds.height <= 0 ||
+        pointer.x < bounds.left ||
+        pointer.x > bounds.right ||
+        pointer.y < bounds.top ||
+        pointer.y > bounds.bottom
+      ) {
+        hideIndicator();
+        return;
+      }
+
+      const tabs = container.querySelectorAll<HTMLElement>("[data-tab-id]");
+      let indicatorX = bounds.left;
+      for (const tab of tabs) {
+        const tabBounds = tab.getBoundingClientRect();
+        if (
+          tab.dataset.tabId !== draggingTabId &&
+          pointer.x < tabBounds.left + tabBounds.width / 2
+        ) {
+          indicatorX = tabBounds.left - 1;
+          break;
+        }
+        indicatorX = tabBounds.right - 1;
+      }
+
+      // A scrolled tab edge must not paint over the adjacent header buttons.
+      indicatorX = Math.max(
+        bounds.left,
+        Math.min(indicatorX, bounds.right - 2)
+      );
+      indicator.style.height = `${bounds.height}px`;
+      indicator.style.transform = `translate3d(${indicatorX}px, ${bounds.top}px, 0)`;
+      indicator.style.display = "block";
+    };
+
+    const scheduleUpdate = () => {
+      if (
+        pointer &&
+        frameId === null &&
+        document.visibilityState !== "hidden"
+      ) {
+        frameId = requestAnimationFrame(updateIndicator);
+      }
+    };
+    const handlePointerMove = (event: PointerEvent) => {
+      pointer = { x: event.clientX, y: event.clientY };
+      scheduleUpdate();
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") hideIndicator();
+      else scheduleUpdate();
+    };
+
+    document.addEventListener("pointermove", handlePointerMove, {
+      passive: true,
+    });
+    container.addEventListener("scroll", scheduleUpdate, {
+      passive: true,
+      capture: true,
+    });
+    window.addEventListener("resize", scheduleUpdate, { passive: true });
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("pointermove", handlePointerMove);
+      container.removeEventListener("scroll", scheduleUpdate, true);
+      window.removeEventListener("resize", scheduleUpdate);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      hideIndicator();
+      indicator.remove();
+    };
+  }, [containerRef, draggingTabId]);
+}


### PR DESCRIPTION
## Problem

My Station's drag highlight is sized from the outer header, so it includes the top gap and button areas instead of matching the chat header's tab band. The insertion line separately uses `TAB_BAR_HEIGHT - 8` and pane/header bounds, which places it too high. Its position updates only when x changes, leaving stale feedback after vertical movement or re-entry. Chat Panel does not share the insertion-marker implementation.

## Solution

- Use the same 32px content band for the rectangle and insertion line in My Station and Chat Panel. Keep My Station's rectangle full-width across tabs and empty space, excluding the leading and trailing button areas.
- Share `useTabInsertionIndicator` between both hosts and remove the old pane lookup and height fallback. Measure current bounds on drag movement, scrolling, and resizing; keep the line inside the tab band.
- Coalesce updates into one animation frame, cancel pending work while hidden, and remove drag listeners/DOM on end, cancel, and unmount. Keep tab reorder callbacks and session-transfer payloads unchanged.
- Add 12 DOM/lifecycle regression tests and the scoped performance/architecture verification notes.

Closes #1112

## Potential risks

Native Tauri drag behavior, live visual alignment at narrow widths/in different themes, and CPU/RSS have not been measured. The geometry/lifecycle tests use mocked DOM rectangles, so real-app validation remains a reviewer follow-up. Active-drag event handling is shared by both hosts; tests cover coalescing, scrolling, hidden/visible transitions, repeated end/cancel, and unmount cleanup.

There are no dependency, persistence, schema, configuration-format, or public API/IPC/wire changes. No historical data cleanup is needed. Reverting this commit restores the previous presentation behavior. Missing runtime evidence is disclosed here; the PR is ready for review under `PR_RULES.md`.

## Verification

Rerun in the isolated merge-resolution worktree after integrating `develop` at `89bda2ea13f2a758b00f3fd0e55bd554d7e624fe`:

- `pnpm exec vitest run src/shared/dnd/useTabInsertionIndicator.test.ts src/shared/dnd/sessionTabDrag.test.ts src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts src/engines/ChatPanel/ChatPanelTabBar/ChatPanelTabBar.test.ts src/modules/WorkStation/shared/TabBar/components/SortableTab/__tests__/index.test.ts` — **45 tests passed**, including 12 marker tests.
- `pnpm exec eslint src/shared/dnd/useTabInsertionIndicator.ts src/shared/dnd/useTabInsertionIndicator.test.ts src/modules/WorkStation/shared/TabBar/hooks/useTabDrag.ts src/modules/WorkStation/shared/TabBar/index.tsx src/engines/ChatPanel/ChatPanelTabBar/index.tsx src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx --max-warnings 0 --report-unused-disable-directives` — passed.
- `pnpm run typecheck` — passed. The unrelated Input/Textarea test edits from the original working directory are excluded from this branch.
- `pnpm run check:test-placement` — passed across 434 directories.
- `git diff --check` — passed.
- Source/diff review: both production hosts use the shared hook; header buttons remain outside My Station's highlighted band; no secrets, personal paths, debug logs, build artifacts, or unrelated working-tree changes are included.
- Live Tauri screenshots/recordings, native-window interaction, and CPU/RSS checks were not run because desktop control was not authorized. Existing Vite/Sass deprecation and i18next test warnings remain.

Performance verdict: scoped automated lifecycle checks pass; full runtime sign-off remains blocked by the unexecuted Tauri checks. See `docs/org2-performance-guard-2026-08-31/TabDragFeedback.md` for the lifecycle and architecture scope.

## Merge conflict resolution

Integrated the latest `develop` without rewriting the existing PR commit. The only conflict was equivalent PR-lifecycle guidance in `AGENTS.md`; retained the wording already on `develop`, which follows `PR_RULES.md`. `AGENTS.md` is therefore no longer part of the final PR diff. The tab-drag implementation and tests are unchanged, and the current sidebar changes from `develop` are preserved.
