### PR TITLE
fix(sidebar): remove redundant grouping submenu title

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
@@ -495,9 +495,6 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
               onMouseDown={handleSubmenuMouseDown}
             >
               <div className={DROPDOWN_CLASSES.itemsColumnPadded}>
-                <div className={DROPDOWN_CLASSES.sectionLabel}>
-                  {t("sidebar.groupBy.title")}
-                </div>
                 {groupByModes.map((mode) => (
                   <DropdownItem
                     key={mode}


### PR DESCRIPTION
## Problem

The grouping submenu repeats the parent row's “Group by” label above its choices. The extra heading adds an unnecessary row before the available grouping options.

## Solution

Remove only the repeated visible title from the grouping flyout in SessionFilterButton. The submenu starts directly with its existing options; the parent label, option labels, selected state, event handlers, and spacing tokens are unchanged.

## Potential risks

The submenu becomes shorter and starts its choices at the top. No grouping logic, translations, dependencies, persistence, or API behavior changes. Native light/dark-theme and constrained-viewport screenshots were not captured because desktop UI control was not authorized; visual positioning remains unverified in the native app. Reverting the three-line deletion restores the heading.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts` — all 6 tests pass, covering the parent label, submenu opening, selected mode, selection/close, and dismissal.
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx --max-warnings 0 --report-unused-disable-directives` — passes.
- `pnpm run typecheck --incremental --tsBuildInfoFile .git/.tsbuildinfo` — passes in the clean PR checkout.
- `git diff --check` — passes.
- Diff inspected: one file, three deleted lines, no behavior or styling-token changes. No new tests were added for this small presentation-only removal.
