### PR TITLE
fix(chat): show icon-only conversation mode choices

### DIFF
--- a/docs/frontend-ui-audit-2026-08-31/ConversationModePill.md
+++ b/docs/frontend-ui-audit-2026-08-31/ConversationModePill.md
@@ -1,0 +1,33 @@
+# ConversationModePill UI audit
+
+| Line                                                                     | Element                                        | Verdict          | Reason                                                                                                                                                                                       | Suggested change                                                                                                           |
+| ------------------------------------------------------------------------ | ---------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx:30` | Agent / Team chat switch                       | fix              | Both destinations need to remain discoverable without crowding the docked composer. The user's requested GUI / TUI pill already supplies the shared surface.                                 | Applied: use `SegmentedTextPill`, showing `Infinity01Icon` / `MessagesSquareIcon` in every pane size, including maximized. |
+| `src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx:49` | Explanatory tooltips (also line 69)            | fix              | Icon choices need the existing destination explanations, using the app's shortcut-tooltip presentation rather than native title hints. No keyboard shortcut is registered for these choices. | Applied: `KeyboardShortcutTooltipContent` with `noShortcut`, attached to each complete segment button by the shared pill.  |
+| `src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx:38` | Accessible labels and selection (also line 58) | keep with reason | Localized button names remain available when visible text is replaced by decorative icons. Native buttons and `aria-pressed` preserve keyboard activation and selection semantics.           | None.                                                                                                                      |
+| `src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx:43` | Size and theme                                 | keep with reason | Icons use `PILL_SM_ICON_SIZE`; surfaces, text colors, height, and padding remain owned by the shared pill. No custom colors or new fixed widths are introduced.                              | None.                                                                                                                      |
+
+Verdict totals: **2 fix**, **2 keep with reason**, **0 abstract**.
+
+The visibility guard, per-session mode atom, and submit routing are unchanged.
+The switch is icon-only in every pane size and no longer subscribes to the
+maximize preference. It does not resize the pane or change the selected mode.
+There is no new keyboard binding or translation key.
+
+Verification:
+
+- `pnpm exec vitest run src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts src/components/SegmentedTextPill/SegmentedTextPill.test.ts src/components/Tooltip/index.test.ts src/components/KeyboardShortcut/index.test.ts` — passed, 23 tests. Includes real component rendering, both glyphs, accessible labels, maximize/restore, session isolation, selection, tooltip text/dismissal, availability guards, and three open/unmount cycles.
+- `pnpm exec eslint src/components/SegmentedTextPill/index.tsx src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts src/icons.ts --max-warnings 0 --report-unused-disable-directives` — passed.
+- `pnpm run check:test-placement` — passed.
+- `pnpm run typecheck` — passed in the isolated PR checkout based on the latest `develop`.
+- Desktop screenshots, theme appearance, and narrow localized layouts were not visually verified: Computer Use was not requested. DOM tests do not establish pixel-level appearance.
+
+The shared-component review is in `SegmentedTextPill.md`; lifecycle evidence and
+remaining performance verification limits are in
+`../org2-performance-guard-2026-08-31/ConversationModePill.md`.
+
+Icon-only follow-up: the same 23 focused tests were rerun, including the updated
+maximize/restore assertion. Targeted lint and formatting cover
+`ConversationModePill.tsx` and `ConversationModePill.test.ts`; the shared primitive
+is unchanged. Full typecheck was rerun and passed in the clean PR checkout.
+Desktop measurements were not run because Computer Use was not requested.

--- a/docs/frontend-ui-audit-2026-08-31/SegmentedTextPill.md
+++ b/docs/frontend-ui-audit-2026-08-31/SegmentedTextPill.md
@@ -1,0 +1,20 @@
+# SegmentedTextPill UI audit
+
+| Line                                            | Element                                 | Verdict          | Reason                                                                                                                                                                                                | Suggested change                                                                                                             |
+| ----------------------------------------------- | --------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `src/components/SegmentedTextPill/index.tsx:5`  | Per-option metadata                     | fix              | The compact conversation switch needs accessible names for glyph-only options and tooltips over the whole button. These are generic option concerns, not conversation state.                          | Applied: optional `ariaLabel` and `tooltip` fields; only options supplying tooltips instantiate the existing shared Tooltip. |
+| `src/components/SegmentedTextPill/index.tsx:56` | Native segment button                   | keep with reason | This is the design-system primitive itself. Native button type, disabled behavior, click forwarding, and pressed state remain intact; Tooltip clones the same button without adding a layout wrapper. | None.                                                                                                                        |
+| `src/components/SegmentedTextPill/index.tsx:25` | Established dimensions and theme tokens | keep with reason | Existing small/default sizing and themed backgrounds are unchanged, preserving GUI / TUI, Write / Preview, and other consumers that do not supply the new optional fields.                            | None.                                                                                                                        |
+
+Verdict totals: **1 fix**, **2 keep with reason**, **0 abstract**.
+
+No shared style sweep or unrelated consumer migration is needed. The two optional
+fields default to the prior rendering path. The conversation integration tests
+exercise tooltip click forwarding and preservation of the same native buttons
+across maximize/restore; existing pill tests verify both size variants.
+
+Architecture scope: checked compilation results, reuse, naming, generic/domain
+separation, unchanged defaults, and compatibility of existing call sites. No
+backend, persistence, IPC, initialization, or resolver behavior changed.
+
+See `ConversationModePill.md` for exact verification commands and limitations.

--- a/docs/org2-performance-guard-2026-08-31/ConversationModePill.md
+++ b/docs/org2-performance-guard-2026-08-31/ConversationModePill.md
@@ -1,0 +1,32 @@
+# ConversationModePill performance guard
+
+| Area               | Verdict | Evidence                                                                                                                                            | Change or reason kept                                                               | Verification                                                                                                               |
+| ------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Background work    | keep    | Tooltips own interaction delays and add scroll/resize listeners only while open. No polling, scans, network requests, or workers are added.         | Reuse Tooltip; do not add a second tooltip lifecycle in the conversation component. | Rendered tests observe zero idle timers/listeners and removal of active listeners/timers across three open/unmount cycles. |
+| Memory             | keep    | Two option tooltips per mounted switch; the maximize atom subscription has been removed; no new module-level collections or retained session state. | Shared components and Jotai own disposal.                                           | Portals disappear and pending hide timers are cleared on unmount.                                                          |
+| Scope/isolation    | keep    | The existing session-specific mode atom owns selection; the switch no longer reads maximize state.                                                  | No new persistence writer, cloud scope, or model/submit route.                      | Clicking Team chat changes only its session; maximize/restore preserves mode and button identity.                          |
+| Rendering/hot path | keep    | The maximize subscription is removed; no transcript/streaming state is read. Tooltip-free consumers retain their previous render branch.            | Two bounded option elements; no manual subscription or resize observer.             | Component tests and existing small/default pill tests pass. No runtime CPU/RSS claim is made.                              |
+
+Lifecycle scope:
+
+| State                                        | Expected behavior                                                                                    | Evidence                                                                   |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Mounted, idle                                | No tooltip timers or layout listeners                                                                | Asserted on three mounts                                                   |
+| Hover/open                                   | Bounded delay; only the active tooltip installs layout listeners                                     | Real Tooltip exercised with fake timers; one scroll and one resize handler |
+| Select                                       | Shared tooltip closes; session mode changes once                                                     | Both destinations tested                                                   |
+| Maximize/restore                             | Keep both glyphs without replacing controls or changing mode                                         | Tested in both directions                                                  |
+| Unmount with a pending hide                  | Clear timer, listeners, and portal                                                                   | Asserted over three cycles                                                 |
+| Missing session/discussion target            | No switch or tooltip                                                                                 | Both guards tested                                                         |
+| Hidden document, real desktop idle, shutdown | No new recurring activity is introduced; real-app CPU/RSS and focus-return behavior are not measured | Source inspection only; desktop control was not requested                  |
+| Identity/network/provider transitions        | No changed I/O, provider history, transport, or identity owner                                       | Not applicable to this presentation change                                 |
+
+Verification:
+
+- `pnpm exec vitest run src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts src/components/SegmentedTextPill/SegmentedTextPill.test.ts src/components/Tooltip/index.test.ts src/components/KeyboardShortcut/index.test.ts` — 23 tests passed.
+- Targeted ESLint and test-placement check passed (commands recorded in the UI audit).
+- `pnpm run typecheck` — passed in the isolated PR checkout based on the latest `develop`.
+- Real desktop visible/hidden CPU/RSS, theme appearance, and screenshot checks were not run because Computer Use was not requested.
+
+Performance verdict: **blocked** for a full-app sign-off only by unmeasured
+desktop states. Typecheck and the bounded DOM lifecycle checks pass; this is not
+a claim of measured runtime performance improvement.

--- a/src/components/SegmentedTextPill/index.tsx
+++ b/src/components/SegmentedTextPill/index.tsx
@@ -1,8 +1,12 @@
 import type { ReactNode } from "react";
 
+import Tooltip from "@src/components/Tooltip";
+
 export interface SegmentedTextPillOption<T extends string> {
+  ariaLabel?: string;
   disabled?: boolean;
   label: ReactNode;
+  tooltip?: ReactNode;
   value: T;
 }
 
@@ -28,7 +32,7 @@ const BUTTON_SIZE_CLASSES: Record<SegmentedTextPillSize, string> = {
   default: "h-6 px-2.5",
 };
 
-/** Compact text-only segmented control shared by creator setup rows. */
+/** Compact segmented control with optional tooltips and accessible icon labels. */
 export default function SegmentedTextPill<T extends string>({
   ariaLabel,
   className = "",
@@ -48,7 +52,7 @@ export default function SegmentedTextPill<T extends string>({
       {options.map((option) => {
         const selected = option.value === value;
 
-        return (
+        const button = (
           <button
             key={option.value}
             type="button"
@@ -58,11 +62,27 @@ export default function SegmentedTextPill<T extends string>({
                 : "text-text-3 hover:text-text-1"
             } ${option.disabled ? "cursor-not-allowed opacity-50" : ""}`}
             disabled={option.disabled}
+            aria-label={option.ariaLabel}
             aria-pressed={selected}
             onClick={() => onChange(option.value)}
           >
             {option.label}
           </button>
+        );
+
+        return option.tooltip ? (
+          <Tooltip
+            key={option.value}
+            content={option.tooltip}
+            position="top"
+            mouseEnterDelay={200}
+            framedPanel
+            smartPlacement
+          >
+            {button}
+          </Tooltip>
+        ) : (
+          button
         );
       })}
     </div>

--- a/src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import i18n from "i18next";
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { I18nextProvider } from "react-i18next";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
+
+import { ConversationModePill } from "./ConversationModePill";
+import { conversationComposerModeAtomFamily } from "./conversationComposerMode";
+
+const comments = vi.hoisted(() => ({ available: true }));
+
+vi.mock("../SessionComments/SessionCommentsContext", () => ({
+  useSessionCommentsContext: () => (comments.available ? { target: {} } : null),
+}));
+
+const SESSION_ID = "conversation-mode-pill-test";
+let container: HTMLDivElement;
+let root: Root;
+let store: ReturnType<typeof createStore>;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.useFakeTimers();
+  comments.available = true;
+  store = createStore();
+  store.set(chatPanelMaximizedAtom, false);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function renderPill(sessionId: string | null = SESSION_ID): void {
+  act(() => {
+    root.render(
+      createElement(
+        Provider,
+        { store },
+        createElement(
+          I18nextProvider,
+          { i18n },
+          createElement(ConversationModePill, { sessionId })
+        )
+      )
+    );
+  });
+}
+
+function button(label: string): HTMLButtonElement {
+  const element = container.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`
+  );
+  expect(element).not.toBeNull();
+  return element!;
+}
+
+function hover(element: HTMLElement): void {
+  act(() => {
+    element.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+  });
+  act(() => vi.advanceTimersByTime(250));
+}
+
+describe("ConversationModePill", () => {
+  it("shows accessible icon choices in the non-maximized pane", () => {
+    renderPill();
+
+    expect(
+      button("Agent").querySelector('[data-icon="infinity"]')
+    ).not.toBeNull();
+    expect(
+      button("Team chat").querySelector('[data-icon="messages-square"]')
+    ).not.toBeNull();
+    expect(button("Agent").textContent).toBe("");
+    expect(button("Team chat").textContent).toBe("");
+    expect(button("Agent").getAttribute("aria-pressed")).toBe("true");
+    expect(button("Team chat").getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("keeps mode selection session-scoped and stable when clicking the selected choice", () => {
+    renderPill();
+    const modeAtom = conversationComposerModeAtomFamily(SESSION_ID);
+
+    act(() => button("Team chat").click());
+    expect(store.get(modeAtom)).toBe("team_chat");
+    expect(button("Team chat").getAttribute("aria-pressed")).toBe("true");
+    expect(store.get(conversationComposerModeAtomFamily("other-session"))).toBe(
+      "prompt"
+    );
+
+    act(() => button("Team chat").click());
+    expect(store.get(modeAtom)).toBe("team_chat");
+
+    act(() => button("Agent").click());
+    expect(store.get(modeAtom)).toBe("prompt");
+  });
+
+  it("keeps both choices icon-only when maximized without resetting the mode", () => {
+    renderPill();
+    const teamButton = button("Team chat");
+    act(() => teamButton.click());
+
+    act(() => store.set(chatPanelMaximizedAtom, true));
+    expect(button("Agent").textContent).toBe("");
+    expect(button("Team chat").textContent).toBe("");
+    expect(
+      button("Agent").querySelector('[data-icon="infinity"]')
+    ).not.toBeNull();
+    expect(
+      button("Team chat").querySelector('[data-icon="messages-square"]')
+    ).not.toBeNull();
+    expect(button("Team chat")).toBe(teamButton);
+    expect(teamButton.getAttribute("aria-pressed")).toBe("true");
+
+    act(() => store.set(chatPanelMaximizedAtom, false));
+    expect(button("Team chat")).toBe(teamButton);
+    expect(teamButton.textContent).toBe("");
+    expect(store.get(conversationComposerModeAtomFamily(SESSION_ID))).toBe(
+      "team_chat"
+    );
+  });
+
+  it.each([
+    ["Agent", "Send to the agent"],
+    ["Team chat", "Message teammates — does not prompt the agent"],
+  ])(
+    "explains %s with the shared tooltip and dismisses it on selection",
+    (label, explanation) => {
+      renderPill();
+      hover(button(label));
+
+      const tooltip = document.querySelector(".native-tooltip-framed-panel");
+      expect(tooltip?.textContent).toBe(explanation);
+      expect(tooltip?.querySelector("kbd")).toBeNull();
+
+      act(() => button(label).click());
+      expect(document.querySelector(".native-tooltip")).toBeNull();
+    }
+  );
+
+  it.each(["no-session", "no-discussion"])(
+    "hides the switch for %s",
+    (reason) => {
+      comments.available = reason !== "no-discussion";
+      renderPill(reason === "no-session" ? null : SESSION_ID);
+
+      expect(container.querySelector("button")).toBeNull();
+      expect(document.querySelector(".native-tooltip")).toBeNull();
+    }
+  );
+
+  it("does no idle tooltip work and cleans up after repeated open/unmount cycles", () => {
+    const addListener = vi.spyOn(window, "addEventListener");
+    const removeListener = vi.spyOn(window, "removeEventListener");
+    const layoutEvents = new Set(["scroll", "resize"]);
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      addListener.mockClear();
+      removeListener.mockClear();
+      renderPill();
+      expect(vi.getTimerCount()).toBe(0);
+      expect(
+        addListener.mock.calls.filter(([event]) => layoutEvents.has(event))
+      ).toHaveLength(0);
+
+      hover(button("Agent"));
+      const listeners = addListener.mock.calls.filter(([event]) =>
+        layoutEvents.has(event)
+      );
+      expect(listeners.map(([event]) => event).sort()).toEqual([
+        "resize",
+        "scroll",
+      ]);
+
+      act(() => {
+        button("Agent").dispatchEvent(
+          new MouseEvent("mouseout", { bubbles: true })
+        );
+        root.render(null);
+      });
+
+      expect(document.querySelector(".native-tooltip")).toBeNull();
+      expect(vi.getTimerCount()).toBe(0);
+      for (const listener of listeners) {
+        expect(removeListener).toHaveBeenCalledWith(...listener);
+      }
+    }
+  });
+});

--- a/src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx
+++ b/src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import SelectorPill from "@src/components/SelectorPill";
-import { BotIcon, HugeiconsIcon, MessageMultiple01Icon } from "@src/icons";
+import { PILL_SM_ICON_SIZE } from "@src/components/CompoundPill/config";
+import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
+import SegmentedTextPill from "@src/components/SegmentedTextPill";
+import { Infinity01Icon, HugeiconsIcon, MessagesSquareIcon } from "@src/icons";
 
 import {
   useConversationComposerMode,
@@ -10,7 +12,7 @@ import {
 } from "./useConversationComposer";
 
 /**
- * Composer target toggle: Prompt (agent turn) vs Team chat (discussion
+ * Composer target switch: Agent (agent turn) vs Team chat (discussion
  * message). Hidden entirely on sessions without a cloud discussion plane.
  */
 export function ConversationModePill({
@@ -24,40 +26,55 @@ export function ConversationModePill({
 
   if (!available || !sessionId) return null;
 
-  const teamChat = mode === "team_chat";
   return (
-    <SelectorPill
-      icon={
-        teamChat ? (
-          <HugeiconsIcon
-            icon={MessageMultiple01Icon}
-            data-icon="messages-square"
-            size={14}
-            strokeWidth={1.75}
-          />
-        ) : (
-          <HugeiconsIcon
-            icon={BotIcon}
-            data-icon="bot"
-            size={14}
-            strokeWidth={1.75}
-          />
-        )
-      }
-      label={
-        teamChat ? t("conversation.teamChatMode") : t("conversation.promptMode")
-      }
-      tooltip={
-        teamChat
-          ? t("conversation.teamChatTooltip")
-          : t("conversation.promptTooltip")
-      }
-      tooltipFramed
-      tooltipPosition="top"
-      active={teamChat}
+    <SegmentedTextPill
+      ariaLabel={`${t("conversation.promptMode")} / ${t("conversation.teamChatMode")}`}
+      className="whitespace-nowrap"
       dataTestId="conversation-mode-pill"
-      onClick={() => setMode(teamChat ? "prompt" : "team_chat")}
-      size="sm"
+      value={mode}
+      options={[
+        {
+          value: "prompt",
+          ariaLabel: t("conversation.promptMode"),
+          label: (
+            <HugeiconsIcon
+              icon={Infinity01Icon}
+              data-icon="infinity"
+              size={PILL_SM_ICON_SIZE}
+              strokeWidth={1.75}
+              className="block"
+              aria-hidden
+            />
+          ),
+          tooltip: (
+            <KeyboardShortcutTooltipContent
+              label={t("conversation.promptTooltip")}
+              noShortcut
+            />
+          ),
+        },
+        {
+          value: "team_chat",
+          ariaLabel: t("conversation.teamChatMode"),
+          label: (
+            <HugeiconsIcon
+              icon={MessagesSquareIcon}
+              data-icon="messages-square"
+              size={PILL_SM_ICON_SIZE}
+              strokeWidth={1.75}
+              className="block"
+              aria-hidden
+            />
+          ),
+          tooltip: (
+            <KeyboardShortcutTooltipContent
+              label={t("conversation.teamChatTooltip")}
+              noShortcut
+            />
+          ),
+        },
+      ]}
+      onChange={setMode}
     />
   );
 }

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -310,6 +310,7 @@ export { default as MessageCircleMoreIcon } from "@hugeicons/core-free-icons/Mes
 export { default as MessageCircleQuestionMarkIcon } from "@hugeicons/core-free-icons/MessageCircleQuestionMarkIcon";
 export { default as MessageCircleWarningIcon } from "@hugeicons/core-free-icons/MessageCircleWarningIcon";
 export { default as MessageMultiple01Icon } from "@hugeicons/core-free-icons/MessageMultiple01Icon";
+export { default as MessagesSquareIcon } from "@hugeicons/core-free-icons/MessagesSquareIcon";
 export { default as MessageSquareMoreIcon } from "@hugeicons/core-free-icons/MessageSquareMoreIcon";
 export { default as MessageSquareReplyIcon } from "@hugeicons/core-free-icons/MessageSquareReplyIcon";
 export { default as Mic01Icon } from "@hugeicons/core-free-icons/Mic01Icon";


### PR DESCRIPTION
## Problem

The composer exposes only the active Agent or Team chat destination, so the alternate destination is hard to discover. Showing both as text also crowds the compact chat toolbar.

## Solution

- Reuse the GUI / TUI segmented pill for two always-visible, icon-only choices: infinity for Agent and MessagesSquare for Team chat, including when the pane is maximized.
- Preserve translated accessible names and explain each destination with the shared shortcut-tooltip presentation. No keyboard binding exists for these modes, so the tooltips do not advertise one.
- Add optional per-option accessible labels and tooltip content to the shared pill. Existing consumers that omit these fields retain their prior rendering.
- Preserve per-session mode state, availability guards, selection behavior, and submit routing. Add rendered tests for selection, maximize/restore, explanations, and tooltip cleanup.

## Potential risks

The shared pill now supports optional tooltips, so pointer handling and layout are the main regression surfaces. Existing size variants and the new conversation interaction path are covered by tests, but the real Tauri app, themes, narrow translated layouts, and visible/hidden CPU/RSS were not checked. Computer Use was not requested, so no after-change screenshots were captured.

There are no dependency, lockfile, backend, persistence, or wire changes. The component's optional props preserve existing call sites. Full performance sign-off remains limited to the documented DOM lifecycle evidence; no measured runtime improvement is claimed.

## Verification

Run in an isolated checkout based on the latest `develop`:

- `pnpm run typecheck` — passed.
- `pnpm exec eslint src/components/SegmentedTextPill/index.tsx src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts src/icons.ts --max-warnings 0 --report-unused-disable-directives` — passed.
- `pnpm exec prettier --check src/components/SegmentedTextPill/index.tsx src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts src/icons.ts` — passed.
- `pnpm exec vitest run src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts src/components/SegmentedTextPill/SegmentedTextPill.test.ts src/components/Tooltip/index.test.ts src/components/KeyboardShortcut/index.test.ts` — 23 tests passed.
- `pnpm run check:test-placement` — passed.
- `git diff --cached --check` — passed.

The focused tests cover both glyphs and accessible names, session isolation, selected-choice clicks, maximize/restore, both explanations, tooltip dismissal, hidden controls without a discussion target, and three open/unmount cycles with timer/listener cleanup. The full test suite, Rust checks, and desktop visual/performance measurements were not run for this UI-only change.

## Audit

UI audit: 3 fixes, 4 kept with reasons, 0 abstractions across the conversation switch and shared pill. Reports and lifecycle limits are included under the dated UI/performance audit folders.
