### PR TITLE
fix(chat-panel): collapse single-tab headers in split view

### DIFF
--- a/src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts
+++ b/src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts
@@ -75,22 +75,12 @@ describe("transcript top padding under floating chrome", () => {
 });
 
 describe("collapsing the tab row into the published header", () => {
-  it("folds a maximized pane that holds a single tab", () => {
-    expect(
-      shouldCollapseChatPanelTabRow({ chatMaximized: true, tabCount: 1 })
-    ).toBe(true);
+  it("folds a pane that holds a single tab regardless of maximization", () => {
+    expect(shouldCollapseChatPanelTabRow({ tabCount: 1 })).toBe(true);
   });
 
   it("keeps the row whenever a second tab exists to switch to", () => {
-    expect(
-      shouldCollapseChatPanelTabRow({ chatMaximized: true, tabCount: 2 })
-    ).toBe(false);
-  });
-
-  it("keeps the row while the pane shares the workbench with a Station", () => {
-    expect(
-      shouldCollapseChatPanelTabRow({ chatMaximized: false, tabCount: 1 })
-    ).toBe(false);
+    expect(shouldCollapseChatPanelTabRow({ tabCount: 2 })).toBe(false);
   });
 
   it("keeps the window-edge gap the folded tab row used to hold", () => {

--- a/src/engines/ChatPanel/header/chatPanelHeaderLayout.ts
+++ b/src/engines/ChatPanel/header/chatPanelHeaderLayout.ts
@@ -42,26 +42,23 @@ export function resolveTranscriptTopPaddingPx(
 }
 
 interface ChatPanelTabRowCollapseState {
-  /** Whether the pane currently owns the full workbench width. */
-  chatMaximized: boolean;
   tabCount: number;
 }
 
 /**
  * Whether the 44px tab row folds into the 40px published header.
  *
- * A maximized pane holding a single tab has nothing to switch between: the
+ * A pane holding a single tab has nothing to switch between, maximized or not: the
  * lone pill only repeats the surface title published one row below it, so the
  * row costs 44px of chrome and buys nothing. Collapsing moves its controls
- * (new tab / close tab / restore) onto the published row, which is why that
+ * (new tab / maximize or restore) onto the published row, which is why that
  * row is force-rendered while collapsed even for surfaces that publish no
  * slots of their own.
  */
 export function shouldCollapseChatPanelTabRow({
-  chatMaximized,
   tabCount,
 }: ChatPanelTabRowCollapseState): boolean {
-  return chatMaximized && tabCount === 1;
+  return tabCount === 1;
 }
 
 /**

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -577,7 +577,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       humanSessionActive,
     });
     const tabRowCollapsed = shouldCollapseChatPanelTabRow({
-      chatMaximized: isChatFocus,
       tabCount,
     });
     const chromeTopInsetPx = resolveChatPanelChromeTopInsetPx(


### PR DESCRIPTION
## Problem

A chat pane with one tab still shows a redundant tab row when sharing the workbench with a Station. The existing collapse rule requires chat to be maximized, so the tab title repeats the session header and uses an extra row in split view.

## Solution

Collapse the tab row whenever the pane has exactly one tab, independently of maximization. Remove the unused maximization input from the rule and its caller, and update the existing layout tests. The existing collapsed header retains the new-tab menu and maximize/restore control and supplies the reduced transcript inset. Multiple tabs continue to show the tab strip.

## Potential risks

The existing collapsed header now also appears in narrower split panes; native window dragging and control spacing at narrow widths and across themes have not been visually verified. No persistence, dependency, IPC, or backend changes are included. Reverting this commit restores the previous maximized-only rule.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts src/engines/ChatPanel/ChatPanelHeader.test.ts` — passed, 20 tests across two files.
- `pnpm exec eslint src/engines/ChatPanel/index.tsx src/engines/ChatPanel/header/chatPanelHeaderLayout.ts src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts --max-warnings 0` — passed.
- `git diff --check -- src/engines/ChatPanel/index.tsx src/engines/ChatPanel/header/chatPanelHeaderLayout.ts src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts` — passed.
- `pnpm run typecheck` — reported 12 unrelated `data-testid` typing errors in untracked `src/components/Input/Input.test.ts` and `src/components/Textarea/Textarea.test.ts`; neither file is part of this PR.
- Native desktop visual checks and screenshots were not performed because computer control is opt-in and was not requested. Existing static-render tests cover the collapsed header controls; native interaction and visual coverage remain unverified.
