### PR TITLE
style(dropdowns): use plain arrows for external actions

### DIFF
--- a/src/modules/ProjectManager/Projects/projectContextMenu.tsx
+++ b/src/modules/ProjectManager/Projects/projectContextMenu.tsx
@@ -2,6 +2,7 @@ import { createElement } from "react";
 
 import { DROPDOWN_ITEM } from "@src/components/Dropdown/tokens";
 import {
+  ArrowUpRight01Icon,
   Calendar01Icon,
   Cardiogram01Icon,
   CircleDotIcon,
@@ -12,7 +13,6 @@ import {
   Flag01Icon,
   HugeiconsIcon,
   ListChevronsDownUpIcon,
-  SquareArrowUpRight02Icon,
   Tag01Icon,
   Unlink02Icon,
   UserIcon,
@@ -464,7 +464,7 @@ export function getProjectContextMenuItems(options: ProjectContextMenuOptions) {
       id: "open",
       label: t("common:actions.open"),
       icon: createElement(HugeiconsIcon, {
-        icon: SquareArrowUpRight02Icon,
+        icon: ArrowUpRight01Icon,
         size: DROPDOWN_ITEM.iconSize,
       }),
       secondary:

--- a/src/modules/WorkStation/shared/StatusBar/CiStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/CiStatusMenu.tsx
@@ -24,6 +24,7 @@ import { useDropdownEngine } from "@src/hooks/dropdown";
 import { useActiveRepoRef } from "@src/hooks/git/useActiveRepoRef";
 import { useBranchPullRequestStatus } from "@src/hooks/git/useBranchPullRequestStatus";
 import {
+  ArrowUpRight01Icon,
   CancelCircleIcon,
   CheckmarkCircle01Icon,
   CircleDashedIcon,
@@ -32,7 +33,6 @@ import {
   HugeiconsIcon,
   Loading03Icon,
   Refresh04Icon,
-  SquareArrowUpRight02Icon,
 } from "@src/icons";
 import type { BranchCiStatus } from "@src/services/git/branchPullRequestStatus";
 import {
@@ -189,8 +189,8 @@ const CheckRow: React.FC<CheckRowProps> = memo(({ item, onOpenDetails }) => {
             }}
           >
             <HugeiconsIcon
-              icon={SquareArrowUpRight02Icon}
-              data-icon="square-arrow-out-up-right"
+              icon={ArrowUpRight01Icon}
+              data-icon="arrow-up-right"
               size={MENU_ICON_SIZE}
             />
           </button>

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationItemRow.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationItemRow.tsx
@@ -10,11 +10,7 @@ import { IconButton } from "@src/components/IconButton";
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
 import Tooltip from "@src/components/Tooltip";
 import { WORKSTATION_TRAIL_CONTENT } from "@src/config/workstation/tokens";
-import {
-  Cancel01Icon,
-  HugeiconsIcon,
-  SquareArrowUpRight02Icon,
-} from "@src/icons";
+import { ArrowUpRight01Icon, Cancel01Icon, HugeiconsIcon } from "@src/icons";
 
 import { RailItemStatus } from "./RailItemStatus";
 import type { FocusedChatRailItem } from "./types";
@@ -73,7 +69,7 @@ export function WorkstationItemRow({
       {item.status ? <RailItemStatus status={item.status} /> : null}
       {item.external ? (
         <HugeiconsIcon
-          icon={SquareArrowUpRight02Icon}
+          icon={ArrowUpRight01Icon}
           data-icon="arrow-up-right"
           aria-hidden
           className="shrink-0 text-text-2"

--- a/src/scaffold/GlobalSpotlight/components/SpotlightFooterAction.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightFooterAction.tsx
@@ -5,7 +5,7 @@
  */
 import React from "react";
 
-import { HugeiconsIcon, SquareArrowUpRight02Icon } from "@src/icons";
+import { ArrowUpRight01Icon, HugeiconsIcon } from "@src/icons";
 
 export interface SpotlightFooterActionProps {
   label: string;
@@ -25,7 +25,7 @@ export const SpotlightFooterAction: React.FC<SpotlightFooterActionProps> = ({
       >
         <span>{label}</span>
         <HugeiconsIcon
-          icon={SquareArrowUpRight02Icon}
+          icon={ArrowUpRight01Icon}
           data-icon="arrow-up-right"
           size={10}
           strokeWidth={2.5}

--- a/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
@@ -26,6 +26,7 @@ import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip"
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import {
   ArrowRight01Icon,
+  ArrowUpRight01Icon,
   FilterMailIcon,
   FolderInputIcon,
   FolderOutputIcon,
@@ -35,7 +36,6 @@ import {
   ListChevronsDownUpIcon,
   Refresh04Icon,
   SlidersHorizontalIcon,
-  SquareArrowUpRight02Icon,
   TickDouble01Icon,
 } from "@src/icons";
 import { getViewportSize } from "@src/util/ui/window/viewport";
@@ -462,7 +462,7 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                       }
                       suffix={
                         <HugeiconsIcon
-                          icon={SquareArrowUpRight02Icon}
+                          icon={ArrowUpRight01Icon}
                           data-icon="arrow-up-right"
                           size={DROPDOWN_ITEM.iconSize}
                           strokeWidth={2}


### PR DESCRIPTION
## Problem

Several dropdown actions still use a boxed external arrow, while the session action menu uses the plain up-right arrow. The sidebar filter menu's Manage external sources action is one visible example of this inconsistency.

## Solution

Replace `SquareArrowUpRight02Icon` with the existing `ArrowUpRight01Icon` at five shared menu locations:

- Sidebar filters: Manage external sources.
- Project context menus: Open.
- CI status menu: check details.
- Opened-tab rows: external comparison/PR actions. The shared row also renders the expanded workstation rail, keeping both presentations consistent.
- Picker footer actions: Manage agents, Manage models, and Manage keys through `SpotlightFooterAction`.

Preserve the existing sizes, stroke widths, colors, spacing, labels, and callbacks. Update the CI icon's `data-icon` marker to match the plain arrow. The already-correct session menu and the separate editor-menu PR remain unchanged; standalone toolbar and chat-card icons are outside this dropdown sweep.

## Potential risks

This changes only icon selection, import formatting, and one icon marker. No navigation, state, polling, listeners, persistence, API, dependency, or configuration changes are introduced. The shared workstation row intentionally updates both its compact menu and expanded rail variants. Actual desktop appearance across themes and viewport sizes was not verified. Rollback is a source revert with no data recovery required.

## Verification

Passed on the isolated PR branch based on the latest `origin/develop`: 17 tests across five existing suites, scoped ESLint, full TypeScript checking, and whitespace checks.

```sh
pnpm exec vitest run src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts src/modules/ProjectManager/Projects/projectContextMenu.test.ts src/modules/shared/layouts/FocusedChatWorkstationRail/trailingAlignment.test.ts src/modules/WorkStation/shared/StatusBar/__tests__/EditorStatusBar.hostless.test.ts src/modules/WorkStation/shared/StatusBar/components/EditorStatusBarRight.test.ts
pnpm exec eslint src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx src/modules/ProjectManager/Projects/projectContextMenu.tsx src/modules/WorkStation/shared/StatusBar/CiStatusMenu.tsx src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationItemRow.tsx src/scaffold/GlobalSpotlight/components/SpotlightFooterAction.tsx --max-warnings 0
pnpm run typecheck
git diff --cached --check
```

A repository source inventory located the remaining boxed menu indicators. A TypeScript AST comparison of all five changed files, normalizing the selected icon and the CI marker, confirmed no other import, JSX, or behavior changes. Existing tests cover sidebar submenu interaction, project actions, shared row alignment, and status-bar rendering. No new tests were added for this reversible icon-only change.

Desktop screenshots and manual visual checks were not captured because computer control requires explicit opt-in and was not requested. Rust and backend checks were not run because this PR only changes frontend icons.
