### PR TITLE
fix(model-picker): use AI settings icon for empty selection

### DIFF
--- a/src/components/ModelSelectorPill/index.tsx
+++ b/src/components/ModelSelectorPill/index.tsx
@@ -28,7 +28,7 @@ import {
   useModelEffortSegment,
   useModelPillLabel,
 } from "@src/hooks/models";
-import { GripIcon, HugeiconsIcon } from "@src/icons";
+import { AiSettingIcon, HugeiconsIcon } from "@src/icons";
 import type { LastModelSelection } from "@src/store/session/creatorDefaultModelAtom";
 
 export interface ModelSelectorPillProps {
@@ -127,8 +127,8 @@ const ModelSelectorPill = forwardRef<HTMLButtonElement, ModelSelectorPillProps>(
           />
         ) : (
           <HugeiconsIcon
-            icon={GripIcon}
-            data-icon="grip"
+            icon={AiSettingIcon}
+            data-icon="ai-setting"
             size={iconSize}
             strokeWidth={1.75}
             className="text-primary-6"

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorOrgMembersPanel.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorOrgMembersPanel.tsx
@@ -15,7 +15,7 @@ import Switch from "@src/components/Switch";
 import { resolveAgentIcon } from "@src/config/agentIcons";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
 import { useModelPillLabel } from "@src/hooks/models";
-import { GripIcon, HugeiconsIcon, UserMultipleIcon } from "@src/icons";
+import { AiSettingIcon, HugeiconsIcon, UserMultipleIcon } from "@src/icons";
 import {
   type AgentDefinition,
   type AvailableCliAgent,
@@ -317,8 +317,8 @@ const SessionCreatorOrgMembersPanel: React.FC<SessionCreatorOrgMembersPanelProps
                             />
                           ) : (
                             <HugeiconsIcon
-                              icon={GripIcon}
-                              data-icon="grip"
+                              icon={AiSettingIcon}
+                              data-icon="ai-setting"
                               size={PILL_SM_ICON_SIZE}
                               strokeWidth={1.75}
                               className="text-primary-6"

--- a/src/features/SessionCreator/variants/Install/index.tsx
+++ b/src/features/SessionCreator/variants/Install/index.tsx
@@ -18,7 +18,7 @@ import SelectorPill from "@src/components/SelectorPill";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import type { AdvancedConfig } from "@src/features/SessionCreator/types";
 import { useModelPillLabel } from "@src/hooks/models";
-import { GripIcon, HugeiconsIcon } from "@src/icons";
+import { AiSettingIcon, HugeiconsIcon } from "@src/icons";
 import { UnifiedModelPalette } from "@src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette";
 
 export interface SessionCreatorInstallProps {
@@ -83,8 +83,8 @@ const SessionCreatorInstall: React.FC<SessionCreatorInstallProps> = memo(
               />
             ) : (
               <HugeiconsIcon
-                icon={GripIcon}
-                data-icon="grip"
+                icon={AiSettingIcon}
+                data-icon="ai-setting"
                 size={iconSize}
                 strokeWidth={1.75}
                 className="text-primary-6"

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -28,6 +28,7 @@ export { default as Add01Icon } from "@hugeicons/core-free-icons/Add01Icon";
 export { default as AiGenerativeIcon } from "@hugeicons/core-free-icons/AiGenerativeIcon";
 export { default as AiNetworkIcon } from "@hugeicons/core-free-icons/AiNetworkIcon";
 export { default as AiProgrammingIcon } from "@hugeicons/core-free-icons/AiProgrammingIcon";
+export { default as AiSettingIcon } from "@hugeicons/core-free-icons/AiSettingIcon";
 export { default as Airplane01Icon } from "@hugeicons/core-free-icons/Airplane01Icon";
 export { default as Alert01Icon } from "@hugeicons/core-free-icons/Alert01Icon";
 export { default as AlertCircleIcon } from "@hugeicons/core-free-icons/AlertCircleIcon";


### PR DESCRIPTION
## Problem

When no model is selected, model pickers show a generic grip icon. It does not communicate that the control configures a model and appears in three separate picker surfaces.

## Solution

Use `AiSettingIcon` for the empty-selection branch in the shared chat model picker, install flow, and team-member model picker. Export the glyph through the existing icon barrel and update its data-icon marker.

Selected-model icons, labels, selection predicates, dimensions, colors, and picker behavior remain unchanged. The icon is already available in the installed Hugeicons dependency.

## Potential risks

The change is limited to a glyph replacement in the existing empty-state branches. No dependencies, lockfiles, state, persistence, public APIs, or wire formats change.

Real Tauri rendering, theme appearance, and picker interactions were not visually checked. Computer Use was not requested, so no after-change screenshots were captured. The import/render smoke check confirms the glyph produces SVG paths but does not replace a visual review.

## Verification

Run in an isolated checkout based on the latest `develop`:

- `pnpm run typecheck` — passed.
- `pnpm exec eslint src/components/ModelSelectorPill/index.tsx src/features/SessionCreator/variants/ChatPanel/SessionCreatorOrgMembersPanel.tsx src/features/SessionCreator/variants/Install/index.tsx src/icons.ts --max-warnings 0 --report-unused-disable-directives` — passed.
- `pnpm exec prettier --check src/components/ModelSelectorPill/index.tsx src/features/SessionCreator/variants/ChatPanel/SessionCreatorOrgMembersPanel.tsx src/features/SessionCreator/variants/Install/index.tsx src/icons.ts` — passed.
- `git diff --check` — passed.
- The following ESM import/SVG render check passed:

```sh
node --input-type=module -e 'import icon from "@hugeicons/core-free-icons/AiSettingIcon"; import React from "react"; import { renderToStaticMarkup } from "react-dom/server"; import { HugeiconsIcon } from "@hugeicons/react"; if (!Array.isArray(icon) || icon.length === 0) throw new Error("AiSettingIcon is not a renderable glyph"); const markup = renderToStaticMarkup(React.createElement(HugeiconsIcon, { icon, size: 14, strokeWidth: 1.75 })); if (!markup.includes("<svg") || !markup.includes("<path")) throw new Error("Icon did not render SVG paths"); console.log("AiSettingIcon import and SVG rendering passed")'
```

No new unit tests or full-suite/Rust runs were added for this reversible glyph-only change. The final diff was inspected to confirm that selected-model branches and unrelated icons are unchanged.
