### PR TITLE
fix(keyboard-shortcut): use a backspace icon for the back hint

### DIFF
--- a/src/components/KeyboardShortcut/index.tsx
+++ b/src/components/KeyboardShortcut/index.tsx
@@ -7,7 +7,6 @@ import {
   ArrowUpBigIcon,
   CommandIcon,
   CornerDownLeftIcon,
-  Delete01Icon,
   HugeiconsIcon,
   OptionIcon,
 } from "@src/icons";
@@ -242,7 +241,21 @@ function SpecialKey({
       );
     case "backspace":
       return (
-        <HugeiconsIcon icon={Delete01Icon} data-icon="delete" {...iconProps} />
+        <svg
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          data-icon="backspace"
+          aria-hidden="true"
+        >
+          <path d="M9 5h11a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H9l-7-7Z" />
+          <path d="m12 9 6 6m0-6-6 6" />
+        </svg>
       );
     case "esc":
       return <span className="leading-none">esc</span>;


### PR DESCRIPTION
## Problem

The Spotlight footer's Back hint renders a trash can because the shared `KeyboardShortcut` component maps Backspace to `Delete01Icon`. The symbol suggests deleting an item instead of pressing the Backspace key.

## Solution

Render the Backspace key as a left-pointing key outline with an X, matching the familiar ⌫ symbol. Keep the existing icon size, stroke weight, inherited color, keycap layout, key parsing, and keyboard behavior. This corrects the shared Backspace glyph without changing destructive-action icons elsewhere.

## Potential risks

All Backspace aliases rendered by `KeyboardShortcut`, including its existing Delete alias, now use this glyph. The small SVG has not been visually checked in the running app across themes, platforms, or constrained viewports. No dependencies, persistence formats, APIs, or keyboard handlers change. Reverting this commit restores the previous glyph.

## Verification

- `pnpm exec eslint src/components/KeyboardShortcut/index.tsx --max-warnings 0` — passed.
- `pnpm exec vitest run src/components/KeyboardShortcut/index.test.ts` — passed, 2 existing tests. These cover shortcut/tooltip rendering, not a visual snapshot of the new glyph.
- `git diff --check -- src/components/KeyboardShortcut/index.tsx` — passed.
- Inspected the Backspace rendering branch and the Spotlight footer caller: the existing Backspace shortcut now uses the new SVG at the unchanged size and stroke weight.
- Reviewed the final diff: only `src/components/KeyboardShortcut/index.tsx` is included; no secrets, private configuration, build artifacts, or unrelated changes.
- No running-app screenshots or desktop interaction: computer control is explicitly opt-in and was not requested. Full application build, standalone typecheck, and E2E checks were not run for this icon-only change.
- GitHub CI is intentionally not awaited; the author will check it.
