### PR TITLE
fix(layout): align pane toggle icons with visibility

### DIFF
--- a/src/engines/ChatPanel/ChatPanelHeader.test.ts
+++ b/src/engines/ChatPanel/ChatPanelHeader.test.ts
@@ -42,6 +42,7 @@ function render({
   return renderToStaticMarkup(
     createElement(ChatPanelHeader, {
       activeSessionExists: true,
+      chatPanelPosition: "left",
       copyEventJsonLabel: "idle" as const,
       currentSessionId: "session-a",
       displayMode: "full" as const,
@@ -111,6 +112,7 @@ describe("ChatPanelHeader tab row collapse", () => {
     expect(markup).toContain('data-testid="chat-panel-collapsed-tab-controls"');
     // + / restore / close all survive the fold.
     expect(markup).toContain('data-plus-menu="true"');
+    expect(markup).toContain('data-icon="layout-align-right"');
     expect(markup).toContain('data-icon="panel-right"');
     // Swapped, never cross-faded — overlapping the two near-identical
     // outlines is what made the icon shake on hover.

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -13,6 +13,7 @@ import {
   ArrowExpand01Icon,
   ComputerVideoIcon,
   HugeiconsIcon,
+  LayoutAlignRightIcon,
   PanelRightIcon,
   PanelRightOpenIcon,
   SquareTerminalIcon,
@@ -20,6 +21,7 @@ import {
 import { HEADER_ICON_SIZE } from "@src/modules/WorkStation/shared/tokens";
 import { CollapsedSidebarButton } from "@src/scaffold/NavigationSidebar/CollapsedSidebarButton";
 import type { ChatHistoryDisplayMode } from "@src/store/ui/chatPanelAtom";
+import type { ChatPanelPosition } from "@src/store/ui/workStationLayout/chatPositionAtoms";
 import { isWindows } from "@src/util/platform/tauri";
 
 import { SessionHeaderActionsMenu } from "./components/SessionHeaderActionsMenu";
@@ -44,6 +46,7 @@ const CHAT_PANEL_HEADER_ICON_SIZE = 14;
 
 interface ChatPanelHeaderProps {
   activeSessionExists: boolean;
+  chatPanelPosition: ChatPanelPosition;
   copyEventJsonLabel: "idle" | "copied" | "failed";
   currentSessionId: string | null;
   displayMode: ChatHistoryDisplayMode;
@@ -102,6 +105,7 @@ interface ChatPanelHeaderProps {
 
 export function ChatPanelHeader({
   activeSessionExists,
+  chatPanelPosition,
   copyEventJsonLabel,
   currentSessionId,
   displayMode,
@@ -264,24 +268,34 @@ export function ChatPanelHeader({
         className="group"
       >
         {isChatFocus ? (
-          // Swapped with `hidden`, never cross-faded. Both glyphs draw the
-          // same rounded-rect outline from different path strings (opposite
-          // winding, different start point); fading one through the other
-          // rasterizes that identical outline twice at slightly different
-          // anti-aliasing, which reads as the icon shaking. Only ever
-          // painting one keeps the hover to what actually differs — the
-          // chevron `PanelRightOpenIcon` adds.
+          // Swap glyphs without cross-fading so their outlines never overlap.
           <span className="flex h-4 w-4 items-center justify-center">
             <HugeiconsIcon
-              icon={PanelRightIcon}
-              data-icon="panel-right"
+              icon={
+                chatPanelPosition === "left"
+                  ? LayoutAlignRightIcon
+                  : PanelRightIcon
+              }
+              data-icon={
+                chatPanelPosition === "left"
+                  ? "layout-align-right"
+                  : "panel-right"
+              }
               size={HEADER_ICON_SIZE.md}
               strokeWidth={1.75}
               className="group-hover:hidden"
             />
             <HugeiconsIcon
-              icon={PanelRightOpenIcon}
-              data-icon="panel-right-open"
+              icon={
+                chatPanelPosition === "left"
+                  ? PanelRightIcon
+                  : PanelRightOpenIcon
+              }
+              data-icon={
+                chatPanelPosition === "left"
+                  ? "panel-right"
+                  : "panel-right-open"
+              }
               size={HEADER_ICON_SIZE.md}
               strokeWidth={1.75}
               className="hidden group-hover:block"

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -587,6 +587,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     const headerSection = (
       <ChatPanelHeader
         activeSessionExists={Boolean(activeSession)}
+        chatPanelPosition={position}
         copyEventJsonLabel={copyEventJsonLabel}
         currentSessionId={currentSessionId ?? null}
         displayMode={displayMode}

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -389,6 +389,8 @@ export { default as Shield02Icon } from "@hugeicons/core-free-icons/Shield02Icon
 export { default as ShieldAlertIcon } from "@hugeicons/core-free-icons/ShieldAlertIcon";
 export { default as SidebarBottomIcon } from "@hugeicons/core-free-icons/SidebarBottomIcon";
 export { default as SidebarLeft01Icon } from "@hugeicons/core-free-icons/SidebarLeft01Icon";
+export { default as SidebarLeftIcon } from "@hugeicons/core-free-icons/SidebarLeftIcon";
+export { default as SidebarRightIcon } from "@hugeicons/core-free-icons/SidebarRightIcon";
 export { default as SignalFull01Icon } from "@hugeicons/core-free-icons/SignalFull01Icon";
 export { default as SkipBackIcon } from "@hugeicons/core-free-icons/SkipBackIcon";
 export { default as SlashIcon } from "@hugeicons/core-free-icons/SlashIcon";

--- a/src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.test.ts
+++ b/src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.test.ts
@@ -25,7 +25,7 @@ describe("WorkstationMaximizeChatIcon", () => {
     );
 
     expect(markup).toContain('data-icon="panel-right"');
-    expect(markup).toContain('data-icon="panel-right-close"');
-    expect(markup).toContain("group-hover:opacity-100");
+    expect(markup).toContain('data-icon="layout-align-right"');
+    expect(markup).toContain("hidden group-hover:block");
   });
 });

--- a/src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.tsx
+++ b/src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.tsx
@@ -19,7 +19,7 @@ import {
   BubbleChatIcon,
   Cancel01Icon,
   HugeiconsIcon,
-  PanelRightCloseIcon,
+  LayoutAlignRightIcon,
   PanelRightIcon,
 } from "@src/icons";
 import ProjectManagerWorkItemsTabBarTrailing from "@src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerWorkItemsTabBarTrailing";
@@ -65,20 +65,20 @@ export function WorkstationMaximizeChatIcon({
   }
 
   return (
-    <span className="relative flex h-4 w-4 items-center justify-center">
+    <span className="flex h-4 w-4 items-center justify-center">
       <HugeiconsIcon
         icon={PanelRightIcon}
         data-icon="panel-right"
         size={HEADER_ICON_SIZE.md}
         strokeWidth={2}
-        className="absolute transition-opacity duration-150 group-hover:opacity-0"
+        className="group-hover:hidden"
       />
       <HugeiconsIcon
-        icon={PanelRightCloseIcon}
-        data-icon="panel-right-close"
+        icon={LayoutAlignRightIcon}
+        data-icon="layout-align-right"
         size={HEADER_ICON_SIZE.md}
         strokeWidth={2}
-        className="absolute opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+        className="hidden group-hover:block"
       />
     </span>
   );

--- a/src/modules/WorkStation/shared/SidebarToggleButton.tsx
+++ b/src/modules/WorkStation/shared/SidebarToggleButton.tsx
@@ -22,13 +22,14 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip";
-import { PanelLeftIcon, PanelRightIcon } from "@src/components/PanelIcons";
 import type { TooltipProps } from "@src/components/Tooltip";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import {
   HugeiconsIcon,
   LayoutAlignLeftIcon,
   LayoutAlignRightIcon,
+  SidebarLeftIcon,
+  SidebarRightIcon,
 } from "@src/icons";
 import {
   simulatorPrimarySidebarCollapsedAtom,
@@ -83,7 +84,7 @@ const SidebarToggleButtonComponent: React.FC<SidebarToggleButtonProps> = ({
   showShortcut = true,
 }) => {
   const { t } = useTranslation("sessions");
-  const Icon = position === "right" ? PanelRightIcon : PanelLeftIcon;
+  const SidebarIcon = position === "right" ? SidebarRightIcon : SidebarLeftIcon;
   const AlignmentIcon =
     position === "right" ? LayoutAlignRightIcon : LayoutAlignLeftIcon;
   const label = collapsed
@@ -105,6 +106,7 @@ const SidebarToggleButtonComponent: React.FC<SidebarToggleButtonProps> = ({
           size="small"
           iconOnly
           disabled={disabled}
+          className={disabled ? undefined : "group/sidebar-toggle"}
           onClick={disabled ? undefined : onToggle}
           aria-label={label}
           icon={
@@ -116,11 +118,22 @@ const SidebarToggleButtonComponent: React.FC<SidebarToggleButtonProps> = ({
                 strokeWidth={2.25}
               />
             ) : (
-              <Icon
-                size={iconSize}
-                strokeWidth={1.75}
-                fillSidebar={!collapsed}
-              />
+              <>
+                <HugeiconsIcon
+                  icon={collapsed ? AlignmentIcon : SidebarIcon}
+                  data-icon={`${collapsed ? "layout-align" : "sidebar"}-${position}`}
+                  size={iconSize}
+                  strokeWidth={2.25}
+                  className="group-hover/sidebar-toggle:hidden"
+                />
+                <HugeiconsIcon
+                  icon={collapsed ? SidebarIcon : AlignmentIcon}
+                  data-icon={`${collapsed ? "sidebar" : "layout-align"}-${position}`}
+                  size={iconSize}
+                  strokeWidth={2.25}
+                  className="hidden group-hover/sidebar-toggle:block"
+                />
+              </>
             )
           }
         />
@@ -174,7 +187,6 @@ const WorkStationSidebarToggleButtonComponent: React.FC<
       onToggle={callbacks.onTogglePrimaryPanel ?? handleFallbackToggle}
       position={position}
       iconSize={iconSize}
-      stableAlignmentIcon
       tooltipPosition={activeApp === "browser" ? "top" : "bottom"}
       disabled={disabled}
     />

--- a/src/scaffold/NavigationSidebar/CollapsedSidebarButton.tsx
+++ b/src/scaffold/NavigationSidebar/CollapsedSidebarButton.tsx
@@ -7,7 +7,7 @@ import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut
 import Tooltip from "@src/components/Tooltip";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { getCollapsedSidebarButtonLeft } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
-import { HugeiconsIcon, PanelLeftIcon } from "@src/icons";
+import { HugeiconsIcon, LayoutAlignLeftIcon, PanelLeftIcon } from "@src/icons";
 import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
 
 const CollapsedSidebarButtonComponent: React.FC = () => {
@@ -50,16 +50,27 @@ const CollapsedSidebarButtonComponent: React.FC = () => {
             variant="tertiary"
             size="small"
             iconOnly
+            className="group/collapsed-sidebar"
             onClick={handleClick}
             title={label}
             aria-label={label}
             icon={
-              <HugeiconsIcon
-                icon={PanelLeftIcon}
-                data-icon="panel-left"
-                size={16}
-                strokeWidth={2}
-              />
+              <>
+                <HugeiconsIcon
+                  icon={LayoutAlignLeftIcon}
+                  data-icon="layout-align-left"
+                  size={16}
+                  strokeWidth={2}
+                  className="group-hover/collapsed-sidebar:hidden"
+                />
+                <HugeiconsIcon
+                  icon={PanelLeftIcon}
+                  data-icon="panel-left"
+                  size={16}
+                  strokeWidth={2}
+                  className="hidden group-hover/collapsed-sidebar:block"
+                />
+              </>
             }
           />
         </span>

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -33,8 +33,8 @@ import {
   Add01Icon,
   Cancel01Icon,
   HugeiconsIcon,
+  LayoutAlignLeftIcon,
   PanelLeftIcon,
-  SidebarLeft01Icon,
 } from "@src/icons";
 import {
   PANE_WIDTH_TRANSITION_CLASSES,
@@ -425,21 +425,21 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
                         className="group flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-sidebar-selected"
                         onClick={handleCollapse}
                       >
-                        <span className="relative flex h-4 w-4 items-center justify-center">
+                        <span className="flex h-4 w-4 items-center justify-center">
                           <HugeiconsIcon
                             icon={PanelLeftIcon}
                             data-icon="panel-left"
                             size={16}
                             strokeWidth={2}
-                            className="absolute text-text-2 transition-opacity duration-150 group-hover:opacity-0"
+                            className="text-text-2 group-hover:hidden"
                             style={iconThemeStyle}
                           />
                           <HugeiconsIcon
-                            icon={SidebarLeft01Icon}
-                            data-icon="sidebar-left-01"
+                            icon={LayoutAlignLeftIcon}
+                            data-icon="layout-align-left"
                             size={16}
                             strokeWidth={2}
-                            className="absolute text-text-2 opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+                            className="hidden text-text-2 group-hover:block"
                             style={iconThemeStyle}
                           />
                         </span>


### PR DESCRIPTION
## Problem

The navigation sidebar and My Station visibility controls use inconsistent icon states: some show the same alignment icon whether the pane is open or closed, while hover introduces a separate arrow icon instead of showing the resulting state.

## Solution

- Use an alignment icon when the navigation sidebar is hidden and retain its original panel icon when shown. Hover previews the opposite state.
- Apply the same pattern to the My Station pane toggle when chat is left and My Station is right, preserving the original shown-state icon and the reversed layout.
- Use `SidebarLeftIcon` / `SidebarRightIcon` and matching alignment icons for My Station's primary sidebar, according to its position and visibility. Hover previews the opposite state with a matching stroke weight.
- Swap visibility with CSS instead of overlapping cross-fades. Keep click handlers, keyboard shortcuts, labels, and Agent Station behavior unchanged.

## Potential risks

- Native hover appearance, themes, narrow viewports, and disabled-state visuals have not been exercised in the running desktop app. No new screenshots or recordings were captured because desktop computer control was not authorized; rendered tests do not replace that visual check.
- This is a frontend presentation change with no dependency, persistence, IPC, or schema changes. Existing pane state and lifecycle ownership are unchanged. Reverting the commit restores the previous icons.

## Verification

All commands ran in an isolated checkout based on the latest `origin/develop`, with only these nine files changed.

- `pnpm typecheck` — passed.
- `pnpm test -- src/modules/WorkStation/shared/SidebarToggleButton.test.ts src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.test.ts src/engines/ChatPanel/ChatPanelHeader.test.ts src/components/Button/index.test.ts src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.test.ts src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts` — 6 files, 20 tests passed. Existing Vite/Sass deprecation warnings only.
- `pnpm exec eslint src/icons.ts src/scaffold/NavigationSidebar/CollapsedSidebarButton.tsx src/scaffold/NavigationSidebar/SidebarBase.tsx src/engines/ChatPanel/ChatPanelHeader.tsx src/engines/ChatPanel/ChatPanelHeader.test.ts src/engines/ChatPanel/index.tsx src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.tsx src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.test.ts src/modules/WorkStation/shared/SidebarToggleButton.tsx --max-warnings 0` — passed.
- `git diff --check` and `git diff --cached --check` — passed. Reviewed every changed file and excluded unrelated workspace edits and icon exports; no secrets, private configuration, debug output, or generated artifacts are included.
- The full test suite and Rust checks were not run for this scoped frontend icon change. Desktop visual validation remains outstanding as described above.
