### PR TITLE
fix(chat): align header controls with and without tabs

### DIFF
--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -28,6 +28,7 @@ import { SessionHeaderActionsMenu } from "./components/SessionHeaderActionsMenu"
 import {
   CHAT_PANEL_HEADER_DRAG_STYLE,
   CHAT_PANEL_HEADER_NO_DRAG_STYLE,
+  CHAT_PANEL_HEADER_RIGHT_PADDING_CLASS,
   ChatPanelCollapsedTabHeading,
   ChatPanelPublishedHeader,
   chatPanelHeaderSlotsAtom,
@@ -454,7 +455,7 @@ export function ChatPanelHeader({
           (HEADER_CONTENT_LEFT_PADDING_CLASS 15px + breadcrumb px-1 4px). */}
       {tabRowCollapsed ? null : (
         <div
-          className={`workspace-header header-tab-group z-40 flex h-11 min-h-11 items-center gap-1.5 pl-1 pr-[7px] pt-2 ${
+          className={`workspace-header header-tab-group z-40 flex h-11 min-h-11 items-center gap-1.5 pl-1 pt-2 ${CHAT_PANEL_HEADER_RIGHT_PADDING_CLASS} ${
             overlayPublishedHeader
               ? "absolute left-0 right-0 top-0"
               : "relative flex-shrink-0"

--- a/src/engines/ChatPanel/header/ChatPanelHeaderPrimitives.tsx
+++ b/src/engines/ChatPanel/header/ChatPanelHeaderPrimitives.tsx
@@ -8,5 +8,12 @@ export const CHAT_PANEL_HEADER_NO_DRAG_STYLE = {
   WebkitAppRegion: "no-drag",
 } as React.CSSProperties;
 
+/**
+ * Intentional 7px inset: accounts for the 1px pane separator when aligning
+ * controls with My Station. Keep both chat header rows on this value; do not
+ * normalize it to pr-2 (8px).
+ */
+export const CHAT_PANEL_HEADER_RIGHT_PADDING_CLASS = "pr-[7px]";
+
 /** Optical alignment for detail-header icons against the first tab icon. */
 export const CHAT_PANEL_TAB_FIRST_ICON_LEFT_PADDING_CLASS = "!pl-5";

--- a/src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx
+++ b/src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx
@@ -5,6 +5,7 @@ import { PublishedHeaderSlotsView } from "@src/components/WindowChrome";
 import {
   CHAT_PANEL_HEADER_DRAG_STYLE,
   CHAT_PANEL_HEADER_NO_DRAG_STYLE,
+  CHAT_PANEL_HEADER_RIGHT_PADDING_CLASS,
 } from "./ChatPanelHeaderPrimitives";
 import type { ChatPanelHeaderSlots } from "./chatPanelHeaderSlots";
 
@@ -26,7 +27,7 @@ export const ChatPanelPublishedHeader: React.FC<ChatPanelPublishedHeaderProps> =
 
     return (
       <div
-        className={`relative z-40 flex h-9 shrink-0 items-center gap-2 pr-2 ${
+        className={`relative z-40 flex h-9 shrink-0 items-center gap-2 ${CHAT_PANEL_HEADER_RIGHT_PADDING_CLASS} ${
           slots.joinWithFollowingRow ? "" : "border-b border-border-2"
         }`}
         data-testid="chat-panel-published-header"


### PR DESCRIPTION
## Problem

The chat pane uses 7px of right padding in the tab row but 8px in the published header. Hiding the tab bar therefore shifts the + and pane controls by 1px. The 7px value is intentional: it accounts for the pane separator when aligning the controls with My Station.

## Solution

Use one `CHAT_PANEL_HEADER_RIGHT_PADDING_CLASS` (`pr-[7px]`) in both chat header rows. Keep the tabbed layout's existing inset and bring the published/collapsed header into alignment. Add a comment documenting the separator compensation so a future spacing cleanup does not round it to 8px.

Button sizes, gaps, vertical positioning, and actions are unchanged. The diff contains only the shared spacing constant and its two consumers.

## Potential risks

The published header's trailing controls move 1px toward the right edge, both when tabs are visible and when they are hidden. Desktop rendering across platforms, themes, and narrow pane widths has not been visually verified. There are no dependency, persistence, API, or lifecycle changes; rollback is a revert of this styling change.

## Verification

Passed on the isolated branch based on the latest `develop`:

- `pnpm exec eslint src/engines/ChatPanel/ChatPanelHeader.tsx src/engines/ChatPanel/header/ChatPanelHeaderPrimitives.tsx src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx --max-warnings 0 --report-unused-disable-directives`
- `pnpm test src/engines/ChatPanel/ChatPanelHeader.test.ts src/engines/ChatPanel/header/ChatPanelPublishedHeader.test.ts src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts` — 23 tests passed across 3 files
- `pnpm run typecheck`
- `git diff --check`

Inspected both rendering paths: they use the same right inset and retain the same button components and spacing. Reviewed the scoped diff for unrelated edits, secrets, private paths, and generated artifacts; none are included.

No desktop screenshots or rendered E2E checks were taken because local desktop control requires explicit opt-in. The full test suite was not run for this limited spacing change. The frontend UI audit's pure-styling exemption applies; no component structure or runtime work changed.
