### PR TITLE
fix(chat): refine workstation rail and terminal controls

### DIFF
--- a/docs/architecture-audit-2026-08-31/TrailPanelCornerResize.md
+++ b/docs/architecture-audit-2026-08-31/TrailPanelCornerResize.md
@@ -1,0 +1,76 @@
+# Workstation trail terminal controls architecture review
+
+Acceptance criteria: resize only the expanded terminal from its bottom-left
+corner; keep Workstation Trail fixed; show one terminal name or a chevron plus at most three terminal
+tabs on one horizontally scrollable row, with no generic expanded title or overflow menu; use shared red stop controls for actual process
+termination; fold to a centered process count and trail width; preserve pinned
+terminal exclusion and one-owner PTY mounting; save dimensions only on commit.
+
+| Layer                     | Coverage and result                                                                                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1 Compilation             | Isolated PR worktree passes full TypeScript checking, scoped lint, and 113 tests across 20 suites                                                                        |
+| 2 Ownership/deduplication | Local dimension hook owns only terminal preferences; one stop primitive serves all requested termination surfaces; existing terminal atoms remain authoritative          |
+| 3 Naming                  | Panel dimensions are CSS pixels, separate from the column's 8px inset; stop actions remain distinct from closing views                                                   |
+| 4 Semantic distinctions   | Docked terminal stays in flow; hiding releases claims without killing; read-only main view closes without killing; process count counts claimed terminal sessions        |
+| 5 Defaults                | Trail is fixed at the shipped size; terminal defaults to 400x260 and clamps restored sizes to width 320–720 / height 120–720                                             |
+| 6 Boundaries              | Shared claim writer now guards capacity before creation; the optional creation-options argument is backward compatible; no new backend paths                             |
+| 7 Readability             | Header presentation, grip lifecycle, dimensions, and persistence are separated; obsolete trail size state/menu/helpers are removed                                       |
+| 8 Wire protocol           | Not applicable: no API, IPC signature, database, or network serialization changes                                                                                        |
+| 9 Entry parity            | Pointer and keyboard resize share calculations and commit callbacks; click and keyboard tab selection use the same atom; all dock creation uses the guarded claim writer |
+| 10 Resolver symmetry      | New numeric terminal preferences use best-effort reads and clamping; collapsed geometry ignores expanded size without discarding it                                      |
+
+Only two new numeric localStorage preferences remain:
+`orgii:workstationTrailTerminalWidth` and
+`orgii:workstationTrailTerminalHeight`. Older trail width/minimum/height keys are
+ignored, not destructively removed. Older builds ignore the new keys; clearing
+only the two terminal keys restores 400x260 defaults. No user content is migrated.
+
+The Open Tabs exclusion is an explicit product requirement for valid pinned
+terminals. Authoritative sessions remain in `terminalSessionsAtom`, claims in
+`miniTerminalClaimedIdsAtom`. `openMiniTerminalAtom` now checks the shared limit
+of three before creation or admission; already claimed terminals can still be
+focused at capacity. The panel now forwards optional shell/profile/cwd settings
+through that atom instead of creating before claiming. This closes both the
+UI and programmatic paths, including repeated stale add callbacks. Tests verify
+that rejection does not add sessions and existing unclaimed Workstation
+terminals are untouched. Claims are transient and not persisted; no stored
+terminal cleanup or migration is needed. Stopping still reaches
+`closeMiniTerminalSessionAtom` → `closeTerminalSessionAtom` → `close_pty`; the
+integration test spies on that IPC boundary and verifies only the selected
+session is removed. The same test proves hide preserves all sessions.
+
+No terminal output subscription, PTY owner, process-management protocol, or
+background scan changed. Agent sidebar stop still uses its existing actual kill
+callback; the main read-only agent view retains its existing close-only behavior.
+
+Unverified: native WebView geometry, theme appearance, actual xterm fit, and a
+native window resize midway through a drag. Very short windows retain the capped
+flex-column behavior, which can constrain actual visible panel height.
+
+Horizontal scrolling uses browser overflow. Selected-tab reveal reads two rectangles only when active selection or folded state changes, compensates for CSS scaling, and writes only the strip’s scrollLeft; no observer, global scroll, timer or scroll listener is added.
+
+Header geometry follow-up: shared trail controls now consume the existing
+BUTTON_SIZE.sm (20px) token. Header and section right padding is 3px, compensating
+for the former 26px control, while the containing row is 24px tall. The tab-bar
+action-cluster token owns 1px button gaps; callers pass fragments. An absent title creates no
+empty padded span. In single-terminal mode the plain name owns the same label ID
+that the selected tab owns in multi-terminal mode, preserving the content’s
+aria-labelledby relationship. No state, persistence, IPC or backend changes are
+introduced by this styling/presentation follow-up.
+
+Font follow-up (layers 2–7, 9–10): the pinned host passes 12px through an optional
+`fontSize` prop on TerminalCore and TerminalView. TerminalView resolves the prop
+against the existing global setting once per render; both the initial appearance
+snapshot and live appearance effect consume that same resolved value. Shared
+terminal code has no pinned-host branch or fixed compact font default. Other
+hosts omit the prop and keep their existing behavior. Removing an override returns
+to the current setting, and changing it does not affect the xterm mount effect's
+dependencies. The integration test exercises two real component chains with
+mocked xterm/native setup, checking initial size, live setting changes, override
+changes/removal, refit, and no terminal recreation. Layer 1 passes in the isolated
+PR worktree; layer 8 still has no wire or persisted format changes.
+
+Collapsed icons reuse ToolbarTooltip with the existing item shortcut metadata.
+No shortcut bindings change. The collapsed renderer previously dropped that
+metadata in favor of native titles. Tests check keycaps, portal cleanup on hover
+exit and expansion, and cancellation of a pending tooltip when its trigger unmounts.

--- a/docs/frontend-ui-audit-2026-08-31/TrailPanelCornerResize.md
+++ b/docs/frontend-ui-audit-2026-08-31/TrailPanelCornerResize.md
@@ -1,0 +1,41 @@
+# Workstation trail terminal controls UI audit
+
+| Line                                     | Element                           | Verdict          | Reason                                                                                                                                                                                                                           | Suggested change |
+| ---------------------------------------- | --------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `ProcessStopButton/index.tsx:16`         | Process stop primitive            | keep with reason | One shared control now serves the dock, main terminal, both terminal sidebar row types, Open Tabs, and server watcher; always-red styling preserves the watcher reference without changing the generic muted danger-button token | None             |
+| `WorkstationTrailTerminalHeader.tsx:65`  | Inline terminal header            | keep with reason | One terminal uses its exact name once in the title slot; multiple expanded terminals omit the title and show chevron plus tabs; the content retains a valid accessible label through both modes                                  | None             |
+| `WorkstationTrailTerminalHeader.tsx:179` | Compact terminal tabs             | keep with reason | Tabs hug labels at 20px height with 1px gaps and rounded-lg corners, matching their neighboring controls; native horizontal scrolling and local selection reveal are preserved                                                   | None             |
+| `WorkstationTrailTerminalHeader.tsx:98`  | Three-terminal limit              | keep with reason | Add is absent at three in expanded and folded states; the shared claim/create writer enforces the same limit before creating a session; no overflow menu remains                                                                 | None             |
+| `WorkstationTrailSurface.tsx:43`         | Shared control size and alignment | keep with reason | BUTTON_SIZE.sm supplies the requested 20px controls across trails; 24px rows center them, while explicit 3px right padding preserves icon centers; the action wrapper reuses TAB_BAR_TRAILING_CLUSTER_CLASS for tab-bar spacing  | None             |
+| `TrailPanelResizeHandle.tsx:20`          | Corner target and glyph           | keep with reason | Native 20px grip follows the requested control size, with pointer and keyboard resizing, named colors and visible focus; the decorative currentColor SVG describes a two-axis corner interaction                                 | None             |
+| `WorkstationTrailTerminal.tsx:164`       | Terminal grip clearance           | keep with reason | Only the expanded terminal reserves footer space and renders a grip; folded state removes both and restores saved dimensions on expansion                                                                                        | None             |
+| `index.tsx:676`                          | Fixed Workstation Trail           | keep with reason | Trail sizing follows the shipped 256px column/248px surface; edge drag, corner grip, height override, width menu, and old preference readers are removed per the user's correction                                               | None             |
+| `types.ts:31`                            | Stop versus close/hide            | keep with reason | Process actions are explicit; file close, dock hide, and read-only view close retain X controls and do not gain process termination behavior                                                                                     | None             |
+| `WorkstationTrailTerminal.tsx:198`       | Pinned terminal font              | keep with reason | A 12px host override reaches xterm initialization and live appearance updates through TerminalCore and TerminalView; no CSS scaling, global setting write, or terminal remount is introduced                                     | None             |
+| `index.tsx:786`                          | Collapsed shortcut tooltips       | keep with reason | ToolbarTooltip receives the existing label, status and shortcut metadata; native titles are removed to avoid duplicate tooltips, and unmount cleanup is tested                                                                   | None             |
+
+Verdict totals: **0 fix**, **11 keep with reason**, **0 abstract**.
+
+The requested stop-control sweep is implemented through one shared component,
+not a global danger-token change. The expanded terminal minimum is 320px to keep
+the terminal name or scrollable tabs and controls on one row. Labels and count
+plurals are supplied in all 13 locales. No additional config-level sweep remains.
+
+Rendered jsdom integration verifies three-terminal admission, repeated clicks, local horizontal scrolling and keyboard focus,
+stop/hide semantics, folded process counts, mount retention and restored sizing.
+No native screenshots, theme checks, or actual xterm geometry were captured:
+computer control was not authorized. These remain verification limitations.
+
+The requested size sweep is applied at the shared control and header, including
+project/work-item PropertiesPanel and PR section controls. The trailing center
+remains at the same nominal offset: old `26 / 2 = 13px`; new `3 + 20 / 2 = 13px`.
+The surface and outer rail insets remain unchanged, preserving the tab-bar icon
+alignment. Collapsed narrow rails retain centered controls without the new
+one-sided padding. Terminal single/multiple transitions, 20px controls and 1px
+gaps are covered by the dock integration suite; project and PR consumers pass
+their targeted suites. Native pixels/themes were not visually measured.
+
+Expanded trail controls and pinned-terminal tabs use the final requested 20px
+size. This preserves PR #1131's explicit 28px collapsed rail controls. The
+standalone chevron remains because the user retracted the title-click request.
+Header icons retain their 14px glyphs, matching tab-bar icon buttons.

--- a/docs/org2-performance-guard-2026-08-31/TrailPanelCornerResize.md
+++ b/docs/org2-performance-guard-2026-08-31/TrailPanelCornerResize.md
@@ -1,0 +1,70 @@
+# Workstation trail terminal controls performance review
+
+| Area               | Verdict | Evidence                                                                           | Change or reason kept                                                                                                               | Verification                                                        |
+| ------------------ | ------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Background work    | keep    | Corner listeners and one pending animation frame exist only during a terminal drag | Release, cancellation, blur, document hidden and unmount dispose resources; the fixed trail no longer installs a resize hook        | Rendered grip lifecycle tests                                       |
+| Memory             | keep    | Fixed dimension state and at most three dock claims                                | Capacity is checked before session creation, including stale callbacks; no new cache, worker, observer or polling loop              | Repeated-drag cleanup, capacity and repeated-add tests              |
+| Scope/isolation    | fix     | Existing sessions and claims remain authoritative in the current Jotai store       | My Station Open Tabs excludes pinned, chat-panel and agent-owned terminals in both wide and compact renderers                       | Production rail tests with real creation, claim and release writers |
+| Rendering/hot path | keep    | Geometry is read at drag start; moves only record coordinates and queue one frame  | Live resizing avoids storage writes and skips unchanged sizes; release flushes final coordinates                                    | 60 moves coalesce into one frame/update; persistence tests          |
+| Terminal ownership | keep    | Collapse changes geometry and visibility without dropping the mounted host         | Only the expanded body reserves extra column width; hide releases claims without killing; stop uses the existing termination writer | Dock integration and claim suites                                   |
+| Font appearance    | keep    | Both initialization and live updates use the resolved host font size               | Pinned host uses 12px; other hosts retain the global setting; no global write or xterm recreation                                   | Two real component chains with mocked xterm/native setup            |
+| Tooltip lifecycle  | keep    | Collapsed icons reuse ToolbarTooltip                                               | Existing hover delay and body portal are cleaned up on leave, expansion and unmount                                                 | Real collapsed tooltip integration and shared tooltip tests         |
+
+## Authoritative boundaries
+
+The terminal session pool contains valid sessions from several owners. Pinned
+membership is authoritative in miniTerminalClaimedIdsAtom, written through
+openMiniTerminalAtom and release/close actions. Open Tabs previously ignored
+that membership and owner scope. Exclusion is the user's explicit My Station
+product requirement, not a workaround for malformed data. Existing owner-ID
+helpers exclude chat-panel and agent PTYs. Collapse retains claims; release/hide
+returns eligible sessions to Open Tabs. No historical cleanup is required.
+
+The creation invariant lives in openMiniTerminalAtom: reject a fourth claim
+before invoking editorAddTerminalSessionAtom, but permit focusing an existing
+claim at capacity. The dock forwards shell/profile/cwd options through this
+writer instead of creating before claiming. Rejection leaves the session pool
+unchanged. Claims are transient; no terminal content or persisted sessions are
+migrated. Stop still reaches closeMiniTerminalSessionAtom, closeTerminalSessionAtom
+and close_pty. Integration spies verify only the selected session is removed;
+no OS process is launched or killed by these tests.
+
+## Lifecycle matrix
+
+- Start/visible idle: no drag listeners or animation-frame work
+- Active drag: one pointer owner and at most one pending frame; foreign pointers ignored
+- Hidden/blur/focus return: end the gesture and remove resources; return does not restart work
+- Repeated open/drag: prior resources are removed before later interactions
+- Collapse/unmount/shutdown: grip cleanup restores cursor/selection and cancels frames; a folded terminal retains its host
+- Tab switching: at most three content-width tabs use native overflow; selection reveal reads only two rectangles and changes local scrollLeft, with no scroll listener or observer
+- Instance scope: no auth, provider, network or sync changes; two numeric size preferences retain existing local UI scope
+
+Only terminal dimensions persist, once at gesture/keyboard commit. The fixed
+trail ignores old width/minimum preferences without deleting them. The two new
+terminal keys are best-effort and clamped when loaded. Older builds ignore them;
+clearing only these keys restores 400x260 defaults. Shared control sizing,
+spacing, and stop presentation add no timers or subscriptions. The server
+watcher's scanning and existing callbacks are unchanged.
+
+## Verification
+
+The isolated PR worktree was used, excluding unrelated Input/Textarea tests from
+the shared checkout.
+
+- Targeted Vitest run: **113 tests across 20 suites pass**, covering the production rail, terminal dock, resize gesture, dimension persistence, claim writer, font override, shared stop/tooltip primitives, responsive layout and project/PR consumers
+- `pnpm run typecheck`: pass
+- Scoped ESLint with `--max-warnings 0`: pass
+- Scoped `pnpm exec prettier --check`: pass
+- `pnpm run check:test-placement`: pass, 435 directories
+- `git diff --check`: pass
+
+Exact final verification commands are included in PR #1131's Verification
+section. These are jsdom, source and compiler checks; xterm setup and termination
+IPC are mocked. No native performance improvement is claimed.
+
+Performance verdict: **blocked for native measurement**. Computer control was
+not authorized, so native WebView/xterm fit, theme/viewport appearance, resizing
+the native window mid-drag, visible/hidden idle CPU/RSS, active frame times and
+post-close native behavior were not measured. Deterministic coalescing and
+resource-cleanup tests pass; native matrix cells remain unverified. This
+limitation is disclosed in the PR, which remains ready for review.

--- a/src/components/ProcessStopButton/index.test.ts
+++ b/src/components/ProcessStopButton/index.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProcessStopButton } from ".";
+
+describe("process stop control", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("stops a process without also opening its containing row", () => {
+    const open = vi.fn();
+    const stop = vi.fn();
+    act(() =>
+      root.render(
+        React.createElement(
+          "div",
+          { onClick: open },
+          React.createElement(ProcessStopButton, {
+            label: "Stop process",
+            onClick: stop,
+          })
+        )
+      )
+    );
+    const button = container.querySelector("button")!;
+    expect(button.getAttribute("aria-label")).toBe("Stop process");
+    expect(button.querySelector('[data-icon="stop"]')).not.toBeNull();
+    act(() => button.click());
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it.each([{ loading: true }, { disabled: true }])(
+    "prevents another stop while unavailable: %o",
+    (state) => {
+      const stop = vi.fn();
+      act(() =>
+        root.render(
+          React.createElement(ProcessStopButton, {
+            label: "Stop process",
+            onClick: stop,
+            ...state,
+          })
+        )
+      );
+      const button = container.querySelector("button")!;
+      expect(button.disabled).toBe(true);
+      act(() => button.click());
+      expect(stop).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/components/ProcessStopButton/index.tsx
+++ b/src/components/ProcessStopButton/index.tsx
@@ -1,0 +1,47 @@
+import type { ButtonHTMLAttributes } from "react";
+
+import { BUTTON_SIZE } from "@src/config/workstation/tokens";
+import { HugeiconsIcon, Loading03Icon, StopIcon } from "@src/icons";
+
+interface ProcessStopButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+> {
+  label: string;
+  size?: keyof typeof BUTTON_SIZE;
+  loading?: boolean;
+}
+
+/** Shared process termination affordance, matching the server watcher. */
+export function ProcessStopButton({
+  label,
+  size = "md",
+  loading = false,
+  disabled,
+  className = "",
+  onClick,
+  ...props
+}: ProcessStopButtonProps) {
+  return (
+    <button
+      {...props}
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled || loading}
+      className={`hover:text-danger-7 inline-flex shrink-0 items-center justify-center rounded text-danger-6 transition-colors hover:bg-danger-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-6 disabled:cursor-not-allowed disabled:opacity-40 ${BUTTON_SIZE[size]} ${className}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick?.(event);
+      }}
+    >
+      <HugeiconsIcon
+        icon={loading ? Loading03Icon : StopIcon}
+        data-icon={loading ? "loader-2" : "stop"}
+        size={14}
+        aria-hidden
+        className={loading ? "animate-spin" : undefined}
+      />
+    </button>
+  );
+}

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
@@ -145,15 +145,15 @@ describe("FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS", () => {
 });
 
 describe("resolveFocusedChatWorkstationSectionOrder", () => {
-  it("places session and local environments before open tabs", () => {
+  it("places the local environment above the session environment and open tabs", () => {
     expect(resolveFocusedChatWorkstationSectionOrder(true, true)).toEqual([
-      "session",
       "workspace",
+      "session",
       "tabs",
     ]);
     expect(resolveFocusedChatWorkstationSectionOrder(false, true)).toEqual([
-      "session",
       "workspace",
+      "session",
     ]);
   });
 

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
@@ -29,8 +29,8 @@ export function resolveFocusedChatWorkstationSectionOrder(
   hasSessionEnvironment: boolean
 ): Array<"session" | "workspace" | "tabs"> {
   return [
-    ...(hasSessionEnvironment ? (["session"] as const) : []),
     "workspace",
+    ...(hasSessionEnvironment ? (["session"] as const) : []),
     ...(hasOpenTabs ? (["tabs"] as const) : []),
   ];
 }

--- a/src/engines/TerminalCore/__tests__/TerminalCore.fontSize.test.ts
+++ b/src/engines/TerminalCore/__tests__/TerminalCore.fontSize.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { settingsAtom } from "@src/store/settings/settingsAtom";
+
+import { TerminalCore } from "..";
+import type { UseTerminalStateReturn } from "../types";
+
+const runtime = vi.hoisted(() => ({ create: vi.fn(), fit: vi.fn() }));
+vi.mock("@src/hooks/terminal", () => ({ useTerminalProcessPoller: () => {} }));
+vi.mock("@/src/scaffold/ContextMenu/exports", () => ({
+  TextSelectionDropdown: () => null,
+}));
+vi.mock("../components/TerminalSearchPanel", () => ({
+  TerminalSearchPanel: () => null,
+}));
+// Keep TerminalCore, TerminalView, and appearance effects real; replace only
+// xterm/native setup so the test never launches a PTY or creates a GPU context.
+vi.mock("../components/TerminalInteractive/terminalSetup", () => ({
+  createTerminalInstance: (options: unknown) => runtime.create(options),
+  initializeWhenContainerVisible: ({
+    setIsReady,
+  }: {
+    setIsReady: (ready: boolean) => void;
+  }) => {
+    setIsReady(true);
+    return () => {};
+  },
+  loadTerminalWebgl: vi.fn(),
+}));
+vi.mock("../components/TerminalInteractive/terminalHandlers", () => ({
+  registerTerminalEventHandlers: () => () => {},
+}));
+vi.mock("../components/TerminalInteractive/terminalLifecycle", () => ({
+  cleanupPtyListeners: vi.fn(),
+}));
+vi.mock("../components/TerminalInteractive/terminalPty", () => ({
+  initPtyConnection: vi.fn(),
+}));
+vi.mock("../components/TerminalInteractive/terminalOutputScheduler", () => ({
+  setPaneForeground: vi.fn(),
+  flushBacklog: vi.fn(),
+}));
+vi.mock("../components/TerminalInteractive/terminalSizing", () => ({
+  createFitTerminal: () => runtime.fit,
+  createRedrawTerminalAfterLayoutChange: () => () => {},
+}));
+vi.mock("../components/TerminalInteractive/useTerminalResizeListeners", () => ({
+  useTerminalResizeListeners: () => {},
+}));
+
+function terminalState(id: string): UseTerminalStateReturn {
+  const session = { id, name: id, isActive: true };
+  return {
+    sessions: [session],
+    activeSessionId: id,
+    activeSession: session,
+    initializedSessions: new Set([id]),
+    addSession: () => "",
+    closeSession: () => {},
+    setActiveSession: () => {},
+    markSessionInitialized: () => {},
+    updateSessionInfo: () => {},
+    renameSession: () => {},
+  };
+}
+
+describe("terminal host font sizes", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let store: ReturnType<typeof createStore>;
+  const pinnedState = terminalState("pinned");
+  const stationState = terminalState("station");
+
+  beforeEach(() => {
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+      setTimeout(() => callback(0), 16)
+    );
+    vi.stubGlobal("cancelAnimationFrame", clearTimeout);
+    store = createStore();
+    store.set(settingsAtom, {
+      ...store.get(settingsAtom),
+      "terminal.fontSize": 18,
+    });
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    runtime.create.mockReset();
+    runtime.fit.mockReset();
+    runtime.create.mockImplementation(
+      ({ terminalFontSize }: { terminalFontSize: number }) => ({
+        terminal: {
+          options: { fontSize: terminalFontSize },
+          rows: 24,
+          open: vi.fn(),
+          dispose: vi.fn(),
+          clearTextureAtlas: vi.fn(),
+          refresh: vi.fn(),
+        },
+        fitAddon: {},
+        searchAddon: {},
+        serializeAddon: {},
+      })
+    );
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    expect(vi.getTimerCount()).toBe(0);
+    container.remove();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  function render(fontSize?: number) {
+    act(() =>
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(TerminalCore, {
+            terminalState: pinnedState,
+            fontSize,
+          }),
+          React.createElement(TerminalCore, { terminalState: stationState })
+        )
+      )
+    );
+  }
+
+  it("scopes initial and live font overrides without recreating either terminal", () => {
+    render(12);
+    expect(runtime.create).toHaveBeenCalledTimes(2);
+    expect(
+      runtime.create.mock.calls.map(([options]) => options.terminalFontSize)
+    ).toEqual([12, 18]);
+    const [pinned, station] = runtime.create.mock.results.map(
+      ({ value }) => value.terminal
+    );
+    act(() => vi.runAllTimers());
+
+    act(() =>
+      store.set(settingsAtom, {
+        ...store.get(settingsAtom),
+        "terminal.fontSize": 20,
+      })
+    );
+    expect(pinned.options.fontSize).toBe(12);
+    expect(station.options.fontSize).toBe(20);
+    act(() => vi.runAllTimers());
+
+    runtime.fit.mockClear();
+    render(11);
+    expect(pinned.options.fontSize).toBe(11);
+    expect(station.options.fontSize).toBe(20);
+    act(() => vi.advanceTimersByTime(50));
+    expect(runtime.fit).toHaveBeenCalledTimes(1);
+
+    render();
+    expect(pinned.options.fontSize).toBe(20);
+    expect(store.get(settingsAtom)["terminal.fontSize"]).toBe(20);
+    expect(runtime.create).toHaveBeenCalledTimes(2);
+    expect(pinned.dispose).not.toHaveBeenCalled();
+    expect(station.dispose).not.toHaveBeenCalled();
+    // Leave the final fit pending: unmount must cancel it in afterEach.
+  });
+});

--- a/src/engines/TerminalCore/components/TerminalInteractive/index.tsx
+++ b/src/engines/TerminalCore/components/TerminalInteractive/index.tsx
@@ -89,6 +89,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       forceRepoCwd,
       nameOverride,
       backgroundColor,
+      fontSize,
       shellIntegration,
     },
     ref
@@ -118,7 +119,8 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     const [_isBrowserMode, setIsBrowserMode] = useState(false);
     const [isReady, setIsReady] = useState(false);
     const terminalTheme = useAtomValue(terminalThemeAtom);
-    const terminalFontSize = useAtomValue(terminalFontSizeAtom);
+    const configuredFontSize = useAtomValue(terminalFontSizeAtom);
+    const terminalFontSize = fontSize ?? configuredFontSize;
     const terminalLetterSpacing = useAtomValue(terminalLetterSpacingAtom);
     const codeFontFamily = useAtomValue(resolvedTerminalFontFamilyAtom);
     const shellType = useAtomValue(shellTypeAtom);

--- a/src/engines/TerminalCore/components/TerminalInteractive/types.ts
+++ b/src/engines/TerminalCore/components/TerminalInteractive/types.ts
@@ -95,6 +95,8 @@ export interface TerminalViewProps {
   nameOverride?: string;
   /** Overrides the xterm surface background for embedded contexts. */
   backgroundColor?: string;
+  /** Font size in pixels for this view; defaults to the terminal setting. */
+  fontSize?: number;
   /** Shell integration event callbacks (OSC 633) */
   shellIntegration?: ShellIntegrationEvents;
 }

--- a/src/engines/TerminalCore/index.tsx
+++ b/src/engines/TerminalCore/index.tsx
@@ -60,6 +60,8 @@ export interface TerminalCoreProps {
   className?: string;
   /** Background color override */
   backgroundColor?: string;
+  /** Font size in pixels for this host; defaults to the terminal setting. */
+  fontSize?: number;
   /** Repository path for terminal working directory */
   repoPath?: string;
   /** Opens file references detected in terminal output */
@@ -89,6 +91,7 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
   terminalState,
   className = "",
   backgroundColor,
+  fontSize,
   repoPath,
   onOpenFileLink,
   visible = true,
@@ -396,6 +399,7 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
                 workingDirectory={session.liveCwd || session.cwd}
                 onOpenFileLink={onOpenFileLink}
                 backgroundColor={bgColor}
+                fontSize={fontSize}
                 // Managed CLI terminals use the configured default shell.
                 // `session.shell` becomes runtime metadata after the PTY connects,
                 // so reusing it as a launch override would recreate xterm.

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1266,7 +1266,10 @@
       "newMiniTerminal": "Neues Mini-Terminal",
       "showMiniTerminals": "Mini-Terminals",
       "sessionInMiniTerminal": "Läuft im Mini-Terminal",
-      "returnFromMiniTerminal": "Hier anzeigen"
+      "returnFromMiniTerminal": "Hier anzeigen",
+      "resizeTerminal": "Terminalgröße ändern",
+      "terminalProcessCount_one": "{{count}} Prozess",
+      "terminalProcessCount_other": "{{count}} Prozesse"
     },
     "pr": {
       "title": "Pull Request",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1154,7 +1154,10 @@
       "newMiniTerminal": "New mini terminal",
       "showMiniTerminals": "Mini terminals",
       "sessionInMiniTerminal": "Running in the mini terminal",
-      "returnFromMiniTerminal": "Show it here"
+      "returnFromMiniTerminal": "Show it here",
+      "resizeTerminal": "Resize terminal",
+      "terminalProcessCount_one": "{{count}} process",
+      "terminalProcessCount_other": "{{count}} processes"
     },
     "messages": {
       "pushSuccess": "Successfully pushed changes to remote",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1266,7 +1266,10 @@
       "newMiniTerminal": "Nuevo miniterminal",
       "showMiniTerminals": "Miniterminales",
       "sessionInMiniTerminal": "En ejecución en el miniterminal",
-      "returnFromMiniTerminal": "Mostrar aquí"
+      "returnFromMiniTerminal": "Mostrar aquí",
+      "resizeTerminal": "Cambiar tamaño del terminal",
+      "terminalProcessCount_one": "{{count}} proceso",
+      "terminalProcessCount_other": "{{count}} procesos"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1266,7 +1266,10 @@
       "newMiniTerminal": "Nouveau mini-terminal",
       "showMiniTerminals": "Mini-terminaux",
       "sessionInMiniTerminal": "En cours d'exécution dans le mini-terminal",
-      "returnFromMiniTerminal": "Afficher ici"
+      "returnFromMiniTerminal": "Afficher ici",
+      "resizeTerminal": "Redimensionner le terminal",
+      "terminalProcessCount_one": "{{count}} processus",
+      "terminalProcessCount_other": "{{count}} processus"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1265,7 +1265,10 @@
       "newMiniTerminal": "新しいミニターミナル",
       "showMiniTerminals": "ミニターミナル",
       "sessionInMiniTerminal": "ミニターミナルで実行中",
-      "returnFromMiniTerminal": "ここに表示"
+      "returnFromMiniTerminal": "ここに表示",
+      "resizeTerminal": "ターミナルのサイズを変更",
+      "terminalProcessCount_one": "{{count}} 個のプロセス",
+      "terminalProcessCount_other": "{{count}} 個のプロセス"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1265,7 +1265,10 @@
       "newMiniTerminal": "새 미니 터미널",
       "showMiniTerminals": "미니 터미널",
       "sessionInMiniTerminal": "미니 터미널에서 실행 중",
-      "returnFromMiniTerminal": "여기에 표시"
+      "returnFromMiniTerminal": "여기에 표시",
+      "resizeTerminal": "터미널 크기 조정",
+      "terminalProcessCount_one": "프로세스 {{count}}개",
+      "terminalProcessCount_other": "프로세스 {{count}}개"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1270,7 +1270,12 @@
       "newMiniTerminal": "Nowy miniterminal",
       "showMiniTerminals": "Miniterminale",
       "sessionInMiniTerminal": "Działa w miniterminalu",
-      "returnFromMiniTerminal": "Pokaż tutaj"
+      "returnFromMiniTerminal": "Pokaż tutaj",
+      "resizeTerminal": "Zmień rozmiar terminala",
+      "terminalProcessCount_one": "{{count}} proces",
+      "terminalProcessCount_other": "{{count}} procesu",
+      "terminalProcessCount_few": "{{count}} procesy",
+      "terminalProcessCount_many": "{{count}} procesów"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1266,7 +1266,10 @@
       "newMiniTerminal": "Novo miniterminal",
       "showMiniTerminals": "Miniterminais",
       "sessionInMiniTerminal": "Em execução no miniterminal",
-      "returnFromMiniTerminal": "Mostrar aqui"
+      "returnFromMiniTerminal": "Mostrar aqui",
+      "resizeTerminal": "Redimensionar terminal",
+      "terminalProcessCount_one": "{{count}} processo",
+      "terminalProcessCount_other": "{{count}} processos"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1270,7 +1270,12 @@
       "newMiniTerminal": "Новый мини-терминал",
       "showMiniTerminals": "Мини-терминалы",
       "sessionInMiniTerminal": "Выполняется в мини-терминале",
-      "returnFromMiniTerminal": "Показать здесь"
+      "returnFromMiniTerminal": "Показать здесь",
+      "resizeTerminal": "Изменить размер терминала",
+      "terminalProcessCount_one": "{{count}} процесс",
+      "terminalProcessCount_other": "{{count}} процесса",
+      "terminalProcessCount_few": "{{count}} процесса",
+      "terminalProcessCount_many": "{{count}} процессов"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1267,7 +1267,10 @@
       "newMiniTerminal": "Yeni mini terminal",
       "showMiniTerminals": "Mini terminaller",
       "sessionInMiniTerminal": "Mini terminalde çalışıyor",
-      "returnFromMiniTerminal": "Burada göster"
+      "returnFromMiniTerminal": "Burada göster",
+      "resizeTerminal": "Terminali yeniden boyutlandır",
+      "terminalProcessCount_one": "{{count}} işlem",
+      "terminalProcessCount_other": "{{count}} işlem"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1265,7 +1265,10 @@
       "newMiniTerminal": "Terminal thu nhỏ mới",
       "showMiniTerminals": "Terminal thu nhỏ",
       "sessionInMiniTerminal": "Đang chạy trong terminal thu nhỏ",
-      "returnFromMiniTerminal": "Hiển thị tại đây"
+      "returnFromMiniTerminal": "Hiển thị tại đây",
+      "resizeTerminal": "Thay đổi kích thước terminal",
+      "terminalProcessCount_one": "{{count}} tiến trình",
+      "terminalProcessCount_other": "{{count}} tiến trình"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1278,7 +1278,10 @@
       "newMiniTerminal": "新增迷你終端機",
       "showMiniTerminals": "迷你終端機",
       "sessionInMiniTerminal": "正在迷你終端機中執行",
-      "returnFromMiniTerminal": "在此處顯示"
+      "returnFromMiniTerminal": "在此處顯示",
+      "resizeTerminal": "調整終端大小",
+      "terminalProcessCount_one": "{{count}} 個程序",
+      "terminalProcessCount_other": "{{count}} 個程序"
     },
     "pr": {
       "title": "Pull request",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1142,7 +1142,10 @@
       "newMiniTerminal": "新建迷你终端",
       "showMiniTerminals": "迷你终端",
       "sessionInMiniTerminal": "正在迷你终端中运行",
-      "returnFromMiniTerminal": "在此处显示"
+      "returnFromMiniTerminal": "在此处显示",
+      "resizeTerminal": "调整终端大小",
+      "terminalProcessCount_one": "{{count}} 个进程",
+      "terminalProcessCount_other": "{{count}} 个进程"
     },
     "pr": {
       "title": "Pull request",

--- a/src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesPanel.test.ts
+++ b/src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesPanel.test.ts
@@ -2,7 +2,9 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import WorkstationTrailSurface from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
+import WorkstationTrailSurface, {
+  WorkstationTrailIconButton,
+} from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
 
 import PropertiesPanel from ".";
 
@@ -22,6 +24,11 @@ describe("PropertiesPanel", () => {
             title: "Project Properties",
             fitContent: true,
             headerVariant: "workstation-trail",
+            headerActions: createElement(
+              WorkstationTrailIconButton,
+              { "aria-label": "Collapse properties" },
+              ">>"
+            ),
           },
           createElement("span", null, "Status")
         )
@@ -34,7 +41,9 @@ describe("PropertiesPanel", () => {
     expect(markup).toContain("p-1");
     expect(markup).toContain("shadow-dropdown");
     expect(markup).toContain("mb-1");
-    expect(markup).toContain("h-7");
+    expect(markup).toContain("h-6");
+    expect(markup).toContain("h-5 w-5");
+    expect(markup).toContain("justify-between pl-1 pr-[3px]");
     expect(markup).toContain("px-1 text-[11px]");
     expect(markup).toContain("max-h-full");
     expect(markup).not.toContain("flex-1 overflow-y-auto");

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx
@@ -11,8 +11,9 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import { Placeholder } from "@src/components/Placeholder";
+import { ProcessStopButton } from "@src/components/ProcessStopButton";
 import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
-import { Delete02Icon, HugeiconsIcon } from "@src/icons";
+import { Cancel01Icon, HugeiconsIcon } from "@src/icons";
 import {
   FileHeader,
   TerminalInfoButton,
@@ -169,21 +170,25 @@ const TerminalMainContent: React.FC<TerminalMainContentProps> = ({
           </>
         )}
         <span className="flex items-center gap-px">
-          <Button
-            htmlType="button"
-            variant="tertiary"
-            size="small"
-            iconOnly
-            title={t("tooltips.killTerminal")}
-            onClick={handleKillTerminal}
-            icon={
-              <HugeiconsIcon
-                icon={Delete02Icon}
-                data-icon="trash-2"
-                size={14}
-              />
-            }
-          />
+          {isAgentTerminal ? (
+            <Button
+              htmlType="button"
+              variant="tertiary"
+              size="small"
+              iconOnly
+              title={t("common:actions.close")}
+              aria-label={t("common:actions.close")}
+              onClick={handleKillTerminal}
+              icon={
+                <HugeiconsIcon icon={Cancel01Icon} data-icon="x" size={14} />
+              }
+            />
+          ) : (
+            <ProcessStopButton
+              label={t("common:tooltips.killTerminal")}
+              onClick={handleKillTerminal}
+            />
+          )}
           {!isAgentTerminal && (
             <TerminalInfoButton
               title={t("common:terminology.myTerminalInfo")}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrSidebar.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrSidebar.test.ts
@@ -145,8 +145,8 @@ describe("PrSidebar", () => {
     const reviewerTrigger = surface?.querySelector(
       "[data-testid='pr-reviewer-action']"
     );
-    expect(reviewerTrigger?.className).toContain("h-[26px]");
-    expect(reviewerTrigger?.className).toContain("w-[26px]");
+    expect(reviewerTrigger?.className).toContain("h-5");
+    expect(reviewerTrigger?.className).toContain("w-5");
     expect(reviewerTrigger?.className).toContain("rounded-lg");
     const reviewers = container.querySelector(
       "[data-testid='pr-sidebar-reviewers']"

--- a/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalSidebarRows.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalSidebarRows.tsx
@@ -2,11 +2,8 @@ import { useAtomValue } from "jotai";
 import React, { memo } from "react";
 import { useTranslation } from "react-i18next";
 
-import {
-  TreeRowAction,
-  TreeRowBase,
-  type TreeRowNode,
-} from "@src/components/TreeRow";
+import { ProcessStopButton } from "@src/components/ProcessStopButton";
+import { TreeRowBase, type TreeRowNode } from "@src/components/TreeRow";
 // `types`, not the `exports` barrel — the barrel re-exports the TerminalCore
 // component and would drag xterm into the sidebar-modules chunk.
 import {
@@ -15,7 +12,6 @@ import {
 } from "@src/engines/TerminalCore/types";
 import {
   Infinity01Icon,
-  Cancel01Icon,
   ComputerTerminal01Icon,
   HugeiconsIcon,
 } from "@src/icons";
@@ -53,13 +49,13 @@ export const AgentSessionRow: React.FC<AgentSessionRowProps> = memo(
           data-icon="infinity"
           size={14}
           strokeWidth={1.75}
-          className="shrink-0 text-primary-6 group-hover/item:hidden"
+          className="shrink-0 text-primary-6 group-focus-within/item:hidden group-hover/item:hidden"
         />
-        <TreeRowAction
-          icon={Cancel01Icon}
+        <ProcessStopButton
+          size="sm"
+          className="hidden group-focus-within/item:flex group-hover/item:flex"
           onClick={onClose}
-          title={t("controlTower.sidebar.stopAgentProcess")}
-          variant="danger"
+          label={t("controlTower.sidebar.stopAgentProcess")}
         />
       </TreeRowBase>
     );
@@ -95,11 +91,11 @@ export const PtySessionRow: React.FC<PtySessionRowProps> = memo(
 
     return (
       <TreeRowBase node={node} depth={0} isSelected={isActive} onClick={onOpen}>
-        <TreeRowAction
-          icon={Cancel01Icon}
+        <ProcessStopButton
+          size="sm"
+          className="hidden group-focus-within/item:flex group-hover/item:flex"
           onClick={onClose}
-          title={t("controlTower.sidebar.closeSession")}
-          variant="danger"
+          label={t("common:tooltips.killTerminal")}
         />
       </TreeRowBase>
     );

--- a/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
@@ -14,6 +14,7 @@ import {
   DROPDOWN_PANEL,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
+import { ProcessStopButton } from "@src/components/ProcessStopButton";
 import { REFRESH_ICON_TOKENS } from "@src/components/RefreshIcon/tokens";
 import { resolveTimeZoneForIntl } from "@src/config/timezone";
 import { useDropdownEngine } from "@src/hooks/dropdown";
@@ -23,10 +24,8 @@ import {
   Copy01Icon,
   HugeiconsIcon,
   InternetIcon,
-  Loading03Icon,
   Refresh04Icon,
   ServerStack03Icon,
-  StopIcon,
 } from "@src/icons";
 import {
   addressForPort,
@@ -164,32 +163,11 @@ const PortRow: React.FC<PortRowProps> = memo(
             />
           </button>
           {canStop && (
-            <button
-              type="button"
-              className="hover:text-danger-7 inline-flex h-6 w-6 items-center justify-center rounded text-danger-6 transition-colors hover:bg-danger-1 disabled:opacity-40"
-              title={t("workstation.ports.stopProcess")}
-              aria-label={t("workstation.ports.stopProcess")}
-              disabled={stopping}
-              onClick={(event) => {
-                event.stopPropagation();
-                onStop(port);
-              }}
-            >
-              {stopping ? (
-                <HugeiconsIcon
-                  icon={Loading03Icon}
-                  data-icon="loader-2"
-                  size={MENU_ICON_SIZE}
-                  className="animate-spin text-danger-6"
-                />
-              ) : (
-                <HugeiconsIcon
-                  icon={StopIcon}
-                  data-icon="stop"
-                  size={MENU_ICON_SIZE}
-                />
-              )}
-            </button>
+            <ProcessStopButton
+              label={t("workstation.ports.stopProcess")}
+              loading={stopping}
+              onClick={() => onStop(port)}
+            />
           )}
         </div>
       </div>

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/FocusedChatWorkstationRail.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/FocusedChatWorkstationRail.test.ts
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+import i18next from "i18next";
+import { Provider, createStore } from "jotai";
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { I18nextProvider } from "react-i18next";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import common from "@src/i18n/locales/en/common.json";
+import navigation from "@src/i18n/locales/en/navigation.json";
+import { createChatPanelTerminalAtom } from "@src/store/chatPanel/chatPanelTerminalAtom";
+import {
+  closeMiniTerminalAtom,
+  miniTerminalCollapsedAtom,
+  openMiniTerminalAtom,
+  releaseMiniTerminalSessionAtom,
+} from "@src/store/ui/miniTerminalAtom";
+import {
+  editorAddTerminalSessionAtom,
+  markTerminalInitializedAtom,
+  terminalSessionsAtom,
+} from "@src/store/workstation/codeEditor/terminal";
+import { workstationLayoutAtom } from "@src/store/workstation/tabs";
+
+import { FocusedChatWorkstationRail } from ".";
+
+vi.mock("@src/hooks/git/useActiveRepoRef", () => ({
+  useActiveRepoRef: () => ({ repoId: null, repoPath: "" }),
+}));
+vi.mock("@src/hooks/git/useRepoSelection", () => ({
+  useRepoSelection: () => ({ currentBranch: "" }),
+}));
+vi.mock("@src/hooks/git/useWorkingTreeDiffTotals", () => ({
+  useWorkingTreeDiffTotals: () => ({ additions: 0, deletions: 0 }),
+}));
+vi.mock("@src/hooks/git/useBranchPullRequestStatus", () => ({
+  useBranchPullRequestStatus: () => ({ ciStatus: null, pr: null }),
+}));
+vi.mock("@src/hooks/tabHost/useCloseTabWithGuard", () => ({
+  useCloseTabWithGuard: () => vi.fn(),
+}));
+// Exercise the parent projection and both real section renderers without
+// launching a PTY or depending on popup positioning/animation in jsdom.
+vi.mock("./WorkstationTrailTerminal", () => ({
+  WorkstationTrailTerminal: () => null,
+}));
+vi.mock("@src/components/FileTypeIcon", () => ({ default: () => null }));
+vi.mock("@src/components/Dropdown", () => ({
+  default: ({
+    children,
+    droplist,
+  }: React.PropsWithChildren<{
+    droplist: React.ReactNode;
+  }>) => React.createElement(React.Fragment, null, children, droplist),
+}));
+
+const i18n = i18next.createInstance();
+await i18n.init({
+  lng: "en",
+  fallbackLng: "en",
+  resources: { en: { common, navigation } },
+  interpolation: { escapeValue: false },
+});
+
+describe.each(["wide rail", "compact menu"])(
+  "environment tabs in %s",
+  (view) => {
+    let root: Root;
+    let container: HTMLDivElement;
+    let menuHost: HTMLDivElement;
+    let store: ReturnType<typeof createStore>;
+
+    beforeEach(() => {
+      Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+      localStorage.clear();
+      store = createStore();
+      container = document.createElement("div");
+      menuHost = document.createElement("div");
+      document.body.append(container, menuHost);
+      root = createRoot(container);
+      store.set(terminalSessionsAtom, []);
+      store.set(workstationLayoutAtom, {
+        mainPane: {
+          tabs: [
+            {
+              id: "file:readme",
+              type: "file",
+              title: "README.md",
+              data: { filePath: "/workspace/README.md" },
+            },
+          ],
+          activeTabId: "file:readme",
+        },
+      });
+    });
+
+    afterEach(() => {
+      act(() => root.unmount());
+      container.remove();
+      menuHost.remove();
+      localStorage.clear();
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+      Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    });
+
+    function addStationTerminal(name: string) {
+      const id = store.set(editorAddTerminalSessionAtom, {
+        name,
+        bypassCreationCooldown: true,
+      });
+      store.set(markTerminalInitializedAtom, id);
+      return id;
+    }
+
+    async function mount() {
+      await act(async () => {
+        root.render(
+          React.createElement(
+            Provider,
+            { store },
+            React.createElement(
+              I18nextProvider,
+              { i18n },
+              React.createElement(
+                MemoryRouter,
+                null,
+                React.createElement(FocusedChatWorkstationRail, {
+                  compactMenuHost: menuHost,
+                  conversationMinimapHostRef: () => {},
+                })
+              )
+            )
+          )
+        );
+      });
+    }
+
+    function tabSection() {
+      const host = view === "wide rail" ? container : menuHost;
+      return [...host.querySelectorAll("section")].find((section) =>
+        section.textContent?.includes("Open Tabs")
+      );
+    }
+
+    if (view === "wide rail") {
+      it("shows shortcut tooltips on collapsed icons and disposes them on expansion", async () => {
+        vi.useFakeTimers();
+        await mount();
+        act(() =>
+          container
+            .querySelector('[data-icon="chevrons-right"]')!
+            .closest("button")!
+            .click()
+        );
+
+        for (const [label, key] of [
+          ["Review", "E"],
+          ["Terminal", "J"],
+          ["Files", "G"],
+          ["Browser", null],
+        ]) {
+          const button = container.querySelector<HTMLButtonElement>(
+            `button[aria-label="${label}"]`
+          )!;
+          expect(button).not.toBeNull();
+          expect(button.hasAttribute("title")).toBe(false);
+          act(() =>
+            button.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
+          );
+          act(() => vi.advanceTimersByTime(200));
+          act(() => vi.advanceTimersByTime(32));
+
+          const tooltip = document.querySelector(".native-tooltip")!;
+          expect(tooltip?.textContent).toContain(label);
+          expect(tooltip.classList.contains("native-tooltip-visible")).toBe(
+            true
+          );
+          expect(container.contains(tooltip)).toBe(false);
+          const keys = tooltip.querySelectorAll("kbd");
+          expect(keys).toHaveLength(key ? 2 : 0);
+          if (key) expect(keys[1].textContent).toBe(key);
+
+          act(() =>
+            button.dispatchEvent(
+              new MouseEvent("mouseout", {
+                bubbles: true,
+                relatedTarget: document.body,
+              })
+            )
+          );
+          act(() => vi.advanceTimersByTime(100));
+          expect(document.querySelector(".native-tooltip")).toBeNull();
+        }
+
+        // Expanding before the delay expires must not leave a stale popup.
+        const review = container.querySelector('button[aria-label="Review"]')!;
+        act(() =>
+          review.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
+        );
+        act(() =>
+          container
+            .querySelector('[data-icon="chevrons-left"]')!
+            .closest("button")!
+            .click()
+        );
+        act(() => vi.advanceTimersByTime(250));
+        expect(document.querySelector(".native-tooltip")).toBeNull();
+      });
+    }
+
+    it("lists My Station files and terminals without docked or chat-panel terminals", async () => {
+      addStationTerminal("Station shell");
+      const pinned = addStationTerminal("Pinned shell");
+      store.set(openMiniTerminalAtom, pinned);
+      const chatTerminal = store.set(createChatPanelTerminalAtom, {
+        name: "Chat shell",
+      });
+      store.set(markTerminalInitializedAtom, chatTerminal);
+      store.set(terminalSessionsAtom, (sessions) => [
+        ...sessions,
+        { id: "agent-pty-task", name: "Agent shell", isActive: false },
+      ]);
+      store.set(markTerminalInitializedAtom, "agent-pty-task");
+
+      await mount();
+
+      expect(tabSection()?.textContent).toContain("README.md");
+      expect(tabSection()?.textContent).toContain("Station shell");
+      expect(tabSection()?.textContent).not.toContain("Pinned shell");
+      expect(tabSection()?.textContent).not.toContain("Chat shell");
+      expect(tabSection()?.textContent).not.toContain("Agent shell");
+      expect(store.get(terminalSessionsAtom)).toHaveLength(4);
+    });
+
+    it("keeps pins excluded while collapsed and restores them only on release", async () => {
+      const first = addStationTerminal("First shell");
+      const second = addStationTerminal("Second shell");
+      await mount();
+      expect(tabSection()?.textContent).toContain("First shell");
+      expect(tabSection()?.textContent).toContain("Second shell");
+
+      await act(async () => {
+        store.set(openMiniTerminalAtom, first);
+        store.set(openMiniTerminalAtom, second);
+        store.set(miniTerminalCollapsedAtom, true);
+      });
+      expect(tabSection()?.textContent).not.toContain("First shell");
+      expect(tabSection()?.textContent).not.toContain("Second shell");
+
+      await act(async () => store.set(releaseMiniTerminalSessionAtom, first));
+      expect(tabSection()?.textContent).toContain("First shell");
+      expect(tabSection()?.textContent).not.toContain("Second shell");
+
+      await act(async () => store.set(closeMiniTerminalAtom));
+      expect(tabSection()?.textContent).toContain("First shell");
+      expect(tabSection()?.textContent).toContain("Second shell");
+      expect(store.get(terminalSessionsAtom)).toHaveLength(2);
+    });
+  }
+);

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/TrailPanelResizeHandle.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/TrailPanelResizeHandle.test.ts
@@ -1,0 +1,289 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TrailPanelResizeHandle } from "./TrailPanelResizeHandle";
+
+describe("trail panel corner resize", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let panel: HTMLDivElement;
+  let button: HTMLButtonElement;
+  let width: number;
+  let height: number;
+  let scale: number;
+  let frames: Map<number, FrameRequestCallback>;
+  let nextFrame: number;
+  const onResize = vi.fn();
+  const onResizeEnd = vi.fn();
+  const onResizingChange = vi.fn();
+
+  function pointer(
+    target: EventTarget,
+    type: string,
+    x: number,
+    y: number,
+    pointerId = 1,
+    mouseButton = 0
+  ) {
+    const event = new MouseEvent(type, {
+      bubbles: true,
+      clientX: x,
+      clientY: y,
+      button: mouseButton,
+    });
+    Object.defineProperties(event, {
+      pointerId: { value: pointerId },
+      isPrimary: { value: true },
+    });
+    act(() => target.dispatchEvent(event));
+  }
+  function flushFrame() {
+    const pending = [...frames.values()];
+    frames.clear();
+    act(() => pending.forEach((callback) => callback(0)));
+  }
+
+  beforeEach(() => {
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    width = 400;
+    height = 260;
+    scale = 1;
+    frames = new Map();
+    nextFrame = 0;
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frames.set(++nextFrame, callback);
+        return nextFrame;
+      })
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((id: number) => frames.delete(id))
+    );
+    onResize.mockReset().mockImplementation((size) => {
+      width = size.width;
+      height = size.height;
+    });
+    onResizeEnd.mockReset();
+    onResizingChange.mockReset();
+    container = document.createElement("div");
+    panel = document.createElement("div");
+    panel.dataset.workstationTrailPanel = "";
+    container.appendChild(panel);
+    document.body.appendChild(container);
+    Object.defineProperties(panel, {
+      offsetWidth: { get: () => width },
+      offsetHeight: { get: () => height },
+    });
+    vi.spyOn(panel, "getBoundingClientRect").mockImplementation(() => ({
+      left: 800 - width * scale,
+      right: 800,
+      top: 100,
+      bottom: 100 + height * scale,
+      width: width * scale,
+      height: height * scale,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    }));
+    root = createRoot(panel);
+    act(() =>
+      root.render(
+        React.createElement(TrailPanelResizeHandle, {
+          label: "Resize panel",
+          min: { width: 220, height: 80 },
+          max: { width: 720, height: 720 },
+          onResize,
+          onResizeEnd,
+          onResizingChange,
+        })
+      )
+    );
+    button = panel.querySelector("button")!;
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("does no scheduled work before a drag and ignores right click", () => {
+    const add = vi.spyOn(window, "addEventListener");
+    pointer(button, "pointerdown", 400, 360, 1, 2);
+    expect(add).not.toHaveBeenCalled();
+    expect(frames.size).toBe(0);
+    expect(onResizingChange).not.toHaveBeenCalled();
+  });
+
+  it("grows left/down at UI scale and coalesces pointer bursts into one frame", () => {
+    scale = 2;
+    pointer(button, "pointerdown", 0, 620);
+    for (let index = 1; index <= 60; index++) {
+      pointer(window, "pointermove", -index * 2, 620 + index);
+    }
+    expect(frames.size).toBe(1);
+    expect(onResize).not.toHaveBeenCalled();
+    flushFrame();
+    expect(onResize).toHaveBeenCalledTimes(1);
+    expect(onResize).toHaveBeenLastCalledWith({ width: 460, height: 290 });
+    expect(onResizeEnd).not.toHaveBeenCalled();
+    pointer(window, "pointerup", -120, 680);
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(onResizeEnd).toHaveBeenLastCalledWith({
+      width: 460,
+      height: 290,
+    });
+    expect(frames.size).toBe(0);
+  });
+
+  it("flushes the final pointer position before committing, without waiting for RAF", () => {
+    pointer(button, "pointerdown", 400, 360);
+    pointer(window, "pointermove", 390, 370);
+    pointer(window, "pointerup", 330, 430);
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(onResizeEnd).toHaveBeenLastCalledWith({
+      width: 470,
+      height: 330,
+    });
+    expect(frames.size).toBe(0);
+  });
+
+  it("clamps both dimensions while shrinking", () => {
+    pointer(button, "pointerdown", 400, 360);
+    pointer(window, "pointerup", 1400, -100);
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(onResizeEnd).toHaveBeenLastCalledWith({
+      width: 220,
+      height: 80,
+    });
+  });
+
+  it("uses a release back at the starting point instead of retaining a stale move", () => {
+    pointer(button, "pointerdown", 400, 360);
+    pointer(window, "pointermove", 350, 410);
+    flushFrame();
+    pointer(window, "pointerup", 400, 360);
+    expect(onResizeEnd).toHaveBeenLastCalledWith({ width: 400, height: 260 });
+  });
+
+  it("leaves room for the panel below and the track padding", () => {
+    container.dataset.workstationTrailTrack = "";
+    container.style.paddingBottom = "4px";
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
+      bottom: 600,
+    } as DOMRect);
+    const sibling = document.createElement("div");
+    sibling.style.marginTop = "4px";
+    vi.spyOn(sibling, "getBoundingClientRect").mockReturnValue({
+      height: 150,
+    } as DOMRect);
+    container.appendChild(sibling);
+    pointer(button, "pointerdown", 400, 360);
+    pointer(window, "pointerup", 350, 1500);
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(onResizeEnd).toHaveBeenLastCalledWith({
+      width: 450,
+      height: 342,
+    });
+  });
+
+  it("ignores other pointers during the active drag", () => {
+    pointer(button, "pointerdown", 400, 360);
+    pointer(window, "pointermove", 0, 0, 2);
+    pointer(window, "pointercancel", 0, 0, 2);
+    pointer(window, "pointerup", 0, 0, 2);
+    expect(onResizeEnd).not.toHaveBeenCalled();
+    expect(document.body.style.cursor).toBe("nesw-resize");
+    pointer(window, "pointerup", 390, 370);
+    expect(onResizeEnd).toHaveBeenCalledTimes(1);
+    expect(onResizeEnd).toHaveBeenLastCalledWith({
+      width: 410,
+      height: 270,
+    });
+  });
+
+  it.each(["blur", "pointercancel", "visibilitychange"])(
+    "cleans up an interrupted drag on %s",
+    (type) => {
+      document.body.style.cursor = "crosshair";
+      document.body.style.userSelect = "text";
+      pointer(button, "pointerdown", 400, 360);
+      pointer(window, "pointermove", 350, 400);
+      if (type === "visibilitychange") {
+        vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+        act(() => document.dispatchEvent(new Event(type)));
+      } else if (type === "pointercancel") {
+        pointer(window, type, 0, 0);
+      } else {
+        act(() => window.dispatchEvent(new Event(type)));
+      }
+      expect(onResizeEnd).toHaveBeenCalledTimes(1);
+      expect(onResizeEnd).toHaveBeenLastCalledWith({
+        width: 450,
+        height: 300,
+      });
+      expect(document.body.style.cursor).toBe("crosshair");
+      expect(document.body.style.userSelect).toBe("text");
+      expect(frames.size).toBe(0);
+      pointer(window, "pointermove", 0, 0);
+      expect(frames.size).toBe(0);
+    }
+  );
+
+  it("removes listeners and pending work if the grip unmounts mid-drag", () => {
+    const remove = vi.spyOn(window, "removeEventListener");
+    pointer(button, "pointerdown", 400, 360);
+    pointer(window, "pointermove", 350, 400);
+    act(() => root.render(null));
+    expect(remove.mock.calls.map(([type]) => type)).toEqual(
+      expect.arrayContaining([
+        "pointermove",
+        "pointerup",
+        "pointercancel",
+        "blur",
+      ])
+    );
+    expect(frames.size).toBe(0);
+    expect(onResizeEnd).not.toHaveBeenCalled();
+    expect(document.body.style.cursor).toBe("");
+    pointer(window, "pointerup", 0, 0);
+    expect(onResizeEnd).not.toHaveBeenCalled();
+  });
+
+  it("supports keyboard resizing with the same bounds and commit path", () => {
+    act(() =>
+      button.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true })
+      )
+    );
+    expect(onResizeEnd).toHaveBeenLastCalledWith({ width: 410, height: 260 });
+    act(() =>
+      button.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          shiftKey: true,
+          bubbles: true,
+        })
+      )
+    );
+    expect(onResizeEnd).toHaveBeenLastCalledWith({ width: 410, height: 300 });
+    expect(frames.size).toBe(0);
+  });
+
+  it("does not accumulate active listeners across repeated drags", () => {
+    for (let index = 0; index < 4; index++) {
+      pointer(button, "pointerdown", 400, 360);
+      pointer(window, "pointerup", 390, 370);
+    }
+    expect(onResizeEnd).toHaveBeenCalledTimes(4);
+    pointer(window, "pointermove", 0, 0);
+    expect(frames.size).toBe(0);
+  });
+});

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/TrailPanelResizeHandle.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/TrailPanelResizeHandle.tsx
@@ -1,0 +1,43 @@
+import { type TrailPanelSize } from "./trailPanelSize";
+import { useTrailPanelResize } from "./useTrailPanelResize";
+
+interface TrailPanelResizeHandleProps {
+  label: string;
+  min: TrailPanelSize;
+  max: TrailPanelSize;
+  onResize: (size: TrailPanelSize) => void;
+  onResizeEnd: (size: TrailPanelSize) => void;
+  onResizingChange: (resizing: boolean) => void;
+}
+
+/** Shared bottom-left grip; arrow keys resize too (Shift takes larger steps). */
+export function TrailPanelResizeHandle({
+  label,
+  ...options
+}: TrailPanelResizeHandleProps) {
+  const handlers = useTrailPanelResize(options);
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      {...handlers}
+      className="absolute bottom-0 left-0 z-40 flex h-5 w-5 cursor-nesw-resize touch-none select-none items-center justify-center rounded-bl-xl rounded-tr text-text-3 hover:text-primary-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-6"
+    >
+      <svg
+        aria-hidden="true"
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+      >
+        <path
+          d="m3 5 8 8M3 9l4 4"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationGroupToggle.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationGroupToggle.tsx
@@ -2,8 +2,8 @@ import { ArrowDown01Icon, ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
 
 import { WorkstationTrailIconButton } from "../blocks/WorkstationTrailSurface";
 
-const WORKSTATION_GROUP_TOGGLE_REVEAL_CLASS =
-  "pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 group-focus-within/workstation-trail:pointer-events-auto group-focus-within/workstation-trail:opacity-100 group-hover/workstation-trail:pointer-events-auto group-hover/workstation-trail:opacity-100";
+export const WORKSTATION_TRAIL_ACTION_REVEAL_CLASS =
+  "pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover/workstation-trail:pointer-events-auto group-hover/workstation-trail:opacity-100";
 
 export function WorkstationGroupToggle({
   collapseLabel,
@@ -20,7 +20,7 @@ export function WorkstationGroupToggle({
 }) {
   return (
     <WorkstationTrailIconButton
-      className={WORKSTATION_GROUP_TOGGLE_REVEAL_CLASS}
+      className={WORKSTATION_TRAIL_ACTION_REVEAL_CLASS}
       data-workstation-group-toggle={groupKey}
       onClick={onToggle}
       aria-label={collapsed ? expandLabel : collapseLabel}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationItemRow.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationItemRow.tsx
@@ -8,6 +8,7 @@ import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
 import FileTypeIcon from "@src/components/FileTypeIcon";
 import { IconButton } from "@src/components/IconButton";
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
+import { ProcessStopButton } from "@src/components/ProcessStopButton";
 import Tooltip from "@src/components/Tooltip";
 import { WORKSTATION_TRAIL_CONTENT } from "@src/config/workstation/tokens";
 import { ArrowUpRight01Icon, Cancel01Icon, HugeiconsIcon } from "@src/icons";
@@ -108,7 +109,15 @@ export function WorkstationItemRow({
       ) : (
         action
       )}
-      {item.onClose && (
+      {item.onStop ? (
+        <ProcessStopButton
+          size="sm"
+          label={item.stopLabel ?? item.label}
+          className={`opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 ${compact ? "ml-0.5" : "mr-1"}`}
+          onClick={item.onStop}
+          role={compact ? "menuitem" : undefined}
+        />
+      ) : item.onClose ? (
         <IconButton
           size="sm"
           variant="defaultTreeRow"
@@ -124,7 +133,7 @@ export function WorkstationItemRow({
         >
           <HugeiconsIcon icon={Cancel01Icon} data-icon="x" size={12} />
         </IconButton>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationSections.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationSections.tsx
@@ -47,7 +47,7 @@ export function WorkstationSections({
             }
           >
             {section.label && (
-              <div className="flex h-7 items-center">
+              <div className="flex h-6 items-center">
                 <div className={WORKSTATION_TRAIL_CONTENT.sectionLabelInline}>
                   {section.label}
                 </div>

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationSections.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationSections.tsx
@@ -35,7 +35,7 @@ export function WorkstationSections({
           !compact && collapsedGroupKeys?.has(section.key) === true;
 
         // In the wide rail, the panel header is also the heading for the first
-        // (session-environment) group. Do not leave an empty spacer for its
+        // (local-environment) group. Do not leave an empty spacer for its
         // unlabelled section when that group is collapsed.
         if (groupCollapsed && !section.label) return null;
 

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.test.ts
@@ -1,0 +1,335 @@
+// @vitest-environment jsdom
+import i18next from "i18next";
+import { Provider, createStore } from "jotai";
+import React, { act, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { I18nextProvider } from "react-i18next";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TerminalCoreProps } from "@src/engines/TerminalCore";
+import common from "@src/i18n/locales/en/common.json";
+import navigation from "@src/i18n/locales/en/navigation.json";
+import {
+  miniTerminalActiveIdAtom,
+  miniTerminalClaimedIdsAtom,
+  miniTerminalCollapsedAtom,
+  miniTerminalHostMountedAtom,
+  miniTerminalVisibleAtom,
+  openMiniTerminalAtom,
+} from "@src/store/ui/miniTerminalAtom";
+import { terminalSessionsAtom } from "@src/store/workstation/codeEditor/terminal";
+import * as tauri from "@src/util/platform/tauri/init";
+import * as creationThrottle from "@src/util/ui/terminal/creationThrottle";
+import { toBackendPtySessionId } from "@src/util/ui/terminal/ptySessionId";
+
+import { WorkstationTrailTerminal } from "./WorkstationTrailTerminal";
+
+const lifecycle = vi.hoisted(() => ({ mount: vi.fn(), unmount: vi.fn() }));
+vi.mock("@src/engines/TerminalCore", () => ({
+  default: function TerminalProbe({
+    visible,
+    fontSize,
+    terminalState,
+  }: TerminalCoreProps) {
+    useEffect(() => {
+      lifecycle.mount();
+      return () => lifecycle.unmount();
+    }, []);
+    return React.createElement(
+      "output",
+      {
+        "aria-label": "Terminal runtime",
+        "data-visible": visible,
+        "data-font-size": fontSize,
+      },
+      terminalState?.activeSessionId
+    );
+  },
+}));
+
+const i18n = i18next.createInstance();
+await i18n.init({
+  lng: "en",
+  fallbackLng: "en",
+  resources: { en: { common, navigation } },
+  interpolation: { escapeValue: false },
+});
+
+describe("docked terminal controls", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let store: ReturnType<typeof createStore>;
+  const props = {
+    width: 570,
+    height: 350,
+    onResize: vi.fn(),
+    onResizeEnd: vi.fn(),
+    onResizingChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    store = createStore();
+    store.set(miniTerminalHostMountedAtom, true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    lifecycle.mount.mockClear();
+    lifecycle.unmount.mockClear();
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    localStorage.clear();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  async function mount(count: number) {
+    const sessions = Array.from({ length: count }, (_, index) => ({
+      id: `shell-${index + 1}`,
+      name: `Shell ${index + 1}`,
+      isActive: false,
+    }));
+    store.set(terminalSessionsAtom, sessions);
+    sessions.forEach(({ id }) => store.set(openMiniTerminalAtom, id));
+    await act(async () => {
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(
+            I18nextProvider,
+            { i18n },
+            React.createElement(WorkstationTrailTerminal, props)
+          )
+        )
+      );
+    });
+  }
+  async function clickLabel(label: string) {
+    const button = [
+      ...container.querySelectorAll<HTMLButtonElement>("button"),
+    ].find((node) => node.getAttribute("aria-label") === label);
+    expect(button).toBeDefined();
+    await act(async () => button!.click());
+  }
+  function tabs() {
+    return [...container.querySelectorAll<HTMLButtonElement>('[role="tab"]')];
+  }
+
+  it("uses the single terminal name as the header without a duplicate tab", async () => {
+    await mount(1);
+    const header = container.querySelector("aside")!.firstElementChild!;
+    expect(header.textContent).toBe("Shell 1");
+    expect(tabs()).toHaveLength(0);
+    expect(header.querySelector('[role="tablist"]')).toBeNull();
+    expect(header.querySelector('[data-icon="chevron-down"]')).not.toBeNull();
+    expect(header.querySelector('[data-icon="stop"]')).not.toBeNull();
+    expect(
+      container
+        .querySelector('[aria-label="Terminal runtime"]')
+        ?.getAttribute("data-font-size")
+    ).toBe("12");
+    const labelId = container
+      .querySelector('[role="tabpanel"]')!
+      .getAttribute("aria-labelledby")!;
+    expect(document.getElementById(labelId)?.textContent).toBe("Shell 1");
+    await clickLabel("Collapse");
+    expect(header.textContent).toBe("Shell 1");
+    expect(header.querySelector('[data-icon="chevron-right"]')).not.toBeNull();
+  });
+
+  it("shows all three tabs without an add button or overflow menu", async () => {
+    await mount(3);
+    const header = container.querySelector("aside")!.firstElementChild!;
+    expect(header.textContent).not.toContain("Terminals");
+    expect(header.querySelector('[data-icon="chevron-down"]')).not.toBeNull();
+    expect(tabs().map((tab) => tab.textContent)).toEqual([
+      "Shell 1",
+      "Shell 2",
+      "Shell 3",
+    ]);
+    expect(container.querySelector('[data-icon="plus"]')).toBeNull();
+    expect(container.querySelector("[aria-haspopup]")).toBeNull();
+    for (const button of header.querySelectorAll("button")) {
+      expect(button.classList.contains("h-5")).toBe(true);
+      if (button.getAttribute("role") !== "tab")
+        expect(button.classList.contains("w-5")).toBe(true);
+    }
+    expect(
+      header.querySelector('[role="tablist"]')!.classList.contains("gap-px")
+    ).toBe(true);
+    expect(
+      container
+        .querySelector('[role="tabpanel"]')!
+        .getAttribute("aria-labelledby")
+    ).toBe(tabs()[2].id);
+    expect(tabs()[2].getAttribute("aria-controls")).toBe(
+      container.querySelector('[role="tabpanel"]')!.id
+    );
+    expect(
+      container.querySelector('[role="tablist"]')!.textContent
+    ).not.toContain("+");
+    await clickLabel("Collapse");
+    expect(container.querySelector('[data-icon="plus"]')).toBeNull();
+  });
+
+  it("hides add at three, rejects a repeated click, and restores add after stopping", async () => {
+    await mount(2);
+    const create = vi
+      .spyOn(creationThrottle, "tryBeginTerminalCreation")
+      .mockReturnValue(true);
+    const add = container.querySelector<HTMLButtonElement>(
+      '[aria-label="New mini terminal"]'
+    )!;
+    expect(add).not.toBeNull();
+    await act(async () => {
+      add.click();
+      add.click();
+    });
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(store.get(terminalSessionsAtom)).toHaveLength(3);
+    expect(tabs()).toHaveLength(3);
+    expect(container.querySelector('[data-icon="plus"]')).toBeNull();
+    await clickLabel(common.tooltips.killTerminal);
+    expect(tabs()).toHaveLength(2);
+    expect(container.querySelector('[data-icon="plus"]')).not.toBeNull();
+  });
+
+  it.each([1, 2])(
+    "scrolls the tab strip in both directions at %sx scale",
+    async (scale) => {
+      await mount(3);
+      const list = container.querySelector<HTMLElement>('[role="tablist"]')!;
+      vi.spyOn(list, "getBoundingClientRect").mockReturnValue(
+        new DOMRect(100, 0, 120 * scale, 24 * scale)
+      );
+      Object.defineProperty(list, "offsetWidth", {
+        configurable: true,
+        value: 120,
+      });
+      tabs().forEach((tab, index) => {
+        vi.spyOn(tab, "getBoundingClientRect").mockImplementation(
+          () =>
+            new DOMRect(
+              100 + (index * 100 - list.scrollLeft) * scale,
+              0,
+              100 * scale,
+              24 * scale
+            )
+        );
+      });
+      container.scrollLeft = 12;
+      await act(async () =>
+        tabs()[2].dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Home", bubbles: true })
+        )
+      );
+      await act(async () =>
+        tabs()[0].dispatchEvent(
+          new KeyboardEvent("keydown", { key: "End", bubbles: true })
+        )
+      );
+      expect(list.scrollLeft).toBe(180);
+      expect(document.activeElement).toBe(tabs()[2]);
+      await act(async () =>
+        tabs()[2].dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Home", bubbles: true })
+        )
+      );
+      expect(list.scrollLeft).toBe(0);
+      expect(document.activeElement).toBe(tabs()[0]);
+      expect(container.scrollLeft).toBe(12);
+    }
+  );
+
+  it("switches visible tabs with keyboard focus", async () => {
+    await mount(3);
+    await act(async () =>
+      tabs()[2].dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Home", bubbles: true })
+      )
+    );
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("shell-1");
+    expect(document.activeElement).toBe(tabs()[0]);
+    await act(async () =>
+      tabs()[0].dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
+      )
+    );
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("shell-2");
+    expect(tabs()[1].getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(tabs()[1]);
+  });
+
+  it("folds to a centered process count without unmounting the terminal, then restores its size", async () => {
+    await mount(3);
+    const surface = container.querySelector("aside")!;
+    expect(surface.style.width).toBe("570px");
+    expect(surface.style.height).toBe("350px");
+    await clickLabel("Collapse");
+    expect(store.get(miniTerminalCollapsedAtom)).toBe(true);
+    expect(tabs()).toHaveLength(0);
+    expect(surface.firstElementChild!.textContent).toBe("3 processes");
+    expect(surface.firstElementChild!.classList.contains("mb-1")).toBe(false);
+    expect(surface.style.width).toBe("");
+    expect(surface.style.height).toBe("");
+    expect(
+      container.querySelector('[aria-label="Resize terminal"]')
+    ).toBeNull();
+    expect(
+      container.querySelector("output")!.getAttribute("data-visible")
+    ).toBe("false");
+    expect(lifecycle.mount).toHaveBeenCalledTimes(1);
+    expect(lifecycle.unmount).not.toHaveBeenCalled();
+    await clickLabel("Expand");
+    expect(surface.style.width).toBe("570px");
+    expect(surface.style.height).toBe("350px");
+    expect(
+      container.querySelector('[aria-label="Resize terminal"]')
+    ).not.toBeNull();
+    expect(lifecycle.mount).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops only the selected PTY through the existing terminal writer", async () => {
+    await mount(3);
+    vi.spyOn(tauri, "isTauriReady").mockReturnValue(true);
+    const invoke = vi.spyOn(tauri, "invokeTauri").mockResolvedValue(undefined);
+    await clickLabel(common.tooltips.killTerminal);
+    expect(invoke).toHaveBeenCalledWith("close_pty", {
+      sessionId: toBackendPtySessionId("shell-3"),
+    });
+    expect(store.get(terminalSessionsAtom).map(({ id }) => id)).toEqual([
+      "shell-1",
+      "shell-2",
+    ]);
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual([
+      "shell-1",
+      "shell-2",
+    ]);
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("shell-1");
+  });
+
+  it("returns to a single named header when only one terminal remains", async () => {
+    await mount(2);
+    await clickLabel(common.tooltips.killTerminal);
+    const header = container.querySelector("aside")!.firstElementChild!;
+    expect(header.textContent).toBe("Shell 1");
+    expect(tabs()).toHaveLength(0);
+    const labelId = container
+      .querySelector('[role="tabpanel"]')!
+      .getAttribute("aria-labelledby")!;
+    expect(document.getElementById(labelId)?.textContent).toBe("Shell 1");
+  });
+
+  it("hides the dock without stopping sessions", async () => {
+    await mount(3);
+    const invoke = vi.spyOn(tauri, "invokeTauri").mockResolvedValue(undefined);
+    await clickLabel("Hide mini terminal");
+    expect(store.get(miniTerminalVisibleAtom)).toBe(false);
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual([]);
+    expect(store.get(terminalSessionsAtom)).toHaveLength(3);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.tsx
@@ -4,7 +4,7 @@
  * The trail's terminal: a short panel docked directly under the trail
  * surface, in the trail's own column and on an identical surface. It is not
  * a floating window — it cannot be dragged, it collapses to its header row,
- * and it widens the trail track to `MINI_TERMINAL_TRAIL_WIDTH` when opened.
+ * and its expanded width/height can be resized from the bottom-left corner.
  *
  * # Reuses the Workstation terminal, does not clone it
  *
@@ -20,7 +20,7 @@
  * mounted behind `display: none` while collapsed so the PTY keeps its view.
  */
 import { useAtomValue, useSetAtom } from "jotai";
-import React, { Suspense, useCallback, useMemo } from "react";
+import React, { Suspense, useCallback, useId, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -28,14 +28,6 @@ import {
   type UseTerminalStateReturn,
   getTerminalDisplayTitle,
 } from "@src/engines/TerminalCore/types";
-import {
-  Add01Icon,
-  ArrowDown01Icon,
-  ArrowRight01Icon,
-  Cancel01Icon,
-  Delete02Icon,
-  HugeiconsIcon,
-} from "@src/icons";
 import { selectedRepoPathAtom } from "@src/store/repo";
 import {
   closeMiniTerminalAtom,
@@ -48,7 +40,6 @@ import {
   setMiniTerminalActiveIdAtom,
 } from "@src/store/ui/miniTerminalAtom";
 import {
-  editorAddTerminalSessionAtom,
   initializedTerminalIdsAtom,
   markTerminalInitializedAtom,
   renameTerminalSessionAtom,
@@ -56,23 +47,38 @@ import {
   updateTerminalSessionInfoAtom,
 } from "@src/store/workstation/codeEditor/terminal";
 
+import { WorkstationTrailSurface } from "../blocks";
+import { TrailPanelResizeHandle } from "./TrailPanelResizeHandle";
 import {
-  DetailTabStrip,
-  type DetailTabStripItem,
-  WorkstationTrailHeader,
-  WorkstationTrailIconButton,
-  WorkstationTrailSurface,
-} from "../blocks";
+  type TrailTerminalTab,
+  WorkstationTrailTerminalHeader,
+} from "./WorkstationTrailTerminalHeader";
+import {
+  TRAIL_TERMINAL_SIZE_LIMITS,
+  type TrailPanelSize,
+} from "./trailPanelSize";
 
 // Lazy: pulls TerminalCore (xterm + addons) only once the trail terminal is
 // actually opened, so the focused chat does not pay for it by default.
 const TerminalCore = React.lazy(() => import("@src/engines/TerminalCore"));
 
-/** Expanded panel height. Collapsed, the surface is just its header row. */
-export const WORKSTATION_TRAIL_TERMINAL_HEIGHT_PX = 260;
+interface WorkstationTrailTerminalProps {
+  width: number;
+  height: number;
+  onResize: (size: TrailPanelSize) => void;
+  onResizeEnd: (size: TrailPanelSize) => void;
+  onResizingChange: (resizing: boolean) => void;
+}
 
-export function WorkstationTrailTerminal() {
+export function WorkstationTrailTerminal({
+  width,
+  height,
+  onResize,
+  onResizeEnd,
+  onResizingChange,
+}: WorkstationTrailTerminalProps) {
   const { t } = useTranslation();
+  const panelId = useId();
   const claimedIds = useAtomValue(miniTerminalClaimedIdsAtom);
   const activeId = useAtomValue(miniTerminalActiveIdAtom);
   const suppressedIds = useAtomValue(miniTerminalSuppressedIdsAtom);
@@ -86,7 +92,6 @@ export function WorkstationTrailTerminal() {
   const markInitialized = useSetAtom(markTerminalInitializedAtom);
   const updateInfo = useSetAtom(updateTerminalSessionInfoAtom);
   const renameSession = useSetAtom(renameTerminalSessionAtom);
-  const addWorkstationSession = useSetAtom(editorAddTerminalSessionAtom);
   const openMiniTerminal = useSetAtom(openMiniTerminalAtom);
   const closeMiniTerminal = useSetAtom(closeMiniTerminalAtom);
   const closeMiniTerminalSession = useSetAtom(closeMiniTerminalSessionAtom);
@@ -97,15 +102,8 @@ export function WorkstationTrailTerminal() {
   );
 
   const handleAddSession = useCallback(
-    (options?: AddSessionOptions) => {
-      const sessionId = addWorkstationSession({
-        cwd: repoPath || undefined,
-        ...options,
-      });
-      if (sessionId) openMiniTerminal(sessionId);
-      return sessionId;
-    },
-    [addWorkstationSession, openMiniTerminal, repoPath]
+    (options?: AddSessionOptions) => openMiniTerminal(null, options) ?? "",
+    [openMiniTerminal]
   );
 
   // Scoped runtime: the real Workstation sessions, narrowed to this panel's
@@ -138,7 +136,7 @@ export function WorkstationTrailTerminal() {
     ]
   );
 
-  const terminalTabs = useMemo<DetailTabStripItem[]>(
+  const terminalTabs = useMemo<TrailTerminalTab[]>(
     () =>
       sessions.map((session) => ({
         key: session.id,
@@ -147,14 +145,6 @@ export function WorkstationTrailTerminal() {
     [sessions]
   );
 
-  const activeSession = terminalState.activeSession;
-  const activeTitle = activeSession
-    ? getTerminalDisplayTitle(activeSession)
-    : t("common:tabs.terminal");
-  const showTabs = !collapsed && sessions.length > 1;
-  // The strip already names every terminal; repeating the active one in the
-  // header title would say it twice.
-  const title = showTabs ? t("common:tabs.terminal") : activeTitle;
   // Only mount once the Workstation pane has actually let go of the session.
   const terminalMountable = activeId != null && suppressedIds.has(activeId);
 
@@ -162,101 +152,37 @@ export function WorkstationTrailTerminal() {
     <WorkstationTrailSurface
       as="aside"
       aria-label={t("common:git.rail.showMiniTerminals")}
-      className="group/workstation-trail-terminal mt-1 hidden shrink-0 @[1100px]/focusedchat:flex"
+      className={`group/workstation-trail-terminal relative ml-auto mt-1 hidden min-h-0 ${collapsed ? "shrink-0" : "pb-5"} @[1100px]/focusedchat:flex`}
       style={
         collapsed
           ? undefined
           : {
-              height: WORKSTATION_TRAIL_TERMINAL_HEIGHT_PX,
-              // Never let the terminal swallow the whole trail column on a
-              // short window — the trail above it stays readable.
-              maxHeight: "60%",
+              width,
+              height,
             }
       }
       data-workstation-trail-terminal
+      data-workstation-trail-panel
     >
-      <WorkstationTrailHeader
-        title={title}
-        titleActions={
-          <WorkstationTrailIconButton
-            onClick={() => setCollapsed(!collapsed)}
-            aria-label={t(
-              collapsed ? "common:actions.expand" : "common:actions.collapse"
-            )}
-            aria-expanded={!collapsed}
-          >
-            <HugeiconsIcon
-              icon={collapsed ? ArrowRight01Icon : ArrowDown01Icon}
-              data-icon={collapsed ? "chevron-right" : "chevron-down"}
-              size={14}
-              strokeWidth={1.75}
-            />
-          </WorkstationTrailIconButton>
-        }
-        actions={
-          <div className="flex items-center">
-            <WorkstationTrailIconButton
-              onClick={() => handleAddSession()}
-              aria-label={t("common:git.rail.newMiniTerminal")}
-              title={t("common:git.rail.newMiniTerminal")}
-            >
-              <HugeiconsIcon
-                icon={Add01Icon}
-                data-icon="plus"
-                size={14}
-                strokeWidth={1.75}
-              />
-            </WorkstationTrailIconButton>
-            <WorkstationTrailIconButton
-              onClick={closeMiniTerminal}
-              aria-label={t("common:git.rail.hideMiniTerminal")}
-              title={t("common:git.rail.hideMiniTerminal")}
-            >
-              <HugeiconsIcon
-                icon={Cancel01Icon}
-                data-icon="x"
-                size={14}
-                strokeWidth={1.75}
-              />
-            </WorkstationTrailIconButton>
-          </div>
-        }
+      <WorkstationTrailTerminalHeader
+        activeId={activeId}
+        collapsed={collapsed}
+        panelId={panelId}
+        tabs={terminalTabs}
+        onSelect={setActiveId}
+        onToggleCollapsed={() => setCollapsed(!collapsed)}
+        onAdd={() => handleAddSession()}
+        onHide={closeMiniTerminal}
+        onStop={closeMiniTerminalSession}
       />
-      {showTabs ? (
-        // Same strip the pull-request detail header uses, in its compact
-        // header variant: one tab per claimed terminal, and a trailing
-        // control that kills the terminal the strip is showing.
-        <DetailTabStrip
-          activeTab={activeId ?? ""}
-          ariaLabel={t("common:git.rail.showMiniTerminals")}
-          className="mb-1 px-1"
-          idPrefix="workstation-trail-terminal"
-          onChange={setActiveId}
-          tabs={terminalTabs}
-          variant="header"
-          trailing={
-            activeId ? (
-              <WorkstationTrailIconButton
-                onClick={() => closeMiniTerminalSession(activeId)}
-                aria-label={t("common:git.rail.closeItem", {
-                  label: activeTitle,
-                })}
-                title={t("common:git.rail.closeItem", { label: activeTitle })}
-              >
-                <HugeiconsIcon
-                  icon={Delete02Icon}
-                  data-icon="trash"
-                  size={14}
-                  strokeWidth={1.75}
-                />
-              </WorkstationTrailIconButton>
-            ) : null
-          }
-        />
-      ) : null}
       {/* Kept mounted while collapsed: unmounting would drop the xterm this
           panel is the only host for, leaving the claimed PTY unattached. */}
       <div
+        role="tabpanel"
+        id={panelId}
+        aria-labelledby={
+          !collapsed && activeId ? `${panelId}-tab-${activeId}` : undefined
+        }
         className={
           collapsed
             ? "hidden"
@@ -269,11 +195,28 @@ export function WorkstationTrailTerminal() {
               terminalState={terminalState}
               repoPath={repoPath || undefined}
               backgroundColor="var(--cm-editor-background)"
+              fontSize={12}
               visible={!collapsed}
             />
           ) : null}
         </Suspense>
       </div>
+      {!collapsed ? (
+        <TrailPanelResizeHandle
+          label={t("common:git.rail.resizeTerminal")}
+          min={{
+            width: TRAIL_TERMINAL_SIZE_LIMITS.minWidth,
+            height: TRAIL_TERMINAL_SIZE_LIMITS.minHeight,
+          }}
+          max={{
+            width: TRAIL_TERMINAL_SIZE_LIMITS.maxWidth,
+            height: TRAIL_TERMINAL_SIZE_LIMITS.maxHeight,
+          }}
+          onResize={onResize}
+          onResizeEnd={onResizeEnd}
+          onResizingChange={onResizingChange}
+        />
+      ) : null}
     </WorkstationTrailSurface>
   );
 }

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminalHeader.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminalHeader.tsx
@@ -1,0 +1,188 @@
+import { useLayoutEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+
+import { ProcessStopButton } from "@src/components/ProcessStopButton";
+import {
+  Add01Icon,
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  Cancel01Icon,
+  HugeiconsIcon,
+} from "@src/icons";
+import { MINI_TERMINAL_SESSION_LIMIT } from "@src/store/ui/miniTerminalAtom";
+
+import { WorkstationTrailHeader, WorkstationTrailIconButton } from "../blocks";
+
+export interface TrailTerminalTab {
+  key: string;
+  label: string;
+}
+
+interface WorkstationTrailTerminalHeaderProps {
+  activeId: string | null;
+  collapsed: boolean;
+  panelId: string;
+  tabs: TrailTerminalTab[];
+  onSelect: (id: string) => void;
+  onToggleCollapsed: () => void;
+  onAdd: () => void;
+  onHide: () => void;
+  onStop: (id: string) => void;
+}
+
+export function WorkstationTrailTerminalHeader({
+  activeId,
+  collapsed,
+  panelId,
+  tabs,
+  onSelect,
+  onToggleCollapsed,
+  onAdd,
+  onHide,
+  onStop,
+}: WorkstationTrailTerminalHeaderProps) {
+  const { t } = useTranslation();
+  const tabListRef = useRef<HTMLDivElement>(null);
+  const activeTab = tabs.find((tab) => tab.key === activeId);
+  useLayoutEffect(() => {
+    const list = tabListRef.current;
+    const selected = list?.querySelector<HTMLButtonElement>(
+      '[aria-selected="true"]'
+    );
+    if (!list || !selected || collapsed) return;
+    // Reveal only within the tab strip; never scroll the surrounding chat.
+    const listRect = list.getBoundingClientRect();
+    const tabRect = selected.getBoundingClientRect();
+    if (!listRect.width) return;
+    const scale = list.offsetWidth ? listRect.width / list.offsetWidth : 1;
+    if (tabRect.left < listRect.left)
+      list.scrollLeft += (tabRect.left - listRect.left) / scale;
+    else if (tabRect.right > listRect.right)
+      list.scrollLeft += (tabRect.right - listRect.right) / scale;
+  }, [activeId, collapsed]);
+  const terminalsLabel = t("navigation:labels.terminals");
+  const showTabs = !collapsed && tabs.length > 1;
+  const title = showTabs ? null : tabs.length > 1 ? (
+    t("common:git.rail.terminalProcessCount", { count: tabs.length })
+  ) : (
+    <span
+      id={activeId ? `${panelId}-tab-${activeId}` : undefined}
+      className="normal-case"
+    >
+      {activeTab?.label ?? terminalsLabel}
+    </span>
+  );
+
+  return (
+    <WorkstationTrailHeader
+      standalone={collapsed}
+      title={title}
+      titleActions={
+        <WorkstationTrailIconButton
+          className="pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 group-focus-within/workstation-trail-terminal:pointer-events-auto group-focus-within/workstation-trail-terminal:opacity-100 group-hover/workstation-trail-terminal:pointer-events-auto group-hover/workstation-trail-terminal:opacity-100"
+          onClick={onToggleCollapsed}
+          aria-label={t(
+            collapsed ? "common:actions.expand" : "common:actions.collapse"
+          )}
+          aria-expanded={!collapsed}
+        >
+          <HugeiconsIcon
+            icon={collapsed ? ArrowRight01Icon : ArrowDown01Icon}
+            data-icon={collapsed ? "chevron-right" : "chevron-down"}
+            size={14}
+            strokeWidth={1.75}
+          />
+        </WorkstationTrailIconButton>
+      }
+      actions={
+        <>
+          {!collapsed && activeTab ? (
+            <ProcessStopButton
+              className="rounded-lg"
+              size="sm"
+              label={t("common:tooltips.killTerminal")}
+              onClick={() => onStop(activeTab.key)}
+            />
+          ) : null}
+          {tabs.length < MINI_TERMINAL_SESSION_LIMIT ? (
+            <WorkstationTrailIconButton
+              onClick={onAdd}
+              aria-label={t("common:git.rail.newMiniTerminal")}
+              title={t("common:git.rail.newMiniTerminal")}
+            >
+              <HugeiconsIcon
+                icon={Add01Icon}
+                data-icon="plus"
+                size={14}
+                strokeWidth={1.75}
+              />
+            </WorkstationTrailIconButton>
+          ) : null}
+          <WorkstationTrailIconButton
+            onClick={onHide}
+            aria-label={t("common:git.rail.hideMiniTerminal")}
+            title={t("common:git.rail.hideMiniTerminal")}
+          >
+            <HugeiconsIcon
+              icon={Cancel01Icon}
+              data-icon="x"
+              size={14}
+              strokeWidth={1.75}
+            />
+          </WorkstationTrailIconButton>
+        </>
+      }
+    >
+      {showTabs ? (
+        <div
+          ref={tabListRef}
+          role="tablist"
+          aria-label={terminalsLabel}
+          className="flex min-w-0 flex-1 items-center gap-px overflow-x-auto py-0.5 scrollbar-hide"
+          onKeyDown={(event) => {
+            const index = tabs.findIndex((tab) => tab.key === activeId);
+            let next: number;
+            switch (event.key) {
+              case "ArrowLeft":
+                next = (index - 1 + tabs.length) % tabs.length;
+                break;
+              case "ArrowRight":
+                next = (index + 1) % tabs.length;
+                break;
+              case "Home":
+                next = 0;
+                break;
+              case "End":
+                next = tabs.length - 1;
+                break;
+              default:
+                return;
+            }
+            event.preventDefault();
+            onSelect(tabs[next].key);
+            event.currentTarget
+              .querySelectorAll<HTMLButtonElement>('[role="tab"]')
+              [next]?.focus({ preventScroll: true });
+          }}
+        >
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              id={`${panelId}-tab-${tab.key}`}
+              aria-controls={panelId}
+              aria-selected={tab.key === activeId}
+              tabIndex={tab.key === activeId ? 0 : -1}
+              title={tab.label}
+              onClick={() => onSelect(tab.key)}
+              className={`h-5 max-w-28 shrink-0 truncate rounded-lg px-2 text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-6 ${tab.key === activeId ? "bg-fill-2 font-medium text-text-1" : "text-text-3 hover:bg-fill-2 hover:text-text-1"}`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </WorkstationTrailHeader>
+  );
+}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/index.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/index.tsx
@@ -1,11 +1,5 @@
 import { useAtomValue, useSetAtom } from "jotai";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
@@ -15,8 +9,10 @@ import AnyIcon from "@src/components/AnyIcon";
 import Button from "@src/components/Button";
 import Dropdown from "@src/components/Dropdown";
 import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
+import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { ROUTES } from "@src/config/routes";
+import { BUTTON_SIZE } from "@src/config/workstation/tokens";
 import {
   FOCUSED_CHAT_WORKSTATION_MINIMAP_HOST_CLASS,
   isSameFocusedChatGitEnvironment,
@@ -30,7 +26,6 @@ import { useBranchPullRequestStatus } from "@src/hooks/git/useBranchPullRequestS
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { useWorkingTreeDiffTotals } from "@src/hooks/git/useWorkingTreeDiffTotals";
 import { useCloseTabWithGuard } from "@src/hooks/tabHost/useCloseTabWithGuard";
-import { useResizeHandle } from "@src/hooks/ui";
 import {
   ArrowLeftDoubleIcon,
   ArrowRightDoubleIcon,
@@ -44,11 +39,12 @@ import {
   SquareTerminalIcon,
 } from "@src/icons";
 import { openBranchSpotlight } from "@src/scaffold/GlobalSpotlight/openSpotlight";
-import { VerticalResizeHandle } from "@src/scaffold/Resize";
 import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
 import {
   closeMiniTerminalAtom,
+  miniTerminalClaimedIdsAtom,
+  miniTerminalCollapsedAtom,
   miniTerminalHostMountedAtom,
   miniTerminalVisibleAtom,
   openMiniTerminalAtom,
@@ -73,6 +69,8 @@ import {
 } from "@src/store/workstation/tabRegistry";
 import type { WorkStationTab } from "@src/store/workstation/tabs/types";
 import { openExternalLink } from "@src/util/platform/ipcRenderer";
+import { isChatPanelTerminalId } from "@src/util/ui/terminal/chatPanelSessionId";
+import { isAgentPtySessionId } from "@src/util/ui/terminal/ptySessionId";
 
 import {
   WORKSTATION_TRAIL_ICON_BUTTON_CLASS,
@@ -90,25 +88,17 @@ import { WorkstationSections } from "./WorkstationSections";
 import { WorkstationTrailTerminal } from "./WorkstationTrailTerminal";
 import {
   getStoredRailCollapsed,
-  getStoredRailMinWidth,
-  getStoredRailWidth,
   persistRailCollapsed,
-  persistRailMinWidth,
-  persistRailWidth,
   resolveRailStatusDotClass,
 } from "./railStorage";
-import {
-  WORKSTATION_TRAIL_WIDTH_LIMITS,
-  clampTrailWidth,
-  resolveTrailMinWidth,
-  resolveTrailWidthVariables,
-} from "./trailWidth";
+import { resolveTrailWidthVariables } from "./trailWidth";
 import type {
   FocusedChatRailItem,
   FocusedChatRailSection,
   FocusedChatSessionContext,
   FocusedChatWorkstationRailProps,
 } from "./types";
+import { useTrailPanelDimensions } from "./useTrailPanelDimensions";
 import { useWorkstationTrailMenu } from "./useWorkstationTrailMenu";
 
 export type { FocusedChatSessionContext } from "./types";
@@ -155,72 +145,7 @@ export function FocusedChatWorkstationRail({
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(getStoredRailCollapsed);
-  // Expanded width and the user's own floor. `minWidth` only ever gates the
-  // width the user is actively changing — "set current width as minimum"
-  // pins the trail where it stands and never resizes it.
-  const [minWidth, setMinWidth] = useState(() =>
-    resolveTrailMinWidth(getStoredRailMinWidth())
-  );
-  const [width, setWidth] = useState(() =>
-    clampTrailWidth(
-      getStoredRailWidth(),
-      resolveTrailMinWidth(getStoredRailMinWidth())
-    )
-  );
-  // Latest width for `onResizeEnd`, which must persist without re-subscribing
-  // the drag listeners on every RAF-throttled width update.
-  const widthRef = useRef(width);
-
-  // Drag: state only, so the RAF-throttled stream never touches storage.
-  const handleWidthChange = useCallback((next: number) => {
-    widthRef.current = next;
-    setWidth(next);
-  }, []);
-  const handleResizeEnd = useCallback(() => {
-    persistRailWidth(widthRef.current);
-  }, []);
-  const { handleMouseDown: handleResizeMouseDown, isResizing } =
-    useResizeHandle(width, handleWidthChange, {
-      direction: "horizontal",
-      minSize: minWidth,
-      maxSize: WORKSTATION_TRAIL_WIDTH_LIMITS.max,
-      // The trail sits at the pane's right edge: dragging left grows it.
-      isReversed: true,
-      onResizeEnd: handleResizeEnd,
-    });
-
-  /** Menu-driven width change: clamp and persist immediately. */
-  const applyWidth = useCallback(
-    (next: number) => {
-      const clamped = clampTrailWidth(next, minWidth);
-      widthRef.current = clamped;
-      setWidth(clamped);
-      persistRailWidth(clamped);
-    },
-    [minWidth]
-  );
-
-  /** Pin the current width as the floor. Deliberately does not resize. */
-  const setCurrentWidthAsMinimum = useCallback(() => {
-    const nextMinimum = resolveTrailMinWidth(width);
-    setMinWidth(nextMinimum);
-    persistRailMinWidth(nextMinimum);
-  }, [width]);
-
-  /**
-   * Restore the shipped width. The user-set floor is cleared with it — a
-   * floor above 256px would otherwise leave this command a no-op with no
-   * way back from the menu.
-   */
-  const restoreDefaultWidth = useCallback(() => {
-    const nextMinimum = WORKSTATION_TRAIL_WIDTH_LIMITS.floor;
-    const nextWidth = WORKSTATION_TRAIL_WIDTH_LIMITS.default;
-    widthRef.current = nextWidth;
-    setMinWidth(nextMinimum);
-    setWidth(nextWidth);
-    persistRailMinWidth(nextMinimum);
-    persistRailWidth(nextWidth);
-  }, []);
+  const panelDimensions = useTrailPanelDimensions();
 
   const [collapsedGroupKeys, setCollapsedGroupKeys] = useState<Set<string>>(
     () => new Set()
@@ -298,6 +223,8 @@ export function FocusedChatWorkstationRail({
   const setChatPanelMaximized = useSetAtom(chatPanelMaximizedAtom);
   const requestNewBrowserSession = useSetAtom(requestNewBrowserSessionAtom);
   const miniTerminalVisible = useAtomValue(miniTerminalVisibleAtom);
+  const miniTerminalClaimedIds = useAtomValue(miniTerminalClaimedIdsAtom);
+  const miniTerminalCollapsed = useAtomValue(miniTerminalCollapsedAtom);
   const openMiniTerminal = useSetAtom(openMiniTerminalAtom);
   const closeMiniTerminal = useSetAtom(closeMiniTerminalAtom);
   const setMiniTerminalHostMounted = useSetAtom(miniTerminalHostMountedAtom);
@@ -311,7 +238,7 @@ export function FocusedChatWorkstationRail({
 
   /**
    * Show the docked terminal. The terminal carries its own width, so the
-   * trail above it keeps whatever width the user gave it — only the column
+   * trail above it keeps its fixed width — only the column
    * grows, and only when the terminal is the wider of the two.
    */
   const showMiniTerminal = useCallback(
@@ -379,6 +306,12 @@ export function FocusedChatWorkstationRail({
       .filter(
         (session) =>
           !session.readOnly &&
+          // Opened Tabs is a My Station list, not the shared PTY pool.
+          !isChatPanelTerminalId(session.id) &&
+          !isAgentPtySessionId(session.id) &&
+          // Pinned terminals belong only in their docked panel, even when
+          // collapsed; Opened Tabs must not repeat them.
+          !miniTerminalClaimedIds.includes(session.id) &&
           initializedTerminalIds.has(session.id) &&
           (!session.isDefaultSession || session.hasUserInput === true)
       )
@@ -386,11 +319,9 @@ export function FocusedChatWorkstationRail({
         key: `terminal-session:${session.id}`,
         label: getTerminalDisplayTitle(session),
         icon: SquareTerminalIcon,
-        closeLabel: t("common:git.rail.closeItem", {
-          label: getTerminalDisplayTitle(session),
-        }),
         onClick: () => openTerminalSession(session.id),
-        onClose: () => closePtySession(session.id),
+        stopLabel: t("common:tooltips.killTerminal"),
+        onStop: () => closePtySession(session.id),
       }));
 
     const tabItems = openTabs
@@ -419,6 +350,7 @@ export function FocusedChatWorkstationRail({
     closePtySession,
     closeTab,
     initializedTerminalIds,
+    miniTerminalClaimedIds,
     openTabs,
     openTerminalSession,
     openWorkstationTab,
@@ -678,11 +610,6 @@ export function FocusedChatWorkstationRail({
   const showTrailTerminal = miniTerminalVisible && !collapsed;
 
   const handleTrailContextMenu = useWorkstationTrailMenu({
-    width,
-    minWidth,
-    onWidthChange: applyWidth,
-    onSetMinimum: setCurrentWidthAsMinimum,
-    onRestoreDefault: restoreDefaultWidth,
     miniTerminalVisible,
     onOpenMiniTerminal: () => showMiniTerminal(null),
     onHideMiniTerminal: closeMiniTerminal,
@@ -746,53 +673,32 @@ export function FocusedChatWorkstationRail({
   return (
     <>
       {compactMenu}
-      {/* Expanded column is continuously resizable (drag its leading edge, or
-          right-click the trail for the native width menu); the collapsed
-          column stays the fixed 44px button-controlled rail. */}
+      {/* Only the terminal can widen this column; the trail keeps its fixed width. */}
       <div
         data-workstation-pane-control
         data-workstation-trail-track
         className={`relative flex h-full shrink-0 flex-col items-start ${
-          isResizing
+          panelDimensions.isCornerResizing
             ? ""
             : "transition-[width] duration-200 ease-out motion-reduce:transition-none"
         } ${resolveFocusedChatWorkstationRailTrackClass(collapsed)}`}
         style={{
           ...resolveFocusedChatWorkstationRailInsetStyle(topInset),
-          ...resolveTrailWidthVariables(width, {
+          ...resolveTrailWidthVariables({
             collapsed,
-            terminalShown: showTrailTerminal,
+            // A folded terminal fills the trail's width; only its expanded
+            // body needs the wider column. Keep the panel mounted in both.
+            terminalShown: showTrailTerminal && !miniTerminalCollapsed,
+            terminalWidth: panelDimensions.terminalWidth,
           }),
         }}
       >
-        {/* Trail + terminal, grouped so the resize edge spans exactly them
-            and stops where they stop — the minimap track below is not part
-            of the resizable surface. */}
-        {/* The trail's own `max-h-full` is inert here — it resolves against
-            this group, whose height is content-driven — so the group carries
-            the cap instead: `max-h-full` against the full-height column plus
-            `min-h-0` so it can actually shrink into it. Without both, a long
-            trail outgrows the column and starves the minimap track below.
-            No `overflow-hidden`: it would clip the resize edge's hit area,
-            which reaches 6px past this box. */}
+        {/* Cap the panel group so long content still leaves the minimap in
+            the column. Each panel can shrink within the available height. */}
         <div className="relative hidden max-h-full min-h-0 w-full flex-col @[1100px]/focusedchat:flex">
-          {!collapsed ? (
-            <div className="absolute inset-y-0 left-0 z-30 flex">
-              <VerticalResizeHandle
-                className="h-full"
-                isResizing={isResizing}
-                onMouseDown={handleResizeMouseDown}
-                onContextMenu={handleTrailContextMenu}
-                tooltipLabel={t("common:git.rail.resizeTrail")}
-                variant="transparent"
-              />
-            </div>
-          ) : null}
           <WorkstationTrailSurface
             as="aside"
             aria-label={environmentLabel}
-            // Right-click anywhere on the trail opens the same native width
-            // menu as its resize edge — the edge alone is a 13px target.
             onContextMenu={handleTrailContextMenu}
             // `min-h-0` unconditionally: inside the capped group the trail
             // has to be able to shrink past its content height, whether what
@@ -814,7 +720,7 @@ export function FocusedChatWorkstationRail({
                 ) : null
               }
               actions={
-                <div className="flex items-center">
+                <>
                   {!collapsed ? (
                     <WorkstationTrailIconButton
                       onClick={toggleMiniTerminal}
@@ -842,7 +748,7 @@ export function FocusedChatWorkstationRail({
                   <WorkstationTrailIconButton
                     className={
                       collapsed
-                        ? "!h-7 !w-7"
+                        ? BUTTON_SIZE.lg
                         : WORKSTATION_TRAIL_ACTION_REVEAL_CLASS
                     }
                     onClick={toggleCollapsed}
@@ -869,7 +775,7 @@ export function FocusedChatWorkstationRail({
                       />
                     )}
                   </WorkstationTrailIconButton>
-                </div>
+                </>
               }
             />
             {collapsed ? (
@@ -877,28 +783,33 @@ export function FocusedChatWorkstationRail({
                 {collapsedWorkspaceItems.map((item) => {
                   const icon = item.icon;
                   return (
-                    <button
+                    <ToolbarTooltip
                       key={item.key}
-                      type="button"
-                      className={`${WORKSTATION_TRAIL_ICON_BUTTON_CLASS} relative !h-7 !w-7`}
-                      onClick={item.onClick}
-                      aria-label={
-                        item.status
-                          ? `${item.label}, ${item.status.label}`
-                          : item.label
-                      }
-                      title={item.status?.title ?? item.label}
+                      label={item.status?.title ?? item.label}
+                      shortcut={item.shortcut}
+                      position="left"
                     >
-                      <AnyIcon icon={icon} size={16} strokeWidth={1.75} />
-                      {item.status ? (
-                        <span
-                          aria-hidden
-                          className={`absolute bottom-1 right-1 h-1.5 w-1.5 rounded-full ring-1 ring-bg-1 ${resolveRailStatusDotClass(
-                            item.status.state
-                          )}`}
-                        />
-                      ) : null}
-                    </button>
+                      <button
+                        type="button"
+                        className={`${WORKSTATION_TRAIL_ICON_BUTTON_CLASS} ${BUTTON_SIZE.lg} relative`}
+                        onClick={item.onClick}
+                        aria-label={
+                          item.status
+                            ? `${item.label}, ${item.status.label}`
+                            : item.label
+                        }
+                      >
+                        <AnyIcon icon={icon} size={16} strokeWidth={1.75} />
+                        {item.status ? (
+                          <span
+                            aria-hidden
+                            className={`absolute bottom-1 right-1 h-1.5 w-1.5 rounded-full ring-1 ring-bg-1 ${resolveRailStatusDotClass(
+                              item.status.state
+                            )}`}
+                          />
+                        ) : null}
+                      </button>
+                    </ToolbarTooltip>
                   );
                 })}
               </div>
@@ -914,7 +825,15 @@ export function FocusedChatWorkstationRail({
               </WorkstationTrailBody>
             )}
           </WorkstationTrailSurface>
-          {showTrailTerminal ? <WorkstationTrailTerminal /> : null}
+          {showTrailTerminal ? (
+            <WorkstationTrailTerminal
+              width={panelDimensions.terminalWidth}
+              height={panelDimensions.terminalHeight}
+              onResize={panelDimensions.resizeTerminal}
+              onResizeEnd={panelDimensions.commitTerminalSize}
+              onResizingChange={panelDimensions.setIsCornerResizing}
+            />
+          ) : null}
         </div>
         <div
           ref={conversationMinimapHostRef}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/index.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/index.tsx
@@ -82,7 +82,10 @@ import {
   WorkstationTrailIconButton,
   WorkstationTrailSurface,
 } from "../blocks";
-import { WorkstationGroupToggle } from "./WorkstationGroupToggle";
+import {
+  WORKSTATION_TRAIL_ACTION_REVEAL_CLASS,
+  WorkstationGroupToggle,
+} from "./WorkstationGroupToggle";
 import { WorkstationSections } from "./WorkstationSections";
 import { WorkstationTrailTerminal } from "./WorkstationTrailTerminal";
 import {
@@ -622,10 +625,10 @@ export function FocusedChatWorkstationRail({
     ).map((sectionKey) => ({
       ...FOCUSED_CHAT_RAIL_SECTIONS[sectionKey],
       label:
-        sectionKey === "session"
+        sectionKey === "workspace"
           ? null
-          : sectionKey === "workspace"
-            ? t("navigation:labels.localEnvironment")
+          : sectionKey === "session"
+            ? t("navigation:labels.sessionEnvironment")
             : t("common:git.rail.openTabs"),
       items:
         sectionKey === "tabs"
@@ -653,14 +656,15 @@ export function FocusedChatWorkstationRail({
   ]);
 
   const environmentLabel = t("navigation:labels.sessionEnvironment");
+  const localEnvironmentLabel = t("navigation:labels.localEnvironment");
   const compactSections = useMemo<FocusedChatRailSection[]>(
     () =>
       sections.map((section) =>
-        section.key === "session"
-          ? { ...section, label: environmentLabel }
+        section.key === "workspace"
+          ? { ...section, label: localEnvironmentLabel }
           : section
       ),
-    [environmentLabel, sections]
+    [localEnvironmentLabel, sections]
   );
   const toggleCollapsed = () => {
     setCollapsed((current) => {
@@ -796,16 +800,16 @@ export function FocusedChatWorkstationRail({
             className={`group/workstation-trail ml-auto flex min-h-0 ${WORKSTATION_TRAIL_WIDTH.surfaceResponsiveClass}`}
           >
             <WorkstationTrailHeader
-              title={environmentLabel}
+              title={localEnvironmentLabel}
               collapsed={collapsed}
               titleActions={
-                !collapsed && hasSessionEnvironment ? (
+                !collapsed ? (
                   <WorkstationGroupToggle
                     collapseLabel={t("common:actions.collapse")}
-                    collapsed={collapsedGroupKeys.has("session")}
+                    collapsed={collapsedGroupKeys.has("workspace")}
                     expandLabel={t("common:actions.expand")}
-                    groupKey="session"
-                    onToggle={() => toggleGroup("session")}
+                    groupKey="workspace"
+                    onToggle={() => toggleGroup("workspace")}
                   />
                 ) : null
               }
@@ -825,7 +829,7 @@ export function FocusedChatWorkstationRail({
                           ? "common:git.rail.hideMiniTerminal"
                           : "common:git.rail.openMiniTerminal"
                       )}
-                      className={miniTerminalVisible ? "bg-fill-2" : ""}
+                      className={`${WORKSTATION_TRAIL_ACTION_REVEAL_CLASS} ${miniTerminalVisible ? "bg-fill-2" : ""}`}
                     >
                       <HugeiconsIcon
                         icon={SquareTerminalIcon}
@@ -836,6 +840,11 @@ export function FocusedChatWorkstationRail({
                     </WorkstationTrailIconButton>
                   ) : null}
                   <WorkstationTrailIconButton
+                    className={
+                      collapsed
+                        ? "!h-7 !w-7"
+                        : WORKSTATION_TRAIL_ACTION_REVEAL_CLASS
+                    }
                     onClick={toggleCollapsed}
                     aria-label={t(
                       collapsed
@@ -871,7 +880,7 @@ export function FocusedChatWorkstationRail({
                     <button
                       key={item.key}
                       type="button"
-                      className={`${WORKSTATION_TRAIL_ICON_BUTTON_CLASS} relative`}
+                      className={`${WORKSTATION_TRAIL_ICON_BUTTON_CLASS} relative !h-7 !w-7`}
                       onClick={item.onClick}
                       aria-label={
                         item.status

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/railStorage.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/railStorage.ts
@@ -1,17 +1,16 @@
 /**
- * Rail collapse / width persistence and CI status-dot mapping.
+ * Rail collapse / terminal size persistence and CI status-dot mapping.
  *
  * Storage is best-effort: the responsive control still works when
  * localStorage is unavailable, and every reader falls back to the shipped
- * defaults in `./trailWidth`.
+ * defaults in the terminal size model.
  */
 import type { BranchCiStatus } from "@src/services/git/branchPullRequestStatus";
 
 const FOCUSED_CHAT_RAIL_COLLAPSED_KEY =
   "orgii:focusedChatWorkstationRailCollapsed";
-const FOCUSED_CHAT_RAIL_WIDTH_KEY = "orgii:focusedChatWorkstationRailWidth";
-const FOCUSED_CHAT_RAIL_MIN_WIDTH_KEY =
-  "orgii:focusedChatWorkstationRailMinWidth";
+const TRAIL_TERMINAL_WIDTH_KEY = "orgii:workstationTrailTerminalWidth";
+const TRAIL_TERMINAL_HEIGHT_KEY = "orgii:workstationTrailTerminalHeight";
 
 function readStoredNumber(key: string): number | null {
   try {
@@ -28,26 +27,21 @@ function writeStoredNumber(key: string, value: number): void {
   try {
     localStorage.setItem(key, String(Math.round(value)));
   } catch {
-    // The trail still resizes for this session when storage is unavailable.
+    // The terminal still resizes for this session when storage is unavailable.
   }
 }
 
-/** Persisted expanded width, or `null` when never set / unreadable. */
-export function getStoredRailWidth(): number | null {
-  return readStoredNumber(FOCUSED_CHAT_RAIL_WIDTH_KEY);
+export function getStoredTrailTerminalWidth(): number | null {
+  return readStoredNumber(TRAIL_TERMINAL_WIDTH_KEY);
 }
 
-export function persistRailWidth(width: number): void {
-  writeStoredNumber(FOCUSED_CHAT_RAIL_WIDTH_KEY, width);
+export function getStoredTrailTerminalHeight(): number | null {
+  return readStoredNumber(TRAIL_TERMINAL_HEIGHT_KEY);
 }
 
-/** Persisted user-set minimum width, or `null` when never set. */
-export function getStoredRailMinWidth(): number | null {
-  return readStoredNumber(FOCUSED_CHAT_RAIL_MIN_WIDTH_KEY);
-}
-
-export function persistRailMinWidth(minWidth: number): void {
-  writeStoredNumber(FOCUSED_CHAT_RAIL_MIN_WIDTH_KEY, minWidth);
+export function persistTrailTerminalSize(width: number, height: number): void {
+  writeStoredNumber(TRAIL_TERMINAL_WIDTH_KEY, width);
+  writeStoredNumber(TRAIL_TERMINAL_HEIGHT_KEY, height);
 }
 
 export function getStoredRailCollapsed(): boolean {

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/trailPanelSize.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/trailPanelSize.ts
@@ -1,0 +1,34 @@
+export interface TrailPanelSize {
+  width: number;
+  height: number;
+}
+
+export const TRAIL_TERMINAL_SIZE_LIMITS = {
+  // Fits the title, scrollable tabs, and process controls in one row.
+  minWidth: 320,
+  maxWidth: 720,
+  minHeight: 120,
+  maxHeight: 720,
+  defaultHeight: 260,
+} as const;
+
+export function clampPanelDimension(value: number, min: number, max: number) {
+  return Math.round(Math.max(0, Math.min(max, Math.max(min, value))));
+}
+
+export function resizeTrailPanel(
+  start: TrailPanelSize,
+  delta: TrailPanelSize,
+  min: TrailPanelSize,
+  max: TrailPanelSize
+): TrailPanelSize {
+  return {
+    // The top/right edges stay anchored: left grows width, down grows height.
+    width: clampPanelDimension(start.width - delta.width, min.width, max.width),
+    height: clampPanelDimension(
+      start.height + delta.height,
+      min.height,
+      max.height
+    ),
+  };
+}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.test.ts
@@ -1,119 +1,57 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  WORKSTATION_TRAIL_TERMINAL_WIDTH,
-  WORKSTATION_TRAIL_TRACK_PADDING_X,
   WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE,
-  WORKSTATION_TRAIL_WIDTH_LIMITS,
   WORKSTATION_TRAIL_WIDTH_VARIABLE,
-  clampTrailWidth,
-  resolveNextWiderTrailWidth,
-  resolveTrailMinWidth,
   resolveTrailWidthVariables,
 } from "./trailWidth";
 
-const {
-  default: DEFAULT_WIDTH,
-  floor,
-  max,
-  step,
-} = WORKSTATION_TRAIL_WIDTH_LIMITS;
-
-describe("resolveTrailMinWidth", () => {
-  it("falls back to the floor when nothing is stored", () => {
-    expect(resolveTrailMinWidth(null)).toBe(floor);
-    expect(resolveTrailMinWidth(Number.NaN)).toBe(floor);
-  });
-
-  it("keeps a user-set minimum wider than the shipped default", () => {
-    // "Set current width as minimum" pins whatever the trail is at, which
-    // may be a width the user dragged well past 256px.
-    expect(resolveTrailMinWidth(DEFAULT_WIDTH + step)).toBe(
-      DEFAULT_WIDTH + step
-    );
-  });
-
-  it("clamps a stored minimum into the hard bounds", () => {
-    expect(floor).toBe(220);
-    expect(resolveTrailMinWidth(10)).toBe(floor);
-    expect(resolveTrailMinWidth(max + 400)).toBe(max);
-  });
-});
-
-describe("clampTrailWidth", () => {
-  it("defaults to the shipped width when nothing is stored", () => {
-    expect(clampTrailWidth(null, floor)).toBe(DEFAULT_WIDTH);
-  });
-
-  it("never returns a width below the user-set minimum", () => {
-    expect(clampTrailWidth(200, 320)).toBe(320);
-  });
-
-  it("respects a minimum above the shipped default", () => {
-    expect(clampTrailWidth(null, 400)).toBe(400);
-  });
-
-  it("caps at the maximum", () => {
-    expect(clampTrailWidth(max + 100, floor)).toBe(max);
-  });
-});
-
-describe("resolveNextWiderTrailWidth", () => {
-  it("grows by one step", () => {
-    expect(resolveNextWiderTrailWidth(DEFAULT_WIDTH, floor)).toBe(
-      DEFAULT_WIDTH + step
-    );
-  });
-
-  it("returns the same width at the maximum, so the menu can disable it", () => {
-    expect(resolveNextWiderTrailWidth(max, floor)).toBe(max);
-  });
-});
-
-describe("resolveTrailWidthVariables", () => {
-  it("keeps the trail box inside the column's edge inset", () => {
-    // The measured width is the *column*, the same thing the old `w-64`
-    // track was, so the trail box inside it is one inset narrower and never
-    // reaches the pane edge.
-    expect(resolveTrailWidthVariables(288)).toEqual({
-      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: `${
-        288 - WORKSTATION_TRAIL_TRACK_PADDING_X
-      }px`,
-      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "288px",
-    });
-  });
-
-  it("reproduces the shipped track the trail had before it could resize", () => {
-    expect(resolveTrailWidthVariables(DEFAULT_WIDTH)).toEqual({
+describe("fixed trail and resizable terminal column", () => {
+  it("keeps the fixed trail inside the column inset", () => {
+    expect(resolveTrailWidthVariables()).toEqual({
       [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "248px",
       [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "256px",
     });
   });
 
-  it("widens only the column when the terminal is the wider of the two", () => {
-    // Opening the terminal must not resize the trail itself, and the
-    // terminal still gets its full width inside the inset.
-    expect(resolveTrailWidthVariables(256, { terminalShown: true })).toEqual({
+  it("widens only the column when opening the terminal", () => {
+    expect(resolveTrailWidthVariables({ terminalShown: true })).toEqual({
       [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "248px",
-      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: `${
-        WORKSTATION_TRAIL_TERMINAL_WIDTH + WORKSTATION_TRAIL_TRACK_PADDING_X
-      }px`,
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "408px",
     });
   });
 
-  it("leaves a trail wider than the terminal owning the column", () => {
-    const wide = WORKSTATION_TRAIL_TERMINAL_WIDTH + 60;
-    expect(resolveTrailWidthVariables(wide, { terminalShown: true })).toEqual({
-      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: `${
-        wide - WORKSTATION_TRAIL_TRACK_PADDING_X
-      }px`,
-      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: `${wide}px`,
-    });
-  });
-
-  it("lets the collapsed rail's own class own the column", () => {
+  it("reserves the terminal's resized width without changing the trail", () => {
     expect(
-      resolveTrailWidthVariables(288, { collapsed: true, terminalShown: true })
+      resolveTrailWidthVariables({ terminalShown: true, terminalWidth: 610 })
+    ).toEqual({
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "248px",
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "618px",
+    });
+    expect(
+      resolveTrailWidthVariables({ terminalShown: true, terminalWidth: 220 })
+    ).toEqual({
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "248px",
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "256px",
+    });
+  });
+
+  it("releases the terminal's extra width when folded or hidden", () => {
+    expect(
+      resolveTrailWidthVariables({ terminalShown: false, terminalWidth: 610 })
+    ).toEqual({
+      [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "248px",
+      [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "256px",
+    });
+  });
+
+  it("lets the collapsed rail's fixed class own the column", () => {
+    expect(
+      resolveTrailWidthVariables({
+        collapsed: true,
+        terminalShown: true,
+        terminalWidth: 610,
+      })
     ).toEqual({
       [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "100%",
       [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "100%",

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.ts
@@ -1,104 +1,13 @@
-/**
- * Workstation trail width model.
- *
- * The trail used to be a two-state track (256px expanded / 44px collapsed)
- * driven purely by responsive Tailwind classes. It is now continuously
- * resizable while expanded, so the expanded track reads its width from the
- * `--workstation-trail-width` custom property this module produces.
- *
- * Two persisted numbers drive it:
- *   - `width`     — the current expanded width.
- *   - `minWidth`  — the user's own floor, set from the context menu's
- *                   "set current width as minimum". Drag and the width
- *                   clamp both respect it, so a trail the user decided is
- *                   as narrow as it should get can never be dragged past
- *                   that point.
- *
- * `FLOOR` is the hard lower bound a user-set minimum itself is clamped to:
- * below it the trail rows stop being readable and the collapsed track is
- * the better control.
- */
 import type { CSSProperties } from "react";
 
-export const WORKSTATION_TRAIL_WIDTH_LIMITS = {
-  /** Shipped width, and the target of "restore original width". */
-  default: 256,
-  /** Hard lower bound for both the width and a user-set minimum. */
-  floor: 220,
-  /** Hard upper bound; the chat column keeps its own min width on top. */
-  max: 520,
-  /** How much one "wider" step grows the trail. */
-  step: 48,
-} as const;
+import { WORKSTATION_TRAIL_WIDTH } from "../blocks/WorkstationTrailSurface";
 
-/** Width of the trail surface itself. */
 export const WORKSTATION_TRAIL_WIDTH_VARIABLE = "--workstation-trail-width";
-/** Width of the whole trail column, which the terminal can widen on its own. */
 export const WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE =
   "--workstation-trail-track-width";
-
-/**
- * Width of the docked terminal. It is the terminal's own width, not the
- * trail's: a 256px trail is fine to read but too narrow for a shell, so the
- * terminal takes this width and the trail above it keeps whatever width the
- * user gave it. The column is as wide as the wider of the two.
- */
 export const WORKSTATION_TRAIL_TERMINAL_WIDTH = 400;
-
-/**
- * Horizontal inset the column reserves so neither box touches the pane edge
- * — `FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS`'s `px-1`, 4px a side.
- *
- * Widths in this module are *column* widths, matching the `w-64` the track
- * used to carry: the boxes inside are that much narrower, because the column
- * is `box-sizing: border-box` and the padding comes out of its width.
- */
+/** The column's px-1 padding reserves 4px on either side. */
 export const WORKSTATION_TRAIL_TRACK_PADDING_X = 8;
-
-/**
- * Clamp a user-set minimum into `[floor, max]`.
- *
- * The minimum is allowed above the shipped default: "set current width as
- * minimum" pins whatever the trail is at right now, including a width the
- * user dragged past 256px. It never moves the current width — see
- * `clampTrailWidth`, which is only applied to widths the user is actively
- * changing.
- */
-export function resolveTrailMinWidth(storedMinWidth: number | null): number {
-  if (storedMinWidth == null || !Number.isFinite(storedMinWidth)) {
-    return WORKSTATION_TRAIL_WIDTH_LIMITS.floor;
-  }
-  return Math.min(
-    WORKSTATION_TRAIL_WIDTH_LIMITS.max,
-    Math.max(WORKSTATION_TRAIL_WIDTH_LIMITS.floor, Math.round(storedMinWidth))
-  );
-}
-
-/** Clamp a width into `[minWidth, max]`, falling back to the default. */
-export function clampTrailWidth(
-  width: number | null,
-  minWidth: number
-): number {
-  if (width == null || !Number.isFinite(width)) {
-    return Math.max(minWidth, WORKSTATION_TRAIL_WIDTH_LIMITS.default);
-  }
-  return Math.min(
-    WORKSTATION_TRAIL_WIDTH_LIMITS.max,
-    Math.max(minWidth, Math.round(width))
-  );
-}
-
-/**
- * Next width one "wider" step up, clamped to the maximum. Returns the same
- * width when the trail is already at the maximum, which the menu reads as
- * "disable this item".
- */
-export function resolveNextWiderTrailWidth(
-  width: number,
-  minWidth: number
-): number {
-  return clampTrailWidth(width + WORKSTATION_TRAIL_WIDTH_LIMITS.step, minWidth);
-}
 
 /**
  * Style payload for the trail column: the trail surface's own width, and the
@@ -110,20 +19,23 @@ export function resolveNextWiderTrailWidth(
  * trail must stay at zero and the compact dropdown takes over. Collapsed,
  * the shipped `w-11` class owns the column and both boxes just fill it.
  */
-export function resolveTrailWidthVariables(
-  width: number,
-  options?: { collapsed?: boolean; terminalShown?: boolean }
-): CSSProperties {
+export function resolveTrailWidthVariables(options?: {
+  collapsed?: boolean;
+  terminalShown?: boolean;
+  terminalWidth?: number;
+}): CSSProperties {
   if (options?.collapsed) {
     return {
       [WORKSTATION_TRAIL_WIDTH_VARIABLE]: "100%",
       [WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE]: "100%",
     } as CSSProperties;
   }
+  const width = WORKSTATION_TRAIL_WIDTH.expandedPx;
   const trackWidth = options?.terminalShown
     ? Math.max(
         width,
-        WORKSTATION_TRAIL_TERMINAL_WIDTH + WORKSTATION_TRAIL_TRACK_PADDING_X
+        (options.terminalWidth ?? WORKSTATION_TRAIL_TERMINAL_WIDTH) +
+          WORKSTATION_TRAIL_TRACK_PADDING_X
       )
     : width;
   return {

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/types.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/types.ts
@@ -27,6 +27,9 @@ export type FocusedChatRailItem = {
   onClick?: () => void;
   onClose?: () => void;
   closeLabel?: string;
+  /** Process termination stays distinct from closing a document or view. */
+  onStop?: () => void;
+  stopLabel?: string;
   /** Working-tree +/- shown after the label (the Review row). */
   additions?: number;
   deletions?: number;

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/useTrailPanelDimensions.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/useTrailPanelDimensions.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getStoredTrailTerminalHeight,
+  getStoredTrailTerminalWidth,
+  persistTrailTerminalSize,
+} from "./railStorage";
+import { useTrailPanelDimensions } from "./useTrailPanelDimensions";
+
+function DimensionProbe() {
+  const dimensions = useTrailPanelDimensions();
+  const terminal = { width: 570, height: 350 };
+  return React.createElement(
+    "div",
+    null,
+    React.createElement(
+      "output",
+      null,
+      JSON.stringify({
+        terminalWidth: dimensions.terminalWidth,
+        terminalHeight: dimensions.terminalHeight,
+      })
+    ),
+    React.createElement(
+      "button",
+      { onClick: () => dimensions.resizeTerminal(terminal) },
+      "resize terminal"
+    ),
+    React.createElement(
+      "button",
+      { onClick: () => dimensions.commitTerminalSize(terminal) },
+      "commit terminal"
+    )
+  );
+}
+
+describe("terminal dimension persistence", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  function click(label: string) {
+    const button = [...container.querySelectorAll("button")].find(
+      (node) => node.textContent === label
+    )!;
+    act(() => button.click());
+  }
+  function read() {
+    return JSON.parse(container.querySelector("output")!.textContent!);
+  }
+  beforeEach(() => {
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+    localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    localStorage.clear();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("uses terminal defaults independently of obsolete trail preferences", () => {
+    localStorage.setItem("orgii:focusedChatWorkstationRailWidth", "500");
+    localStorage.setItem("orgii:focusedChatWorkstationRailHeight", "500");
+    act(() => root.render(React.createElement(DimensionProbe)));
+    expect(read()).toEqual({
+      terminalWidth: 400,
+      terminalHeight: 260,
+    });
+  });
+
+  it("updates live dimensions without storage writes, then persists on release", () => {
+    act(() => root.render(React.createElement(DimensionProbe)));
+    click("resize terminal");
+    expect(read()).toEqual({
+      terminalWidth: 570,
+      terminalHeight: 350,
+    });
+    expect(getStoredTrailTerminalWidth()).toBeNull();
+    expect(getStoredTrailTerminalHeight()).toBeNull();
+    click("commit terminal");
+    expect(getStoredTrailTerminalWidth()).toBe(570);
+    expect(getStoredTrailTerminalHeight()).toBe(350);
+    act(() => root.render(null));
+    act(() => root.render(React.createElement(DimensionProbe)));
+    expect(read()).toMatchObject({
+      terminalWidth: 570,
+      terminalHeight: 350,
+    });
+  });
+
+  it("clamps persisted dimensions before they reach the panel layout", () => {
+    persistTrailTerminalSize(9999, -20);
+    act(() => root.render(React.createElement(DimensionProbe)));
+    expect(read()).toMatchObject({
+      terminalWidth: 720,
+      terminalHeight: 120,
+    });
+  });
+
+  it("keeps resizing functional if browser storage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("unavailable");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("unavailable");
+    });
+    act(() => root.render(React.createElement(DimensionProbe)));
+    expect(() => {
+      click("resize terminal");
+      click("commit terminal");
+    }).not.toThrow();
+    expect(read()).toMatchObject({ terminalWidth: 570, terminalHeight: 350 });
+  });
+
+  it("keeps restored terminal widths large enough for the single-row controls", () => {
+    persistTrailTerminalSize(220, 350);
+    act(() => root.render(React.createElement(DimensionProbe)));
+    expect(read()).toEqual({ terminalWidth: 320, terminalHeight: 350 });
+  });
+});

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/useTrailPanelDimensions.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/useTrailPanelDimensions.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+
+import {
+  getStoredTrailTerminalHeight,
+  getStoredTrailTerminalWidth,
+  persistTrailTerminalSize,
+} from "./railStorage";
+import {
+  TRAIL_TERMINAL_SIZE_LIMITS,
+  type TrailPanelSize,
+  clampPanelDimension,
+} from "./trailPanelSize";
+import { WORKSTATION_TRAIL_TERMINAL_WIDTH } from "./trailWidth";
+
+export function useTrailPanelDimensions() {
+  const [terminalWidth, setTerminalWidth] = useState(() => {
+    const stored = getStoredTrailTerminalWidth();
+    return stored === null
+      ? null
+      : clampPanelDimension(
+          stored,
+          TRAIL_TERMINAL_SIZE_LIMITS.minWidth,
+          TRAIL_TERMINAL_SIZE_LIMITS.maxWidth
+        );
+  });
+  const [terminalHeight, setTerminalHeight] = useState(() =>
+    clampPanelDimension(
+      getStoredTrailTerminalHeight() ??
+        TRAIL_TERMINAL_SIZE_LIMITS.defaultHeight,
+      TRAIL_TERMINAL_SIZE_LIMITS.minHeight,
+      TRAIL_TERMINAL_SIZE_LIMITS.maxHeight
+    )
+  );
+  const [isCornerResizing, setIsCornerResizing] = useState(false);
+
+  const resizeTerminal = useCallback((size: TrailPanelSize) => {
+    setTerminalWidth(size.width);
+    setTerminalHeight(size.height);
+  }, []);
+  const commitTerminalSize = useCallback((size: TrailPanelSize) => {
+    persistTrailTerminalSize(size.width, size.height);
+  }, []);
+
+  return {
+    terminalWidth: terminalWidth ?? WORKSTATION_TRAIL_TERMINAL_WIDTH,
+    terminalHeight,
+    isCornerResizing,
+    setIsCornerResizing,
+    resizeTerminal,
+    commitTerminalSize,
+  };
+}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/useTrailPanelResize.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/useTrailPanelResize.ts
@@ -1,0 +1,183 @@
+import {
+  type KeyboardEvent,
+  type PointerEvent,
+  useEffect,
+  useRef,
+} from "react";
+
+import { type TrailPanelSize, resizeTrailPanel } from "./trailPanelSize";
+
+interface TrailPanelResizeOptions {
+  min: TrailPanelSize;
+  max: TrailPanelSize;
+  onResize: (size: TrailPanelSize) => void;
+  onResizeEnd: (size: TrailPanelSize) => void;
+  onResizingChange: (resizing: boolean) => void;
+}
+
+/** One drag owner for in-flow, right-anchored trail panels (not floating windows). */
+export function useTrailPanelResize(options: TrailPanelResizeOptions) {
+  const cleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const readGeometry = (handle: HTMLElement) => {
+    const panel = handle.closest<HTMLElement>("[data-workstation-trail-panel]");
+    if (!panel) return null;
+    const rect = panel.getBoundingClientRect();
+    if (
+      !panel.offsetWidth ||
+      !panel.offsetHeight ||
+      !rect.width ||
+      !rect.height
+    ) {
+      return null;
+    }
+    const scaleX = rect.width / panel.offsetWidth;
+    const scaleY = rect.height / panel.offsetHeight;
+    const track = panel.closest<HTMLElement>("[data-workstation-trail-track]");
+    // Read layout only at the beginning of an interaction. Leave room for a
+    // docked sibling below this panel, and for the track's bottom padding.
+    let availableHeight = options.max.height;
+    if (track) {
+      let followingHeight = 0;
+      let sibling = panel.nextElementSibling;
+      while (sibling) {
+        if (sibling instanceof HTMLElement) {
+          const style = getComputedStyle(sibling);
+          followingHeight += sibling.getBoundingClientRect().height / scaleY;
+          followingHeight +=
+            (Number.parseFloat(style.marginTop) || 0) +
+            (Number.parseFloat(style.marginBottom) || 0);
+        }
+        sibling = sibling.nextElementSibling;
+      }
+      availableHeight =
+        (track.getBoundingClientRect().bottom - rect.top) / scaleY -
+        followingHeight -
+        (Number.parseFloat(getComputedStyle(track).paddingBottom) || 0);
+    }
+    if (availableHeight <= 0) return null;
+    return {
+      size: { width: panel.offsetWidth, height: panel.offsetHeight },
+      scaleX,
+      scaleY,
+      max: {
+        ...options.max,
+        height: Math.min(options.max.height, availableHeight),
+      },
+    };
+  };
+
+  const onPointerDown = (event: PointerEvent<HTMLElement>) => {
+    if (event.button !== 0 || event.isPrimary === false) return;
+    const geometry = readGeometry(event.currentTarget);
+    if (!geometry) return;
+    event.preventDefault();
+    event.stopPropagation();
+    cleanupRef.current?.();
+
+    const pointerId = event.pointerId;
+    const startX = event.clientX;
+    const startY = event.clientY;
+    let latestX = startX;
+    let latestY = startY;
+    let size = geometry.size;
+    let frame: number | null = null;
+    let moved = false;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+
+    const apply = () => {
+      frame = null;
+      const nextSize = resizeTrailPanel(
+        geometry.size,
+        {
+          width: (latestX - startX) / geometry.scaleX,
+          height: (latestY - startY) / geometry.scaleY,
+        },
+        options.min,
+        geometry.max
+      );
+      if (nextSize.width !== size.width || nextSize.height !== size.height) {
+        size = nextSize;
+        options.onResize(size);
+      }
+    };
+    const move = (next: globalThis.PointerEvent) => {
+      if (next.pointerId !== pointerId) return;
+      latestX = next.clientX;
+      latestY = next.clientY;
+      moved = true;
+      if (frame === null) frame = requestAnimationFrame(apply);
+    };
+    const cleanup = () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", finish);
+      window.removeEventListener("pointercancel", cancelPointer);
+      window.removeEventListener("blur", cancel);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      if (frame !== null) cancelAnimationFrame(frame);
+      frame = null;
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      cleanupRef.current = null;
+      options.onResizingChange(false);
+    };
+    const commit = () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+        apply();
+      }
+      cleanup();
+      if (moved) options.onResizeEnd(size);
+    };
+    const finish = (last: globalThis.PointerEvent) => {
+      if (last.pointerId !== pointerId) return;
+      if (moved || last.clientX !== startX || last.clientY !== startY)
+        move(last);
+      commit();
+    };
+    const cancel = () => commit();
+    const cancelPointer = (event: globalThis.PointerEvent) => {
+      if (event.pointerId === pointerId) cancel();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") cancel();
+    };
+
+    cleanupRef.current = cleanup;
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", finish);
+    window.addEventListener("pointercancel", cancelPointer);
+    window.addEventListener("blur", cancel);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    document.body.style.cursor = "nesw-resize";
+    document.body.style.userSelect = "none";
+    options.onResizingChange(true);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    const step = event.shiftKey ? 40 : 10;
+    const delta = {
+      ArrowLeft: { width: -step, height: 0 },
+      ArrowRight: { width: step, height: 0 },
+      ArrowUp: { width: 0, height: -step },
+      ArrowDown: { width: 0, height: step },
+    }[event.key];
+    if (!delta) return;
+    const geometry = readGeometry(event.currentTarget);
+    if (!geometry) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const size = resizeTrailPanel(
+      geometry.size,
+      delta,
+      options.min,
+      geometry.max
+    );
+    options.onResize(size);
+    options.onResizeEnd(size);
+  };
+
+  return { onPointerDown, onKeyDown };
+}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/useWorkstationTrailMenu.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/useWorkstationTrailMenu.ts
@@ -1,56 +1,19 @@
-/**
- * Right-click menu for the Workstation trail's resize handle.
- *
- * Width commands:
- *   - "Restore original width" — back to the shipped 256px. It also clears a
- *     user-set minimum, because a minimum above 256px would otherwise make
- *     the command a no-op with no way back from the menu.
- *   - "Set current width as minimum" — pins the trail's *current* width as
- *     the floor for dragging. It never resizes the trail.
- *   - "Wider" — one `step` up, disabled at the maximum.
- *
- * Terminal commands open / hide the terminal docked under the trail, which
- * is the trail's terminal entry point now that the Workstation-navigating
- * terminal, files and browser rows are gone.
- */
+/** Native trail menu. The trail has a fixed size; only its terminal resizes. */
 import i18next from "i18next";
 import { type MouseEvent, useCallback } from "react";
 
 import { createLogger } from "@src/hooks/logger";
-import {
-  type NativeMenuItemOptions,
-  popupNativeMenu,
-} from "@src/util/platform/tauri/nativeMenuPopup";
-
-import {
-  WORKSTATION_TRAIL_WIDTH_LIMITS,
-  resolveNextWiderTrailWidth,
-} from "./trailWidth";
+import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
 
 const log = createLogger("useWorkstationTrailMenu");
 
 export interface UseWorkstationTrailMenuOptions {
-  /** Current expanded width in px. */
-  width: number;
-  /** Effective minimum width in px (user-set or the shipped floor). */
-  minWidth: number;
-  onWidthChange: (width: number) => void;
-  /** Persist `width` as the new minimum without resizing the trail. */
-  onSetMinimum: () => void;
-  /** Restore the shipped width and clear a user-set minimum. */
-  onRestoreDefault: () => void;
-  /** Mini terminal currently on screen. */
   miniTerminalVisible: boolean;
   onOpenMiniTerminal: () => void;
   onHideMiniTerminal: () => void;
 }
 
 export function useWorkstationTrailMenu({
-  width,
-  minWidth,
-  onWidthChange,
-  onSetMinimum,
-  onRestoreDefault,
   miniTerminalVisible,
   onOpenMiniTerminal,
   onHideMiniTerminal,
@@ -59,60 +22,23 @@ export function useWorkstationTrailMenu({
     (event: MouseEvent) => {
       event.preventDefault();
       event.stopPropagation();
-
-      const isDefaultWidth = width === WORKSTATION_TRAIL_WIDTH_LIMITS.default;
-      const nextWider = resolveNextWiderTrailWidth(width, minWidth);
-      const isAlreadyMinimum = minWidth === width;
-
       void popupNativeMenu({
         source: "workstation-trail",
-        buildItems: () => {
-          const items: NativeMenuItemOptions[] = [
-            {
-              text: i18next.t("common:git.rail.restoreWidth", {
-                width: WORKSTATION_TRAIL_WIDTH_LIMITS.default,
-              }),
-              enabled: !isDefaultWidth,
-              action: onRestoreDefault,
-            },
-            {
-              text: i18next.t("common:git.rail.setMinimumWidth", { width }),
-              enabled: !isAlreadyMinimum,
-              action: onSetMinimum,
-            },
-            {
-              text: i18next.t("common:git.rail.widerWidth", {
-                width: nextWider,
-              }),
-              enabled: nextWider !== width,
-              action: () => onWidthChange(nextWider),
-            },
-            { item: "Separator" },
-            miniTerminalVisible
-              ? {
-                  text: i18next.t("common:git.rail.hideMiniTerminal"),
-                  action: onHideMiniTerminal,
-                }
-              : {
-                  text: i18next.t("common:git.rail.openMiniTerminal"),
-                  action: onOpenMiniTerminal,
-                },
-          ];
-          return items;
-        },
+        buildItems: () => [
+          miniTerminalVisible
+            ? {
+                text: i18next.t("common:git.rail.hideMiniTerminal"),
+                action: onHideMiniTerminal,
+              }
+            : {
+                text: i18next.t("common:git.rail.openMiniTerminal"),
+                action: onOpenMiniTerminal,
+              },
+        ],
       }).catch((error) => {
         log.error("Failed to show workstation trail menu:", error);
       });
     },
-    [
-      miniTerminalVisible,
-      minWidth,
-      onHideMiniTerminal,
-      onOpenMiniTerminal,
-      onRestoreDefault,
-      onSetMinimum,
-      onWidthChange,
-      width,
-    ]
+    [miniTerminalVisible, onHideMiniTerminal, onOpenMiniTerminal]
   );
 }

--- a/src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts
+++ b/src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts
@@ -62,13 +62,15 @@ describe("WorkstationTrailSurface", () => {
     );
 
     expect(markup).toContain("mb-1");
-    expect(markup).toContain("h-7");
+    expect(markup).toContain("h-6");
     expect(markup).toContain("justify-between pl-1");
+    expect(markup).toContain("pr-[3px]");
     expect(markup).toContain("px-1 text-[11px]");
     expect(markup).toContain("uppercase tracking-wide");
     expect(markup).toContain("Collapse groups");
     expect(markup).toContain("flex min-w-0 flex-1 items-center");
-    expect(markup).toContain("h-[26px] w-[26px]");
+    expect(markup).toContain("h-5 w-5");
+    expect(markup).toContain("items-center gap-px");
     expect(markup).toContain("rounded-lg");
   });
 
@@ -94,7 +96,8 @@ describe("WorkstationTrailSurface", () => {
     expect(markup).toContain("No reviews");
     // A section action occupies the same row geometry as the trail header's
     // own control, so the two line up across surfaces.
-    expect(markup).toContain("flex h-7 items-center justify-between");
+    expect(markup).toContain("flex h-6 items-center justify-between");
+    expect(markup).toContain("gap-2");
     expect(markup).not.toContain("pr-1");
 
     const noActionMarkup = renderToStaticMarkup(
@@ -103,7 +106,7 @@ describe("WorkstationTrailSurface", () => {
     // Actionless sections keep the same label row, so every section title in a
     // rail sits on one baseline.
     expect(noActionMarkup).toContain("<h3");
-    expect(noActionMarkup).toContain("flex h-7 items-center");
+    expect(noActionMarkup).toContain("flex h-6 items-center");
   });
 
   it("shares one direct scroll body below trail headers", () => {

--- a/src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx
+++ b/src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx
@@ -8,7 +8,9 @@ import {
 
 import { DROPDOWN_PANEL } from "@src/components/Dropdown/tokens";
 import {
+  BUTTON_SIZE,
   EDITOR_TAB_CANVAS_BG_CLASS,
+  TAB_BAR_TRAILING_CLUSTER_CLASS,
   WORKSTATION_TRAIL_CONTENT,
 } from "@src/config/workstation/tokens";
 
@@ -38,37 +40,51 @@ export const WORKSTATION_TRAIL_WIDTH = {
 export const WORKSTATION_TRAIL_RAIL_PADDING_CLASS = "px-1 pb-1 pt-2";
 export const FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS =
   "@[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2";
-export const WORKSTATION_TRAIL_ICON_BUTTON_CLASS =
-  "flex h-[26px] w-[26px] items-center justify-center rounded-lg text-text-1 transition-colors hover:bg-fill-2";
+export const WORKSTATION_TRAIL_ICON_BUTTON_CLASS = `flex ${BUTTON_SIZE.sm} shrink-0 items-center justify-center rounded-lg text-text-1 transition-colors hover:bg-fill-2`;
 
 export interface WorkstationTrailHeaderProps {
   actions?: ReactNode;
   collapsed?: boolean;
+  /** Omit the body gap when the header is the only visible row. */
+  standalone?: boolean;
   title: ReactNode;
   titleActions?: ReactNode;
+  /** Inline content between the title controls and trailing actions. */
+  children?: ReactNode;
 }
 
 /** Exact title row used by the focused-chat Workstation environment trail. */
 export const WorkstationTrailHeader: FC<WorkstationTrailHeaderProps> = ({
   actions,
   collapsed = false,
+  standalone = false,
   title,
   titleActions,
+  children,
 }) => (
   <div
-    className={`mb-1 flex h-7 shrink-0 items-center ${
-      collapsed ? "justify-center" : "justify-between pl-1"
+    // Three right pixels keep a 20px button's center aligned with the tab
+    // bar: 3 + 20 / 2 = the original 26px control's 13px offset.
+    className={`flex shrink-0 items-center gap-px ${standalone ? "" : "mb-1"} ${
+      collapsed ? "h-7 justify-center" : "h-6 justify-between pl-1 pr-[3px]"
     }`}
   >
     {!collapsed ? (
-      <div className="flex min-w-0 flex-1 items-center">
-        <span className="min-w-0 truncate px-1 text-[11px] font-medium uppercase tracking-wide text-text-3">
-          {title}
-        </span>
+      <div className="flex min-w-0 flex-1 items-center gap-px">
+        {title != null ? (
+          <span
+            className={`min-w-0 truncate px-1 text-[11px] font-medium uppercase tracking-wide text-text-3 ${children ? "max-w-20 shrink-0" : ""}`}
+          >
+            {title}
+          </span>
+        ) : null}
         {titleActions}
+        {children}
       </div>
     ) : null}
-    {actions}
+    {actions ? (
+      <div className={TAB_BAR_TRAILING_CLUSTER_CLASS}>{actions}</div>
+    ) : null}
   </div>
 );
 
@@ -117,7 +133,7 @@ export const WorkstationTrailSection: FC<WorkstationTrailSectionProps> = ({
       {/* Same row geometry as WorkstationTrailHeader, so a section action lands
           on the exact spot the trail's own collapse control occupies. Rendered
           unconditionally to keep every section label on one baseline. */}
-      <div className="flex h-7 items-center justify-between gap-2">
+      <div className="flex h-6 items-center justify-between gap-2 pr-[3px]">
         {label}
         {action}
       </div>

--- a/src/store/ui/__tests__/miniTerminalAtom.test.ts
+++ b/src/store/ui/__tests__/miniTerminalAtom.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { terminalSessionsAtom } from "@src/store/workstation/codeEditor/terminal";
 
 import {
+  MINI_TERMINAL_SESSION_LIMIT,
   closeMiniTerminalAtom,
   miniTerminalActiveIdAtom,
   miniTerminalClaimedIdsAtom,
@@ -27,6 +28,73 @@ function seedStore(sessionIds: string[]) {
 }
 
 describe("mini terminal claims", () => {
+  it("caps claims at three without deleting other Workstation sessions", () => {
+    const store = seedStore(["a", "b", "c", "d"]);
+    for (const id of ["a", "b", "c"]) store.set(openMiniTerminalAtom, id);
+
+    expect(store.set(openMiniTerminalAtom, "d")).toBeNull();
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual(["a", "b", "c"]);
+    expect(store.get(miniTerminalClaimedIdsAtom)).toHaveLength(
+      MINI_TERMINAL_SESSION_LIMIT
+    );
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("c");
+    expect(store.get(terminalSessionsAtom)).toHaveLength(4);
+    expect(store.get(miniTerminalSuppressedIdsAtom).has("d")).toBe(false);
+  });
+
+  it("rejects creation at capacity before adding any Workstation session", () => {
+    const store = seedStore(["a", "b", "c"]);
+    for (const id of ["a", "b", "c"]) store.set(openMiniTerminalAtom, id);
+    const originalSessions = store.get(terminalSessionsAtom);
+
+    for (let attempt = 0; attempt < 5; attempt++) {
+      expect(
+        store.set(openMiniTerminalAtom, null, { bypassCreationCooldown: true })
+      ).toBeNull();
+    }
+    expect(store.get(terminalSessionsAtom)).toBe(originalSessions);
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual(["a", "b", "c"]);
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("c");
+  });
+
+  it("still focuses an existing claim when the dock is full", () => {
+    const store = seedStore(["a", "b", "c"]);
+    for (const id of ["a", "b", "c"]) store.set(openMiniTerminalAtom, id);
+    store.set(miniTerminalVisibleAtom, false);
+
+    expect(store.set(openMiniTerminalAtom, "b")).toBe("b");
+    expect(store.get(miniTerminalActiveIdAtom)).toBe("b");
+    expect(store.get(miniTerminalVisibleAtom)).toBe(true);
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual(["a", "b", "c"]);
+  });
+
+  it("allows creation again after release and preserves session options", () => {
+    const store = seedStore(["a", "b", "c"]);
+    for (const id of ["a", "b", "c"]) store.set(openMiniTerminalAtom, id);
+    store.set(releaseMiniTerminalSessionAtom, "b");
+
+    const id = store.set(openMiniTerminalAtom, null, {
+      name: "Build",
+      shell: "/bin/sh",
+      cwd: "/workspace/project",
+      profileId: "build-profile",
+      bypassCreationCooldown: true,
+    });
+    expect(id).toBeTruthy();
+    expect(store.get(miniTerminalClaimedIdsAtom)).toEqual(["a", "c", id]);
+    expect(
+      store.get(terminalSessionsAtom).find((session) => session.id === id)
+    ).toMatchObject({
+      name: "Build",
+      shell: "/bin/sh",
+      cwd: "/workspace/project",
+      profileId: "build-profile",
+    });
+    expect(
+      store.get(terminalSessionsAtom).some((session) => session.id === "b")
+    ).toBe(true);
+  });
+
   it("claims a session and suppresses it in the Workstation pane", () => {
     const store = seedStore(["a", "b"]);
     store.set(openMiniTerminalAtom, "a");

--- a/src/store/ui/miniTerminalAtom.ts
+++ b/src/store/ui/miniTerminalAtom.ts
@@ -17,6 +17,7 @@
  */
 import { atom } from "jotai";
 
+import type { AddSessionOptions } from "@src/engines/TerminalCore/types";
 import { selectedRepoPathAtom } from "@src/store/repo";
 import {
   activeTerminalIdAtom,
@@ -24,6 +25,8 @@ import {
   editorAddTerminalSessionAtom,
   terminalSessionsAtom,
 } from "@src/store/workstation/codeEditor/terminal";
+
+export const MINI_TERMINAL_SESSION_LIMIT = 3;
 
 /** Panel shown. Suppression lifts whenever it hides. */
 export const miniTerminalVisibleAtom = atom<boolean>(false);
@@ -98,17 +101,26 @@ setMiniTerminalActiveIdAtom.debugLabel = "chatPanel/miniTerminal/setActiveId";
 /**
  * Show the panel on `sessionId`, or on a brand-new Workstation PTY when
  * called with `null`. Claiming an already-claimed session just focuses it.
+ * Check capacity before creating anything so a full dock cannot leave an
+ * extra Workstation session behind, including from stale UI callbacks.
  */
 export const openMiniTerminalAtom = atom(
   null,
-  (get, set, sessionId: string | null) => {
+  (get, set, sessionId: string | null, options?: AddSessionOptions) => {
+    const claimed = get(miniTerminalClaimedIdsAtom);
+    if (
+      claimed.length >= MINI_TERMINAL_SESSION_LIMIT &&
+      (sessionId === null || !claimed.includes(sessionId))
+    ) {
+      return null;
+    }
     const targetId =
       sessionId ??
       set(editorAddTerminalSessionAtom, {
         cwd: get(selectedRepoPathAtom) || undefined,
+        ...options,
       });
     if (!targetId) return null;
-    const claimed = get(miniTerminalClaimedIdsAtom);
     if (!claimed.includes(targetId)) {
       set(miniTerminalClaimedIdsStateAtom, [...claimed, targetId]);
     }


### PR DESCRIPTION
## Problem

The focused-chat Workstation rail and its pinned terminals do not behave consistently as one dock. The environment groups are ordered and labeled awkwardly, pinned and other non-station terminals appear in My Station's Open Tabs list, and collapsed terminal panels reserve expanded width. Terminal controls use a second tab row and inconsistent sizing, and collapsed rail icons omit shortcut metadata by rendering native titles instead of the shared tooltip.

The terminal admission writer also has no three-session limit, so hiding the add button alone would still permit extra sessions through stale or programmatic callbacks.

## Solution

This PR delivers the workstation rail and pinned-terminal control update as one cohesive dock interaction change:

- Preserve the original PR's Local environment → Session environment → Open Tabs ordering in wide and compact views, local-group heading ownership, hover/keyboard reveal for expanded rail actions, and always-available 28px collapsed rail controls.
- Keep Workstation Trail at its fixed width. Only the expanded pinned terminal resizes, using its bottom-left corner or arrow keys. Live drag updates are frame-coalesced; dimensions persist only when the interaction commits, with cleanup on release, cancellation, blur, hidden document and unmount.
- Collapse the terminal to a vertically centered header at the trail width, without unmounting its terminal host. One session shows its name once; multiple expanded sessions show a chevron and content-width, horizontally scrollable tabs; multiple collapsed sessions show a localized process count.
- Cap pinned terminals at three in `openMiniTerminalAtom` before creating or claiming a session. Hide add at capacity, retain focusing of existing claims, with no overflow counters/menus. Rejected requests cannot create orphan sessions.
- Limit both Open Tabs presentations to eligible My Station entries. Exclude live pinned claims and existing chat-panel/agent PTY owners without deleting valid sessions; eligible station sessions return after release/hide.
- Use a shared red stop control for actual termination in the dock, terminal pane/sidebar, rail and server watcher. File/view close and dock hide retain X controls and their existing behavior.
- Use 20px expanded trail controls and terminal tabs, 1px gaps, matching terminal tab/button radii and adjusted shared header padding. Project/work-item/PR trail consumers inherit the alignment. Pinned terminal output uses a 12px host override; other terminals retain their global font setting.
- Restore shared shortcut tooltips on collapsed rail icons, retaining the existing shortcut bindings and cleaning up pending/visible tooltips when the rail expands.

The standalone chevron remains; the retracted title-click interaction is not included. Unrelated composer, chat-history, loading-skeleton, settings, configuration-relocation and icon edits from the shared checkout are excluded.

## Potential risks

- Native Tauri/WebView visuals, light/dark themes, narrow/short viewports, actual xterm fit, and resizing the native window mid-drag remain unverified. Computer control was explicitly not authorized. No new screenshots or recordings were captured. jsdom tests mock xterm setup and termination IPC; they do not launch or kill OS processes.
- Native visible/hidden idle CPU/RSS, active frame time and post-close behavior were not measured. The performance audit remains blocked for those measurements; deterministic lifecycle and coalescing tests are evidence for resource handling, not a measured performance improvement.
- Shared expanded control sizing affects project properties and PR trail consumers; targeted tests cover their structure and alignment tokens, not native pixel geometry. Very short windows can constrain visible terminal height through the existing capped flex column.
- Two new best-effort numeric localStorage preferences persist terminal width and height: `orgii:workstationTrailTerminalWidth` and `orgii:workstationTrailTerminalHeight`. Defaults are 400×260; restored values clamp to width 320–720 and height 120–720. Legacy trail width/minimum preferences are ignored, not deleted. Older builds ignore the new keys. Revert the added terminal-controls commit and clear only these two keys to restore prior behavior/defaults; no user content or sessions are migrated.
- Dock claims are transient. Existing unclaimed station sessions remain intact when capacity rejects a pin. The optional terminal creation-options and font-size props preserve existing callers' defaults. No dependency, lockfile, database, backend, IPC or network protocol changes are included.

## Verification

Validated in an isolated worktree containing only this PR's changes:

```sh
pnpm exec vitest run src/components/ProcessStopButton src/components/Tooltip/index.test.ts src/components/KeyboardShortcut/index.test.ts src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts src/engines/TerminalCore/__tests__/TerminalCore.fontSize.test.ts src/engines/TerminalCore/components/TerminalInteractive/__tests__/useTerminalAppearance.test.ts src/modules/shared/layouts/FocusedChatWorkstationRail src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesPanel.test.ts src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesRailFrame.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrSidebar.test.ts src/modules/shared/components/GitHubDetailSkeleton/index.test.ts src/store/ui/__tests__/miniTerminalAtom.test.ts
```

Pass: **113 tests across 20 suites**, including real rail projections, claim/create writers, terminal stop/hide behavior, collapse and tooltip cleanup, tab scrolling and keyboard focus, resize lifecycle, persistence, font override initialization/live updates without recreation, and shared project/PR consumers.

```sh
pnpm exec vitest run src/components/Dropdown/index.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/restorePtySelection.test.ts
```

Pass: **7 tests across 2 suites**; total **120 tests across 22 suites**.

```sh
pnpm run typecheck
git diff --name-only --diff-filter=ACMR origin/develop...HEAD -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0 --report-unused-disable-directives
git diff --name-only --diff-filter=ACMR origin/develop...HEAD | xargs pnpm exec prettier --check
pnpm run check:test-placement
git diff origin/develop...HEAD --check
```

Pass: full TypeScript checking, scoped ESLint/Prettier, test placement across 435 directories, and whitespace checks. The unrelated Input/Textarea test errors in the shared checkout are not present in this PR. The normal pre-commit hooks ran. An additional Node/i18next check parsed all 13 locales and resolved resize labels plus process counts 1–3. The final scoped diff was checked for credentials, personal paths, debug logs, build artifacts and unrelated changes.

`git fetch origin develop dev/chat-rail-environment-controls` and `git merge-tree --write-tree HEAD origin/develop` pass: the latest fetched base integrates without conflicts and no existing commit was rewritten. Native UI/CPU/RSS verification was not run for the authorization and measurement limitations above; no Rust checks were needed because no Rust code changed.

## Audit

- Frontend UI: **0 fix candidates, 11 keep-with-reason, 0 abstractions**; shared stop and sizing sweeps are included as requested.
- Architecture: layers 1–10 reviewed; no wire-protocol change applies. Capacity is enforced at the producing writer; Open Tabs exclusion is an explicit product requirement for valid domain data, with no historical cleanup required.
- Performance: deterministic resource ownership and cleanup checks pass; **native measurement remains blocked** because computer control was not authorized.

Reports: `docs/frontend-ui-audit-2026-08-31/TrailPanelCornerResize.md`, `docs/architecture-audit-2026-08-31/TrailPanelCornerResize.md`, and `docs/org2-performance-guard-2026-08-31/TrailPanelCornerResize.md`.
