### PR TITLE
fix(github-detail): stabilize PR and issue loading skeletons

### DIFF
--- a/docs/frontend-ui-audit-2026-08-31/GitHubDetailLoading.md
+++ b/docs/frontend-ui-audit-2026-08-31/GitHubDetailLoading.md
@@ -1,0 +1,32 @@
+# GitHub detail loading UI audit
+
+Scope: the shared GitHub issue/PR loading frame, PR tab presentation, and its
+Inbox and Source Control loading hosts. Existing unrelated workspace edits are
+outside this audit.
+
+| Line                                                                                                                                                                              | Element                                        | Verdict          | Reason                                                                                                                                                                                                                                                                             | Suggested change |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/shared/components/GitHubPrDetailTabs.tsx:59`                                                                                                                         | Loading and loaded PR tabs                     | keep with reason | Both states use `DetailTabStrip` and one set of existing translated labels and icons. Only unknown counts get placeholders. No duplicate tab styling or translation keys were added.                                                                                               | None.            |
+| `src/modules/shared/layouts/blocks/DetailTabStrip.tsx:55`                                                                                                                         | Native tab buttons and count badges            | keep with reason | This is the shared tab primitive itself. Native buttons retain keyboard activation, selection, and panel associations; the loading badge is decorative and the tab exposes its busy state. Existing badge geometry is preserved.                                                   | None.            |
+| `src/modules/shared/components/GitHubDetailSkeleton/index.tsx:30`                                                                                                                 | Content and field placeholder bars             | keep with reason | Private decorative shapes use theme fill tokens and reduced-motion support. Labels and known titles are outside the animated shapes. There are no new JavaScript timers or effects.                                                                                                | None.            |
+| `src/modules/shared/components/GitHubDetailSkeleton/index.tsx:112`                                                                                                                | Known PR title                                 | keep with reason | The title and number come from the existing selection. Typography matches `GitHubFlowHeader`; the loading frame does not invent an author, status, or merge count. The existing 920px content maximum has no equivalent token in the inspected Tailwind/workstation configuration. | None.            |
+| `src/modules/shared/components/GitHubDetailSkeleton/index.tsx:168`                                                                                                                | Immediate right properties pane                | keep with reason | Uses `WORKSTATION_TRAIL_WIDTH.expandedPx`, shared rail padding, `WorkstationTrailSurface`, `WorkstationTrailBody`, and `WorkstationTrailSection`. PR and issue labels use existing translations, with placeholders instead of false empty values or actionable editors.            | None.            |
+| `src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx:90`                                                           | Initial count projection and live loading tabs | keep with reason | Existing load state gates count placeholders. Real zero/nonzero counts return after loading, and cached counts remain during refresh. Navigation remains connected to the existing per-PR selection state without adding requests or subscriptions.                                | None.            |
+| `src/modules/MainApp/TeamInbox/components/TeamInboxDetailPane.tsx:110`; `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx:126` | Lazy chunk fallbacks                           | keep with reason | Both hosts render the shared frame immediately. Inbox reuses its existing header actions during chunk loading and after mount. No new host-specific skeleton or configuration sweep is needed.                                                                                     | None.            |
+
+Verdict totals: **0 fix**, **7 keep with reason**, **0 abstract**.
+
+Source review covered design-system use, tokens, literal sizing/colors,
+accessibility, and repeated presentation. Focused DOM/SSR checks cover initial
+render, data loading, populated counts, cached refresh, host-owned tabs, and the
+reserved sidebar width. Native-app visual checks were not run because desktop
+control was not requested.
+
+Verification on the isolated PR branch: 55 tests passed across
+`GitHubDetailSkeleton`, `DetailTabStrip`, `PrDetailPanel`,
+`AssignedWorkItemDetail`, `TeamInboxView.layout`, `useWorkstationPrDetail`, and
+`PrSidebar`. Full `pnpm run typecheck`, scoped ESLint, Prettier, test-placement,
+and diff-whitespace checks passed. Reused translation keys exist in every
+locale. Unrelated local icon, label, shadow, and test edits were excluded.
+Native screenshots, theme/viewport checks, and runtime CPU/RSS measurements
+were not run because computer control was not requested.

--- a/docs/org2-performance-guard-2026-08-31/GitHubDetailLoading.md
+++ b/docs/org2-performance-guard-2026-08-31/GitHubDetailLoading.md
@@ -1,0 +1,31 @@
+# GitHub detail loading performance review
+
+Scope: shared GitHub issue/PR skeletons, PR tab presentation, and the Inbox and
+Source Control PR chunk-loading fallbacks. No loader, cache, transport, or
+persistence implementation is changed.
+
+| Area               | Verdict | Evidence                                                                                                                             | Change or reason kept                                                                   | Verification                                                                                                         |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Background work    | keep    | `PrDetailPanel` remains the owner of `useWorkstationPrDetail`; skeletons and shared tabs have no request, effect, timer, or listener | Existing loader retains request deduplication, stale-result checks, and unmount cleanup | 8 existing loader tests pass; source trace of chunk fallback through panel mount                                     |
+| Memory             | keep    | Skeleton arrays and four tab descriptors are render-local; no new retained map, cache, or buffer                                     | Existing per-PR state owns navigation; React owns mounted tab subscriptions             | Loading/hydration/refresh tests pass; native RSS growth not measured                                                 |
+| Scope/isolation    | keep    | Live tabs use the existing `workstationPrScopeKey(repoId, repoPath, number)` atom; chunk fallbacks consume identity props only       | No new auth/cache keys or data writers; unmount preserves existing view-state semantics | Existing loader tests pass; account/endpoint and secondary-instance checks not run because those paths are unchanged |
+| Rendering/hot path | keep    | Four fixed tab descriptors and three/four sidebar sections; count placeholders use CSS pulse with reduced-motion support             | No JavaScript animation loop; labels stay real and only unknown values are placeholders | 44 focused DOM/SSR tests and 3 existing sidebar tests pass; native visible/hidden CPU not measured                   |
+
+Lifecycle matrix:
+
+| State                                   | Expected ownership/behavior                                                        | Evidence                                                                                  |
+| --------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Lazy chunk loading                      | Static shared frame; no PR fetch or atom subscription in the fallback              | Source inspection of both Suspense hosts                                                  |
+| Initial detail loading                  | Panel owns loading; its live tabs subscribe to the existing scoped atom            | Panel/header variants retain labels and navigation in DOM tests                           |
+| Hydrated and cached refresh             | Real counts replace placeholders; cached refresh keeps counts and selected tab     | Focused DOM tests                                                                         |
+| Offline/error                           | Existing loader error path and panel banner remain unchanged                       | Existing loader regression suite; no network test                                         |
+| Unmount/reopen                          | React releases component subscriptions; existing loader cleanup retains view state | Source trace and loader regression suite; repeated native open/close not measured         |
+| Visible/hidden/focus return             | No new JS polling; CSS animation scheduling is controlled by the webview           | Native idle/hidden CPU and focus-return measurements not run                              |
+| Account/endpoint/scope/instance changes | Existing state and loader ownership are unchanged                                  | No new identity, transport, or persistence implementation; native topology checks not run |
+
+Performance verdict: blocked for runtime measurement. Computer control was not
+requested, so native visible-idle, hidden-idle, focus-return, repeated-open/close,
+and post-close CPU/RSS checks were not run. Source review and automated checks
+found no new background resource owner or unbounded retained collection; this
+is not a measured performance-improvement claim. The verification gap is
+explicitly disclosed in the pull request.

--- a/src/modules/MainApp/TeamInbox/components/TeamInboxDetailPane.tsx
+++ b/src/modules/MainApp/TeamInbox/components/TeamInboxDetailPane.tsx
@@ -14,6 +14,8 @@ import {
   SquareArrowUpRight02Icon,
 } from "@src/icons";
 import type { ManagedPrItem } from "@src/modules/MainApp/WorkManagement/githubManagedItemModel";
+import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
+import GitHubPrDetailTabs from "@src/modules/shared/components/GitHubPrDetailTabs";
 import { LoadingBar } from "@src/modules/shared/layouts/blocks";
 import type { PrIdentity } from "@src/store/workstation/codeEditor/workstationSelectedPrAtom";
 import type { WorkItem } from "@src/types/core/workItem";
@@ -67,54 +69,60 @@ export const TeamInboxDetailPane: React.FC<TeamInboxDetailPaneProps> = ({
   onWorkItemUpdated,
 }) => {
   if (selectedPullRequest && selectedPullRequestIdentity) {
+    const tabActions = (
+      <div
+        className="flex items-center gap-px"
+        data-testid="team-inbox-pr-detail-actions"
+      >
+        <TeamInboxHeaderIconAction
+          label={t("previews.openInExternalBrowser")}
+          icon={
+            <HugeiconsIcon
+              icon={InternetIcon}
+              data-icon="chrome"
+              size={14}
+              strokeWidth={1.75}
+              aria-hidden
+            />
+          }
+          onClick={() => void openExternalLink(selectedPullRequestIdentity.url)}
+          testId="team-inbox-open-github-pr"
+        />
+        {onOpenPullRequestTab ? (
+          <TeamInboxHeaderIconAction
+            label={t("teamInbox.actions.openPullRequest", "Open pull request")}
+            icon={
+              <HugeiconsIcon
+                icon={SquareArrowUpRight02Icon}
+                data-icon="square-arrow-out-up-right"
+                size={14}
+                strokeWidth={1.75}
+                aria-hidden
+              />
+            }
+            onClick={() => onOpenPullRequestTab(selectedPullRequest)}
+            testId="team-inbox-open-pr-tab"
+          />
+        ) : null}
+      </div>
+    );
     return (
-      <React.Suspense fallback={<LoadingBar />}>
+      <React.Suspense
+        fallback={
+          <GitHubDetailSkeleton
+            kind="pr"
+            showHeader={false}
+            title={selectedPullRequestIdentity.title}
+            number={selectedPullRequestIdentity.number}
+            tabs={<GitHubPrDetailTabs trailing={tabActions} />}
+          />
+        }
+      >
         <PullRequestDetailPanel
           identity={selectedPullRequestIdentity}
           repoPath={selectedPullRequest.repoPath}
           repoId={selectedPullRequest.repoId}
-          tabActions={
-            <div
-              className="flex items-center gap-px"
-              data-testid="team-inbox-pr-detail-actions"
-            >
-              <TeamInboxHeaderIconAction
-                label={t("previews.openInExternalBrowser")}
-                icon={
-                  <HugeiconsIcon
-                    icon={InternetIcon}
-                    data-icon="chrome"
-                    size={14}
-                    strokeWidth={1.75}
-                    aria-hidden
-                  />
-                }
-                onClick={() =>
-                  void openExternalLink(selectedPullRequestIdentity.url)
-                }
-                testId="team-inbox-open-github-pr"
-              />
-              {onOpenPullRequestTab ? (
-                <TeamInboxHeaderIconAction
-                  label={t(
-                    "teamInbox.actions.openPullRequest",
-                    "Open pull request"
-                  )}
-                  icon={
-                    <HugeiconsIcon
-                      icon={SquareArrowUpRight02Icon}
-                      data-icon="square-arrow-out-up-right"
-                      size={14}
-                      strokeWidth={1.75}
-                      aria-hidden
-                    />
-                  }
-                  onClick={() => onOpenPullRequestTab(selectedPullRequest)}
-                  testId="team-inbox-open-pr-tab"
-                />
-              ) : null}
-            </div>
-          }
+          tabActions={tabActions}
         />
       </React.Suspense>
     );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
@@ -15,6 +15,7 @@ import {
   NoTabsPlaceholder,
   type QuickAction,
 } from "@src/modules/WorkStation/shared";
+import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
 import { useGitHubIssueDetailState } from "@src/modules/shared/hooks/useGitHubIssueDetailState";
 import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { PrIdentity } from "@src/store/workstation/codeEditor/workstationSelectedPrAtom";
@@ -122,7 +123,16 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
 
   if (prIdentity) {
     return (
-      <Suspense fallback={<DetailFallback />}>
+      <Suspense
+        fallback={
+          <GitHubDetailSkeleton
+            kind="pr"
+            showHeader={false}
+            title={prIdentity.title}
+            number={prIdentity.number}
+          />
+        }
+      >
         <PrDetailPanel
           identity={prIdentity}
           repoPath={repoPath ?? ""}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
@@ -21,7 +21,7 @@ import {
   workstationSelectedPrAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationSelectedPrAtom";
 
-import { PrDetailPanel } from "./PrDetailPanel";
+import { PrDetailPanel, PrDetailTabs } from "./PrDetailPanel";
 import { formatPrFilesCount } from "./prFilesDisplay";
 
 const childProps = vi.hoisted(() => ({
@@ -736,6 +736,110 @@ describe("PrDetailPanel tabs", () => {
       sidebar?.querySelector("[data-testid='pr-level-actions']")
     ).not.toBeNull();
   });
+
+  it.each(["panel", "hostHeader"] as const)(
+    "keeps %s labels and selection through loading, hydration, and refresh",
+    (tabsPlacement) => {
+      const store = createStore();
+      const scopeKey = workstationPrScopeKey(undefined, "/repo", 42);
+      const selectedPrAtom = workstationSelectedPrAtomFamily(scopeKey);
+      const identity = {
+        number: 42,
+        title: "Render the known title immediately",
+        url: "https://github.com/org/repo/pull/42",
+        status: "open",
+        headBranch: "fix/loading-shell",
+      };
+      act(() => {
+        root.render(
+          createElement(
+            Provider,
+            { store },
+            tabsPlacement === "hostHeader"
+              ? createElement(PrDetailTabs, {
+                  identity,
+                  repoPath: "/repo",
+                  variant: "header",
+                })
+              : null,
+            createElement(PrDetailPanel, {
+              identity,
+              repoPath: "/repo",
+              tabsPlacement,
+            })
+          )
+        );
+      });
+
+      expect(container.querySelectorAll('[role="tablist"]')).toHaveLength(1);
+      const tabs = Array.from(
+        container.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+      );
+      expect(tabs.map((tab) => tab.textContent)).toEqual([
+        "Conversation",
+        "Commits",
+        "Checks",
+        "Files changed",
+      ]);
+      expect(
+        container.querySelectorAll('[data-testid="detail-tab-count-skeleton"]')
+      ).toHaveLength(4);
+      expect(container.querySelector("h2")?.textContent).toContain(
+        identity.title
+      );
+      const sidebar = container.querySelector(
+        '[data-testid="github-pr-detail-skeleton-sidebar"]'
+      );
+      expect(sidebar?.textContent).toBe("ReviewersAssigneesLabelsActions");
+      expect(sidebar?.querySelector("button")).toBeNull();
+
+      act(() => {
+        store.set(selectedPrAtom, (current) => ({ ...current, loading: true }));
+        tabs[1]?.click();
+      });
+      expect(tabs[1]?.getAttribute("aria-selected")).toBe("true");
+      expect(container.querySelector('[role="tabpanel"]')?.id).toBe(
+        "pr-detail-tabpanel-commits"
+      );
+
+      act(() => {
+        store.set(selectedPrAtom, (current) => ({
+          ...current,
+          loading: false,
+          detail: {},
+          commits: [{}, {}],
+        }));
+      });
+      expect(
+        container.querySelector('[data-testid="github-pr-detail-skeleton"]')
+      ).toBeNull();
+      expect(
+        container.querySelector('[data-testid="detail-tab-count-skeleton"]')
+      ).toBeNull();
+      const loadedTabs = Array.from(container.querySelectorAll('[role="tab"]'));
+      expect(loadedTabs.map((tab) => tab.textContent)).toEqual([
+        "Conversation0",
+        "Commits2",
+        "Checks0",
+        "Files changed0",
+      ]);
+      expect(loadedTabs[1]?.getAttribute("aria-selected")).toBe("true");
+      expect(
+        container.querySelector('[data-testid="pr-detail-sidebar-rail"]')
+      ).not.toBeNull();
+
+      act(() => {
+        store.set(selectedPrAtom, (current) => ({
+          ...current,
+          refreshing: true,
+        }));
+      });
+      expect(
+        container.querySelector('[data-testid="detail-tab-count-skeleton"]')
+      ).toBeNull();
+      expect(loadedTabs[1]?.textContent).toBe("Commits2");
+    }
+  );
 
   it("shows the PR skeleton on the first render before detail loading starts", () => {
     const store = createStore();

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
@@ -18,17 +18,10 @@ import { useTranslation } from "react-i18next";
 import InlineBanner, {
   useDismissibleMessage,
 } from "@src/components/InlineBanner";
-import {
-  FileDiffIcon,
-  GitCommitHorizontalIcon,
-  HugeiconsIcon,
-  ListChecksIcon,
-  MessageMultiple01Icon,
-} from "@src/icons";
 import { ExternalBrowserButton } from "@src/modules/WorkStation/shared/ExternalBrowserButton";
 import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
+import GitHubPrDetailTabs from "@src/modules/shared/components/GitHubPrDetailTabs";
 import {
-  DetailTabStrip,
   PersistentDetailTabPanel,
   ScrollTrail,
   WORKSTATION_TRAIL_RAIL_PADDING_CLASS,
@@ -61,8 +54,6 @@ interface PrDetailPanelProps {
   onFileSelect?: (path: string) => void;
 }
 
-type PrDetailTab = "conversation" | "commits" | "checks" | "changes";
-
 interface PrDetailTabsProps {
   identity: PrIdentity;
   repoPath: string;
@@ -89,83 +80,25 @@ export const PrDetailTabs: React.FC<PrDetailTabsProps> = ({
   trailing,
   variant = "row",
 }) => {
-  const { t } = useTranslation("common");
   const scopeKey = workstationPrScopeKey(repoId, repoPath, identity.number);
   const [state, setState] = useAtom(workstationSelectedPrAtomFamily(scopeKey));
   const activeTab = state.viewState.activeTab;
-  const tabs = useMemo(
-    () => [
-      {
-        key: "conversation" as const,
-        label: t("git.pr.tabs.conversation", "Conversation"),
-        icon: (
-          <HugeiconsIcon
-            icon={MessageMultiple01Icon}
-            data-icon="messages-square"
-            size={15}
-            strokeWidth={1.8}
-          />
-        ),
-        count: state.conversation.length + state.reviews.length,
-      },
-      {
-        key: "commits" as const,
-        label: t("git.pr.tabs.commits", "Commits"),
-        icon: (
-          <HugeiconsIcon
-            icon={GitCommitHorizontalIcon}
-            data-icon="git-commit-horizontal"
-            size={15}
-            strokeWidth={1.8}
-          />
-        ),
-        count: state.commits.length,
-      },
-      {
-        key: "checks" as const,
-        label: t("git.pr.tabs.checks", "Checks"),
-        icon: (
-          <HugeiconsIcon
-            icon={ListChecksIcon}
-            data-icon="list-checks"
-            size={15}
-            strokeWidth={1.8}
-          />
-        ),
-        count:
-          (state.checks?.check_runs.length ?? 0) +
-          (state.checks?.statuses.length ?? 0),
-      },
-      {
-        key: "changes" as const,
-        label: t("git.pr.changes.title", "Files changed"),
-        icon: (
-          <HugeiconsIcon
-            icon={FileDiffIcon}
-            data-icon="file-diff"
-            size={15}
-            strokeWidth={1.8}
-          />
-        ),
-        count: formatPrFilesCount(state.files.length),
-      },
-    ],
-    [
-      t,
-      state.conversation.length,
-      state.reviews.length,
-      state.commits.length,
-      state.checks,
-      state.files.length,
-    ]
-  );
 
   return (
-    <DetailTabStrip<PrDetailTab>
+    <GitHubPrDetailTabs
       activeTab={activeTab}
-      ariaLabel={t("git.pr.summary.label", "Pull request summary")}
-      idPrefix="pr-detail"
-      tabs={tabs}
+      counts={
+        state.loading || (state.detail === null && state.error === null)
+          ? undefined
+          : {
+              conversation: state.conversation.length + state.reviews.length,
+              commits: state.commits.length,
+              checks:
+                (state.checks?.check_runs.length ?? 0) +
+                (state.checks?.statuses.length ?? 0),
+              changes: formatPrFilesCount(state.files.length),
+            }
+      }
       trailing={trailing}
       variant={variant}
       onChange={(nextTab) => {
@@ -339,28 +272,35 @@ export const PrDetailPanel: React.FC<PrDetailPanelProps> = ({
   const baseBranch =
     state.baseRef ?? identity.baseBranch ?? t("git.pr.baseBranch", "base");
 
+  const tabs =
+    tabsPlacement === "panel" ? (
+      <PrDetailTabs
+        identity={identity}
+        repoPath={repoPath}
+        repoId={repoId}
+        trailing={
+          tabActions ?? <PrDetailExternalLinkButton identity={identity} />
+        }
+      />
+    ) : null;
+
   if (state.loading || (state.detail === null && state.error === null)) {
     return (
       <GitHubDetailSkeleton
         kind="pr"
         showHeader={false}
         showTabs={tabsPlacement === "panel"}
+        tabs={tabs}
+        activeTab={activeTab}
+        title={identity.title}
+        number={identity.number}
       />
     );
   }
 
   return (
     <div className="allow-select-deep flex h-full min-h-0 flex-col overflow-hidden">
-      {tabsPlacement === "panel" ? (
-        <PrDetailTabs
-          identity={identity}
-          repoPath={repoPath}
-          repoId={repoId}
-          trailing={
-            tabActions ?? <PrDetailExternalLinkButton identity={identity} />
-          }
-        />
-      ) : null}
+      {tabs}
 
       {/* A background reconcile clears `state.error` as soon as it succeeds, so
           the strip holds the message until the reader dismisses it. */}

--- a/src/modules/shared/components/GitHubDetailSkeleton/index.test.ts
+++ b/src/modules/shared/components/GitHubDetailSkeleton/index.test.ts
@@ -2,18 +2,31 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { WORKSTATION_TRAIL_WIDTH } from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
+
 import GitHubDetailSkeleton from ".";
 
 describe.each(["issue", "pr"] as const)(
   "GitHubDetailSkeleton %s loading state",
   (kind) => {
-    it("keeps scrolling without rendering a decorative right rail", () => {
+    it("keeps scrolling and reserves the real properties rail width", () => {
       const markup = renderToStaticMarkup(
         createElement(GitHubDetailSkeleton, { kind })
       );
 
       expect(markup).toContain("scrollbar-overlay");
       expect(markup).toContain("overflow-y-auto");
+      expect(markup).toContain(
+        `data-testid="github-${kind}-detail-skeleton-sidebar"`
+      );
+      expect(markup).toContain(`width:${WORKSTATION_TRAIL_WIDTH.expandedPx}px`);
+      for (const label of kind === "pr"
+        ? ["Reviewers", "Assignees", "Labels", "Actions"]
+        : ["Work Item Properties", "Status", "Labels", "Assignment"]) {
+        expect(markup).toContain(`>${label}</`);
+      }
+      expect(markup).not.toContain("No one assigned");
+      expect(markup).not.toContain("None yet");
       expect(markup).not.toContain("border-l border-border-1");
       expect(markup).not.toContain("h-24 w-1 rounded-full");
     });
@@ -21,15 +34,29 @@ describe.each(["issue", "pr"] as const)(
 );
 
 describe("GitHubDetailSkeleton PR tabs", () => {
-  it("shows tab placeholders by default", () => {
+  it("shows actual tab labels and placeholders only for their counts", () => {
     const markup = renderToStaticMarkup(
       createElement(GitHubDetailSkeleton, { kind: "pr" })
     );
 
-    expect(markup).toContain('data-testid="github-pr-detail-skeleton-tabs"');
+    for (const label of [
+      "Conversation",
+      "Commits",
+      "Checks",
+      "Files changed",
+    ]) {
+      expect(markup).toContain(`>${label}</span>`);
+    }
+    expect(
+      markup.match(/data-testid="detail-tab-count-skeleton"/g)
+    ).toHaveLength(4);
+    expect(markup).not.toContain(
+      'data-testid="github-pr-detail-skeleton-tabs"'
+    );
+    expect(markup).not.toContain(">0</span>");
   });
 
-  it("omits tab placeholders when the host owns the tab row", () => {
+  it("omits navigation when the host owns the tab row", () => {
     const markup = renderToStaticMarkup(
       createElement(GitHubDetailSkeleton, {
         kind: "pr",
@@ -37,8 +64,6 @@ describe("GitHubDetailSkeleton PR tabs", () => {
       })
     );
 
-    expect(markup).not.toContain(
-      'data-testid="github-pr-detail-skeleton-tabs"'
-    );
+    expect(markup).not.toContain('role="tablist"');
   });
 });

--- a/src/modules/shared/components/GitHubDetailSkeleton/index.tsx
+++ b/src/modules/shared/components/GitHubDetailSkeleton/index.tsx
@@ -1,16 +1,39 @@
 import React, { memo } from "react";
 import { useTranslation } from "react-i18next";
 
+import { WORKSTATION_TRAIL_CONTENT } from "@src/config/workstation/tokens";
+import WorkstationTrailSurface, {
+  WORKSTATION_TRAIL_RAIL_PADDING_CLASS,
+  WORKSTATION_TRAIL_WIDTH,
+  WorkstationTrailBody,
+  WorkstationTrailHeader,
+  WorkstationTrailSection,
+} from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
+import type { PrDetailTab } from "@src/store/workstation/codeEditor/workstationSelectedPrAtom";
+
+import GitHubPrDetailTabs from "../GitHubPrDetailTabs";
+
 export interface GitHubDetailSkeletonProps {
   kind: "issue" | "pr";
   /** Match hosts that publish the detail title into a shell-owned header. */
   showHeader?: boolean;
-  /** Show the PR tab placeholders when the tabs are owned by this surface. */
+  /** Show PR navigation when the tabs are owned by this surface. */
   showTabs?: boolean;
+  /** Live navigation supplied by a host whose code is already loaded. */
+  tabs?: React.ReactNode;
+  activeTab?: PrDetailTab;
+  /** Render the known selection title without waiting for the detail request. */
+  title?: string;
+  number?: number;
 }
 
 function SkeletonBar({ className }: { className: string }): React.ReactNode {
-  return <div aria-hidden className={`rounded bg-fill-2 ${className}`} />;
+  return (
+    <div
+      aria-hidden
+      className={`animate-pulse rounded bg-fill-2 motion-reduce:animate-none ${className}`}
+    />
+  );
 }
 
 /**
@@ -19,17 +42,38 @@ function SkeletonBar({ className }: { className: string }): React.ReactNode {
  * request never fall back to an empty pane or a page spinner.
  */
 const GitHubDetailSkeleton: React.FC<GitHubDetailSkeletonProps> = memo(
-  ({ kind, showHeader = true, showTabs = true }) => {
-    const { t } = useTranslation();
+  ({
+    kind,
+    showHeader = true,
+    showTabs = true,
+    tabs,
+    activeTab = "conversation",
+    title,
+    number,
+  }) => {
+    const { t } = useTranslation("common");
+    const sidebarSections =
+      kind === "pr"
+        ? [
+            t("git.pr.sidebar.reviewers", "Reviewers"),
+            t("git.pr.sidebar.assignees", "Assignees"),
+            t("git.pr.sidebar.labels", "Labels"),
+            t("git.pr.sidebar.actions", "Actions"),
+          ]
+        : [
+            t("projects:workItems.contextMenu.status", "Status"),
+            t("projects:workItems.properties.labels", "Labels"),
+            t("projects:workItems.properties.assignment", "Assignment"),
+          ];
 
     return (
       <div
-        role="status"
-        aria-busy="true"
-        aria-label={t("status.loading")}
         className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-chat-pane"
         data-testid={`github-${kind}-detail-skeleton`}
       >
+        <span role="status" className="sr-only">
+          {t("status.loading")}
+        </span>
         {showHeader ? (
           <div className="flex h-10 shrink-0 items-center gap-3 px-4">
             <SkeletonBar className="h-5 w-5 rounded-full" />
@@ -38,21 +82,24 @@ const GitHubDetailSkeleton: React.FC<GitHubDetailSkeletonProps> = memo(
           </div>
         ) : null}
 
-        {kind === "pr" && showTabs ? (
-          <div
-            className="flex h-10 shrink-0 items-end gap-2 border-b border-border-2 px-3 pb-1"
-            data-testid="github-pr-detail-skeleton-tabs"
-          >
-            <SkeletonBar className="h-7 w-28 rounded-md" />
-            <SkeletonBar className="h-7 w-20 rounded-md" />
-            <SkeletonBar className="h-7 w-20 rounded-md" />
-            <SkeletonBar className="h-7 w-28 rounded-md" />
-          </div>
-        ) : null}
+        {kind === "pr" && showTabs
+          ? (tabs ?? <GitHubPrDetailTabs activeTab={activeTab} />)
+          : null}
 
-        <div className="flex min-h-0 flex-1 overflow-hidden">
-          <div className="scrollbar-overlay min-h-0 min-w-0 flex-1 overflow-y-auto">
-            <div className="mx-auto flex w-full max-w-[920px] animate-pulse flex-col gap-3 px-5 py-5 motion-reduce:animate-none">
+        <div
+          aria-busy="true"
+          aria-label={t("status.loading")}
+          className="flex min-h-0 flex-1 overflow-hidden"
+        >
+          <div
+            role={kind === "pr" ? "tabpanel" : undefined}
+            id={kind === "pr" ? `pr-detail-tabpanel-${activeTab}` : undefined}
+            aria-labelledby={
+              kind === "pr" ? `pr-detail-tab-${activeTab}` : undefined
+            }
+            className="scrollbar-overlay min-h-0 min-w-0 flex-1 overflow-y-auto"
+          >
+            <div className="mx-auto flex w-full max-w-[920px] flex-col gap-3 px-5 py-5">
               {kind === "issue" ? (
                 <div className="flex flex-wrap items-center gap-2">
                   <SkeletonBar className="h-7 w-20 rounded-full" />
@@ -61,7 +108,18 @@ const GitHubDetailSkeleton: React.FC<GitHubDetailSkeletonProps> = memo(
                 </div>
               ) : (
                 <div className="flex flex-col gap-3 px-1 py-2">
-                  <SkeletonBar className="h-6 w-full max-w-96" />
+                  {title ? (
+                    <h2 className="min-w-0 select-text text-[20px] font-semibold leading-7 text-text-1">
+                      {title}{" "}
+                      {number !== undefined ? (
+                        <span className="whitespace-nowrap font-normal text-text-3">
+                          #{number}
+                        </span>
+                      ) : null}
+                    </h2>
+                  ) : (
+                    <SkeletonBar className="h-6 w-full max-w-96" />
+                  )}
                   <div className="flex flex-wrap items-center gap-2">
                     <SkeletonBar className="h-6 w-20 rounded-full" />
                     <SkeletonBar className="h-4 w-full max-w-72" />
@@ -106,6 +164,33 @@ const GitHubDetailSkeleton: React.FC<GitHubDetailSkeletonProps> = memo(
                 </div>
               </section>
             </div>
+          </div>
+          <div
+            className={`box-border flex h-full shrink-0 flex-col ${WORKSTATION_TRAIL_RAIL_PADDING_CLASS}`}
+            style={{ width: WORKSTATION_TRAIL_WIDTH.expandedPx }}
+            data-testid={`github-${kind}-detail-skeleton-sidebar`}
+          >
+            <WorkstationTrailSurface className="flex self-start">
+              {kind === "issue" ? (
+                <WorkstationTrailHeader
+                  title={t(
+                    "projects:workItems.properties.title",
+                    "Work Item Properties"
+                  )}
+                />
+              ) : null}
+              <WorkstationTrailBody
+                className={`${WORKSTATION_TRAIL_CONTENT.sectionList} py-1`}
+              >
+                {sidebarSections.map((label) => (
+                  <WorkstationTrailSection key={label} title={label}>
+                    <div className="px-2 py-1">
+                      <SkeletonBar className="h-5 w-24" />
+                    </div>
+                  </WorkstationTrailSection>
+                ))}
+              </WorkstationTrailBody>
+            </WorkstationTrailSurface>
           </div>
         </div>
       </div>

--- a/src/modules/shared/components/GitHubPrDetailTabs.tsx
+++ b/src/modules/shared/components/GitHubPrDetailTabs.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  FileDiffIcon,
+  GitCommitHorizontalIcon,
+  HugeiconsIcon,
+  ListChecksIcon,
+  MessageMultiple01Icon,
+} from "@src/icons";
+import DetailTabStrip from "@src/modules/shared/layouts/blocks/DetailTabStrip";
+import type { PrDetailTab } from "@src/store/workstation/codeEditor/workstationSelectedPrAtom";
+
+interface GitHubPrDetailTabsProps {
+  activeTab?: PrDetailTab;
+  counts?: Partial<Record<PrDetailTab, number | string>>;
+  onChange?: (tab: PrDetailTab) => void;
+  trailing?: ReactNode;
+  variant?: "row" | "header";
+}
+
+/** Keep the same labels and geometry during chunk loading and data loading. */
+export default function GitHubPrDetailTabs({
+  activeTab = "conversation",
+  counts,
+  onChange,
+  trailing,
+  variant,
+}: GitHubPrDetailTabsProps) {
+  const { t } = useTranslation("common");
+  const tabs = [
+    {
+      key: "conversation" as const,
+      label: t("git.pr.tabs.conversation", "Conversation"),
+      icon: MessageMultiple01Icon,
+      iconName: "messages-square",
+    },
+    {
+      key: "commits" as const,
+      label: t("git.pr.tabs.commits", "Commits"),
+      icon: GitCommitHorizontalIcon,
+      iconName: "git-commit-horizontal",
+    },
+    {
+      key: "checks" as const,
+      label: t("git.pr.tabs.checks", "Checks"),
+      icon: ListChecksIcon,
+      iconName: "list-checks",
+    },
+    {
+      key: "changes" as const,
+      label: t("git.pr.changes.title", "Files changed"),
+      icon: FileDiffIcon,
+      iconName: "file-diff",
+    },
+  ];
+
+  return (
+    <DetailTabStrip<PrDetailTab>
+      activeTab={activeTab}
+      ariaLabel={t("git.pr.summary.label", "Pull request summary")}
+      idPrefix="pr-detail"
+      tabs={tabs.map((tab) => ({
+        ...tab,
+        icon: (
+          <HugeiconsIcon
+            icon={tab.icon}
+            data-icon={tab.iconName}
+            size={15}
+            strokeWidth={1.8}
+          />
+        ),
+        count: counts?.[tab.key],
+        countLoading: counts?.[tab.key] === undefined,
+        disabled: !onChange,
+      }))}
+      onChange={(tab) => onChange?.(tab)}
+      trailing={trailing}
+      variant={variant}
+    />
+  );
+}

--- a/src/modules/shared/layouts/blocks/DetailTabStrip.tsx
+++ b/src/modules/shared/layouts/blocks/DetailTabStrip.tsx
@@ -5,6 +5,8 @@ export interface DetailTabStripItem<Key extends string = string> {
   label: string;
   icon?: ReactNode;
   count?: number | string;
+  /** Reserve the count badge while its value is being loaded. */
+  countLoading?: boolean;
   disabled?: boolean;
   dataTestId?: string;
 }
@@ -57,6 +59,7 @@ export default function DetailTabStrip<Key extends string>({
             id={`${idPrefix}-tab-${tab.key}`}
             aria-controls={`${idPrefix}-tabpanel-${tab.key}`}
             aria-selected={selected}
+            aria-busy={tab.countLoading || undefined}
             disabled={tab.disabled}
             data-testid={tab.dataTestId}
             className={`relative -mb-px flex shrink-0 items-center gap-1.5 rounded-t-md border px-3 py-1.5 text-[12px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
@@ -72,9 +75,15 @@ export default function DetailTabStrip<Key extends string>({
               </span>
             ) : null}
             <span>{tab.label}</span>
-            {tab.count !== undefined ? (
-              <span className="inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-fill-2 px-1.5 text-[10px] font-semibold tabular-nums text-text-2">
-                {tab.count}
+            {tab.countLoading || tab.count !== undefined ? (
+              <span
+                aria-hidden={tab.countLoading || undefined}
+                data-testid={
+                  tab.countLoading ? "detail-tab-count-skeleton" : undefined
+                }
+                className={`inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-fill-2 px-1.5 text-[10px] font-semibold tabular-nums text-text-2 ${tab.countLoading ? "animate-pulse motion-reduce:animate-none" : ""}`.trim()}
+              >
+                {tab.countLoading ? null : tab.count}
               </span>
             ) : null}
           </button>


### PR DESCRIPTION
## Problem

GitHub PR detail loading replaces known tab labels with blank placeholders, briefly shows zero counts before data arrives, and omits the properties rail. Inbox and Source Control also use generic lazy-chunk fallbacks, so the frame changes between selection, chunk loading, and detail hydration. Issue skeletons similarly omit their properties rail.

This is a presentation defect: existing selection identity and per-PR load state already provide the information needed to render stable chrome. No persisted or remote data is malformed.

## Solution

- Share PR labels, icons, and count rendering through `GitHubPrDetailTabs` and the existing `DetailTabStrip`; only unknown counts get placeholders.
- Keep the selected PR title/number and labeled PR/issue properties rail visible during loading, using the existing workstation rail primitives and width token.
- Render the shared skeleton during Inbox and Source Control lazy-chunk loading; preserve Inbox header actions and existing labels/icons.
- Connect data-loading tabs to the existing per-PR state, preserve selection through hydration, and retain cached counts during background refresh. Chunk-only navigation remains disabled until its controller loads.
- Cover panel-owned and header-owned tabs, first paint, loading/hydration, refresh, labels, counts, and properties-rail geometry with regression tests.

All ten changed files support this loading-frame change. Unrelated local icon/label, shadow, composer, and other workspace edits are excluded. There are no persistence, schema, dependency, public API/IPC, or loader changes; no historical-data cleanup is required.

## Potential risks

- The shared issue skeleton also gains a properties rail. Narrow-pane layout and light/dark themes have DOM/source coverage only; no native screenshots or recordings were captured because computer control was not requested.
- The optional count-loading behavior touches a shared tab primitive. Existing callers keep their behavior unless they opt in; existing tab tests pass.
- Pulse animation is applied to placeholder shapes and count badges with reduced-motion support. Native visible/hidden idle CPU, repeated open/close, focus-return behavior, and RSS were not measured. The performance review explicitly records this gap and makes no performance-improvement claim.
- Full application E2E and a production/native build were not run. Loader, cache, network, identity, and persistence implementations are unchanged. Rollback is a normal revert of this commit with no data recovery or migration required.

## Verification

Passed on the isolated branch based on the latest fetched `origin/develop`:

```sh
pnpm test -- GitHubDetailSkeleton/index.test.ts DetailTabStrip.test.ts PrDetailPanel.test.ts AssignedWorkItemDetail.test.ts TeamInboxView.layout.test.ts useWorkstationPrDetail.test.ts PrSidebar.test.ts
pnpm run typecheck
pnpm run check:test-placement
git diff --cached --name-only -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0 --report-unused-disable-directives
git diff --cached --name-only | xargs pnpm exec prettier --check
git diff --cached --check
```

Results: **55 tests passed across 7 files**, full TypeScript check passed, scoped ESLint/Prettier passed, and test placement passed across 435 directories. Vitest emitted existing Sass legacy-API deprecation warnings. A Python JSON walk verified all 182 reused translation-key values across the 13 locales. Source/diff inspection found no secrets, personal paths, debug logs, generated artifacts, or unrelated changes.

Native visual, theme/viewport, CPU/RSS, and rendered E2E checks were not run, as described above. Automated render coverage is DOM/SSR, not a claim of native visual verification.

## Audit

- Frontend UI: **0 fix, 7 keep with reason, 0 abstract**; report: `docs/frontend-ui-audit-2026-08-31/GitHubDetailLoading.md`.
- Architecture: reviewed layers 1–7 for compilation, shared tab extraction, canonical types, defaults, ownership, and naming; layer 9 for Inbox/Source Control/panel/header loading entry points; layer 10 for count/title fallback symmetry. Layer 8 and Rust/backend checks are intentionally inapplicable because no wire, persistence, or backend contract changes.
- Performance: source review found no new request, timer, listener, cache, or unbounded retained collection. **Performance verdict: blocked for runtime measurement only**, since native visible/hidden/focus-return/open-close CPU/RSS checks were not run. Ownership and lifecycle details: `docs/org2-performance-guard-2026-08-31/GitHubDetailLoading.md`.
