### PR TITLE
fix(ci): skip Rust checks for ordinary Markdown docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 # CI — runs on every pull request to develop / release / master.
 #
 # Frontend starts immediately. A lightweight scope job decides whether the
-# Rust job is relevant; pure frontend diffs keep the required Rust check but
-# mark it skipped/successful without allocating a macOS runner.
+# Rust job is relevant; frontend and ordinary Markdown documentation diffs
+# keep the required Rust check but mark it skipped/successful without
+# allocating a macOS runner.
 #
 # Within the frontend job, lint covers only the files the pull request changed
 # (see scripts/ci/select-lint-targets.cjs). Typecheck and the unit suite stay

--- a/scripts/ci/detect-rust-changes.cjs
+++ b/scripts/ci/detect-rust-changes.cjs
@@ -2,8 +2,8 @@
 
 const fs = require("node:fs");
 
-// Keep this list deliberately narrow. Rust may be skipped only when every
-// changed file is known to be consumed exclusively by frontend tooling.
+// Keep the skip rules deliberately narrow. Rust may be skipped only when
+// every changed file is frontend-only or documentation with no Rust inputs.
 const FRONTEND_ONLY_PREFIXES = Object.freeze([
   "assets/",
   "build/",
@@ -24,6 +24,16 @@ const FRONTEND_ONLY_ROOT_FILES = new Set([
   "webpack.config.js",
 ]);
 
+const DOCUMENTATION_ROOT_FILES = new Set([
+  "AGENTS.md",
+  "CLAUDE.md",
+  "CODE_OF_CONDUCT.md",
+  "CONTRIBUTING.md",
+  "PR_RULES.md",
+  "README.md",
+  "SECURITY.md",
+]);
+
 function isFrontendOnlyPath(filePath) {
   return (
     FRONTEND_ONLY_ROOT_FILES.has(filePath) ||
@@ -31,11 +41,26 @@ function isFrontendOnlyPath(filePath) {
   );
 }
 
+function isDocumentationOnlyPath(filePath) {
+  // The PM protocol directory contains schemas and fixtures read by Rust
+  // conformance tests. Keep the entire contract in Rust scope, including
+  // its Markdown docs; do not exempt arbitrary files under docs/.
+  return (
+    DOCUMENTATION_ROOT_FILES.has(filePath) ||
+    (filePath.startsWith("docs/") &&
+      filePath.endsWith(".md") &&
+      !filePath.startsWith("docs/orgtrack-pm-protocol/"))
+  );
+}
+
 function requiresRust(filePaths) {
   // Fail closed when diff discovery yields nothing unexpectedly.
   return (
     filePaths.length === 0 ||
-    filePaths.some((filePath) => !isFrontendOnlyPath(filePath))
+    filePaths.some(
+      (filePath) =>
+        !isFrontendOnlyPath(filePath) && !isDocumentationOnlyPath(filePath)
+    )
   );
 }
 

--- a/scripts/ci/detect-rust-changes.test.cjs
+++ b/scripts/ci/detect-rust-changes.test.cjs
@@ -33,10 +33,44 @@ test("frontend configs, assets, and repository tests skip Rust", () => {
   );
 });
 
+test("frontend changes with supporting Markdown docs skip Rust", () => {
+  assert.equal(
+    requiresRust([
+      "src/icons.ts",
+      "src/config/segmentRegistry.ts",
+      "docs/hugeicons-migration/icon-mapping.md",
+    ]),
+    false
+  );
+});
+
+test("ordinary Markdown documentation alone skips Rust", () => {
+  for (const filePath of [
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "PR_RULES.md",
+    "README.md",
+    "SECURITY.md",
+    "docs/frontend-ui-audit-2026-08-31/Icons.md",
+    "docs/development/build notes.md",
+  ]) {
+    assert.equal(requiresRust([filePath]), false, filePath);
+  }
+});
+
 test("Rust and mixed changes run Rust", () => {
   assert.equal(requiresRust(["src-tauri/src/lib.rs"]), true);
   assert.equal(
     requiresRust(["src/components/Button.tsx", "src-tauri/Cargo.lock"]),
+    true
+  );
+  assert.equal(
+    requiresRust([
+      "docs/hugeicons-migration/icon-mapping.md",
+      "src-tauri/src/lib.rs",
+    ]),
     true
   );
 });
@@ -47,17 +81,36 @@ test("workflow, script, and protocol changes run Rust conservatively", () => {
   assert.equal(requiresRust(["docs/orgtrack-pm-protocol/README.md"]), true);
 });
 
+test("Rust contracts and non-Markdown documentation inputs stay in Rust scope", () => {
+  for (const filePath of [
+    "docs/orgtrack-pm-protocol/decisions.md",
+    "docs/orgtrack-pm-protocol/schemas/common.schema.json",
+    "docs/orgtrack-pm-protocol/fixtures/routine-spec.json",
+    "docs/examples/Cargo.lock",
+    "docs/examples/main.rs",
+    "docs/fixtures/example.json",
+    "src-tauri/README.md",
+  ]) {
+    assert.equal(requiresRust([filePath]), true, filePath);
+  }
+});
+
 test("empty or unknown diffs fail closed", () => {
   assert.equal(requiresRust([]), true);
-  assert.equal(requiresRust(["README.md"]), true);
+  assert.equal(requiresRust(["unknown.md"]), true);
+  assert.equal(requiresRust(["README.md.backup"]), true);
+  assert.equal(requiresRust(["docs/notes.md.backup"]), true);
   assert.equal(isFrontendOnlyPath("package.json.backup"), false);
 });
 
 test("NUL-delimited paths preserve whitespace and drive the CLI", () => {
-  const input = Buffer.from("src/a file.ts\0public/index.html\0");
+  const input = Buffer.from(
+    "src/a file.ts\0public/index.html\0docs/build notes.md\0"
+  );
   assert.deepEqual(parseNullDelimitedPaths(input), [
     "src/a file.ts",
     "public/index.html",
+    "docs/build notes.md",
   ]);
 
   const result = spawnSync(


### PR DESCRIPTION
## Problem

Frontend PR #1117 started the macOS Rust job solely because it updated `docs/hugeicons-migration/icon-mapping.md`. The scope detector recognizes frontend files but treats all other paths, including ordinary documentation, as Rust inputs. Supporting documentation therefore makes frontend-only changes run Rust compilation and workspace tests unnecessarily.

## Solution

Exempt Markdown files under `docs/` and the explicitly listed root documentation files. Keep the entire `docs/orgtrack-pm-protocol/` contract in Rust scope because its schemas and fixtures are consumed by Rust conformance tests. Non-Markdown documentation inputs, Rust changes, workflow/script changes, unknown paths, and empty diffs still require Rust.

Add regression coverage for frontend-plus-documentation changes, documentation-only changes, mixed Rust changes, protocol inputs, unknown paths, and the NUL-delimited CLI. Update the CI description to match. The shared detector also applies this policy to the Rust cache-warming workflow.

## Potential risks

If Rust begins consuming Markdown from another documentation directory, that input must be added to the protected scope. Existing protocol inputs remain protected, and the default for unrecognized files remains to run Rust. This PR itself still requires Rust CI because it changes the detector and workflow file.

No application behavior, dependencies, persistence formats, or public APIs change. Reverting this commit restores the previous conservative documentation behavior. The terminal test race observed in #1117 is handled separately in #1120.

## Verification

- `node --test scripts/ci/*.test.cjs` — all 28 policy tests passed, including after updating to the latest `develop`.
- `pnpm exec prettier --check scripts/ci/detect-rust-changes.cjs scripts/ci/detect-rust-changes.test.cjs .github/workflows/ci.yml` — passed.
- `git diff --check` — passed.
- `git diff --name-only -z 270d67bfb3d36b787a37f68913a0e93f5640e888...776120df07c11b0b9a4ededf17499e0335a93666 | node scripts/ci/detect-rust-changes.cjs` — returned `false` for the exact 72-file icon PR diff. Regression tests verify that adding Rust source or PM protocol inputs still returns `true`.
- Reviewed the three-file diff for scope, secrets, personal paths, generated artifacts, and unrelated formatting. Unrelated local edits are excluded.
- Full application builds and end-to-end tests were not run for this CI policy change. Screenshots are not applicable because no UI rendering changes.
