### PR TITLE
refactor(source-control): share the connected repository pane

### DIFF
--- a/docs/architecture-audit-2026-08-31/SourceControlPaneConsolidation.md
+++ b/docs/architecture-audit-2026-08-31/SourceControlPaneConsolidation.md
@@ -1,0 +1,43 @@
+# Source Control pane consolidation
+
+Scope: remove the duplicate connected main-repository adapter without changing the UI, state source, selection semantics, or scope lifecycle.
+
+## Architecture coverage
+
+| Layer                      | Review and result                                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1. Compilation             | Full TypeScript check, targeted lint, and behavior tests passed                                                           |
+| 2. Dead code / duplication | Removed `MainRepoSectionContent`; its 123-line callback body was byte-identical to the retained `SourceControlTabContent` |
+| 3. Naming                  | Both hosts now name the same connected repository pane                                                                    |
+| 4. Semantic overloading    | Repository identity remains `repoId` plus `repoPath`; worktree identity remains separate                                  |
+| 5. Defaults                | Prop defaults and `navigateWithoutSelecting` branches unchanged                                                           |
+| 6. Domain boundaries       | `useSourceControlState` remains the owner; worktree and multi-root adapters intentionally remain distinct                 |
+| 7. Discoverability         | One adapter to update for standalone and worktree-hosted main repositories                                                |
+| 8. Wire format             | Not applicable: no API, IPC, payload, schema, or persistence changes                                                      |
+| 9. Initialization parity   | Both live hosts use the same hook/options; existing scope key, forwarded refs, and loading callback remain                |
+| 10. Resolver symmetry      | No resolver changes; file-selection lookup and fallback are unchanged                                                     |
+
+## Behavior and lifecycle evidence
+
+`SourceControlTabPanels.behavior.test.ts` renders both live hosts with both selection modes. It checks repository/options forwarding, file reporting with scope root, selection versus navigation behavior, DOM retention on rerender, loading overlay settlement, and imperative refresh. Existing scope-switch/picker/initialization tests remain unchanged.
+
+| Area               | Verdict | Evidence                                                                  | Change or reason kept                | Verification                              |
+| ------------------ | ------- | ------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------- |
+| Background work    | keep    | Same single `useSourceControlState` per active pane                       | No new subscription or request owner | Hook inputs asserted in both hosts        |
+| Memory             | keep    | Existing refs and scope-keyed child                                       | No additional retained pane or cache | Same DOM node after rerender              |
+| Scope/isolation    | keep    | Main repo keeps `key={scopeKey}` and `mainRef`; worktree branch unchanged | Preserve remount and refresh routing | Scope tests and both-host refresh test    |
+| Rendering/hot path | keep    | Shared callback body unchanged; no markup/style changes                   | Remove duplicate source only         | Selection and forwarding regression tests |
+
+Performance verdict: blocked for real-app CPU/RSS and repeated Tauri open/close measurement; computer control was not authorized. Structural/lifecycle assertions passed, and no runtime performance improvement is claimed.
+
+## Verification
+
+- `pnpm run typecheck --incremental --tsBuildInfoFile "$(git rev-parse --git-path source-control-final.tsbuildinfo)"`: full-project check passed
+
+- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__ --maxWorkers=2 --minWorkers=1`: 4 files, 45 tests passed
+- Targeted ESLint: passed
+- `pnpm run check:circular`: passed, 6,341 modules
+- `git diff --check`: passed
+- No live Tauri/visual E2E, backend tests, or full test suite: underlying view markup and Git operations were not modified
+
+No dependency, configuration, storage, protocol, or migration changes. Reverting this commit restores the duplicate adapter without data recovery.

--- a/docs/frontend-ui-audit-2026-08-31/SourceControlPaneConsolidation.md
+++ b/docs/frontend-ui-audit-2026-08-31/SourceControlPaneConsolidation.md
@@ -1,0 +1,11 @@
+# Source Control pane consolidation UI audit
+
+| Line                             | Element                         | Verdict          | Reason                                                                                                | Suggested change |
+| -------------------------------- | ------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------- | ---------------- |
+| `SourceControlTabPanels.tsx:134` | Shared connected pane           | keep with reason | Existing view props, selection callback, and refresh contract are retained verbatim                   | None             |
+| `SourceControlTabPanels.tsx:423` | Worktree/main-repository switch | keep with reason | Distinct worktree owner remains; main-repository key, ref, and loading overlay contract are unchanged | None             |
+| `SourceControlTabPanels.tsx:439` | Main-repository rendering       | keep with reason | Uses the existing identical adapter; no DOM, copy, theme, spacing, or keyboard changes                | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+No design-system sweep needed. Rendered jsdom behavior checks cover both hosts; live Tauri screenshots were not taken because this is a behavior-preserving internal refactor and desktop control is not authorized.

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTabPanels.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTabPanels.tsx
@@ -2,8 +2,7 @@
  * SourceControlTabPanels
  *
  * Internal panel components for the Source Control tab:
- * - SourceControlTabContent: wraps SourceControlContent with useSourceControlState
- * - MainRepoSectionContent: main repository content for multi-worktree layout
+ * - SourceControlTabContent: shared connected pane for standalone and main-repo views
  * - SourceControlWithWorktrees: scoped host/worktree source control pane
  *
  * Extracted from SourceControlTab.tsx to keep it under 600 lines.
@@ -279,155 +278,6 @@ export const SourceControlTabContent = forwardRef<
 
 SourceControlTabContent.displayName = "SourceControlTabContent";
 
-// ── MainRepoSectionContent ────────────────────────────────────────────────────
-
-export const MainRepoSectionContent = forwardRef<
-  SourceControlContentHandle,
-  SourceControlContentProps
->(
-  (
-    {
-      repoPath,
-      repoId,
-      onGitFileSelect,
-      onGitFilesChange,
-      onGitHistorySelectionChange,
-      showFilter,
-      viewMode,
-      showOnlyStashes,
-      navigateWithoutSelecting,
-      sectionFilter,
-      onLoadingChange,
-      suppressLoadingPlaceholder,
-    },
-    ref
-  ) => {
-    const sourceControlState = useSourceControlState({
-      repoPath,
-      repoId,
-      onGitFileSelect,
-      autoLoadStashes: showOnlyStashes,
-    });
-
-    useEffect(() => {
-      onLoadingChange?.(sourceControlState.loading);
-    }, [onLoadingChange, sourceControlState.loading]);
-
-    useEffect(() => {
-      onGitFilesChange?.(sourceControlState.state.files, repoPath);
-    }, [onGitFilesChange, sourceControlState.state.files, repoPath]);
-
-    const refresh = useCallback(async () => {
-      await sourceControlState.refresh();
-    }, [sourceControlState]);
-
-    const sourceControlFiles = sourceControlState.state.files;
-    const selectSourceControlFile = sourceControlState.state.onFileSelect;
-
-    const handleContentFileSelect = useCallback(
-      (fileId: string) => {
-        if (!navigateWithoutSelecting) {
-          selectSourceControlFile(fileId);
-          return;
-        }
-        const file = sourceControlFiles.find(
-          (candidate) => candidate.id === fileId
-        );
-        if (file) {
-          onGitFileSelect?.(file);
-        }
-      },
-      [
-        navigateWithoutSelecting,
-        onGitFileSelect,
-        selectSourceControlFile,
-        sourceControlFiles,
-      ]
-    );
-
-    useImperativeHandle(ref, () => ({ refresh }), [refresh]);
-
-    return (
-      <SourceControlContent
-        repoId={repoId}
-        repoPath={repoPath}
-        files={sourceControlState.state.files}
-        filteredFiles={sourceControlState.state.filteredFiles}
-        selectedFileId={
-          navigateWithoutSelecting
-            ? ""
-            : sourceControlState.state.selectedFileId
-        }
-        loading={sourceControlState.loading}
-        error={sourceControlState.state.error}
-        onFileSelect={handleContentFileSelect}
-        onStageToggle={sourceControlState.state.onStageToggle}
-        onDiscard={sourceControlState.state.onDiscard}
-        onDiscardFiles={sourceControlState.state.onDiscardFiles}
-        onStageAll={sourceControlState.state.onStageAll}
-        onUnstageAll={sourceControlState.state.onUnstageAll}
-        onDiscardAll={sourceControlState.state.onDiscardAll}
-        onOpenChanges={sourceControlState.state.onOpenChanges}
-        onOpenStagedChanges={sourceControlState.state.onOpenStagedChanges}
-        commitMessage={sourceControlState.state.commitMessage}
-        onCommitMessageChange={sourceControlState.state.onCommitMessageChange}
-        onCommit={sourceControlState.state.onCommit}
-        onCommitAndPush={sourceControlState.state.onCommitAndPush}
-        onCommitAndPublish={sourceControlState.state.onCommitAndPublish}
-        onCommitAndSync={sourceControlState.state.onCommitAndSync}
-        onAmend={sourceControlState.state.onAmend}
-        commitLoading={sourceControlState.state.commitLoading}
-        generateCommitMessageLoading={
-          sourceControlState.state.generateCommitMessageLoading
-        }
-        onGenerateCommitMessage={
-          sourceControlState.state.onGenerateCommitMessage
-        }
-        stagedFilesCount={sourceControlState.state.stagedFilesCount}
-        branchName={sourceControlState.state.branchName}
-        searchQuery={sourceControlState.state.searchQuery}
-        onSearchChange={sourceControlState.state.onSearchChange}
-        showFilter={showFilter}
-        viewMode={viewMode}
-        showOnlyStashes={showOnlyStashes}
-        sectionFilter={sectionFilter}
-        navigateWithoutSelecting={navigateWithoutSelecting}
-        conflictFiles={sourceControlState.state.conflictFiles}
-        hasConflicts={sourceControlState.state.hasConflicts}
-        onStageResolved={sourceControlState.state.onStageResolved}
-        isMerging={sourceControlState.state.isMerging}
-        mergingBranch={sourceControlState.state.mergingBranch}
-        onContinueMerge={sourceControlState.state.onContinueMerge}
-        stashes={sourceControlState.state.stashes}
-        stashOperationLoading={sourceControlState.state.stashOperationLoading}
-        hasChangesToStash={sourceControlState.state.hasChangesToStash}
-        onStashPush={sourceControlState.state.onStashPush}
-        onStashApply={sourceControlState.state.onStashApply}
-        onStashPop={sourceControlState.state.onStashPop}
-        onStashDrop={sourceControlState.state.onStashDrop}
-        onHistorySelectionChange={onGitHistorySelectionChange}
-        ahead={sourceControlState.state.ahead}
-        behind={sourceControlState.state.behind}
-        onSync={sourceControlState.state.onSync}
-        syncLoading={sourceControlState.state.syncLoading}
-        onPull={sourceControlState.state.onPull}
-        pullLoading={sourceControlState.state.pullLoading}
-        onPush={sourceControlState.state.onPush}
-        pushLoading={sourceControlState.state.pushLoading}
-        onFetch={sourceControlState.state.onFetch}
-        fetchLoading={sourceControlState.state.fetchLoading}
-        hasUpstream={sourceControlState.state.hasUpstream}
-        onPublish={sourceControlState.state.onPublish}
-        publishLoading={sourceControlState.state.publishLoading}
-        onRefresh={refresh}
-        suppressLoadingPlaceholder={suppressLoadingPlaceholder}
-      />
-    );
-  }
-);
-
-MainRepoSectionContent.displayName = "MainRepoSectionContent";
-
 // ── SourceControlWithWorktrees ────────────────────────────────────────────────
 
 interface SourceControlWithWorktreesProps {
@@ -586,7 +436,7 @@ export const SourceControlWithWorktrees = forwardRef<
             sectionFilter={sectionFilter}
           />
         ) : (
-          <MainRepoSectionContent
+          <SourceControlTabContent
             key={scopeKey}
             ref={mainRef}
             repoPath={repoPath}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/SourceControlTabPanels.behavior.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/SourceControlTabPanels.behavior.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GitFile } from "@src/types/git/types";
+
+import type { SourceControlContentProps } from "../../content/SourceControlContent/types";
+import {
+  type SourceControlContentHandle,
+  SourceControlTabContent,
+  SourceControlWithWorktrees,
+} from "../SourceControlTabPanels";
+
+const mocks = vi.hoisted(() => ({
+  state: vi.fn(),
+  renderContent: vi.fn(),
+  refresh: vi.fn(async () => {}),
+  select: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/api/tauri/repo", () => ({ repoApi: {} }));
+vi.mock("@src/components/Message", () => ({ default: {} }));
+vi.mock("@src/components/Placeholder", () => ({
+  Placeholder: () => "loading-placeholder",
+}));
+vi.mock("../../hooks/useSourceControlState", () => ({
+  useSourceControlState: mocks.state,
+}));
+vi.mock("../../content/WorktreeSourceControlSection", () => ({
+  WorktreeSourceControlSection: () => "worktree",
+}));
+vi.mock("../../content/SourceControlContent", () => ({
+  default: (props: SourceControlContentProps) => {
+    mocks.renderContent(props);
+    return createElement(
+      "button",
+      { onClick: () => props.onFileSelect("file-1") },
+      props.selectedFileId || "unselected"
+    );
+  },
+}));
+
+const files: GitFile[] = [
+  {
+    id: "file-1",
+    path: "src/file.ts",
+    status: "modified",
+    additions: 1,
+    deletions: 0,
+    staged: false,
+  },
+];
+
+describe.each(["standalone", "main-repo"] as const)(
+  "%s Source Control pane",
+  (host) => {
+    let container: HTMLDivElement;
+    let root: Root;
+    const actEnvironment = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+
+    beforeEach(() => {
+      actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+      vi.clearAllMocks();
+      mocks.state.mockReturnValue({
+        loading: false,
+        refresh: mocks.refresh,
+        state: {
+          files,
+          filteredFiles: files,
+          selectedFileId: "file-1",
+          onFileSelect: mocks.select,
+          error: null,
+        },
+      });
+      container = document.createElement("div");
+      document.body.appendChild(container);
+      root = createRoot(container);
+    });
+
+    afterEach(() => {
+      act(() => root.unmount());
+      container.remove();
+      Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+    });
+
+    it.each([false, true])(
+      "preserves selection, scope reporting and refresh (navigateWithoutSelecting=%s)",
+      async (navigateWithoutSelecting) => {
+        const ref = createRef<SourceControlContentHandle>();
+        const onGitFileSelect = vi.fn();
+        const onGitFilesChange = vi.fn();
+        const props = {
+          ref,
+          repoId: "repo-1",
+          repoPath: "/workspace/repo",
+          showFilter: true,
+          viewMode: "list" as const,
+          showOnlyStashes: true,
+          sectionFilter: "staged" as const,
+          navigateWithoutSelecting,
+          onGitFileSelect,
+          onGitFilesChange,
+        };
+        const renderPane = () =>
+          host === "standalone"
+            ? createElement(SourceControlTabContent, props)
+            : createElement(SourceControlWithWorktrees, {
+                ...props,
+                worktrees: [],
+                scope: { kind: "local" },
+              });
+
+        act(() => root.render(renderPane()));
+        expect(mocks.state).toHaveBeenLastCalledWith({
+          repoId: "repo-1",
+          repoPath: "/workspace/repo",
+          onGitFileSelect,
+          autoLoadStashes: true,
+        });
+        expect(mocks.renderContent).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            files,
+            filteredFiles: files,
+            showFilter: true,
+            viewMode: "list",
+            showOnlyStashes: true,
+            sectionFilter: "staged",
+            navigateWithoutSelecting,
+          })
+        );
+        expect(onGitFilesChange).toHaveBeenCalledWith(files, "/workspace/repo");
+        expect(container.textContent).toBe(
+          navigateWithoutSelecting ? "unselected" : "file-1"
+        );
+        const button = container.querySelector("button");
+        act(() => button?.click());
+        if (navigateWithoutSelecting) {
+          expect(onGitFileSelect).toHaveBeenCalledWith(files[0]);
+          expect(mocks.select).not.toHaveBeenCalled();
+        } else {
+          expect(mocks.select).toHaveBeenCalledWith("file-1");
+          expect(onGitFileSelect).not.toHaveBeenCalled();
+        }
+        act(() => root.render(renderPane()));
+        expect(container.querySelector("button")).toBe(button);
+        await act(async () => {
+          await ref.current?.refresh();
+        });
+        expect(mocks.refresh).toHaveBeenCalledOnce();
+      }
+    );
+  }
+);


### PR DESCRIPTION
## Problem

Standalone Source Control and the worktree host each implement the same connected main-repository pane. Their callback bodies are identical, so behavior fixes require duplicate edits.

## Solution

Use the existing SourceControlTabContent in both live hosts and remove MainRepoSectionContent. Preserve all props, repository identities, scope keys, forwarded refs, loading-overlay handling, selection/navigation behavior, and history callbacks. Worktree and multi-root implementations remain unchanged.

Add rendered regression coverage for both hosts and document the architecture/UI/lifecycle review. No product pane, control, markup, copy, or style is changed.

## Potential risks

Component consolidation can affect mount identity and imperative refresh routing. Both are checked at the adapter boundary; the retained callback body is identical to the base and the host changes only its component name. Actual Git/Tauri operations, native visual appearance, repeated open/close CPU/RSS, and full application E2E were not exercised. Desktop computer control was not authorized. No runtime performance improvement is claimed.

No dependency, configuration, database, persistence, public API, IPC, or wire changes. Reverting the commit requires no data recovery.

## Verification

- `pnpm run typecheck --incremental --tsBuildInfoFile "$(git rev-parse --git-path source-control-final.tsbuildinfo)"`: full-project check passed
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__ --maxWorkers=2 --minWorkers=1`: 4 files / 45 tests passed
- `pnpm exec eslint src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTabPanels.tsx src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/SourceControlTabPanels.behavior.test.ts --max-warnings 0`: passed
- `pnpm run check:circular`: passed, 6,341 modules
- `pnpm run check:test-placement`: passed, 439 directories
- `git diff --check`: passed
- Independent source review confirms identical adapter bodies, all original host props/keys/refs, unchanged worktree/multi-root branches, and unchanged selection/loading/history behavior
- Native screenshots and live Tauri E2E not run: this changes ownership only, leaves view markup/styles intact, and desktop control was not authorized

Rebased onto latest develop `55392aa43` before publication; the full typecheck and all 45 targeted tests passed again afterward. Normal commit hooks ran; their worktree stats path did not append the usual trailer. Nothing was bypassed or fabricated. The separate full-project check above is the compilation evidence.

## Audit

Architecture layers reviewed with nonapplicable backend/wire scopes identified. UI audit: 0 fix / 3 keep with reason / 0 abstract. Runtime performance sign-off remains blocked by absent real-app measurements; unit lifecycle evidence is recorded in the audit.

## Integration verification

All five independent pane-refactor branches also merged cleanly together in a temporary verification worktree based on develop `55392aa43`. The PRs remain separate; this checks their combined compatibility with the newly merged creator-layout work.

- Combined Vitest run below: **56 files / 337 tests passed**, including the project-pane snapshots
- `pnpm run typecheck --incremental --tsBuildInfoFile "$(git rev-parse --git-path pane-combined.tsbuildinfo)"`: full-project check passed
- `pnpm run check:circular`: passed, no cycles across 6,370 modules
- `pnpm run check:test-placement`: passed, 441 directories
- `git diff --cached --check`: passed

<details>
<summary>Exact combined test command</summary>

```sh
pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__ src/modules/MainApp/Integrations src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector src/scaffold/NavigationSidebar/connectors/useProjectsWorkItemMenuItems src/scaffold/NavigationSidebar/connectors/useSessionMenuItems src/scaffold/NavigationSidebar/connectors/__tests__/SidebarGuideButton.test.ts src/scaffold/NavigationSidebar/connectors/__tests__/workstationSidebarData.test.ts src/engines/ChatPanel/panels/ProjectPanelView.test.ts src/modules/ProjectManager/WorkItems/workItemSource.test.ts src/modules/ProjectManager/WorkItems/workItemPartialUpdate.test.ts src/modules/ProjectManager/WorkItems/workItemsViewModel.test.ts src/modules/ProjectManager/WorkItems/hooks/__tests__/workItemsData.test.ts src/modules/ProjectManager/ProjectManagerLayout/components/ProjectWorkItemsTabContentDataLoader.test.ts src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.test.ts src/engines/ChatPanel/hooks/useProjectWorkItemHandlers.test.ts src/engines/ChatPanel/ChatPanelContent.test.ts --maxWorkers=2 --minWorkers=1
```

</details>
