### PR TITLE
test(terminal): serialize shared registry fixtures

### DIFF
--- a/src-tauri/crates/terminal/src/pty_commands/pty.rs
+++ b/src-tauri/crates/terminal/src/pty_commands/pty.rs
@@ -1080,6 +1080,11 @@ mod tests {
     use super::{collect_sweep_sids, leader_is_sweep_candidate, pending_exit_session_leaders};
     use std::collections::HashMap;
 
+    // Hold this across setup, assertions, and cleanup in every registry test.
+    // The registry's own mutex protects individual operations, but another
+    // parallel test can still clear the fixture between register and collect.
+    static REGISTRY_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[cfg(target_os = "linux")]
     mod parse_tpgid_tests {
         use super::super::parse_tpgid_from_stat;
@@ -1139,6 +1144,9 @@ mod tests {
     // the start_time check. Both tracked and registered paths must reject it.
     #[test]
     fn collect_sweep_sids_rejects_reused_pid_in_both_tracked_and_registered() {
+        let _registry_guard = REGISTRY_TEST_LOCK
+            .lock()
+            .expect("registry test lock poisoned");
         reset_registry();
         // Registered leader: shell exited, OS reused its PID for a process
         // with a different start_time.
@@ -1168,6 +1176,9 @@ mod tests {
 
     #[test]
     fn collect_sweep_sids_keeps_shells_with_matching_or_absent_holder() {
+        let _registry_guard = REGISTRY_TEST_LOCK
+            .lock()
+            .expect("registry test lock poisoned");
         reset_registry();
         // Registered leader whose shell is still alive (start_time matches).
         super::register_session_leader(100, 1000);


### PR DESCRIPTION
## Problem

PR #1117 failed in `collect_sweep_sids_keeps_shells_with_matching_or_absent_holder` even though it did not change terminal code. The two sweep tests reset, populate, inspect, and clear the same process-global session-leader registry in parallel. Its existing mutex protects each operation individually, so one test can still clear the other's fixture between registration and collection.

The unchanged test binary reproduced the same missing-live-shell assertion on the first two-thread stress run.

## Solution

Add a test-only mutex and hold it across setup, assertions, and cleanup in both registry tests. This serializes only the two shared fixtures while the remaining tests continue to run in parallel. Production registry access, shutdown behavior, and PID-reuse safety checks are unchanged.

The CI scope issue that triggered Rust for the frontend icon change is handled independently in #1119.

## Potential risks

Future tests that mutate this global registry must hold the same fixture lock. The change is confined to the Unix test module and has been verified on macOS; Linux and Windows builds were not run. No runtime synchronization, dependencies, persistence, IPC, or public APIs change. Reverting this commit restores the old test behavior without any data migration.

## Verification

- From `src-tauri`: `cargo test -p terminal --lib -- --test-threads=8` — all 67 tests passed, including after updating to the latest `develop`.
- From `src-tauri`: `cargo clippy -p terminal --all-targets -- -D warnings` — passed, including after updating to the latest `develop`.
- `rustfmt --check --edition 2021 src-tauri/crates/terminal/src/pty_commands/pty.rs` — passed.
- `git diff --check` — passed.
- Two independent batches of 2,000 consecutive runs of the two registry tests passed with `--test-threads=2` (8,000 individual test executions total). One batch used this command from `src-tauri`:

```sh
python3 - <<'PY'
import json, subprocess
build = subprocess.run(['cargo', 'test', '-p', 'terminal', '--lib', '--no-run', '--message-format=json'], capture_output=True, text=True, check=True)
binary = next(message['executable'] for line in build.stdout.splitlines() if (message := json.loads(line)).get('reason') == 'compiler-artifact' and message.get('executable') and message['target']['name'] == 'terminal' and message['profile']['test'])
for attempt in range(1, 2001):
    result = subprocess.run([binary, 'pty_commands::pty::tests::collect_sweep_sids_', '--test-threads=2', '--quiet'], capture_output=True, text=True)
    if result.returncode:
        raise SystemExit(f'Failed on run {attempt}:\n{result.stdout}{result.stderr}')
print('Passed 2000 consecutive runs of both registry tests with 2 test threads (4000 test executions).')
PY
```

- Reviewed the one-file diff for scope, secrets, personal paths, generated artifacts, and unrelated formatting. No production code or unrelated local edits are included.
- Full Rust workspace tests and Linux/Windows builds were not rerun; verification targets the affected terminal crate. Screenshots are not applicable to this test-only change.
