### PR TITLE
fix(input): prevent leading blank lines in messages and editors

### DIFF
--- a/docs/org2-performance-guard-2026-08-31/LeadingBlankLineInputGuard.md
+++ b/docs/org2-performance-guard-2026-08-31/LeadingBlankLineInputGuard.md
@@ -1,0 +1,56 @@
+# Leading blank line input guard
+
+The user requested a shared input rule: a line break must not leave the first
+line blank, including while editing a sent message. Native textareas previously
+accepted browser line breaks unconditionally; the rich composer's
+`useEditorOperations.insertNewline` also always inserted one. Edit initialization
+passed historical leading blank lines directly into the composer.
+
+The rule now runs before newline insertion. The text before the selection must
+have content on its first line, so moving to the start of existing text or
+selecting the first line cannot introduce a leading blank line. Later blank
+lines, indentation, submit shortcuts, and composition remain supported. Edit
+initialization strips leading blank lines from the editable copy. No stored
+message or imported transcript is rewritten.
+
+| Area               | Verdict | Evidence                                                                                                                        | Change or reason kept                                                                                                                             | Verification                                                                                                                                                 |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Background work    | keep    | `installLeadingBlankLineGuard.ts` adds one delegated `beforeinput` listener; `src/index.tsx` owns installation and HMR disposal | No timer, polling, request, worker, or per-field listener added                                                                                   | Repeated installation shares one listener; dispose/reinstall and stale-disposer tests pass; fake-time visible/hidden idle produces no policy calls or timers |
+| Memory             | keep    | One disposer is retained; textarea string slices and composer prefix fragments are temporary                                    | No per-session or per-field registry; the composer reads pill labels without serializing or base64-encoding stored context                        | Native listener lifecycle tests; real composer tests with a pill and repeated line breaks                                                                    |
+| Scope/isolation    | keep    | Policy reads only the current event target/selection                                                                            | Native readonly/disabled fields and CodeMirror/Monaco/xterm inputs are excluded; no account, org, session, network, or storage state is consulted | Native-field exclusion and selection tests                                                                                                                   |
+| Rendering/hot path | keep    | Ordinary input exits before reading the textarea value; composer checks run only for newline attempts                           | Blocked composer operations return before DOM mutation and do not notify the parent; native line breaks retain undo transactions                  | Composer tests cover Enter modes, selections, pills, IME, native `beforeinput`, noncancelable events, undo, and edit initialization                          |
+
+| Lifecycle                                 | Expected behavior                                                               | Evidence                                                                                                                |
+| ----------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| App start / repeated install              | One native-textarea listener per app document                                   | Idempotent installation test                                                                                            |
+| Visible / hidden idle                     | No scheduled work                                                               | Two 60-second fake-time intervals; zero timers and policy calls                                                         |
+| Active input                              | Evaluate only attempted line breaks; preserve submit and IME handling           | Native textarea and mounted ComposerInput tests                                                                         |
+| HMR / shutdown                            | Dispose on HMR; document destruction releases app-lifetime listener             | Disposal/reinstallation tests; webpack runtime `dispose` API verified locally and declared in the existing ambient type |
+| Composer close / reopen                   | Existing native-event effect owns listener teardown; no new listener kind added | Existing effect cleanup retained; mounted component tests unmount between cases                                         |
+| Identity / network / provider transitions | Not applicable                                                                  | No identity, network, provider, or persistence operations added                                                         |
+
+Verification performed:
+
+```sh
+pnpm exec vitest run src/hooks/keyboard/__tests__ src/components/ComposerInput/__tests__ src/engines/ChatPanel/InputArea/hooks/__tests__/useEditMode.test.ts src/engines/ChatPanel/hooks/useInputArea/__tests__ src/engines/ChatPanel/ChatItems/__tests__/normalizeUserMessageText.test.ts src/engines/ChatPanel/ChatHistory/hooks/__tests__/useEditUserMessage.test.ts src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.test.ts src/store/ui/__tests__/messageQueueAtom.test.ts
+pnpm exec eslint src/util/data/canInsertLineBreak.ts src/hooks/keyboard/installLeadingBlankLineGuard.ts src/hooks/keyboard/__tests__/installLeadingBlankLineGuard.test.ts src/components/ComposerInput/index.tsx src/components/ComposerInput/useEditorOperations.ts src/components/ComposerInput/composerInput.nativeEvents.ts src/components/ComposerInput/__tests__/ComposerInput.lineBreak.test.ts src/engines/ChatPanel/InputArea/hooks/useEditMode.ts src/engines/ChatPanel/InputArea/hooks/__tests__/useEditMode.test.ts src/index.tsx src/types/ambient/global.d.ts --max-warnings 0
+pnpm run check:test-placement
+git diff --check
+```
+
+The initial focused run passed all 254 tests in 30 files. Before PR publication,
+validation was repeated in a clean worktree based on the latest `origin/develop`:
+377 tests in 48 files, scoped ESLint, full `pnpm run typecheck`, test placement,
+and diff checks all pass. The unrelated pending-workspace type errors are not
+present in the isolated PR branch.
+
+The behavioral tests use jsdom and do not establish actual WKWebView keyboard,
+soft-keyboard, IME timing, caret rendering, CPU, or RSS behavior. Native desktop
+verification was not run because Computer Use is explicit opt-in. Noncancelable
+browser input is left to the browser rather than duplicated by a custom DOM
+insertion. Paste and deletion are not intercepted by this newline-only rule;
+the existing send-time normalization remains in place.
+
+Performance verdict: blocked — automated lifecycle checks pass, but native
+Tauri input/performance verification was not run. No runtime performance
+improvement is claimed.

--- a/src/components/ComposerInput/__tests__/ComposerInput.lineBreak.test.ts
+++ b/src/components/ComposerInput/__tests__/ComposerInput.lineBreak.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import ComposerInput, { type ComposerInputRef } from "../index";
+import { placeCaretAtEnd } from "../selection";
+
+vi.mock("@src/util/ui/theme/themeUtils", () => ({
+  useCurrentTheme: () => ({ isDark: false }),
+}));
+
+vi.mock("@src/store/skills/installedSkillsAtom", async () => {
+  const { atom } = await import("jotai");
+  return { installedSkillsAtom: atom([]) };
+});
+
+describe("ComposerInput line breaks in new and edited text", () => {
+  let root: SmokeRoot;
+  let ref: ReturnType<typeof createRef<ComposerInputRef>>;
+  let host: HTMLDivElement;
+  const onChange = vi.fn();
+  const onSubmit = vi.fn();
+
+  beforeEach(() => {
+    root = createSmokeRoot();
+    ref = createRef<ComposerInputRef>();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+    window.getSelection()?.removeAllRanges();
+  });
+
+  async function mount(text = "", requireCmdEnter = true): Promise<void> {
+    await root.render(
+      createElement(ComposerInput, {
+        ref,
+        initialContent: text,
+        requireCmdEnter,
+        onContentChange: onChange,
+        onSubmit,
+      })
+    );
+    host = root.container.querySelector('[contenteditable="true"]')!;
+    placeCaretAtEnd(host);
+    onChange.mockClear();
+  }
+
+  function pressEnter(options: KeyboardEventInit = {}): KeyboardEvent {
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      ...options,
+    });
+    act(() => host.dispatchEvent(event));
+    return event;
+  }
+
+  it.each([
+    [true, {}],
+    [true, { shiftKey: true }],
+    [false, { shiftKey: true }],
+    [false, { metaKey: true }],
+    [false, { ctrlKey: true }],
+  ])(
+    "blocks empty first-line newline chords (requireCmdEnter=%s, %j)",
+    async (requireCmdEnter, chord) => {
+      await mount(" \t", requireCmdEnter);
+      const before = host.innerHTML;
+      expect(pressEnter(chord).defaultPrevented).toBe(true);
+      expect(host.innerHTML).toBe(before);
+      expect(ref.current?.getText()).toBe(" \t");
+      expect(onChange).not.toHaveBeenCalled();
+      expect(onSubmit).not.toHaveBeenCalled();
+    }
+  );
+
+  it("does not split the first line before its content or replace it with a newline", async () => {
+    await mount("    edited message\nnext line");
+    const text = host.firstChild!;
+    const selection = window.getSelection()!;
+    const range = document.createRange();
+    range.setStart(text, 4);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    pressEnter();
+    expect(ref.current?.getText()).toBe("    edited message\nnext line");
+
+    range.selectNodeContents(host);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    pressEnter({ shiftKey: true });
+    expect(ref.current?.getText()).toBe("    edited message\nnext line");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("allows later blank lines and preserves indentation in an edited draft", async () => {
+    await mount();
+    act(() => ref.current?.setContent("    edited message"));
+    placeCaretAtEnd(host);
+    pressEnter();
+    pressEnter();
+    expect(ref.current?.getText()).toBe("    edited message\n\n");
+    expect(onChange).toHaveBeenLastCalledWith("    edited message\n\n");
+  });
+
+  it("counts a reference pill as first-line content", async () => {
+    await mount();
+    act(() =>
+      ref.current?.setContent({
+        parts: [
+          {
+            kind: "pill",
+            attrs: {
+              fileName: "compact",
+              filePath: "/compact",
+              iconType: "skill",
+              isFolder: false,
+              lineStart: null,
+              lineEnd: null,
+            },
+          },
+        ],
+      })
+    );
+    placeCaretAtEnd(host);
+    pressEnter();
+    expect(ref.current?.getTextWithPills()).toContain(
+      "compact [skill:/compact]"
+    );
+    expect(ref.current?.getText()).toMatch(/\n$/u);
+  });
+
+  it.each(["insertParagraph", "insertLineBreak"])(
+    "guards %s without a keyboard event",
+    async (inputType) => {
+      await mount();
+      const attempt = () => {
+        const event = new InputEvent("beforeinput", {
+          bubbles: true,
+          cancelable: true,
+          inputType,
+        });
+        act(() => host.dispatchEvent(event));
+        return event;
+      };
+      expect(attempt().defaultPrevented).toBe(true);
+      expect(ref.current?.getText()).toBe("");
+      expect(onChange).not.toHaveBeenCalled();
+
+      act(() => ref.current?.setContent("first line"));
+      placeCaretAtEnd(host);
+      expect(attempt().defaultPrevented).toBe(true);
+      expect(ref.current?.getText()).toBe("first line\n");
+
+      act(() =>
+        host.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "z",
+            metaKey: true,
+            bubbles: true,
+            cancelable: true,
+          })
+        )
+      );
+      expect(ref.current?.getText()).toBe("first line");
+    }
+  );
+
+  it("preserves IME composition and both submit modes", async () => {
+    await mount();
+    expect(pressEnter({ isComposing: true }).defaultPrevented).toBe(false);
+    const composition = new InputEvent("beforeinput", {
+      bubbles: true,
+      cancelable: true,
+      inputType: "insertParagraph",
+      isComposing: true,
+    });
+    host.dispatchEvent(composition);
+    expect(composition.defaultPrevented).toBe(false);
+
+    const noncancelable = new InputEvent("beforeinput", {
+      bubbles: true,
+      inputType: "insertLineBreak",
+    });
+    host.dispatchEvent(noncancelable);
+    expect(ref.current?.getText()).toBe("");
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => ref.current?.setContent("submit this"));
+    pressEnter({ metaKey: true });
+    expect(onSubmit).toHaveBeenLastCalledWith("submit this");
+
+    await mount("", false);
+    pressEnter();
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    expect(ref.current?.getText()).toBe("submit this");
+  });
+});

--- a/src/components/ComposerInput/composerInput.nativeEvents.ts
+++ b/src/components/ComposerInput/composerInput.nativeEvents.ts
@@ -54,6 +54,7 @@ export function useComposerNativeEvents({
     commitHistoryBoundary,
     reconcilePillsFromDom,
     insertTextAtCaret,
+    insertNewline,
   } = ops;
 
   useEffect(() => {
@@ -67,7 +68,22 @@ export function useComposerNativeEvents({
       compositionEndedAtRef.current = performance.now();
     };
     const handleBeforeInput = (event: InputEvent) => {
-      if (isComposingRef.current) return;
+      if (isComposingRef.current || event.isComposing) return;
+
+      // Soft keyboards and native editing commands can insert line breaks
+      // without keydown. Use the same guarded operation as Enter/Shift+Enter.
+      if (
+        event.inputType === "insertParagraph" ||
+        event.inputType === "insertLineBreak"
+      ) {
+        if (!event.cancelable) return;
+        event.preventDefault();
+        markHistoryBoundary();
+        const inserted = insertNewline();
+        commitHistoryBoundary();
+        if (inserted) handleInput();
+        return;
+      }
 
       // WebKit may express Edit → Undo/Redo (including Cmd+Z) solely as a
       // beforeinput history event. Browser-native history cannot restore
@@ -182,6 +198,7 @@ export function useComposerNativeEvents({
     commitHistoryBoundary,
     reconcilePillsFromDom,
     insertTextAtCaret,
+    insertNewline,
     handlePaste,
     handleDrop,
     handleCut,

--- a/src/components/ComposerInput/index.tsx
+++ b/src/components/ComposerInput/index.tsx
@@ -258,8 +258,7 @@ const ComposerInput = forwardRef<ComposerInputRef, ComposerInputProps>(
     // The op mutates the DOM directly (no `beforeinput`/`input` event),
     // so without this the parent never sees the new `\n`.
     const insertNewlineAndNotify = useCallback(() => {
-      ops.insertNewline();
-      handleInput();
+      if (ops.insertNewline()) handleInput();
     }, [ops, handleInput]);
 
     const undoAndNotify = useCallback(() => {

--- a/src/components/ComposerInput/useEditorOperations.ts
+++ b/src/components/ComposerInput/useEditorOperations.ts
@@ -12,11 +12,14 @@
  */
 import { useCallback, useMemo, useRef, useState } from "react";
 
+import { canInsertLineBreak } from "@src/util/data/canInsertLineBreak";
+
 import {
   insertNodeAtCaret,
   placeCaretAfter,
   placeCaretAfterPill,
   placeCaretAtEnd,
+  rangeInsideHost,
 } from "./selection";
 import type { ComposerPillAttrs, ComposerSnapshot } from "./types";
 import { PILL_DATA_ATTR, extractPlainText, pillDataAttributes } from "./utils";
@@ -75,8 +78,8 @@ export interface UseEditorOperationsResult {
   captureSnapshot: () => ComposerSnapshot;
   /** Empty the editor */
   clearHost: () => void;
-  /** Insert a literal newline (`<br>`) at the caret */
-  insertNewline: () => void;
+  /** Insert a newline only if the first line stays nonblank. Returns success. */
+  insertNewline: () => boolean;
   /** Focus the editor at the end */
   focusHost: () => void;
   /** Remove the first pill whose `filePath` matches */
@@ -180,7 +183,18 @@ export function useEditorOperations(): UseEditorOperationsResult {
 
   const insertNewline = useCallback(() => {
     const host = hostRef.current;
-    if (!host) return;
+    if (!host) return false;
+    const selection = rangeInsideHost(host);
+    const prefix = document.createRange();
+    prefix.selectNodeContents(host);
+    prefix.setEnd(selection.startContainer, selection.startOffset);
+    const prefixContent = document.createElement("div");
+    prefixContent.appendChild(prefix.cloneContents());
+    // Read visible text and pill labels only; serializing a context pill would
+    // unnecessarily encode its stored payload just to decide if the line is blank.
+    if (!canInsertLineBreak(extractPlainText(prefixContent))) {
+      return false;
+    }
     // Insert a literal "\n" text node rather than a <br>. The composer
     // host has `white-space: pre-wrap` (see index.scss), so "\n" renders
     // as a visible line break without the trailing-<br>-phantom quirk
@@ -220,6 +234,7 @@ export function useEditorOperations(): UseEditorOperationsResult {
     // Position the caret immediately after the just-inserted "\n", which
     // lives at the start of the new (empty) row.
     placeCaretAfter(newline);
+    return true;
   }, []);
 
   const setHostContent = useCallback(

--- a/src/engines/ChatPanel/ChatHistory/components/__tests__/UserMessageContent.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/__tests__/UserMessageContent.test.ts
@@ -8,6 +8,15 @@ import UserMessageContent, {
 } from "../UserMessageContent";
 
 describe("external-history Markdown URL pills", () => {
+  it("renders sent text without a blank first line and preserves paragraph spacing", () => {
+    const html = renderToStaticMarkup(
+      createElement(UserMessageContent, {
+        text: "\n \t\n    first line\n\n  next line\n",
+      })
+    );
+    expect(html).toContain(">    first line\n\n  next line\n</span>");
+  });
+
   it("normalizes a self-labelled GitHub issue link to the native issue pill", () => {
     const url = "https://github.com/org2AI/ORG2/issues/556";
 

--- a/src/engines/ChatPanel/ChatItems/__tests__/normalizeUserMessageText.test.ts
+++ b/src/engines/ChatPanel/ChatItems/__tests__/normalizeUserMessageText.test.ts
@@ -80,8 +80,18 @@ describe("normalizeUserMessageText", () => {
   it("leaves ordinary user text unchanged", () => {
     const text = "# Review this file\nKeep the heading.";
     expect(normalizeUserMessageText(text)).toBe(text);
-    expect(normalizeUserMessageText("\n\nKeep intentional spacing.")).toBe(
-      "\n\nKeep intentional spacing."
+  });
+
+  it("removes leading blank lines from ordinary and imported history text", () => {
+    expect(
+      normalizeUserMessageText("\r\n \t\r\n    first line\n\n  next line\n")
+    ).toBe("    first line\n\n  next line\n");
+    expect(
+      normalizeUserMessageText(
+        '\n<in-app-browser-context source="ambient-ui-state">\nContext\n</in-app-browser-context>'
+      )
+    ).toBe(
+      '<in-app-browser-context source="ambient-ui-state">\nContext\n</in-app-browser-context>'
     );
   });
 });

--- a/src/engines/ChatPanel/ChatItems/normalizeUserMessageText.ts
+++ b/src/engines/ChatPanel/ChatItems/normalizeUserMessageText.ts
@@ -1,4 +1,5 @@
 import { serializePillNode } from "@src/components/ComposerInput/utils";
+import { stripLeadingBlankLines } from "@src/util/data/stripLeadingBlankLines";
 import { imageRefToRustPath } from "@src/util/file/imageRefs";
 
 const FILES_MENTIONED_HEADING = /^#{1,6}\s+Files mentioned by the user:\s*$/i;
@@ -28,6 +29,8 @@ function fileEntryPill(line: string): string | null {
  * Normalizes Codex's generated attachment envelope into native ORGII history
  * text. File entries become serialized file/folder pills, while the injected
  * "Files mentioned" and "My request" headings are removed.
+ * All sent messages start on their first nonblank line, including imported
+ * history; this display rule leaves the authoritative transcript untouched.
  */
 export function normalizeUserMessageText(
   text: string,
@@ -41,7 +44,9 @@ export function normalizeUserMessageText(
   if (firstContentLineIndex < 0) return "";
 
   const firstContentLine = normalizeLine(lines[firstContentLineIndex] ?? "");
-  if (!FILES_MENTIONED_HEADING.test(firstContentLine ?? "")) return text;
+  if (!FILES_MENTIONED_HEADING.test(firstContentLine ?? "")) {
+    return stripLeadingBlankLines(text);
+  }
 
   const remainder = lines.slice(firstContentLineIndex + 1).map((line) => {
     if (MY_REQUEST_HEADING.test(normalizeLine(line))) return "";
@@ -51,9 +56,7 @@ export function normalizeUserMessageText(
     return path && imagePaths.has(path) ? "" : pill;
   });
 
-  const normalized = remainder
-    .join("\n")
-    .replace(/^(?:[ \t]*\n)+/, "")
+  const normalized = stripLeadingBlankLines(remainder.join("\n"))
     .replace(/\n{3,}/g, "\n\n")
     .trimEnd();
   return normalized.trim() ? normalized : "";

--- a/src/engines/ChatPanel/InputArea/hooks/__tests__/useEditMode.test.ts
+++ b/src/engines/ChatPanel/InputArea/hooks/__tests__/useEditMode.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ComposerSnapshot } from "@src/components/ComposerInput/types";
+import { createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import { useEditMode } from "../useEditMode";
+
+describe("useEditMode initial message text", () => {
+  const root = createSmokeRoot();
+
+  afterEach(async () => {
+    await root.unmount();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("opens an existing message without leading blank lines and keeps its pills", async () => {
+    vi.useFakeTimers();
+    const setContent = vi.fn<(value: string | ComposerSnapshot) => void>();
+    const editor = {
+      getEditor: () => ({}),
+      getText: () => "",
+      getTextWithPills: () => "",
+      setContent,
+      focus: vi.fn(),
+    };
+    const composerInputRef = { current: editor };
+
+    function Harness(): null {
+      useEditMode({
+        effectiveEditMode: true,
+        isEditMode: true,
+        initialContent:
+          "\n \t\n    inspect note.txt [file:/tmp/note.txt]\n\n  next line",
+        composerInputRef,
+      });
+      return null;
+    }
+
+    await root.render(createElement(Harness));
+    expect(setContent).toHaveBeenCalledWith({
+      parts: [
+        { kind: "text", text: "    inspect " },
+        {
+          kind: "pill",
+          attrs: expect.objectContaining({
+            fileName: "note.txt",
+            filePath: "/tmp/note.txt",
+          }),
+        },
+        { kind: "newline" },
+        { kind: "newline" },
+        { kind: "text", text: "  next line" },
+      ],
+    });
+  });
+});

--- a/src/engines/ChatPanel/InputArea/hooks/useEditMode.ts
+++ b/src/engines/ChatPanel/InputArea/hooks/useEditMode.ts
@@ -11,6 +11,7 @@
 import React, { useCallback, useEffect, useRef } from "react";
 
 import type { ComposerSnapshot } from "@src/components/ComposerInput/types";
+import { stripLeadingBlankLines } from "@src/util/data/stripLeadingBlankLines";
 
 import { applyParsedContent } from "../utils/pillContentParser";
 
@@ -109,7 +110,10 @@ export function useEditMode({
         return;
       }
 
-      applyParsedContent(composerInputRef.current, initialContent);
+      applyParsedContent(
+        composerInputRef.current,
+        stripLeadingBlankLines(initialContent)
+      );
       if (isEditMode) {
         setTimeout(() => composerInputRef.current?.focus(), 50);
       }

--- a/src/engines/ChatPanel/hooks/useInputArea/__tests__/projectOutgoingUserMessage.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/__tests__/projectOutgoingUserMessage.test.ts
@@ -11,6 +11,44 @@ describe("projectOutgoingUserMessage", () => {
     expect(projection.agentContent).toBeUndefined();
   });
 
+  it.each([true, false])(
+    "removes leading blank lines even with agent interceptors set to %s",
+    (enableAgentInterceptors) => {
+      const projection = projectOutgoingUserMessage({
+        displayText: "\r\n \t\r\n    first line\n\n  second line\n",
+        enableAgentInterceptors,
+      });
+      expect(projection.displayContent).toBe(
+        "    first line\n\n  second line\n"
+      );
+      expect(projection.agentContent).toBeUndefined();
+    }
+  );
+
+  it("normalizes both copies before appending agent context", () => {
+    expect(
+      projectOutgoingUserMessage({
+        displayText: "\n\n    inspect this\n\n  next line",
+        contextBlocks: ["```\nserver ready\n```"],
+      })
+    ).toEqual({
+      displayContent: "    inspect this\n\n  next line",
+      agentContent: "    inspect this\n\n  next line\n\n```\nserver ready\n```",
+    });
+  });
+
+  it("does not introduce a leading blank line for context-only input", () => {
+    expect(
+      projectOutgoingUserMessage({
+        displayText: "\n \t",
+        contextBlocks: ["```\nserver ready\n```"],
+      })
+    ).toEqual({
+      displayContent: "",
+      agentContent: "```\nserver ready\n```",
+    });
+  });
+
   it("expands skill pills for the agent while keeping the display copy", () => {
     const projection = projectOutgoingUserMessage({
       displayText: "statusline [skill:/statusline] please",

--- a/src/engines/ChatPanel/hooks/useInputArea/__tests__/useSubmitMessage.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/__tests__/useSubmitMessage.test.ts
@@ -181,6 +181,7 @@ describe("useSubmitMessage composer boundary", () => {
     mocks.parseCompactSlashCommand.mockReturnValue(null);
     mocks.projectOutgoingUserMessage.mockImplementation(
       ({ displayText }: { displayText: string }) => ({
+        displayContent: displayText,
         agentContent: `agent:${displayText}`,
       })
     );
@@ -230,6 +231,50 @@ describe("useSubmitMessage composer boundary", () => {
       ...overrides,
     };
   }
+
+  it.each(["live", "captured", "override"])(
+    "sends the normalized display copy through the %s path",
+    async (path) => {
+      const { projectOutgoingUserMessage } = await vi.importActual<
+        typeof import("../projectOutgoingUserMessage")
+      >("../projectOutgoingUserMessage");
+      mocks.projectOutgoingUserMessage.mockImplementationOnce(
+        projectOutgoingUserMessage
+      );
+      const draft = "\n \t\n    first line\n\n  next line\n";
+      const expected = "    first line\n\n  next line\n";
+      const editorHarness = createEditor(path === "captured" ? "" : draft);
+      const handleSessChatSubmit = vi.fn().mockResolvedValue(undefined);
+      const onSubmitOverride = vi.fn().mockResolvedValue(true);
+      await mount(
+        optionsFor(editorHarness, {
+          handleSessChatSubmit,
+          ...(path === "override" && { onSubmitOverride }),
+        })
+      );
+
+      await act(async () => {
+        await latestSubmit!(path === "captured" ? { capturedText: draft } : {});
+      });
+
+      if (path === "override") {
+        expect(onSubmitOverride).toHaveBeenCalledWith({
+          displayText: expected,
+          agentContent: undefined,
+          imageDataUrls: undefined,
+        });
+        expect(handleSessChatSubmit).not.toHaveBeenCalled();
+      } else {
+        expect(handleSessChatSubmit).toHaveBeenCalledWith(
+          undefined,
+          expected,
+          undefined,
+          undefined
+        );
+      }
+      expect(editorHarness.readText()).toBe("");
+    }
+  );
 
   it("delegates one in-flight send to workspace chat and clears durable composer state", async () => {
     const editorHarness = createEditor("ship the fix");

--- a/src/engines/ChatPanel/hooks/useInputArea/projectOutgoingUserMessage.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/projectOutgoingUserMessage.ts
@@ -3,8 +3,8 @@
  * outgoing user message.
  *
  * The composer keeps two copies of each message:
- *   - `displayContent`: the serialized editor text (pills intact) that history
- *     renders and re-editing round-trips.
+ *   - `displayContent`: the serialized editor text (pills intact, leading
+ *     blank lines removed) that history renders and re-editing round-trips.
  *   - `agentContent`: the Agent-facing copy — skill pills expanded to their
  *     `/<name>` tokens, editor-internal `::base64` pill payloads stripped,
  *     the `/canvas` command replaced by its deterministic tool contract, and
@@ -17,6 +17,8 @@
  * both directions — the model receives raw pill serialization, or the user
  * sees the internal agent contract.
  */
+import { stripLeadingBlankLines } from "@src/util/data/stripLeadingBlankLines";
+
 import { resolveAgentMessageContent } from "./agentMessageContent";
 import {
   expandSkillPills,
@@ -56,12 +58,13 @@ export function projectOutgoingUserMessage(
   options: ProjectOutgoingUserMessageOptions
 ): OutgoingUserMessageProjection {
   const {
-    displayText,
+    displayText: rawDisplayText,
     contextBlocks = [],
     enableAgentInterceptors = true,
     allowCanvasInterception = true,
   } = options;
 
+  const displayText = stripLeadingBlankLines(rawDisplayText);
   const { expanded, hasSkillPills } = expandSkillPills(displayText);
   const agentBase = stripContextPillBase64(expanded);
 
@@ -74,5 +77,11 @@ export function projectOutgoingUserMessage(
     allowCanvasInterception,
   });
 
-  return { displayContent: displayText, agentContent };
+  return {
+    displayContent: displayText,
+    agentContent:
+      agentContent === undefined
+        ? undefined
+        : stripLeadingBlankLines(agentContent),
+  };
 }

--- a/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
@@ -321,13 +321,14 @@ export function useSubmitMessage({
       // the user is sending real content that happens to mention the command
       // — and on session capability: CLI agents have no render_inline_canvas
       // tool, so the message must pass through as ordinary text there.
-      const { agentContent } = projectOutgoingUserMessage({
+      const { displayContent, agentContent } = projectOutgoingUserMessage({
         displayText,
         contextBlocks,
         enableAgentInterceptors,
         allowCanvasInterception:
           !hasAttachedImages && !isCliSession(draftSessionId || null),
       });
+      displayText = displayContent;
 
       const imageDataUrls = imageAttachment.images.map((img) => img.dataUrl);
       const submitKey = JSON.stringify({

--- a/src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.test.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.test.ts
@@ -21,6 +21,21 @@ function composerRef(
 }
 
 describe("prepareLaunchInput", () => {
+  it("starts a context-only agent input on the first content line", async () => {
+    expect(
+      await prepareLaunchInput({
+        editorContent: "",
+        effectiveSource: null,
+        composerInputRef: composerRef("\n \t", {
+          "terminal://1": "server ready",
+        }),
+      })
+    ).toEqual({
+      userInput: "",
+      agentInput: "```\nserver ready\n```",
+    });
+  });
+
   it("keeps the display serialization as userInput but projects agentInput", async () => {
     const { userInput, agentInput } = await prepareLaunchInput({
       editorContent: "",

--- a/src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.ts
@@ -72,7 +72,7 @@ export async function prepareLaunchInput(
   });
 
   return {
-    userInput,
-    agentInput: projection.agentContent ?? userInput,
+    userInput: projection.displayContent,
+    agentInput: projection.agentContent ?? projection.displayContent,
   };
 }

--- a/src/hooks/keyboard/__tests__/installLeadingBlankLineGuard.test.ts
+++ b/src/hooks/keyboard/__tests__/installLeadingBlankLineGuard.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Textarea from "@src/components/Textarea";
+import { createSmokeRoot } from "@src/test/reactSmokeHarness";
+import * as lineBreakPolicy from "@src/util/data/canInsertLineBreak";
+
+import { installLeadingBlankLineGuard } from "../installLeadingBlankLineGuard";
+
+vi.mock("@src/util/ui/theme/themeUtils", () => ({
+  useCurrentTheme: () => ({ isDark: false }),
+}));
+
+function lineBreak(
+  target: HTMLElement,
+  options: InputEventInit = {}
+): InputEvent {
+  const event = new InputEvent("beforeinput", {
+    bubbles: true,
+    cancelable: true,
+    inputType: "insertLineBreak",
+    ...options,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("native textarea leading-line-break guard", () => {
+  let dispose: () => void;
+  let textarea: HTMLTextAreaElement;
+
+  beforeEach(() => {
+    dispose = installLeadingBlankLineGuard();
+    textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+  });
+
+  afterEach(() => {
+    dispose();
+    textarea.parentElement?.closest("[data-test-wrapper]")?.remove();
+    textarea.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["", 0, 0],
+    [" \t\u200B", 3, 3],
+    ["existing message", 0, 0],
+    ["    indented message", 4, 4],
+    ["first line\nsecond line", 0, 10],
+    ["\nexisting message", 5, 5],
+  ])("blocks a line break in %j at selection %i–%i", (value, start, end) => {
+    textarea.value = value;
+    textarea.setSelectionRange(start, end);
+
+    expect(lineBreak(textarea).defaultPrevented).toBe(true);
+    expect(textarea.value).toBe(value);
+    expect(textarea.selectionStart).toBe(start);
+    expect(textarea.selectionEnd).toBe(end);
+  });
+
+  it.each(["hello", "    code", "first\n", "first\n\n", "first\n  next"])(
+    "allows further line breaks after content in %j",
+    (value) => {
+      textarea.value = value;
+      textarea.setSelectionRange(value.length, value.length);
+      expect(lineBreak(textarea).defaultPrevented).toBe(false);
+    }
+  );
+
+  it("also blocks native paragraph insertion", () => {
+    expect(
+      lineBreak(textarea, { inputType: "insertParagraph" }).defaultPrevented
+    ).toBe(true);
+  });
+
+  it("does not claim composition, ordinary typing, paste, deletion, or undo", () => {
+    expect(lineBreak(textarea, { isComposing: true }).defaultPrevented).toBe(
+      false
+    );
+    for (const inputType of [
+      "insertText",
+      "insertFromPaste",
+      "deleteContentBackward",
+      "historyUndo",
+    ]) {
+      expect(lineBreak(textarea, { inputType }).defaultPrevented).toBe(false);
+    }
+  });
+
+  it("leaves Enter and modifier shortcuts to the field's key handler", () => {
+    const onKeyDown = vi.fn();
+    textarea.addEventListener("keydown", onKeyDown);
+    for (const modifiers of [{}, { shiftKey: true }, { metaKey: true }]) {
+      const event = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+        ...modifiers,
+      });
+      textarea.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(false);
+    }
+    expect(onKeyDown).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(["cm-editor", "CodeMirror", "monaco-editor", "xterm"])(
+    "does not change %s input semantics",
+    (className) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = className;
+      wrapper.dataset.testWrapper = "true";
+      document.body.appendChild(wrapper);
+      wrapper.appendChild(textarea);
+      expect(lineBreak(textarea).defaultPrevented).toBe(false);
+    }
+  );
+
+  it("leaves readonly and disabled fields alone", () => {
+    textarea.readOnly = true;
+    expect(lineBreak(textarea).defaultPrevented).toBe(false);
+    textarea.readOnly = false;
+    textarea.disabled = true;
+    expect(lineBreak(textarea).defaultPrevented).toBe(false);
+  });
+
+  it("covers the shared Textarea without each caller installing a handler", async () => {
+    const root = createSmokeRoot();
+    const onChange = vi.fn();
+    try {
+      await root.render(createElement(Textarea, { onChange }));
+      const field = root.container.querySelector("textarea")!;
+      expect(lineBreak(field).defaultPrevented).toBe(true);
+      expect(field.value).toBe("");
+      expect(onChange).not.toHaveBeenCalled();
+    } finally {
+      await root.unmount();
+    }
+  });
+
+  it("installs once, disposes fully, and can reinstall without stale cleanup", () => {
+    dispose();
+    const add = vi.spyOn(document, "addEventListener");
+    const remove = vi.spyOn(document, "removeEventListener");
+    dispose = installLeadingBlankLineGuard();
+    expect(installLeadingBlankLineGuard()).toBe(dispose);
+    expect(
+      add.mock.calls.filter(([type]) => type === "beforeinput")
+    ).toHaveLength(1);
+
+    const oldDispose = dispose;
+    dispose();
+    expect(lineBreak(textarea).defaultPrevented).toBe(false);
+    expect(remove).toHaveBeenCalledWith(
+      "beforeinput",
+      expect.any(Function),
+      true
+    );
+
+    dispose = installLeadingBlankLineGuard();
+    oldDispose();
+    expect(installLeadingBlankLineGuard()).toBe(dispose);
+    expect(lineBreak(textarea).defaultPrevented).toBe(true);
+  });
+
+  it("does no policy work while idle or on unrelated input", () => {
+    vi.useFakeTimers();
+    const evaluate = vi.spyOn(lineBreakPolicy, "canInsertLineBreak");
+    vi.advanceTimersByTime(60_000);
+    expect(vi.getTimerCount()).toBe(0);
+    lineBreak(textarea, { inputType: "insertText", data: "a" });
+    expect(evaluate).not.toHaveBeenCalled();
+
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    vi.advanceTimersByTime(60_000);
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+
+    lineBreak(textarea);
+    expect(evaluate).toHaveBeenCalledOnce();
+  });
+});

--- a/src/hooks/keyboard/installLeadingBlankLineGuard.ts
+++ b/src/hooks/keyboard/installLeadingBlankLineGuard.ts
@@ -1,0 +1,46 @@
+import { canInsertLineBreak } from "@src/util/data/canInsertLineBreak";
+
+let disposeGuard: (() => void) | undefined;
+
+/**
+ * Covers shared and native textareas without claiming Enter shortcuts. The
+ * browser emits beforeinput only when it is actually about to insert a line
+ * break, including soft-keyboard input. Rich composers guard their own DOM
+ * insertion operation; code editors and terminal input keep their semantics.
+ */
+export function installLeadingBlankLineGuard(): () => void {
+  if (disposeGuard) return disposeGuard;
+
+  const handleBeforeInput = (event: InputEvent) => {
+    if (
+      event.defaultPrevented ||
+      event.isComposing ||
+      (event.inputType !== "insertLineBreak" &&
+        event.inputType !== "insertParagraph")
+    ) {
+      return;
+    }
+
+    const target = event.target;
+    if (
+      !(target instanceof HTMLTextAreaElement) ||
+      target.disabled ||
+      target.readOnly ||
+      target.closest(".cm-editor, .CodeMirror, .monaco-editor, .xterm")
+    ) {
+      return;
+    }
+
+    if (!canInsertLineBreak(target.value.slice(0, target.selectionStart))) {
+      event.preventDefault();
+    }
+  };
+
+  document.addEventListener("beforeinput", handleBeforeInput, true);
+  const dispose = () => {
+    document.removeEventListener("beforeinput", handleBeforeInput, true);
+    if (disposeGuard === dispose) disposeGuard = undefined;
+  };
+  disposeGuard = dispose;
+  return dispose;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import {
   applyWindowsNativeChromeAttribute,
 } from "@src/config/windowChromeRadius";
 import { configureCloudAuthCallbackForIdentifier } from "@src/features/Org2Cloud/config";
+import { installLeadingBlankLineGuard } from "@src/hooks/keyboard/installLeadingBlankLineGuard";
 import { installGlobalTauriSelectAllShortcut } from "@src/hooks/keyboard/useTauriSelectAllShortcut";
 import { createLogger, initializeLogging } from "@src/hooks/logger/useLogger";
 import { i18nReady } from "@src/i18n";
@@ -24,6 +25,8 @@ import { initializeTauriAPIs, invokeTauri } from "./util/platform/tauri/init";
 applyHostDesktopWindowChromeRadius();
 initializeLogging();
 installGlobalTauriSelectAllShortcut();
+const disposeLeadingBlankLineGuard = installLeadingBlankLineGuard();
+module.hot?.dispose(disposeLeadingBlankLineGuard);
 
 const log = createLogger("Init");
 

--- a/src/store/ui/__tests__/messageQueueAtom.test.ts
+++ b/src/store/ui/__tests__/messageQueueAtom.test.ts
@@ -319,6 +319,18 @@ describe("messageQueueAtom", () => {
   // =============================================
 
   describe("editMessageAtom", () => {
+    it("saves edited display and agent copies without leading blank lines", () => {
+      store.set(messageQueueAtom, [makeMessage({ id: "m1" })]);
+      store.set(editMessageAtom, {
+        messageId: "m1",
+        content: "\n \t\n    first line\n\n  next line\n",
+      });
+
+      const message = store.get(messageQueueAtom)[0];
+      expect(message.displayContent).toBe("    first line\n\n  next line\n");
+      expect(message.content).toBe(message.displayContent);
+    });
+
     it("updates content and displayContent", () => {
       store.set(enqueueMessageAtom, makeMessage({ id: "m1" }));
       store.set(editMessageAtom, { messageId: "m1", content: "updated" });

--- a/src/types/ambient/global.d.ts
+++ b/src/types/ambient/global.d.ts
@@ -5,6 +5,7 @@
 // Webpack Hot Module Replacement
 interface HotModule {
   accept(callback?: () => void): void;
+  dispose(callback: () => void): void;
   addStatusHandler?(callback: (status: string) => void): void;
 }
 

--- a/src/util/data/__tests__/stripLeadingBlankLines.test.ts
+++ b/src/util/data/__tests__/stripLeadingBlankLines.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { stripLeadingBlankLines } from "../stripLeadingBlankLines";
+
+describe("stripLeadingBlankLines", () => {
+  it.each([
+    ["\nhello", "hello"],
+    ["\n \t\n\nhello", "hello"],
+    ["\r\n \t\r\nhello", "hello"],
+    ["\r \t\rhello", "hello"],
+    ["\u00a0\n\ufeff\nhello", "hello"],
+    ["\n\n    code\n\n  next\n\n", "    code\n\n  next\n\n"],
+    ["\n\thello\r\n\r\nworld\r\n", "\thello\r\n\r\nworld\r\n"],
+    ["    code\n\n  next\n", "    code\n\n  next\n"],
+    ["", ""],
+    [" \t", ""],
+    ["\n \t\r\n \t", ""],
+  ])("normalizes %j to %j", (text, expected) => {
+    expect(stripLeadingBlankLines(text)).toBe(expected);
+    expect(stripLeadingBlankLines(expected)).toBe(expected);
+  });
+});

--- a/src/util/data/canInsertLineBreak.ts
+++ b/src/util/data/canInsertLineBreak.ts
@@ -1,0 +1,8 @@
+/**
+ * A line break replaces the current selection, so only the text before its
+ * start can keep the first line nonblank. Later blank lines remain allowed.
+ */
+export function canInsertLineBreak(textBeforeSelection: string): boolean {
+  const firstLine = textBeforeSelection.split(/\r\n?|\n/u, 1)[0];
+  return /[^\s\u200B]/u.test(firstLine);
+}

--- a/src/util/data/stripLeadingBlankLines.ts
+++ b/src/util/data/stripLeadingBlankLines.ts
@@ -1,0 +1,7 @@
+/**
+ * Start message text on its first nonblank line without removing that line's
+ * indentation or changing internal/trailing whitespace.
+ */
+export function stripLeadingBlankLines(text: string): string {
+  return text.replace(/^(?:[^\S\r\n]*(?:\r\n?|\n|$))+/u, "");
+}


### PR DESCRIPTION
## Problem

Messages can be sent, replayed, or opened for editing with a blank first line. The shared outgoing projection preserved leading blank lines, normal submit ignored its display result, and both the rich composer and native textareas accepted line breaks without checking the first line.

## Solution

- Strip leading blank lines in the shared outgoing projection and use its display result for submit and session launch; resends and queue edits inherit the same rule.
- Apply the display rule to existing history and normalize the editable copy without rewriting stored transcripts.
- Prevent composer and native-textarea newline insertion when the text before the selection would leave the first line blank. Keep later blank lines, indentation, submit shortcuts, reference pills, IME composition, and native newline undo behavior.
- Install one delegated textarea listener with idempotent setup and HMR disposal. Leave code editor and terminal inputs unchanged.

## Potential risks

- This intentionally changes the default newline behavior of regular multiline inputs throughout the app. Paste and deletion are not intercepted; message submission remains the normalization boundary.
- Native WKWebView/mobile keyboard behavior, IME timing, caret rendering, and CPU/RSS have not been verified in the desktop runtime. Tests exercise mounted React components and DOM events in jsdom. Noncancelable input is left to the browser to avoid duplicate insertion.
- No dependency, schema, persistence-format, IPC, or wire changes are included. Existing transcripts remain untouched. Reverting the commit restores the prior behavior for future input; leading blank lines already removed from newly sent messages cannot be reconstructed.

## Verification

Validated in an isolated worktree based on the latest `origin/develop`, excluding unrelated local work:

- **377 tests passed in 48 files**, covering send/override/captured submit, queue edits, launch, history rendering, edit initialization, newline shortcuts, selections, reference pills, IME, native input, undo, and listener lifecycle.
- Full TypeScript check, scoped ESLint, test placement, and diff whitespace checks passed.
- Final diff inspected for unrelated changes, secrets, personal paths, debug logging, and generated artifacts.
- Native desktop/manual keyboard checks and recordings were not run. Static screenshots would not verify the input prevention; no styling changes are included.
- Performance audit: automated lifecycle checks pass; native runtime verification remains incomplete. See `docs/org2-performance-guard-2026-08-31/LeadingBlankLineInputGuard.md`.

<details>
<summary>Exact validation commands</summary>

```sh
pnpm exec vitest run src/hooks/keyboard/__tests__ src/components/ComposerInput/__tests__ src/util/data/__tests__/stripLeadingBlankLines.test.ts src/engines/ChatPanel/InputArea/hooks/__tests__/useEditMode.test.ts src/engines/ChatPanel/hooks/useInputArea/__tests__ src/engines/ChatPanel/ChatItems/__tests__ src/engines/ChatPanel/ChatHistory/components/__tests__ src/engines/ChatPanel/ChatHistory/hooks/__tests__/useEditUserMessage.test.ts src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.test.ts src/store/ui/__tests__/messageQueueAtom.test.ts
pnpm run typecheck
pnpm exec eslint src/util/data/stripLeadingBlankLines.ts src/util/data/__tests__/stripLeadingBlankLines.test.ts src/engines/ChatPanel/hooks/useInputArea/projectOutgoingUserMessage.ts src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts src/engines/ChatPanel/hooks/useInputArea/__tests__/projectOutgoingUserMessage.test.ts src/engines/ChatPanel/hooks/useInputArea/__tests__/useSubmitMessage.test.ts src/engines/ChatPanel/ChatItems/normalizeUserMessageText.ts src/engines/ChatPanel/ChatItems/__tests__/normalizeUserMessageText.test.ts src/engines/ChatPanel/ChatHistory/components/__tests__/UserMessageContent.test.ts src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.ts src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.test.ts src/store/ui/__tests__/messageQueueAtom.test.ts src/util/data/canInsertLineBreak.ts src/hooks/keyboard/installLeadingBlankLineGuard.ts src/hooks/keyboard/__tests__/installLeadingBlankLineGuard.test.ts src/components/ComposerInput/index.tsx src/components/ComposerInput/useEditorOperations.ts src/components/ComposerInput/composerInput.nativeEvents.ts src/components/ComposerInput/__tests__/ComposerInput.lineBreak.test.ts src/engines/ChatPanel/InputArea/hooks/useEditMode.ts src/engines/ChatPanel/InputArea/hooks/__tests__/useEditMode.test.ts src/index.tsx src/types/ambient/global.d.ts --max-warnings 0
pnpm run check:test-placement
git diff --check
```

</details>

