### PR TITLE
fix(dropdown): keep submenus reachable during pointer travel

### DIFF
--- a/docs/architecture-audit-2026-08-31/DropdownHoverGrace.md
+++ b/docs/architecture-audit-2026-08-31/DropdownHoverGrace.md
@@ -1,0 +1,41 @@
+# Dropdown hover grace architecture review
+
+## Acceptance criteria and ownership
+
+- A pointer can spend 300 ms between panels and still enter/click the third option.
+- Crossing an adjacent row briefly does not dismiss or switch the open submenu.
+- Intentional hover switching/dismissal completes after 350 ms; click/keyboard activation remains immediate.
+- There is at most one pending hover transition per menu tree, removed on re-entry, hide, disable/close, explicit activation, and unmount.
+- Existing click-open behavior and caller-provided hover delays remain intact.
+
+The authoritative source is transient component state, not persisted or remote data. ActionMenuSurface wrote `active = null` immediately from mouseleave and from sibling mouseover. Dropdown and WorkItemContextMenu used short independent leave timers (100/150 ms), and repeated leave events could overwrite the timer handle without canceling the prior callback. No historical data remediation is needed.
+
+`useMenuHoverGrace` owns one cancelable pointer transition. Consumers continue to own their visibility/active submenu state. ActionMenuSurface automatically supplies the fix to session-header and file-header menus without editing those consumers. Dropdown supplies it to all callers using its hover trigger; WorkItemContextMenu uses it at both submenu levels.
+
+## Layer coverage
+
+| Layer                     | Result                                                                                                                                                                                                                      |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1 Compilation             | Full `pnpm run typecheck --incremental --tsBuildInfoFile .git/.tsbuildinfo` passes in the clean PR checkout. Changed-file ESLint passes.                                                                                    |
+| 2 Ownership/deduplication | Two standalone timer implementations replaced by one production-used hook. No exported unused timing constant, parallel new dismissal engine, or changes to parent consumers.                                               |
+| 3 Naming                  | `schedule`/`cancel` describe pointer transition ownership; `setActive` remains immediate.                                                                                                                                   |
+| 4 Semantic overloading    | Hover transition and explicit activation have separate paths. Existing menu visibility remains authoritative.                                                                                                               |
+| 5 Defaults                | 350 ms is defined once. Undefined delay uses it; zero/nonpositive override remains immediate. Disabled/hidden owners cannot schedule work.                                                                                  |
+| 6 Boundaries              | Generic hook depends only on React and DOM; no feature-domain imports or persistence changes.                                                                                                                               |
+| 7 Readability             | Cleanup and deliberate pointer-vs-keyboard behavior are documented at the hook and menu event boundaries.                                                                                                                   |
+| 8 Wire protocol           | Not applicable: no IPC, API, serialization, or persisted format changes.                                                                                                                                                    |
+| 9 Entry parity            | DOM tests exercise actual ActionMenuSurface, inline/portaled Dropdown, and both WorkItemContextMenu submenu levels. Click-persistent sidebar/model/slash menus were inspected and retain their existing dismissal behavior. |
+| 10 Resolvers              | Not applicable: no multi-source configuration/data resolver.                                                                                                                                                                |
+
+## Verification
+
+- `pnpm test src/components/Dropdown src/hooks/dropdown/useMenuHoverGrace.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts` — 59 tests across 11 files pass, including 26 new behavior/lifecycle regressions.
+- `pnpm exec eslint src/hooks/dropdown/useMenuHoverGrace.ts src/hooks/dropdown/useMenuHoverGrace.test.ts src/components/Dropdown/ActionMenuSurface.tsx src/components/Dropdown/ActionMenuSurface.test.ts src/components/Dropdown/index.tsx src/components/Dropdown/index.hover.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/index.tsx src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts --max-warnings 0 --report-unused-disable-directives` — passes.
+- `pnpm run typecheck --incremental --tsBuildInfoFile .git/.tsbuildinfo` — passes in the clean PR checkout. The earlier failures in the mixed working tree belonged to unrelated untracked Input/Textarea tests; they are not included in this PR.
+- `git diff --check` — passes.
+- `pnpm run check:circular` — no circular dependencies across 6,335 modules.
+- `pnpm exec prettier --check` with the eight changed TypeScript/source-test paths from the ESLint command — passes.
+- `pnpm run check:test-placement` — passes across 437 directories.
+- Native Tauri pointer travel, physical hit-testing, and CPU/RSS measurement were not run; desktop UI control was not authorized. No measured runtime speedup is claimed.
+
+Risk: menus now wait 350 ms before pointer dismissal/switching. This improves a brief diagonal crossing but is not a geometric safe-polygon implementation and can still close if a user spends longer than the grace period outside both panels. Rollback is confined to the shared hover hook and its three consumers; no data or dependency migration is involved.

--- a/docs/architecture-audit-2026-08-31/DropdownHoverGrace.md
+++ b/docs/architecture-audit-2026-08-31/DropdownHoverGrace.md
@@ -29,6 +29,13 @@ The authoritative source is transient component state, not persisted or remote d
 
 ## Verification
 
+The initial CI run exposed two existing session-header tests that still expected immediate hover switching/dismissal. Both failures were reproduced locally. The consumer tests now use paired pointer events with `relatedTarget` and fake timers to verify the 349/350 ms boundary, bridge re-entry cancellation, one open submenu, and a stable direct app action row. No production behavior was changed for this CI follow-up.
+
+- `pnpm test src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts src/components/Dropdown src/hooks/dropdown/useMenuHoverGrace.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts` — 97 tests across 13 files pass, including both real shared-action-menu consumers.
+- `pnpm exec eslint src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts --max-warnings 0 --report-unused-disable-directives` — passes.
+- `node --test scripts/ci/*.test.cjs` — all 28 CI tooling tests pass.
+- `pnpm typecheck` — passes for the complete clean PR checkout after the consumer-test update.
+- `pnpm test` — the full frontend suite passes: 10,150 tests across 1,288 files, with no failed or skipped tests.
 - `pnpm test src/components/Dropdown src/hooks/dropdown/useMenuHoverGrace.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts` — 59 tests across 11 files pass, including 26 new behavior/lifecycle regressions.
 - `pnpm exec eslint src/hooks/dropdown/useMenuHoverGrace.ts src/hooks/dropdown/useMenuHoverGrace.test.ts src/components/Dropdown/ActionMenuSurface.tsx src/components/Dropdown/ActionMenuSurface.test.ts src/components/Dropdown/index.tsx src/components/Dropdown/index.hover.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/index.tsx src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts --max-warnings 0 --report-unused-disable-directives` — passes.
 - `pnpm run typecheck --incremental --tsBuildInfoFile .git/.tsbuildinfo` — passes in the clean PR checkout. The earlier failures in the mixed working tree belonged to unrelated untracked Input/Textarea tests; they are not included in this PR.

--- a/docs/frontend-ui-audit-2026-08-31/DropdownHoverGrace.md
+++ b/docs/frontend-ui-audit-2026-08-31/DropdownHoverGrace.md
@@ -1,0 +1,16 @@
+# Dropdown hover grace UI audit
+
+Scope: shared action-menu flyouts, hover-triggered Dropdown, and both submenu levels of WorkItemContextMenu. The user requested easier access to lower submenu options across dropdowns. The change is interaction-only; no typography, colors, dimensions, positioning, or settings copy changed.
+
+| Line                                                                                | Element                             | Verdict          | Reason                                                                                                                                                                                            | Suggested change |
+| ----------------------------------------------------------------------------------- | ----------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/components/Dropdown/ActionMenuSurface.tsx:215`                                 | Submenu trigger                     | keep with reason | Uses DropdownItem with menuitem, haspopup, expanded, and keyboard activation semantics. Immediate click/key activation is retained while pointer-only switching gets a short grace period.        | None.            |
+| `src/components/Dropdown/ActionMenuSurface.tsx:238`                                 | Fixed flyout and gap padding        | keep with reason | Fixed placement avoids clipping, the existing panel and width tokens remain authoritative, and re-entry cancels dismissal without adding invisible hit targets over neighboring actions.          | None.            |
+| `src/components/Dropdown/index.tsx:195`                                             | Shared hover trigger/panel behavior | keep with reason | One shared timer owner handles inline and portaled menus; caller-supplied zero/custom delay and click-open behavior are preserved. No new visual constants or config-level style sweep is needed. | None.            |
+| `src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/index.tsx:318` | Context-menu surfaces and rows      | keep with reason | Existing token-based panel/row styling and native button keyboard behavior stay unchanged. Both nested levels share the same grace/cancellation policy rather than independent leave timers.      | None.            |
+
+Verdict totals: **0 fix**, **4 keep with reason**, **0 abstract**.
+
+No additional systematic UI sweep was identified. Other inspected click-persistent sidebar, model, and slash-command panels do not close on leaving their panel, so their dismissal policies were not changed. This does not claim every bespoke submenu uses the new sibling-switch delay.
+
+Visual evidence: no screenshots produced. Appearance is unchanged, and desktop UI control requires explicit user opt-in. DOM interaction regressions cover crossing the gap to the third option, adjacent-row traversal, keyboard focus, immediate clicks, and nested portal re-entry; real Tauri hit-testing and pointer feel remain unverified.

--- a/docs/org2-performance-guard-2026-08-31/DropdownHoverGrace.md
+++ b/docs/org2-performance-guard-2026-08-31/DropdownHoverGrace.md
@@ -1,0 +1,31 @@
+# Dropdown hover grace performance guard
+
+| Area               | Verdict | Evidence                                                                                                                                   | Change or reason kept                                                                                                                                   | Verification                                                                                                                                                            |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Background work    | fix     | Dropdown/WorkItemContextMenu could replace a timeout handle without first clearing the old timer; ActionMenuSurface dismissed immediately. | One replaceable 350 ms timeout; cancel before rescheduling and before explicit activation. Visibility listener exists only during that pending timeout. | Hook tests assert at most one timer, listener removal, and no stale transition after cancel/close/hide/unmount. Component regressions exercise repeated leave/re-entry. |
+| Memory             | keep    | Only a timeout handle, one listener cleanup, and its pending transition closure are retained per active owner.                             | No app-global cache, list, scan, interval, or pointermove listener introduced.                                                                          | Twenty open/close cycles return timer count to zero every time; listener removal is asserted.                                                                           |
+| Scope/isolation    | keep    | All state belongs to a mounted menu tree; no org/session/identity keys or backend state.                                                   | No cross-instance or cross-account resources. Closed/disabled/hidden owners do not schedule work.                                                       | Disabled/hidden/closed/unmounted cases covered in hook and controlled Dropdown tests.                                                                                   |
+| Rendering/hot path | keep    | Existing enter/leave events request a transition; actual state writes happen on opening or on an intentional settled transition.           | No continuous pointer tracking, polling, extra positioning loop, or React state per mousemove. Existing layout and keyboard owners remain intact.       | Actual menu DOM tests pass for third-option selection, adjacent rows, nested portals, and immediate keyboard/click activation. CPU/RSS were not measured.               |
+
+## Lifecycle matrix
+
+| State                                                          | Expected and observed                                                                                             |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Mounted and idle / no submenu open                             | No hover timer or visibility listener; unit-tested.                                                               |
+| Pointer leaves / crosses sibling                               | At most one pending transition; re-schedule replaces the old transition; unit-tested.                             |
+| Pointer returns to trigger / enters child panel                | Pending transition canceled; panel remains open beyond its former deadline; tested in the three real menu owners. |
+| Intentional leave / hover a different row                      | Transition runs once after grace; timer and listener are released; tested.                                        |
+| Hidden / focus return                                          | Pending work is discarded immediately and is not replayed on return; unit-tested.                                 |
+| Controlled close / disabled / unmount                          | Pending work is removed; no late visibility callback; unit-tested.                                                |
+| Repeated open/close                                            | Twenty cycles retain no timer; unit-tested.                                                                       |
+| Network, provider, transport, org, session, secondary instance | Not applicable: local transient pointer state only, no transport or shared resource changes.                      |
+| Real visible/hidden Tauri CPU/RSS and physical pointer motion  | Not run. Desktop UI control is explicit opt-in and was not requested.                                             |
+
+## Verification
+
+- Targeted Vitest command recorded in `docs/architecture-audit-2026-08-31/DropdownHoverGrace.md`: 59 passing tests, 26 added for this change.
+- Exact changed-file ESLint command in that report passes; `git diff --check` passes.
+- Full `pnpm run typecheck --incremental --tsBuildInfoFile .git/.tsbuildinfo` passes in the clean PR checkout. Unrelated Input/Textarea work from the original workspace is not included.
+- No runtime performance improvement is inferred from typecheck or source shape. Deterministic resource-lifecycle assertions passed; native pointer/CPU/RSS verification remains absent.
+
+Performance verdict: blocked — automated lifecycle invariants and compilation pass, but real Tauri pointer/CPU/RSS verification was not run. This is a verification limitation, not a request to change desktop-control permissions.

--- a/src/components/Dropdown/ActionMenuSurface.test.ts
+++ b/src/components/Dropdown/ActionMenuSurface.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import React, { act, createRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ActionMenuSurface, ActionSubmenu } from "./ActionMenuSurface";
+
+describe("ActionMenuSurface hover navigation", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let panelRef: React.RefObject<HTMLDivElement | null>;
+  const selectThird = vi.fn();
+  const onClose = vi.fn();
+
+  function Menu() {
+    const controlsProps: React.ComponentProps<typeof ActionSubmenu> = {
+      label: "UI controls",
+      icon: null,
+      dataTestId: "controls",
+      children: [1, 2, 3].map((number) =>
+        React.createElement(
+          "button",
+          { key: number, onClick: number === 3 ? selectThird : undefined },
+          `Option ${number}`
+        )
+      ),
+    };
+    const otherProps: React.ComponentProps<typeof ActionSubmenu> = {
+      label: "Other group",
+      icon: null,
+      dataTestId: "other-group",
+      children: React.createElement("button", null, "Another option"),
+    };
+    return React.createElement(
+      ActionMenuSurface,
+      { panelRef, onClose },
+      React.createElement(ActionSubmenu, controlsProps),
+      React.createElement(
+        "button",
+        { "data-testid": "sibling" },
+        "Other action"
+      ),
+      React.createElement(ActionSubmenu, otherProps)
+    );
+  }
+
+  function element(selector: string) {
+    const result = container.querySelector<HTMLElement>(selector);
+    expect(result, selector).not.toBeNull();
+    return result!;
+  }
+
+  function move(from: Element | null, to: Element) {
+    act(() => {
+      from?.dispatchEvent(
+        new MouseEvent("mouseout", { bubbles: true, relatedTarget: to })
+      );
+      to.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true, relatedTarget: from })
+      );
+    });
+  }
+
+  function advance(milliseconds: number) {
+    act(() => vi.advanceTimersByTime(milliseconds));
+  }
+
+  const isOpen = () =>
+    container.querySelector('[data-testid="controls-panel"]') !== null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    selectThird.mockClear();
+    onClose.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    panelRef = createRef<HTMLDivElement>();
+    act(() => root.render(React.createElement(Menu)));
+    move(null, element('[data-testid="controls"]'));
+    expect(isOpen()).toBe(true);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    expect(vi.getTimerCount()).toBe(0);
+    container.remove();
+    vi.useRealTimers();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("lets the pointer cross empty space and select the third option", () => {
+    const trigger = element('[data-testid="controls"]');
+    move(trigger, document.body);
+    advance(300);
+    expect(isOpen()).toBe(true);
+    const third = element('[data-testid="controls-panel"] button:nth-child(3)');
+    move(document.body, third);
+    advance(1000);
+    expect(isOpen()).toBe(true);
+    act(() => third.click());
+    expect(selectThird).toHaveBeenCalledOnce();
+  });
+
+  it.each(["sibling", "other-group"])(
+    "keeps the current submenu while crossing %s diagonally",
+    (testId) => {
+      const crossed = element(`[data-testid="${testId}"]`);
+      move(element('[data-testid="controls"]'), crossed);
+      advance(150);
+      expect(isOpen()).toBe(true);
+      move(
+        crossed,
+        element('[data-testid="controls-panel"] button:nth-child(3)')
+      );
+      advance(1000);
+      expect(isOpen()).toBe(true);
+      expect(
+        container.querySelector('[data-testid="other-group-panel"]')
+      ).toBeNull();
+    }
+  );
+
+  it("switches submenus after an intentional hover on another group", () => {
+    move(
+      element('[data-testid="controls"]'),
+      element('[data-testid="other-group"]')
+    );
+    advance(400);
+    expect(isOpen()).toBe(false);
+    expect(
+      container.querySelector('[data-testid="other-group-panel"]')
+    ).not.toBeNull();
+  });
+
+  it("closes after leaving, but re-entry cancels the pending close", () => {
+    move(element('[data-testid="controls"]'), document.body);
+    advance(200);
+    move(document.body, element('[data-testid="controls"]'));
+    advance(1000);
+    expect(isOpen()).toBe(true);
+    move(element('[data-testid="controls"]'), document.body);
+    advance(400);
+    expect(isOpen()).toBe(false);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("lets a click override a pending hover switch immediately", () => {
+    const other = element('[data-testid="other-group"]');
+    move(element('[data-testid="controls"]'), other);
+    act(() => other.click());
+    expect(
+      container.querySelector('[data-testid="other-group-panel"]')
+    ).not.toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps keyboard navigation immediate and discards stale hover intent", () => {
+    move(
+      element('[data-testid="controls"]'),
+      element('[data-testid="other-group"]')
+    );
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "End", bubbles: true })
+      )
+    );
+    expect(document.activeElement?.textContent).toBe("Option 3");
+    advance(1000);
+    expect(isOpen()).toBe(true);
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      )
+    );
+    expect(isOpen()).toBe(false);
+    expect(document.activeElement).toBe(element('[data-testid="controls"]'));
+    // jsdom schedules a selectionchange task when focus returns to the row.
+    advance(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/components/Dropdown/ActionMenuSurface.tsx
+++ b/src/components/Dropdown/ActionMenuSurface.tsx
@@ -1,5 +1,6 @@
 import React, {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useId,
@@ -15,11 +16,14 @@ import {
   DROPDOWN_PANEL,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
+import { useMenuHoverGrace } from "@src/hooks/dropdown/useMenuHoverGrace";
 import { ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
 
 const SubmenuContext = createContext<{
   active: string | null;
   setActive: (id: string | null) => void;
+  hoverSubmenu: (id: string) => void;
+  cancelHover: () => void;
 } | null>(null);
 
 const ACTION_SELECTOR =
@@ -35,7 +39,24 @@ export function ActionMenuSurface({
   panelRef: React.RefObject<HTMLDivElement | null>;
   onClose: () => void;
 }) {
-  const [active, setActive] = useState<string | null>(null);
+  const [active, setActiveId] = useState<string | null>(null);
+  const { cancel: cancelHover, schedule: scheduleHover } = useMenuHoverGrace(
+    active !== null
+  );
+  const setActive = useCallback(
+    (id: string | null) => {
+      cancelHover();
+      setActiveId(id);
+    },
+    [cancelHover]
+  );
+  const hoverSubmenu = (id: string) => {
+    if (active !== null && active !== id) {
+      scheduleHover(() => setActive(id));
+    } else {
+      setActive(id);
+    }
+  };
 
   useEffect(() => {
     const panel = panelRef.current;
@@ -43,6 +64,7 @@ export function ActionMenuSurface({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.isComposing || event.metaKey || event.ctrlKey || event.altKey)
         return;
+      cancelHover();
       const submenu = panel.querySelector<HTMLElement>(
         '[data-action-menu-submenu="true"]'
       );
@@ -103,26 +125,30 @@ export function ActionMenuSurface({
     };
     document.addEventListener("keydown", handleKeyDown, true);
     return () => document.removeEventListener("keydown", handleKeyDown, true);
-  }, [onClose, panelRef]);
+  }, [cancelHover, onClose, panelRef, setActive]);
 
   return (
-    <SubmenuContext.Provider value={{ active, setActive }}>
+    <SubmenuContext.Provider
+      value={{ active, setActive, hoverSubmenu, cancelHover }}
+    >
       <div
         {...props}
         ref={panelRef}
         role="menu"
+        onMouseEnter={cancelHover}
+        onPointerDownCapture={cancelHover}
         onMouseOver={(event) => {
           if (!(event.target instanceof Element)) return;
-          // Keep the flyout open while crossing the parent's padding into
-          // its hover bridge. Only another action row dismisses the group.
+          // Crossing another row on a diagonal must not immediately dismiss
+          // the flyout. Entering it cancels this pending hover transition.
           if (
             event.target.closest(ACTION_SELECTOR) &&
             !event.target.closest("[data-action-menu-group]")
           ) {
-            setActive(null);
+            scheduleHover(() => setActive(null));
           }
         }}
-        onMouseLeave={() => setActive(null)}
+        onMouseLeave={() => scheduleHover(() => setActive(null))}
       >
         {children}
       </div>
@@ -147,7 +173,7 @@ export function ActionSubmenu({
   const id = useId();
   const context = useContext(SubmenuContext);
   if (!context) throw new Error("ActionSubmenu requires an ActionMenuSurface");
-  const { active, setActive } = context;
+  const { active, setActive, hoverSubmenu, cancelHover } = context;
   const open = active === id;
   const rowRef = useRef<HTMLDivElement>(null);
   const flyoutRef = useRef<HTMLDivElement>(null);
@@ -196,7 +222,7 @@ export function ActionSubmenu({
         ariaExpanded={open}
         dataTestId={dataTestId}
         onMouseEnter={() => {
-          if (!disabled) setActive(id);
+          if (!disabled) hoverSubmenu(id);
         }}
         onClick={() => setActive(id)}
         suffix={
@@ -213,6 +239,7 @@ export function ActionSubmenu({
           ref={flyoutRef}
           className="fixed"
           style={{ paddingRight: DROPDOWN_PANEL.submenuGap }}
+          onMouseEnter={cancelHover}
         >
           <div
             ref={panelRef}

--- a/src/components/Dropdown/index.hover.test.ts
+++ b/src/components/Dropdown/index.hover.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Dropdown from ".";
+
+describe("Dropdown hover grace", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const onVisibleChange = vi.fn();
+  const onSelect = vi.fn();
+
+  function render(
+    overrides: Partial<React.ComponentProps<typeof Dropdown>> = {}
+  ) {
+    const props: React.ComponentProps<typeof Dropdown> = {
+      trigger: "hover",
+      onVisibleChange,
+      children: React.createElement("button", null, "Open"),
+      droplist: React.createElement(
+        "button",
+        { "data-testid": "option", onClick: onSelect },
+        "Third option"
+      ),
+      ...overrides,
+    };
+    act(() => root.render(React.createElement(Dropdown, props)));
+    act(() => vi.runAllTicks());
+  }
+  function move(from: Element | null, to: Element) {
+    act(() => {
+      from?.dispatchEvent(
+        new MouseEvent("mouseout", { bubbles: true, relatedTarget: to })
+      );
+      to.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true, relatedTarget: from })
+      );
+    });
+    act(() => vi.runAllTicks());
+  }
+  function advance(milliseconds: number) {
+    act(() => vi.advanceTimersByTime(milliseconds));
+    act(() => vi.runAllTicks());
+  }
+  function trigger() {
+    return container.querySelector(".dropdown-trigger-wrapper")!;
+  }
+  const option = () =>
+    document.querySelector<HTMLElement>('[data-testid="option"]');
+
+  beforeEach(() => {
+    // Dropdown's position effect uses queueMicrotask as well as animation
+    // frames; flush both inside act instead of leaving real microtasks behind.
+    vi.useFakeTimers({
+      toFake: [
+        "setTimeout",
+        "clearTimeout",
+        "requestAnimationFrame",
+        "cancelAnimationFrame",
+        "queueMicrotask",
+      ],
+    });
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    onVisibleChange.mockClear();
+    onSelect.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it.each([false, true])(
+    "allows reaching an option across the gap (portal: %s)",
+    (portal) => {
+      render(portal ? { getPopupContainer: () => document.body } : {});
+      move(null, trigger());
+      move(trigger(), document.body);
+      advance(300);
+      expect(option()).not.toBeNull();
+      move(document.body, option()!);
+      advance(1000);
+      expect(option()).not.toBeNull();
+      act(() => option()!.click());
+      expect(onSelect).toHaveBeenCalledOnce();
+      move(option(), document.body);
+      advance(400);
+      expect(option()).toBeNull();
+    }
+  );
+
+  it("replaces repeated leave timers so re-entry cannot close from a stale timer", () => {
+    render({ getPopupContainer: () => document.body });
+    move(null, trigger());
+    move(trigger(), document.body);
+    advance(100);
+    // A second leave event can precede the panel's enter across portal roots.
+    move(trigger(), document.body);
+    advance(100);
+    move(document.body, option()!);
+    advance(1000);
+    expect(option()).not.toBeNull();
+    expect(onVisibleChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("preserves the caller's immediate-close override", () => {
+    render({ hoverCloseDelayMs: 0 });
+    move(null, trigger());
+    move(trigger(), document.body);
+    expect(option()).toBeNull();
+  });
+
+  it("discards pending hover dismissal when a controlled menu closes", () => {
+    render({ popupVisible: true });
+    move(null, trigger());
+    move(trigger(), document.body);
+    render({ popupVisible: false });
+    onVisibleChange.mockClear();
+    advance(1000);
+    expect(onVisibleChange).not.toHaveBeenCalled();
+  });
+
+  it("leaves click-open menus open when the pointer leaves", () => {
+    render({ trigger: "click", defaultPopupVisible: true });
+    move(null, option()!);
+    move(option(), document.body);
+    advance(1000);
+    expect(option()).not.toBeNull();
+  });
+});

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -36,6 +36,7 @@ import React, {
 } from "react";
 
 import { useDropdownAutoKeyboard } from "@src/hooks/dropdown";
+import { useMenuHoverGrace } from "@src/hooks/dropdown/useMenuHoverGrace";
 import { useOverlayLayer } from "@src/store/ui/overlayLayerAtom";
 
 import DropdownMenuSurface from "./DropdownMenuSurface";
@@ -79,7 +80,7 @@ export interface DropdownProps {
   /** @default 'click' */
   trigger?: "click" | "hover";
 
-  /** Hover close delay in milliseconds. */
+  /** Hover close delay in milliseconds (default 350). Set 0 for immediate close. */
   hoverCloseDelayMs?: number;
 
   /** Controlled visible state */
@@ -150,7 +151,7 @@ const Dropdown: React.FC<DropdownProps> = ({
   children,
   position = "bottom-end",
   trigger = "click",
-  hoverCloseDelayMs = 100,
+  hoverCloseDelayMs,
   popupVisible: controlledVisible,
   defaultPopupVisible = false,
   onVisibleChange,
@@ -186,23 +187,27 @@ const Dropdown: React.FC<DropdownProps> = ({
   });
   const triggerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const positionFrameRef = useRef<number | null>(null);
 
   const isControlled = controlledVisible !== undefined;
   const visible = isControlled ? controlledVisible : internalVisible;
+  const { cancel: cancelHover, schedule: scheduleHover } = useMenuHoverGrace(
+    visible && trigger === "hover" && !disabled,
+    hoverCloseDelayMs
+  );
 
   useOverlayLayer(visible);
 
   const setVisible = useCallback(
     (newVisible: boolean) => {
+      if (!newVisible) cancelHover();
       if (!isControlled) {
         setInternalVisible(newVisible);
       }
       onVisibleChange?.(newVisible);
     },
-    [isControlled, onVisibleChange]
+    [cancelHover, isControlled, onVisibleChange]
   );
 
   // Droplist mode parity with `useDropdownEngine`: discover button rows in
@@ -301,28 +306,16 @@ const Dropdown: React.FC<DropdownProps> = ({
 
   const handleMouseEnter = useCallback(() => {
     if (trigger === "hover" && !disabled) {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      cancelHover();
       setVisible(true);
     }
-  }, [trigger, disabled, setVisible]);
+  }, [trigger, disabled, setVisible, cancelHover]);
 
   const handleMouseLeave = useCallback(() => {
     if (trigger !== "hover") return;
 
-    if (hoverCloseDelayMs <= 0) {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      setVisible(false);
-      return;
-    }
-
-    timeoutRef.current = setTimeout(() => setVisible(false), hoverCloseDelayMs);
-  }, [trigger, hoverCloseDelayMs, setVisible]);
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    };
-  }, []);
+    scheduleHover(() => setVisible(false));
+  }, [trigger, scheduleHover, setVisible]);
 
   const updatePosition = useCallback(() => {
     const triggerElement = triggerRef.current;

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts
@@ -102,6 +102,17 @@ function click(testId: string) {
   act(() => element(testId).click());
 }
 
+function movePointer(from: HTMLElement | null, to: HTMLElement) {
+  act(() => {
+    from?.dispatchEvent(
+      new MouseEvent("mouseout", { bubbles: true, relatedTarget: to })
+    );
+    to.dispatchEvent(
+      new MouseEvent("mouseover", { bubbles: true, relatedTarget: from })
+    );
+  });
+}
+
 function submenuIds(): (string | null)[] {
   return [
     ...props.headerActionsDropdownRef.current!.querySelectorAll(
@@ -464,39 +475,45 @@ describe("SessionHeaderActionsMenu", () => {
     ).toBeNull();
   });
 
-  it("opens one submenu at a time on hover and keeps it open through its bridge", () => {
+  it("preserves the hover grace through the bridge and switches one submenu at a time", () => {
+    vi.useFakeTimers();
     render({ showCloudShareSettings: true });
-    act(() =>
-      element("session-copy-submenu").dispatchEvent(
-        new MouseEvent("mouseover", { bubbles: true })
-      )
-    );
+    const copy = element("session-copy-submenu");
+    const move = element("session-move-submenu");
+    const parent = props.headerActionsDropdownRef.current!;
+    movePointer(null, copy);
     const flyout = element("session-copy-submenu-panel").parentElement!;
     click("session-copy-submenu");
-    act(() =>
-      props.headerActionsDropdownRef.current!.dispatchEvent(
-        new MouseEvent("mouseover", { bubbles: true })
-      )
-    );
+    movePointer(copy, parent);
     element("session-copy-submenu-panel");
-    act(() =>
-      flyout.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
-    );
+    movePointer(parent, flyout);
     element("session-copy-submenu-panel");
-    act(() =>
-      element("session-move-submenu").dispatchEvent(
-        new MouseEvent("mouseover", { bubbles: true })
-      )
-    );
+    movePointer(flyout, move);
+    act(() => vi.advanceTimersByTime(349));
+    element("session-copy-submenu-panel");
+    expect(
+      document.querySelectorAll("[data-action-menu-submenu]")
+    ).toHaveLength(1);
+    // Reaching the flyout bridge cancels the pending sibling switch.
+    movePointer(move, flyout);
+    act(() => vi.advanceTimersByTime(350));
+    element("session-copy-submenu-panel");
+    expect(
+      document.querySelector('[data-testid="session-move-submenu-panel"]')
+    ).toBeNull();
+
+    movePointer(flyout, move);
+    act(() => vi.advanceTimersByTime(349));
+    element("session-copy-submenu-panel");
+    act(() => vi.advanceTimersByTime(1));
     element("session-move-submenu-panel");
     expect(
       document.querySelector('[data-testid="session-copy-submenu-panel"]')
     ).toBeNull();
-    act(() =>
-      element("cloud-session-share-settings-button").dispatchEvent(
-        new MouseEvent("mouseover", { bubbles: true })
-      )
-    );
+    movePointer(move, element("cloud-session-share-settings-button"));
+    act(() => vi.advanceTimersByTime(349));
+    element("session-move-submenu-panel");
+    act(() => vi.advanceTimersByTime(1));
     expect(document.querySelector("[data-action-menu-submenu]")).toBeNull();
   });
 
@@ -779,6 +796,7 @@ describe("SessionHeaderActionsMenu native app action", () => {
   });
 
   it("keeps the direct app row mounted while switching the remaining flyouts", async () => {
+    vi.useFakeTimers();
     mocks.appOpenPlan.mockResolvedValue(appPlan());
     await act(async () => render({ currentSessionId: "claudecodeapp-a" }));
     const row = element("session-open-in-app-menu-item");
@@ -796,10 +814,13 @@ describe("SessionHeaderActionsMenu native app action", () => {
       expect(element(`${testId}-panel`)).toBeDefined();
       expect(element("session-open-in-app-menu-item")).toBe(row);
     }
-    act(() =>
-      row.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
-    );
+    movePointer(element("session-move-submenu"), row);
+    act(() => vi.advanceTimersByTime(349));
+    element("session-move-submenu-panel");
+    expect(element("session-open-in-app-menu-item")).toBe(row);
+    act(() => vi.advanceTimersByTime(1));
     expect(document.querySelector("[data-action-menu-submenu]")).toBeNull();
+    expect(element("session-open-in-app-menu-item")).toBe(row);
     expect(mocks.appOpenPlan).toHaveBeenCalledOnce();
     expect(mocks.openInApp).not.toHaveBeenCalled();
     expect(props.toggleHeaderActionsMenu).not.toHaveBeenCalled();

--- a/src/hooks/dropdown/useMenuHoverGrace.test.ts
+++ b/src/hooks/dropdown/useMenuHoverGrace.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import React, { act, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMenuHoverGrace } from "./useMenuHoverGrace";
+
+describe("useMenuHoverGrace lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let hover: ReturnType<typeof useMenuHoverGrace>;
+  let unmounted: boolean;
+
+  function Harness({
+    enabled,
+    delayMs,
+  }: {
+    enabled: boolean;
+    delayMs?: number;
+  }) {
+    const value = useMenuHoverGrace(enabled, delayMs);
+    useEffect(() => {
+      hover = value;
+    }, [value]);
+    return null;
+  }
+  function render(enabled = true, delayMs?: number) {
+    act(() => root.render(React.createElement(Harness, { enabled, delayMs })));
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    root = createRoot(container);
+    unmounted = false;
+    render();
+  });
+
+  afterEach(() => {
+    if (!unmounted) act(() => root.unmount());
+    expect(vi.getTimerCount()).toBe(0);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("retains only the latest transition and leaves no timer or listener afterward", () => {
+    const first = vi.fn();
+    const latest = vi.fn();
+    const add = vi.spyOn(document, "addEventListener");
+    const remove = vi.spyOn(document, "removeEventListener");
+    hover.schedule(first);
+    vi.advanceTimersByTime(100);
+    hover.schedule(latest);
+    expect(vi.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(300);
+    expect(first).not.toHaveBeenCalled();
+    expect(latest).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(50);
+    expect(latest).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+    for (const [type, listener] of add.mock.calls) {
+      expect(remove).toHaveBeenCalledWith(type, listener);
+    }
+  });
+
+  it.each(["cancel", "disable", "unmount", "hide"])(
+    "discards pending work on %s, including after focus return",
+    (reason) => {
+      const transition = vi.fn();
+      const remove = vi.spyOn(document, "removeEventListener");
+      hover.schedule(transition);
+      if (reason === "cancel") hover.cancel();
+      if (reason === "disable") render(false);
+      if (reason === "unmount") {
+        act(() => root.unmount());
+        unmounted = true;
+      }
+      if (reason === "hide") {
+        vi.spyOn(document, "hidden", "get").mockReturnValue(true);
+        document.dispatchEvent(new Event("visibilitychange"));
+      }
+      expect(vi.getTimerCount()).toBe(0);
+      expect(remove).toHaveBeenCalledWith(
+        "visibilitychange",
+        expect.any(Function)
+      );
+      vi.restoreAllMocks();
+      document.dispatchEvent(new Event("visibilitychange"));
+      vi.advanceTimersByTime(1000);
+      expect(transition).not.toHaveBeenCalled();
+    }
+  );
+
+  it("creates no background work while disabled, hidden, or idle", () => {
+    const transition = vi.fn();
+    const add = vi.spyOn(document, "addEventListener");
+    render(false);
+    hover.schedule(transition);
+    render(true);
+    vi.spyOn(document, "hidden", "get").mockReturnValue(true);
+    hover.schedule(transition);
+    vi.advanceTimersByTime(1000);
+    expect(transition).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit immediate-close behavior without a timer", () => {
+    render(true, 0);
+    const transition = vi.fn();
+    hover.schedule(transition);
+    expect(transition).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cleans up across repeated open/close cycles", () => {
+    const transition = vi.fn();
+    for (let cycle = 0; cycle < 20; cycle += 1) {
+      render(true);
+      hover.schedule(transition);
+      hover.schedule(transition);
+      expect(vi.getTimerCount()).toBe(1);
+      render(false);
+      expect(vi.getTimerCount()).toBe(0);
+    }
+    vi.advanceTimersByTime(1000);
+    expect(transition).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/dropdown/useMenuHoverGrace.ts
+++ b/src/hooks/dropdown/useMenuHoverGrace.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/** Time to cross a gap or an adjacent row on the way into a submenu. */
+const MENU_HOVER_GRACE_MS = 350;
+
+/** One replaceable hover transition; explicit clicks/keys should cancel it. */
+export function useMenuHoverGrace(
+  enabled: boolean,
+  delayMs = MENU_HOVER_GRACE_MS
+) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const visibilityCleanupRef = useRef<(() => void) | null>(null);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    visibilityCleanupRef.current?.();
+    visibilityCleanupRef.current = null;
+  }, []);
+
+  const schedule = useCallback(
+    (transition: () => void) => {
+      cancel();
+      if (!enabled || document.hidden) return;
+      if (delayMs <= 0) {
+        transition();
+        return;
+      }
+
+      // Nothing is subscribed while idle. Hiding the app discards pointer
+      // intent so a throttled timer cannot change a menu on focus return.
+      const onVisibilityChange = () => {
+        if (document.hidden) cancel();
+      };
+      document.addEventListener("visibilitychange", onVisibilityChange);
+      visibilityCleanupRef.current = () =>
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      timerRef.current = setTimeout(() => {
+        cancel();
+        transition();
+      }, delayMs);
+    },
+    [cancel, delayMs, enabled]
+  );
+
+  // Also discard a pending transition when a controlled menu closes,
+  // changes trigger mode, becomes disabled, or changes its delay.
+  useEffect(() => cancel, [cancel, delayMs, enabled]);
+
+  return { cancel, schedule };
+}

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ContextMenuItem } from "@src/types/core/shared";
+
+import WorkItemContextMenu from ".";
+
+describe("WorkItemContextMenu hover navigation", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const selectThird = vi.fn();
+  const onClose = vi.fn();
+  const items: ContextMenuItem[] = [
+    {
+      id: "group",
+      label: "Group",
+      submenu: [
+        {
+          id: "nested",
+          label: "Nested group",
+          submenu: [
+            { id: "nested-first", label: "Nested first" },
+            { id: "nested-second", label: "Nested second" },
+            { id: "nested-third", label: "Nested third", action: selectThird },
+          ],
+        },
+        { id: "second", label: "Second" },
+        { id: "third", label: "Third", action: selectThird },
+      ],
+    },
+    { id: "sibling", label: "Sibling" },
+  ];
+
+  function element(selector: string) {
+    const result = document.querySelector<HTMLElement>(selector);
+    expect(result, selector).not.toBeNull();
+    return result!;
+  }
+  function move(from: Element | null, to: Element) {
+    act(() => {
+      from?.dispatchEvent(
+        new MouseEvent("mouseout", { bubbles: true, relatedTarget: to })
+      );
+      to.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true, relatedTarget: from })
+      );
+    });
+  }
+  function advance(milliseconds: number) {
+    act(() => vi.advanceTimersByTime(milliseconds));
+  }
+  const panels = () =>
+    document.querySelectorAll(".work-item-context-menu--submenu");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    onClose.mockClear();
+    selectThird.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() =>
+      root.render(
+        React.createElement(WorkItemContextMenu, {
+          items,
+          position: { x: 200, y: 100 },
+          onClose,
+        })
+      )
+    );
+    move(null, element('[data-testid="context-menu-item-group"]'));
+    expect(panels()).toHaveLength(1);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    expect(vi.getTimerCount()).toBe(0);
+    container.remove();
+    vi.useRealTimers();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("allows crossing the gap to the third option in the portaled submenu", () => {
+    move(element('[data-testid="context-menu-item-group"]'), document.body);
+    advance(300);
+    expect(panels()).toHaveLength(1);
+    const third = panels()[0].querySelector<HTMLElement>(
+      "button:nth-child(3)"
+    )!;
+    move(document.body, third);
+    advance(1000);
+    expect(panels()).toHaveLength(1);
+    act(() => third.click());
+    expect(selectThird).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not close the submenu while crossing an adjacent parent row", () => {
+    const sibling = element('[data-testid="context-menu-item-sibling"]');
+    move(element('[data-testid="context-menu-item-group"]'), sibling);
+    advance(150);
+    expect(panels()).toHaveLength(1);
+    move(sibling, panels()[0].querySelector("button:nth-child(3)")!);
+    advance(1000);
+    expect(panels()).toHaveLength(1);
+  });
+
+  it("protects the same diagonal path into a third-level submenu", () => {
+    const nested = panels()[0].querySelector("button")!;
+    move(element('[data-testid="context-menu-item-group"]'), nested);
+    expect(panels()).toHaveLength(2);
+    const second = panels()[0].querySelector("button:nth-child(2)")!;
+    move(nested, second);
+    advance(150);
+    expect(panels()).toHaveLength(2);
+    move(second, document.body);
+    advance(200);
+    const third = panels()[1].querySelector<HTMLElement>(
+      "button:nth-child(3)"
+    )!;
+    move(document.body, third);
+    advance(1000);
+    expect(panels()).toHaveLength(2);
+    act(() => third.click());
+    expect(selectThird).toHaveBeenCalledOnce();
+  });
+
+  it("closes submenus after deliberately hovering another parent action", () => {
+    move(
+      element('[data-testid="context-menu-item-group"]'),
+      element('[data-testid="context-menu-item-sibling"]')
+    );
+    advance(400);
+    expect(panels()).toHaveLength(0);
+  });
+
+  it("replaces leave timers and cancels all pending closes on re-entry", () => {
+    const trigger = element('[data-testid="context-menu-item-group"]');
+    move(trigger, document.body);
+    advance(100);
+    move(trigger, document.body);
+    advance(100);
+    move(document.body, panels()[0]);
+    advance(1000);
+    expect(panels()).toHaveLength(1);
+    move(panels()[0], document.body);
+    advance(400);
+    expect(panels()).toHaveLength(0);
+  });
+});

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/index.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/index.tsx
@@ -17,6 +17,7 @@ import {
   KEYBOARD_SHORTCUT_VARIANT,
   KeyboardShortcut,
 } from "@src/components/KeyboardShortcut";
+import { useMenuHoverGrace } from "@src/hooks/dropdown/useMenuHoverGrace";
 import { ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
 import type { ContextMenuItem } from "@src/types/core/shared";
 import { getViewportSize } from "@src/util/ui/window/viewport";
@@ -49,7 +50,9 @@ const WorkItemContextMenu: React.FC<WorkItemContextMenuProps> = ({
   const [openSubmenu, setOpenSubmenu] = useState<SubmenuState | null>(null);
   const [openNestedSubmenu, setOpenNestedSubmenu] =
     useState<SubmenuState | null>(null);
-  const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { cancel: cancelHover, schedule: scheduleHover } = useMenuHoverGrace(
+    openSubmenu !== null
+  );
 
   useLayoutEffect(() => {
     if (!menuRef.current) return;
@@ -128,13 +131,14 @@ const WorkItemContextMenu: React.FC<WorkItemContextMenuProps> = ({
         !clickedInsideSubmenu &&
         !clickedInsideNestedSubmenu
       ) {
+        cancelHover();
         onClose();
       }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [onClose]);
+  }, [cancelHover, onClose]);
 
   const activeSubmenuItem = openSubmenu
     ? items.find((item) => item.id === openSubmenu.itemId)
@@ -156,6 +160,7 @@ const WorkItemContextMenu: React.FC<WorkItemContextMenuProps> = ({
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      cancelHover();
       if (event.key === "Escape") {
         event.preventDefault();
         onClose();
@@ -207,110 +212,105 @@ const WorkItemContextMenu: React.FC<WorkItemContextMenuProps> = ({
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [activeSubmenuItem, executeMenuItem, items, onClose, openSubmenu]);
-
-  useEffect(() => {
-    return () => {
-      if (hoverTimeoutRef.current) {
-        clearTimeout(hoverTimeoutRef.current);
-      }
-    };
-  }, []);
+  }, [
+    activeSubmenuItem,
+    cancelHover,
+    executeMenuItem,
+    items,
+    onClose,
+    openSubmenu,
+  ]);
 
   const handleItemClick = useCallback(
     (item: ContextMenuItem, event: React.MouseEvent) => {
       event.stopPropagation();
+      cancelHover();
       if (item.disabled || item.divider || item.submenu) return;
       item.action?.();
       onClose();
     },
-    [onClose]
+    [cancelHover, onClose]
   );
 
   const handleSubmenuItemClick = useCallback(
     (item: ContextMenuItem, event: React.MouseEvent) => {
       event.stopPropagation();
+      cancelHover();
       if (item.disabled || item.divider || item.submenu) return;
       item.action?.();
       onClose();
     },
-    [onClose]
+    [cancelHover, onClose]
   );
 
   const handleItemMouseEnter = useCallback(
     (item: ContextMenuItem, event: React.MouseEvent) => {
-      if (hoverTimeoutRef.current) {
-        clearTimeout(hoverTimeoutRef.current);
-        hoverTimeoutRef.current = null;
-      }
+      cancelHover();
+      const target = event.currentTarget as HTMLElement;
+      const rect = target.getBoundingClientRect();
+      const menuRect = menuRef.current?.getBoundingClientRect();
 
-      if (item.submenu && item.submenu.length > 0) {
-        const target = event.currentTarget as HTMLElement;
-        const rect = target.getBoundingClientRect();
-        const menuRect = menuRef.current?.getBoundingClientRect();
-
+      const activate = () => {
         setOpenNestedSubmenu(null);
-        setOpenSubmenu({
-          itemId: item.id,
-          position: {
-            x: (menuRect?.right ?? rect.right) + DROPDOWN_PANEL.submenuGap,
-            y: rect.top,
-          },
-        });
+        setOpenSubmenu(
+          item.submenu?.length
+            ? {
+                itemId: item.id,
+                position: {
+                  x:
+                    (menuRect?.right ?? rect.right) + DROPDOWN_PANEL.submenuGap,
+                  y: rect.top,
+                },
+              }
+            : null
+        );
+      };
+      if (openSubmenu && openSubmenu.itemId !== item.id) {
+        scheduleHover(activate);
       } else {
-        setOpenNestedSubmenu(null);
-        setOpenSubmenu(null);
+        activate();
       }
     },
-    []
+    [cancelHover, openSubmenu, scheduleHover]
   );
 
   const handleNestedSubmenuMouseEnter = useCallback(
     (item: ContextMenuItem, event: React.MouseEvent) => {
-      if (hoverTimeoutRef.current) {
-        clearTimeout(hoverTimeoutRef.current);
-        hoverTimeoutRef.current = null;
-      }
+      cancelHover();
+      const target = event.currentTarget as HTMLElement;
+      const rect = target.getBoundingClientRect();
+      const submenuRect = submenuRef.current?.getBoundingClientRect();
 
-      if (item.submenu && item.submenu.length > 0) {
-        const target = event.currentTarget as HTMLElement;
-        const rect = target.getBoundingClientRect();
-        const submenuRect = submenuRef.current?.getBoundingClientRect();
-
-        setOpenNestedSubmenu({
-          itemId: item.id,
-          position: {
-            x: (submenuRect?.right ?? rect.right) + DROPDOWN_PANEL.submenuGap,
-            y: rect.top,
-          },
-        });
+      const activate = () => {
+        setOpenNestedSubmenu(
+          item.submenu?.length
+            ? {
+                itemId: item.id,
+                position: {
+                  x:
+                    (submenuRect?.right ?? rect.right) +
+                    DROPDOWN_PANEL.submenuGap,
+                  y: rect.top,
+                },
+              }
+            : null
+        );
+      };
+      if (openNestedSubmenu && openNestedSubmenu.itemId !== item.id) {
+        scheduleHover(activate);
       } else {
-        setOpenNestedSubmenu(null);
+        activate();
       }
     },
-    []
+    [cancelHover, openNestedSubmenu, scheduleHover]
   );
 
-  const handleSubmenuMouseEnter = useCallback(() => {
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
-      hoverTimeoutRef.current = null;
-    }
-  }, []);
-
-  const handleSubmenuMouseLeave = useCallback(() => {
-    hoverTimeoutRef.current = setTimeout(() => {
-      setOpenNestedSubmenu(null);
-      setOpenSubmenu(null);
-    }, 150);
-  }, []);
-
   const handleMenuMouseLeave = useCallback(() => {
-    hoverTimeoutRef.current = setTimeout(() => {
+    scheduleHover(() => {
       setOpenNestedSubmenu(null);
       setOpenSubmenu(null);
-    }, 150);
-  }, []);
+    });
+  }, [scheduleHover]);
 
   return createPortal(
     <>
@@ -324,7 +324,7 @@ const WorkItemContextMenu: React.FC<WorkItemContextMenuProps> = ({
           opacity: 0,
           pointerEvents: "none",
         }}
-        onMouseEnter={handleSubmenuMouseEnter}
+        onMouseEnter={cancelHover}
         onMouseLeave={handleMenuMouseLeave}
       >
         {items.map((item) => {
@@ -398,8 +398,8 @@ const WorkItemContextMenu: React.FC<WorkItemContextMenuProps> = ({
           activeNestedItemId={openNestedSubmenu?.itemId}
           onItemClick={handleSubmenuItemClick}
           onItemMouseEnter={handleNestedSubmenuMouseEnter}
-          onMouseEnter={handleSubmenuMouseEnter}
-          onMouseLeave={handleSubmenuMouseLeave}
+          onMouseEnter={cancelHover}
+          onMouseLeave={handleMenuMouseLeave}
           showNumericShortcuts
         />
       )}
@@ -412,8 +412,8 @@ const WorkItemContextMenu: React.FC<WorkItemContextMenuProps> = ({
           position={openNestedSubmenu.position}
           onItemClick={handleSubmenuItemClick}
           onItemMouseEnter={() => {}}
-          onMouseEnter={handleSubmenuMouseEnter}
-          onMouseLeave={handleSubmenuMouseLeave}
+          onMouseEnter={cancelHover}
+          onMouseLeave={handleMenuMouseLeave}
           showNumericShortcuts
         />
       )}


### PR DESCRIPTION
## Problem

Dropdown submenus can disappear while the pointer moves diagonally toward lower options. Shared action menus dismiss immediately on leaving the parent or crossing a sibling row; hover dropdowns and work-item menus use short, separate close timers. Repeated leave events can also overwrite a timer handle without canceling the earlier close.

## Solution

Use one cancelable 350 ms hover transition across ActionMenuSurface, hover-triggered Dropdown, and both WorkItemContextMenu submenu levels. Re-entry cancels dismissal, and briefly crossing another row does not immediately switch the active submenu. Explicit clicks and keyboard input cancel pending hover intent and remain immediate. Closing, disabling, hiding, or unmounting the owner releases the pending timer and temporary visibility listener.

Keep click-open dropdown behavior, caller-specified hover delays, styling, and positioning unchanged. Add 26 interaction/lifecycle regressions at the actual menu owners and shared hook, plus focused architecture, UI, and lifecycle audit records. Update two existing session-header consumer tests to use realistic pointer transitions and assert the grace-period boundary, bridge cancellation, and stable direct app row.

## Potential risks

- Pointer dismissal and intentional sibling switching now wait 350 ms. This is a fixed grace period, not a geometric safe-polygon algorithm; movement taking longer outside both panels can still dismiss the submenu.
- Native Tauri pointer feel, physical hit-testing, and CPU/RSS were not measured. Desktop UI control was not authorized. Automated timer/resource assertions do not establish a measured runtime speedup.
- Click-persistent bespoke sidebar/model/slash-command menus retain their existing dismissal policies; this PR does not claim all bespoke menus use the new sibling-switch delay.
- No dependency, persisted-data, IPC, or public wire-format changes. Reverting this PR restores the previous behavior without a migration.

## Verification

- Initial CI failed two session-header tests that still expected immediate hover changes. Both failures were reproduced locally and corrected with fake-timer assertions; no tests were skipped and no runtime behavior was changed in the follow-up.
- `pnpm test` — all 10,150 tests pass across 1,288 files, with no failed or skipped tests.
- `pnpm test src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts src/components/Dropdown src/hooks/dropdown/useMenuHoverGrace.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts` — all 97 tests pass across 13 files, covering both shared-action-menu consumers.
- `pnpm typecheck` — full typecheck passes after the consumer-test update.
- `pnpm exec eslint src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts --max-warnings 0 --report-unused-disable-directives` — passes.
- `node --test scripts/ci/*.test.cjs` — all 28 tests pass.
- `pnpm exec eslint src/hooks/dropdown/useMenuHoverGrace.ts src/hooks/dropdown/useMenuHoverGrace.test.ts src/components/Dropdown/ActionMenuSurface.tsx src/components/Dropdown/ActionMenuSurface.test.ts src/components/Dropdown/index.tsx src/components/Dropdown/index.hover.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/index.tsx src/modules/ProjectManager/WorkItems/components/WorkItemContextMenu/WorkItemContextMenu.test.ts --max-warnings 0 --report-unused-disable-directives` — passes.
- `pnpm run typecheck --incremental --tsBuildInfoFile .git/.tsbuildinfo` — passes in the clean PR checkout.
- `pnpm run check:circular` — no circular dependencies across 6,335 modules.
- `pnpm run check:test-placement` — passes across 437 directories.
- `git diff --check` — passes.
- No native screenshots/recording: appearance is unchanged, and a static screenshot would not demonstrate pointer timing. Native interaction verification was not run; DOM tests cover third-option selection, sibling traversal, nested portals, explicit input, and cleanup.

## Audit

UI consistency: 0 outstanding fixes, 4 keep-with-reason decisions, 0 abstractions. Architecture layers 1–7 and 9 covered; wire protocol and multi-source resolvers are not applicable. Automated lifecycle checks pass; performance sign-off remains blocked on native verification.
