### PR TITLE
fix(inline-alert): compact the CLI update notice

### DIFF
--- a/src/components/InlineAlert/index.tsx
+++ b/src/components/InlineAlert/index.tsx
@@ -8,7 +8,8 @@
  * There is deliberately no danger / warning / success color variant — `type`
  * only selects the leading icon.
  *
- * Padding (p-3), icon size 14. Header row: icon + title + optional action + close;
+ * Padding (p-3, or py-1 pl-3 pr-1 when compact), icon size 14.
+ * Header row: icon + title + optional action + close;
  * body (children) and subtitle render below the header.
  * When action is an object, InlineAlert builds a secondary Button at 28px height.
  */
@@ -127,6 +128,8 @@ export interface InlineAlertProps {
   subtitle?: React.ReactNode;
   /** Extra className on the outer container */
   className?: string;
+  /** Reduce default-card vertical and right padding without shrinking action buttons. */
+  compact?: boolean;
   /** Compact expandable pill that shows only title until expanded */
   presentation?: "default" | "pill";
   /** Optional action — object builds a 28px secondary Button; ReactNode for custom */
@@ -153,6 +156,7 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
   hideIcon = false,
   subtitle,
   className,
+  compact = false,
   presentation = "default",
   action,
   onClose,
@@ -164,6 +168,7 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
 }) => {
   const [expanded, setExpanded] = React.useState(presentation !== "pill");
   const isPill = presentation === "pill";
+  const cardPaddingClass = compact ? "py-1 pl-3 pr-1" : "p-3";
   const showContent = !isPill || expanded;
   const resolvedIcon =
     icon ??
@@ -260,7 +265,7 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
     <div
       role={role}
       data-testid={dataTestId}
-      className={`${ALERT_SURFACE_CLASS} ${isPill ? `inline-block w-fit max-w-full ${expanded ? ALERT_RADIUS_CLASS : "rounded-full"} px-3 py-2` : `${ALERT_RADIUS_CLASS} p-3`} ${className ?? ""}`}
+      className={`${ALERT_SURFACE_CLASS} ${isPill ? `inline-block w-fit max-w-full ${expanded ? ALERT_RADIUS_CLASS : "rounded-full"} px-3 py-2` : `${ALERT_RADIUS_CLASS} ${cardPaddingClass}`} ${className ?? ""}`}
     >
       <div className={`flex items-center ${isPill ? "gap-1" : "gap-3"}`}>
         {isPill ? (

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -330,6 +330,7 @@ const SessionCreatorChatPanelView: React.FC<
       >
         <InlineAlert
           type="warning"
+          compact
           icon={
             <HugeiconsIcon
               icon={Download02Icon}


### PR DESCRIPTION
## Problem

The CLI update notice above the composer inherits InlineAlert's 12px padding on every side, making a single-line notice unnecessarily tall. InlineAlert did not offer a compact card option.

## Solution

- Add an optional `compact` prop to InlineAlert, defaulting to `false`.
- Compact cards use 4px top, bottom, and right padding while retaining 12px left padding.
- Enable compact spacing only for the session creator's CLI update notice. Preserve the 28px action buttons, accessible labels, refresh/mute/close handlers, and existing default-card and pill presentation.

## Potential risks

The tighter spacing around the trailing controls has not been visually checked in the desktop app, including narrow widths, long localized titles, light/dark themes, and refresh/loading states. Button dimensions and behavior are unchanged, and other alert consumers retain their existing spacing because the new prop defaults to false.

There are no dependency, configuration, persistence, IPC, backend, or lifecycle changes. Rollback consists of reverting this commit; no data recovery is needed.

## Verification

Verification was run in an isolated worktree based on the latest fetched `origin/develop`, with only these two source files changed.

- `pnpm test src/components/InlineAlert/InlineAlert.test.ts src/features/SessionCreator/variants/ChatPanel/useCliAgentConfiguration.test.ts` — passed, 8 tests across 2 files.
- `pnpm exec eslint src/components/InlineAlert/index.tsx src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx --max-warnings 0` — passed.
- `pnpm exec prettier --check src/components/InlineAlert/index.tsx src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx` — passed.
- `pnpm typecheck` — passed in the isolated worktree.
- `git diff origin/develop...HEAD --check` — passed.
- Reviewed the final diff for scope, unchanged default/pill sizing and action controls, secrets, private paths, generated artifacts, and unrelated edits.
- No desktop visual check or new screenshot was captured: local UI control was not authorized. The existing tests verify component rendering and update-alert behavior; they do not validate rendered pixel geometry.
