### PR TITLE
refactor(chat-panel): separate creation and access ownership

### DIFF
--- a/docs/architecture-audit-2026-08-31/ChatPanelWorkflowOwnership.md
+++ b/docs/architecture-audit-2026-08-31/ChatPanelWorkflowOwnership.md
@@ -1,0 +1,43 @@
+# Chat panel workflow ownership
+
+Scope: give creation workflows and tab access reconciliation named owners while keeping their state/effects at the existing chat host lifetime. The host retains layout, tabs, chrome, session presentation, and keep-alive policy.
+
+## Architecture coverage
+
+| Layer                      | Review and result                                                                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1. Compilation             | Full TypeScript check, targeted lint, and behavior tests passed                                                                                                    |
+| 2. Dead code / duplication | Move existing code into two live hooks; remove corresponding host imports/state/callbacks                                                                          |
+| 3. Naming                  | `useChatPanelCreationContent` and `useChatPanelAccessReconciliation` describe their ownership                                                                      |
+| 4. Semantic overloading    | Host passes eight presentation/chrome inputs; creation atoms, draft state, API-key/update actions, and agent context stay private to the creation owner            |
+| 5. Defaults                | Slot availability initialization, creator variant, create-target defaults, and cancellation paths preserved                                                        |
+| 6. Domain boundaries       | Existing project/work-item/AI handlers remain authoritative; host no longer imports their domain data                                                              |
+| 7. Discoverability         | Feature workflows can be read independently of layout and session rendering                                                                                        |
+| 8. Wire format             | No API, IPC, schema, payload, storage, or protocol changes                                                                                                         |
+| 9. Initialization parity   | Hooks are unconditional; creator state remains mounted while its returned content is hidden. Access effects retain ordering, dependencies, and cancellation guards |
+| 10. Resolver symmetry      | Existing AI context and create-target resolution reused without modifications                                                                                      |
+
+The existing `ChatPanelEmptyContent` view contract remains internal to the creation owner. This deliberately avoids introducing a conditionally mounted connected component: doing so would discard drafts and creator choices when a session/tab hides it. No extra DOM wrapper is introduced. The owner reuses the host translator and start-page value; access reconciliation also reuses the host selection. This preserves the original translation and atom subscription count.
+
+## Behavior and lifecycle evidence
+
+| Area               | Verdict | Evidence                                                                                | Change or reason kept                                            | Verification                                   |
+| ------------------ | ------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| Background work    | keep    | Three existing access effects, unchanged guards/dependencies                            | Still reconcile while content is hidden; no new timer or polling | Unknown/loaded roster and hidden-content tests |
+| Memory             | keep    | Draft and creator toggles remain host-owned hook state                                  | Same lifetime and reset actions                                  | Hide/show retains draft and manual choices     |
+| Scope/isolation    | keep    | Authoritative roster gates reconciliation; alias lookup uses existing cancellation flag | No stale completion after roster change/unmount                  | Deferred lookup regression test                |
+| Rendering/hot path | keep    | Same `ChatPanelEmptyContent` element and props; session rendering untouched             | No new component wrapper or claim of fewer renders               | Existing transcript keep-alive tests           |
+
+Performance verdict: blocked for real-app CPU/RSS and repeated Tauri open/close measurement; computer control was not authorized. The targeted lifecycle behavior is tested, and no runtime speed or memory improvement is claimed.
+
+## Verification
+
+- `pnpm run typecheck --incremental --tsBuildInfoFile "$(git rev-parse --git-path chat-host-final.tsbuildinfo)"`: full-project check passed
+- Integrated latest develop `55392aa43`; retained its new header actions menu and visibility guard. AST comparison against that base also confirms the updated menu is unchanged except for direct callback aliases
+
+- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.test.ts src/engines/ChatPanel/hooks/useProjectWorkItemHandlers.test.ts src/engines/ChatPanel/ChatPanelContent.test.ts --maxWorkers=2 --minWorkers=1`: 4 files, 14 tests passed
+- Targeted ESLint, circular dependency check (6,344 modules), test-placement check, and `git diff --check`: passed
+- TypeScript AST-printer comparison: nine moved initializers/JSX, three feature-hook calls, and all three access effects match the base implementation
+- No live Tauri, visual E2E, backend tests, or full suite; existing view markup and domain handlers are untouched
+
+No dependency, configuration, persistence, API, or migration changes. Reverting this commit restores inline ownership without data recovery.

--- a/docs/frontend-ui-audit-2026-08-31/ChatPanelWorkflowOwnership.md
+++ b/docs/frontend-ui-audit-2026-08-31/ChatPanelWorkflowOwnership.md
@@ -1,0 +1,12 @@
+# Chat panel workflow ownership UI audit
+
+| Line                                        | Element                    | Verdict          | Reason                                                                                                 | Suggested change |
+| ------------------------------------------- | -------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------ | ---------------- |
+| `index.tsx:335`                             | Creation surface ownership | keep with reason | Hook stays mounted and returns the existing element without adding markup                              | None             |
+| `index.tsx:347`                             | Plus menu                  | keep with reason | New project/work-item callbacks use the original functions directly; removed aliases had no behavior   | None             |
+| `hooks/useChatPanelCreationContent.tsx:165` | Empty-content presentation | keep with reason | Existing component, props, copy, classes, variant, actions, and slot forwarded unchanged               | None             |
+| `ChatPanelContent.tsx:49`                   | Transcript keep-alive      | keep with reason | Existing implementation untouched; mounted-but-hidden transcript behavior is covered by existing tests | None             |
+
+Verdict totals: **0 fix**, **4 keep with reason**, **0 abstract**.
+
+No design-system sweep needed. Live Tauri screenshots were not taken because no view markup, visual tokens, or copy changed and desktop control is not authorized.

--- a/src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.test.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useChatPanelAccessReconciliation } from "./useChatPanelAccessReconciliation";
+
+const mocks = vi.hoisted(() => ({
+  loaded: false,
+  roster: [] as { orgId: string }[],
+  selected: null as { orgId: string } | null,
+  readOrgs: vi.fn(),
+  closeOrganization: vi.fn(),
+  closeProjectOrgs: vi.fn(),
+  closeChannels: vi.fn(),
+}));
+
+vi.mock("jotai", () => ({
+  useAtomValue: (atom: string) =>
+    atom === "roster"
+      ? mocks.roster
+      : atom === "loaded"
+        ? mocks.loaded
+        : mocks.selected,
+  useSetAtom: (atom: string) =>
+    atom === "closeOrganization"
+      ? mocks.closeOrganization
+      : atom === "closeProjectOrgs"
+        ? mocks.closeProjectOrgs
+        : mocks.closeChannels,
+}));
+vi.mock("@src/api/http/project", () => ({
+  projectApi: { readOrgs: mocks.readOrgs },
+}));
+vi.mock("@src/features/Org2Cloud/org2CloudOrgsAtom", () => ({
+  org2CloudOrgsAtom: "roster",
+  org2CloudOrgsLoadedAtom: "loaded",
+}));
+vi.mock("@src/store/chatPanel/chatPanelTabsAtom", () => ({
+  closeOrganizationChatPanelTabAtom: "closeOrganization",
+  closeProjectOrgChatPanelTabsAtom: "closeProjectOrgs",
+  closeRevokedCloudChannelChatPanelTabsAtom: "closeChannels",
+}));
+function Harness() {
+  useChatPanelAccessReconciliation(mocks.selected);
+  return null;
+}
+
+describe("chat tab access reconciliation lifetime", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.clearAllMocks();
+    mocks.loaded = false;
+    mocks.roster = [];
+    mocks.selected = { orgId: "revoked" };
+    mocks.readOrgs.mockResolvedValue([]);
+    container = document.createElement("div");
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("waits for an authoritative roster before closing any tabs", async () => {
+    await act(async () => root.render(createElement(Harness)));
+    expect(mocks.readOrgs).not.toHaveBeenCalled();
+    expect(mocks.closeOrganization).not.toHaveBeenCalled();
+    expect(mocks.closeProjectOrgs).not.toHaveBeenCalled();
+    expect(mocks.closeChannels).not.toHaveBeenCalled();
+  });
+
+  it("reconciles all tab types even when no visible content is rendered", async () => {
+    mocks.loaded = true;
+    mocks.roster = [{ orgId: "retained" }];
+    mocks.readOrgs.mockResolvedValue([
+      {
+        id: "gone-alias",
+        sync_provider: "orgii_collab",
+        external_org_id: "revoked",
+      },
+      {
+        id: "live-alias",
+        sync_provider: "orgii_collab",
+        external_org_id: "retained",
+      },
+      { id: "local", sync_provider: null, external_org_id: null },
+    ]);
+    await act(async () => root.render(createElement(Harness)));
+    expect(container.childNodes).toHaveLength(0);
+    expect(mocks.closeOrganization).toHaveBeenCalledOnce();
+    expect(mocks.closeProjectOrgs).toHaveBeenCalledWith(["gone-alias"]);
+    expect(mocks.closeChannels).toHaveBeenCalledWith(["retained"]);
+  });
+
+  it("discards old roster lookups after scope changes and disposal", async () => {
+    type Alias = { id: string; sync_provider: string; external_org_id: string };
+    const resolvers: ((value: Alias[]) => void)[] = [];
+    mocks.loaded = true;
+    mocks.readOrgs.mockImplementation(
+      () => new Promise<Alias[]>((resolve) => resolvers.push(resolve))
+    );
+    await act(async () => root.render(createElement(Harness)));
+    mocks.roster = [{ orgId: "new-scope" }];
+    await act(async () => root.render(createElement(Harness)));
+    const staleAlias = [
+      { id: "alias", sync_provider: "orgii_collab", external_org_id: "gone" },
+    ];
+    await act(async () => resolvers[0](staleAlias));
+    expect(mocks.closeProjectOrgs).not.toHaveBeenCalled();
+    act(() => root.render(null));
+    await act(async () => resolvers[1](staleAlias));
+    expect(mocks.closeProjectOrgs).not.toHaveBeenCalled();
+    expect(mocks.readOrgs).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.ts
@@ -1,0 +1,76 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import { useEffect } from "react";
+
+import { projectApi } from "@src/api/http/project";
+import {
+  org2CloudOrgsAtom,
+  org2CloudOrgsLoadedAtom,
+} from "@src/features/Org2Cloud/org2CloudOrgsAtom";
+import {
+  closeOrganizationChatPanelTabAtom,
+  closeProjectOrgChatPanelTabsAtom,
+  closeRevokedCloudChannelChatPanelTabsAtom,
+} from "@src/store/chatPanel/chatPanelTabsAtom";
+import type { ChatPanelSelectedCloudOrg } from "@src/store/ui/chatPanelAtom";
+
+/** Tab access reconciliation runs for the host's lifetime, including hidden tabs. */
+export function useChatPanelAccessReconciliation(
+  selectedCloudOrg: ChatPanelSelectedCloudOrg | null
+) {
+  const cloudOrgs = useAtomValue(org2CloudOrgsAtom);
+  const cloudOrgsLoaded = useAtomValue(org2CloudOrgsLoadedAtom);
+  const closeOrganizationTab = useSetAtom(closeOrganizationChatPanelTabAtom);
+  const closeProjectOrgTabs = useSetAtom(closeProjectOrgChatPanelTabsAtom);
+  const closeRevokedCloudChannelTabs = useSetAtom(
+    closeRevokedCloudChannelChatPanelTabsAtom
+  );
+  // A teammate can lose the selected cloud org while its management panel
+  // is open (member removal or org deletion). Once the authoritative roster
+  // has loaded, an absent org is not a recoverable panel state: close the
+  // stale surface immediately instead of leaving deleted names/actions on
+  // screen. Keep the selection during the initial unknown-roster phase so
+  // a cold start does not flicker the panel closed before list_my_orgs lands.
+  useEffect(() => {
+    if (
+      selectedCloudOrg &&
+      cloudOrgsLoaded &&
+      !cloudOrgs.some((org) => org.orgId === selectedCloudOrg.orgId)
+    ) {
+      closeOrganizationTab();
+    }
+  }, [closeOrganizationTab, cloudOrgs, cloudOrgsLoaded, selectedCloudOrg]);
+
+  // `project_orgs` is a durable local mirror, not an authorization source.
+  // Once the managed-cloud roster is authoritative, close any cached detail
+  // tabs whose alias no longer maps to a live membership. The create pickers
+  // apply the same boundary in projectOrgVisibility.
+  useEffect(() => {
+    if (!cloudOrgsLoaded) return undefined;
+    let cancelled = false;
+    const liveCloudOrgIds = new Set(cloudOrgs.map((org) => org.orgId));
+    void projectApi.readOrgs().then((projectOrgs) => {
+      if (cancelled) return;
+      const revokedProjectOrgIds = projectOrgs
+        .filter(
+          (org) =>
+            org.sync_provider === "orgii_collab" &&
+            Boolean(org.external_org_id) &&
+            !liveCloudOrgIds.has(org.external_org_id as string)
+        )
+        .map((org) => org.id);
+      closeProjectOrgTabs(revokedProjectOrgIds);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [closeProjectOrgTabs, cloudOrgs, cloudOrgsLoaded]);
+
+  // Channel tabs live in the CLOUD org id space (unlike the project-org
+  // aliases above) and per-org reconciliation only covers the active
+  // sidebar scope; sweep revoked orgs' channel tabs here once the roster
+  // is authoritative.
+  useEffect(() => {
+    if (!cloudOrgsLoaded) return;
+    closeRevokedCloudChannelTabs(cloudOrgs.map((org) => org.orgId));
+  }, [closeRevokedCloudChannelTabs, cloudOrgs, cloudOrgsLoaded]);
+}

--- a/src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { Provider } from "jotai";
+import { type ComponentProps, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { useTranslation } from "react-i18next";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CHAT_PANEL_CREATE_TARGET } from "@src/store/ui/chatPanelAtom";
+import type { WorkItemDraft } from "@src/store/workstation/projectManager";
+
+import type { ChatPanelEmptyContent } from "../ChatPanelEmptyContent";
+import type { useAiWorkItemCreator } from "./useAiWorkItemCreator";
+import { useChatPanelCreationContent } from "./useChatPanelCreationContent";
+
+type ContentProps = ComponentProps<typeof ChatPanelEmptyContent>;
+const mocks = vi.hoisted(() => ({
+  content: null as ContentProps | null,
+  aiOptions: null as Parameters<typeof useAiWorkItemCreator>[0] | null,
+  navigate: vi.fn(),
+  resetActiveSession: vi.fn(),
+  launchpad: vi.fn(),
+  openSession: vi.fn(),
+  installUpdate: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("react-router-dom", () => ({ useNavigate: () => mocks.navigate }));
+vi.mock("@src/api/http/project", () => ({ workItemDataToUI: vi.fn() }));
+vi.mock("@src/scaffold/AppUpdater", () => ({
+  installAvailableAppUpdate: mocks.installUpdate,
+}));
+vi.mock("@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom", async () => {
+  const { atom } = await import("jotai");
+  return { allAgentDefsAtom: atom([]) };
+});
+vi.mock("@src/store/session", async () => {
+  const { atom } = await import("jotai");
+  return { sessionCreatorStateAtom: atom({}) };
+});
+vi.mock("@src/store/project/projectAtom", async () => {
+  const { atom } = await import("jotai");
+  return { projectListRefreshAtom: atom(0) };
+});
+vi.mock("@src/store/ui/chatPanelAtom", async () => {
+  const { atom } = await import("jotai");
+  return {
+    CHAT_PANEL_CREATE_TARGET: {
+      AGENT_SESSION: "agent-session",
+      PROJECT: "project",
+      WORK_ITEM: "work-item",
+      COLLAB_ORG: "collab-org",
+      PARALLEL_RUN: "parallel-run",
+      GITHUB_ISSUES_PROJECT: "github-issues-project",
+    },
+    chatPanelStartPageOpenAtom: atom(false),
+    chatPanelCreateTargetAtom: atom("work-item"),
+    chatPanelCollabOrgCreateIntentAtom: atom(null),
+    chatPanelCreateProjectContextAtom: atom(null),
+    chatPanelSelectedProjectAtom: atom(null),
+    chatPanelSelectedWorkItemAtom: atom(null),
+  };
+});
+vi.mock("@src/store/chatPanel/chatPanelTabsAtom", async () => {
+  const { atom } = await import("jotai");
+  return {
+    openProjectInChatPanelTabAtom: atom(null, vi.fn()),
+    openWorkItemInChatPanelTabAtom: atom(null, vi.fn()),
+    openSessionInNewChatTabAtom: atom(null, (_get, _set, value) =>
+      mocks.openSession(value)
+    ),
+  };
+});
+vi.mock("./useChatPanelNavigationActions", () => ({
+  useChatPanelNavigationActions: () => ({
+    dispatchClearSession: vi.fn(),
+    resetActiveSession: mocks.resetActiveSession,
+    setActiveSessionId: vi.fn(),
+    setWorkstationActiveSessionId: vi.fn(),
+  }),
+}));
+vi.mock("./useAiWorkItemCreator", () => ({
+  useAiWorkItemCreator: (
+    options: Parameters<typeof useAiWorkItemCreator>[0]
+  ) => {
+    mocks.aiOptions = options;
+    return {
+      defaultAiWorkItemExecutionTarget: null,
+      handleAiWorkItemSessionStart: vi.fn(),
+      resolveAiWorkItemContext: vi.fn(),
+    };
+  },
+}));
+vi.mock("../ChatPanelEmptyContent", () => ({
+  ChatPanelEmptyContent: (props: ContentProps) => {
+    mocks.content = props;
+    return createElement("div", { "data-testid": "creator" });
+  },
+}));
+
+const slot = () => null;
+function Harness({ visible }: { visible: boolean }) {
+  const { t } = useTranslation([
+    "sessions",
+    "common",
+    "projects",
+    "navigation",
+  ]);
+  const content = useChatPanelCreationContent({
+    t,
+    startPageOpen: false,
+    sessionCreatorSlot: slot,
+    creatorVariant: "fullScreen",
+    handleShowRuntime: vi.fn(),
+    handleOpenLaunchpadTab: mocks.launchpad,
+    handleOpenCliTerminal: vi.fn(),
+    handleRegionNoticeChange: vi.fn(),
+  });
+  return visible ? content : null;
+}
+
+describe("chat creation ownership", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  function render(visible: boolean) {
+    act(() =>
+      root.render(
+        createElement(Provider, null, createElement(Harness, { visible }))
+      )
+    );
+  }
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("retains drafts and manual creator choices while another tab hides the surface", () => {
+    render(true);
+    const draft: WorkItemDraft = {
+      name: "unfinished work",
+      description: "",
+      status: "todo",
+      priority: "medium",
+      labelIds: [],
+    };
+    act(() => {
+      mocks.content!.setWorkItemCreateDraft(draft);
+      mocks.content!.handleWorkItemAgentCreatorToggle(false);
+      mocks.content!.handleProjectAgentCreatorToggle(false);
+    });
+    render(false);
+    expect(container.childNodes).toHaveLength(0);
+    expect(mocks.aiOptions!.workItemCreateDraft).toBe(draft);
+    render(true);
+    expect(mocks.aiOptions!.workItemCreateDraft).toBe(draft);
+    expect(mocks.content!.showWorkItemAgentCreator).toBe(false);
+    expect(mocks.content!.showProjectAgentCreator).toBe(false);
+    expect(mocks.content!.creatorVariant).toBe("fullScreen");
+    expect(mocks.launchpad).not.toHaveBeenCalled();
+  });
+
+  it("keeps existing target-reset and cancel navigation semantics", () => {
+    render(true);
+    act(() => {
+      mocks.content!.setWorkItemCreateDraft({
+        name: "draft",
+        description: "",
+        status: "todo",
+        priority: "medium",
+        labelIds: [],
+      });
+      mocks.content!.handleWorkItemAgentCreatorToggle(false);
+    });
+    act(() =>
+      mocks.content!.handleCreateTargetChange(
+        CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT
+      )
+    );
+    expect(mocks.aiOptions!.workItemCreateDraft).toBeNull();
+    expect(mocks.content!.showWorkItemAgentCreator).toBe(true);
+    expect(mocks.content!.showProjectAgentCreator).toBe(false);
+    act(() => mocks.content!.handleCancelWorkItemCreate());
+    expect(mocks.content!.createTarget).toBe(
+      CHAT_PANEL_CREATE_TARGET.AGENT_SESSION
+    );
+    expect(mocks.launchpad).toHaveBeenCalledOnce();
+    expect(mocks.resetActiveSession).toHaveBeenCalledOnce();
+  });
+});

--- a/src/engines/ChatPanel/hooks/useChatPanelCreationContent.tsx
+++ b/src/engines/ChatPanel/hooks/useChatPanelCreationContent.tsx
@@ -1,0 +1,198 @@
+import type { TFunction } from "i18next";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import React, { useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import {
+  WIZARD_IDS,
+  buildIntegrationsPath,
+  buildWizardPath,
+} from "@src/config/mainAppPaths";
+import type { CreatedOrgResult } from "@src/features/TeamCollaboration/components/CreateCollabOrgView";
+import { allAgentDefsAtom } from "@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom";
+import { installAvailableAppUpdate } from "@src/scaffold/AppUpdater";
+import { openSessionInNewChatTabAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
+import { projectListRefreshAtom } from "@src/store/project/projectAtom";
+import { sessionCreatorStateAtom } from "@src/store/session";
+import {
+  CHAT_PANEL_CREATE_TARGET,
+  chatPanelCollabOrgCreateIntentAtom,
+  chatPanelCreateProjectContextAtom,
+  chatPanelCreateTargetAtom,
+  chatPanelSelectedProjectAtom,
+  chatPanelSelectedWorkItemAtom,
+} from "@src/store/ui/chatPanelAtom";
+import type { WorkItemDraft } from "@src/store/workstation/projectManager";
+
+import { ChatPanelEmptyContent } from "../ChatPanelEmptyContent";
+import type { ChatPanelProps, ChatPanelRegionNotice } from "../types";
+import { useAiWorkItemCreator } from "./useAiWorkItemCreator";
+import { useChatPanelCreateTarget } from "./useChatPanelCreateTarget";
+import { useChatPanelNavigationActions } from "./useChatPanelNavigationActions";
+import type { useChatPanelTabsController } from "./useChatPanelTabsController";
+import { useProjectWorkItemHandlers } from "./useProjectWorkItemHandlers";
+
+interface UseChatPanelCreationContentOptions {
+  t: TFunction<["sessions", "common", "projects", "navigation"]>;
+  startPageOpen: boolean;
+  sessionCreatorSlot: ChatPanelProps["sessionCreatorSlot"];
+  creatorVariant: "default" | "fullScreen";
+  handleShowRuntime: () => void;
+  handleOpenLaunchpadTab: () => void;
+  handleOpenCliTerminal: ReturnType<
+    typeof useChatPanelTabsController
+  >["handleOpenCliTerminal"];
+  handleRegionNoticeChange: (notice: ChatPanelRegionNotice | null) => void;
+}
+
+/**
+ * Owns creation workflows at the chat host lifetime, even while the returned
+ * surface is not rendered. Moving this state into the conditional creator
+ * component would reset in-progress work-item drafts on session/tab switches.
+ */
+export function useChatPanelCreationContent({
+  t,
+  startPageOpen,
+  sessionCreatorSlot: SessionCreatorSlot,
+  creatorVariant,
+  handleShowRuntime,
+  handleOpenLaunchpadTab,
+  handleOpenCliTerminal,
+  handleRegionNoticeChange,
+}: UseChatPanelCreationContentOptions): React.ReactNode {
+  const navigate = useNavigate();
+  const {
+    dispatchClearSession,
+    resetActiveSession,
+    setActiveSessionId,
+    setWorkstationActiveSessionId,
+  } = useChatPanelNavigationActions();
+  const [createTarget, setCreateTarget] = useAtom(chatPanelCreateTargetAtom);
+  const setCollabOrgCreateIntent = useSetAtom(
+    chatPanelCollabOrgCreateIntentAtom
+  );
+  const [workItemCreateDraft, setWorkItemCreateDraft] =
+    useState<WorkItemDraft | null>(null);
+  const [showWorkItemAgentCreator, setShowWorkItemAgentCreator] = useState(
+    Boolean(SessionCreatorSlot)
+  );
+  const [showProjectAgentCreator, setShowProjectAgentCreator] = useState(
+    Boolean(SessionCreatorSlot)
+  );
+  const createProjectContext = useAtomValue(chatPanelCreateProjectContextAtom);
+  const creatorState = useAtomValue(sessionCreatorStateAtom);
+  const bumpProjectListRefresh = useSetAtom(projectListRefreshAtom);
+  const allAgentDefs = useAtomValue(allAgentDefsAtom);
+  const handleReturnToSessionCreator = useCallback(() => {
+    handleOpenLaunchpadTab();
+    setCreateTarget(CHAT_PANEL_CREATE_TARGET.AGENT_SESSION);
+    resetActiveSession();
+  }, [handleOpenLaunchpadTab, resetActiveSession, setCreateTarget]);
+  const openLaunchedSessionTab = useSetAtom(openSessionInNewChatTabAtom);
+  const handleStartPageSessionStart = useCallback(
+    (info: { sessionId: string }) => {
+      openLaunchedSessionTab({ sessionId: info.sessionId });
+    },
+    [openLaunchedSessionTab]
+  );
+  const handleChatPanelCollabOrgCreated = useCallback(
+    (_result: CreatedOrgResult) => {
+      bumpProjectListRefresh((previous) => previous + 1);
+      handleReturnToSessionCreator();
+    },
+    [bumpProjectListRefresh, handleReturnToSessionCreator]
+  );
+
+  const handleStartPageAddApiKey = useCallback(() => {
+    const accountsPath = `${buildIntegrationsPath({ category: "models" })}?modelsTab=my-accounts`;
+    navigate(buildWizardPath(accountsPath, WIZARD_IDS.KEY_ADD));
+  }, [navigate]);
+
+  const handleStartPageInstallLatestUpdate = useCallback(() => {
+    void installAvailableAppUpdate();
+  }, []);
+  const { createTargetOptions, handleCreateTargetChange } =
+    useChatPanelCreateTarget({
+      sessionCreatorAvailable: Boolean(SessionCreatorSlot),
+      setCollabOrgCreateIntent,
+      setCreateTarget,
+      setShowProjectAgentCreator,
+      setShowWorkItemAgentCreator,
+      setWorkItemCreateDraft,
+      t,
+    });
+  const setSelectedProject = useSetAtom(chatPanelSelectedProjectAtom);
+  const setSelectedWorkItem = useSetAtom(chatPanelSelectedWorkItemAtom);
+  const {
+    handleCancelCollabOrgCreate,
+    handleCancelProjectCreate,
+    handleCancelWorkItemCreate,
+    handleChatPanelProjectCreated,
+    handleChatPanelWorkItemCreated,
+    handleProjectAgentCreatorToggle,
+    handleWorkItemAgentCreatorToggle,
+  } = useProjectWorkItemHandlers({
+    bumpProjectListRefresh,
+    createProjectContext,
+    dispatchClearSession,
+    handleReturnToSessionCreator,
+    sessionCreatorAvailable: Boolean(SessionCreatorSlot),
+    setActiveSessionId,
+    setCreateTarget,
+    setSelectedProject,
+    setSelectedWorkItem,
+    setShowProjectAgentCreator,
+    setShowWorkItemAgentCreator,
+    setWorkItemCreateDraft,
+    setWorkstationActiveSessionId,
+  });
+  const {
+    defaultAiWorkItemExecutionTarget,
+    handleAiWorkItemSessionStart,
+    resolveAiWorkItemContext,
+  } = useAiWorkItemCreator({
+    allAgentDefs,
+    createProjectContext,
+    creatorState,
+    setActiveSessionId,
+    setSelectedProject,
+    setWorkItemCreateDraft,
+    setWorkstationActiveSessionId,
+    workItemCreateDraft,
+  });
+  const creatorClassName = "min-h-0 flex-1";
+  const emptyChatContent = (
+    <ChatPanelEmptyContent
+      createProjectContext={createProjectContext}
+      createTarget={createTarget}
+      createTargetOptions={createTargetOptions}
+      creatorClassName={creatorClassName}
+      creatorVariant={creatorVariant}
+      defaultAiWorkItemExecutionTarget={defaultAiWorkItemExecutionTarget}
+      handleAiWorkItemSessionStart={handleAiWorkItemSessionStart}
+      handleCancelWorkItemCreate={handleCancelWorkItemCreate}
+      handleCancelCollabOrgCreate={handleCancelCollabOrgCreate}
+      handleCancelProjectCreate={handleCancelProjectCreate}
+      handleCreateTargetChange={handleCreateTargetChange}
+      handleChatPanelProjectCreated={handleChatPanelProjectCreated}
+      handleChatPanelCollabOrgCreated={handleChatPanelCollabOrgCreated}
+      handleChatPanelWorkItemCreated={handleChatPanelWorkItemCreated}
+      handleOpenCliTerminal={handleOpenCliTerminal}
+      handleRegionNoticeChange={handleRegionNoticeChange}
+      handleStartPageAddApiKey={handleStartPageAddApiKey}
+      handleStartPageInstallLatestUpdate={handleStartPageInstallLatestUpdate}
+      handleStartPageShowRuntime={handleShowRuntime}
+      handleStartPageSessionStart={handleStartPageSessionStart}
+      handleProjectAgentCreatorToggle={handleProjectAgentCreatorToggle}
+      handleWorkItemAgentCreatorToggle={handleWorkItemAgentCreatorToggle}
+      resolveAiWorkItemContext={resolveAiWorkItemContext}
+      SessionCreatorSlot={SessionCreatorSlot}
+      setWorkItemCreateDraft={setWorkItemCreateDraft}
+      showStartPage={startPageOpen}
+      showProjectAgentCreator={showProjectAgentCreator}
+      showWorkItemAgentCreator={showWorkItemAgentCreator}
+      t={t}
+    />
+  );
+  return emptyChatContent;
+}

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -1,15 +1,8 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import React, { memo, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
 
-import { projectApi } from "@src/api/http/project";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
-import {
-  WIZARD_IDS,
-  buildIntegrationsPath,
-  buildWizardPath,
-} from "@src/config/mainAppPaths";
 import {
   CHAT_WIDTH_CSS_VAR,
   clampChatWidth,
@@ -17,31 +10,18 @@ import {
 } from "@src/engines/ChatPanel/config";
 import { ConversationParticipantsChip } from "@src/features/Org2Cloud/SessionConversation/ConversationParticipantsChip";
 import SessionViewersIndicator from "@src/features/Org2Cloud/SessionViewersIndicator";
-import {
-  org2CloudOrgsAtom,
-  org2CloudOrgsLoadedAtom,
-} from "@src/features/Org2Cloud/org2CloudOrgsAtom";
-import type { CreatedOrgResult } from "@src/features/TeamCollaboration/components/CreateCollabOrgView";
 import SessionForkHeaderExtras from "@src/features/TeamCollaboration/components/SessionForkHeaderExtras";
 import { useShouldOffsetChatPanelHeader } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
-import { allAgentDefsAtom } from "@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom";
 import { getChatPanelBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
-import { installAvailableAppUpdate } from "@src/scaffold/AppUpdater";
 import {
   chatPanelTabCountAtom,
-  closeOrganizationChatPanelTabAtom,
-  closeProjectOrgChatPanelTabsAtom,
-  closeRevokedCloudChannelChatPanelTabsAtom,
   isChatPanelTabStationAvailable,
   openRuntimeInChatPanelTabAtom,
-  openSessionInNewChatTabAtom,
   patchChatPanelWorkItemTabAtom,
   resolveChatPanelMaximizedForLayout,
   syncActiveChatPanelTabStateAtom,
   toggleActiveChatPanelMaximizedAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
-import { projectListRefreshAtom } from "@src/store/project/projectAtom";
-import { sessionCreatorStateAtom } from "@src/store/session";
 import {
   type SessionContinuation,
   retargetChatPanelSessionTabAtom,
@@ -49,11 +29,7 @@ import {
 import { tuiModeAtom } from "@src/store/session/tuiModeAtom";
 import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";
 import {
-  CHAT_PANEL_CREATE_TARGET,
-  chatPanelCollabOrgCreateIntentAtom,
   chatPanelContentModeAtom,
-  chatPanelCreateProjectContextAtom,
-  chatPanelCreateTargetAtom,
   chatPanelExploreOpenAtom,
   chatPanelMaximizedAtom,
   chatPanelSelectedCloudOrgAtom,
@@ -65,12 +41,10 @@ import {
   chatWidthAtom,
 } from "@src/store/ui/chatPanelAtom";
 import { openSideChatAtom } from "@src/store/ui/sideChatAtom";
-import type { WorkItemDraft } from "@src/store/workstation/projectManager";
 import { isHumanSession } from "@src/util/session/sessionDispatch";
 
 import { useReloadSession } from "./ChatHistory/hooks/useReloadSession";
 import { ChatPanelContent } from "./ChatPanelContent";
-import { ChatPanelEmptyContent } from "./ChatPanelEmptyContent";
 import { ChatPanelHeader } from "./ChatPanelHeader";
 import { ChatPanelShell } from "./ChatPanelShell";
 import {
@@ -98,16 +72,15 @@ import {
   shouldCollapseChatPanelTabRow,
   shouldOverlayChatSessionHeaders,
 } from "./header/chatPanelHeaderLayout";
-import { useAiWorkItemCreator } from "./hooks/useAiWorkItemCreator";
+import { useChatPanelAccessReconciliation } from "./hooks/useChatPanelAccessReconciliation";
 import { useChatPanelContentState } from "./hooks/useChatPanelContentState";
-import { useChatPanelCreateTarget } from "./hooks/useChatPanelCreateTarget";
+import { useChatPanelCreationContent } from "./hooks/useChatPanelCreationContent";
 import { useChatPanelHeaderActions } from "./hooks/useChatPanelHeaderActions";
 import { useChatPanelNavigationActions } from "./hooks/useChatPanelNavigationActions";
 import { useChatPanelResize } from "./hooks/useChatPanelResize";
 import { useChatPanelSessionModals } from "./hooks/useChatPanelSessionModals";
 import { useChatPanelTabsController } from "./hooks/useChatPanelTabsController";
 import { usePanelTitle } from "./hooks/usePanelTitle";
-import { useProjectWorkItemHandlers } from "./hooks/useProjectWorkItemHandlers";
 import { useSessionViewMode } from "./hooks/useSessionViewMode";
 import type { ChatPanelProps, ChatPanelRegionNotice } from "./types";
 
@@ -130,7 +103,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     const isLeftPosition = position === "left";
     const shouldOffsetHeaderForCollapsedSidebar =
       useShouldOffsetChatPanelHeader({ position, useExternalWidth });
-    const navigate = useNavigate();
     const { currentSessionId, currentSession, panelTitle } = usePanelTitle();
     const activeSession = currentSession ?? undefined;
     const humanSessionActive =
@@ -143,38 +115,14 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     });
 
     const contentMode = useAtomValue(chatPanelContentModeAtom);
-    const [createTarget, setCreateTarget] = useAtom(chatPanelCreateTargetAtom);
-    const setCollabOrgCreateIntent = useSetAtom(
-      chatPanelCollabOrgCreateIntentAtom
-    );
     const startPageOpen = useAtomValue(chatPanelStartPageOpenAtom);
-    const [workItemCreateDraft, setWorkItemCreateDraft] =
-      useState<WorkItemDraft | null>(null);
-    const [showWorkItemAgentCreator, setShowWorkItemAgentCreator] = useState(
-      Boolean(SessionCreatorSlot)
-    );
-    const [showProjectAgentCreator, setShowProjectAgentCreator] = useState(
-      Boolean(SessionCreatorSlot)
-    );
-
     const selectedWorkItem = useAtomValue(chatPanelSelectedWorkItemAtom);
     const selectedProject = useAtomValue(chatPanelSelectedProjectAtom);
     const selectedProjectOrg = useAtomValue(chatPanelSelectedProjectOrgAtom);
     const selectedWorkspace = useAtomValue(chatPanelSelectedWorkspaceAtom);
     const selectedCloudOrg = useAtomValue(chatPanelSelectedCloudOrgAtom);
-    const cloudOrgs = useAtomValue(org2CloudOrgsAtom);
-    const cloudOrgsLoaded = useAtomValue(org2CloudOrgsLoadedAtom);
-    const closeOrganizationTab = useSetAtom(closeOrganizationChatPanelTabAtom);
-    const closeProjectOrgTabs = useSetAtom(closeProjectOrgChatPanelTabsAtom);
-    const closeRevokedCloudChannelTabs = useSetAtom(
-      closeRevokedCloudChannelChatPanelTabsAtom
-    );
     const exploreOpen = useAtomValue(chatPanelExploreOpenAtom);
-    const createProjectContext = useAtomValue(
-      chatPanelCreateProjectContextAtom
-    );
     const patchWorkItemTab = useSetAtom(patchChatPanelWorkItemTabAtom);
-    const openRuntimeTab = useSetAtom(openRuntimeInChatPanelTabAtom);
 
     // Work-item edits flow through `chatPanelSelectedWorkItemAtom`; mirror them
     // back onto the owning work-item tab so re-activating the tab does not
@@ -196,55 +144,8 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     );
     const chatWidth = clampChatWidth(rawChatWidth, viewportWidth);
 
-    // A teammate can lose the selected cloud org while its management panel
-    // is open (member removal or org deletion). Once the authoritative roster
-    // has loaded, an absent org is not a recoverable panel state: close the
-    // stale surface immediately instead of leaving deleted names/actions on
-    // screen. Keep the selection during the initial unknown-roster phase so
-    // a cold start does not flicker the panel closed before list_my_orgs lands.
-    useEffect(() => {
-      if (
-        selectedCloudOrg &&
-        cloudOrgsLoaded &&
-        !cloudOrgs.some((org) => org.orgId === selectedCloudOrg.orgId)
-      ) {
-        closeOrganizationTab();
-      }
-    }, [closeOrganizationTab, cloudOrgs, cloudOrgsLoaded, selectedCloudOrg]);
+    useChatPanelAccessReconciliation(selectedCloudOrg);
 
-    // `project_orgs` is a durable local mirror, not an authorization source.
-    // Once the managed-cloud roster is authoritative, close any cached detail
-    // tabs whose alias no longer maps to a live membership. The create pickers
-    // apply the same boundary in projectOrgVisibility.
-    useEffect(() => {
-      if (!cloudOrgsLoaded) return undefined;
-      let cancelled = false;
-      const liveCloudOrgIds = new Set(cloudOrgs.map((org) => org.orgId));
-      void projectApi.readOrgs().then((projectOrgs) => {
-        if (cancelled) return;
-        const revokedProjectOrgIds = projectOrgs
-          .filter(
-            (org) =>
-              org.sync_provider === "orgii_collab" &&
-              Boolean(org.external_org_id) &&
-              !liveCloudOrgIds.has(org.external_org_id as string)
-          )
-          .map((org) => org.id);
-        closeProjectOrgTabs(revokedProjectOrgIds);
-      });
-      return () => {
-        cancelled = true;
-      };
-    }, [closeProjectOrgTabs, cloudOrgs, cloudOrgsLoaded]);
-
-    // Channel tabs live in the CLOUD org id space (unlike the project-org
-    // aliases above) and per-org reconciliation only covers the active
-    // sidebar scope; sweep revoked orgs' channel tabs here once the roster
-    // is authoritative.
-    useEffect(() => {
-      if (!cloudOrgsLoaded) return;
-      closeRevokedCloudChannelTabs(cloudOrgs.map((org) => org.orgId));
-    }, [closeRevokedCloudChannelTabs, cloudOrgs, cloudOrgsLoaded]);
     const chatWidthStyleValue =
       chatWidth > 0 ? `var(${CHAT_WIDTH_CSS_VAR})` : chatWidth;
     const { isDragging, panelRef, handleMouseDown } = useChatPanelResize({
@@ -272,15 +173,8 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       []
     );
 
-    const {
-      dispatchClearSession,
-      openProjectCreate,
-      openWorkItemCreate,
-      resetActiveSession,
-      setActiveSessionId,
-      setWorkstationActiveSessionId,
-      showSessionSurface,
-    } = useChatPanelNavigationActions();
+    const { openProjectCreate, openWorkItemCreate, showSessionSurface } =
+      useChatPanelNavigationActions();
 
     const {
       activeTab,
@@ -351,10 +245,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       syncActiveTabState();
     }, [activeTab, syncActiveTabState]);
 
-    const creatorState = useAtomValue(sessionCreatorStateAtom);
-    const bumpProjectListRefresh = useSetAtom(projectListRefreshAtom);
-    const allAgentDefs = useAtomValue(allAgentDefsAtom);
-
     const {
       closeHeaderActionsMenu,
       copyEventJsonLabel,
@@ -381,58 +271,12 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       handleReloadSession,
     });
 
-    const handleReturnToSessionCreator = useCallback(() => {
-      handleOpenLaunchpadTab();
-      setCreateTarget(CHAT_PANEL_CREATE_TARGET.AGENT_SESSION);
-      resetActiveSession();
-    }, [handleOpenLaunchpadTab, resetActiveSession, setCreateTarget]);
-    const handleStartPageNewWorkItem = openWorkItemCreate;
-    const handleStartPageNewProject = openProjectCreate;
-    const openLaunchedSessionTab = useSetAtom(openSessionInNewChatTabAtom);
-    const handleStartPageSessionStart = useCallback(
-      (info: { sessionId: string }) => {
-        openLaunchedSessionTab({ sessionId: info.sessionId });
-      },
-      [openLaunchedSessionTab]
-    );
-
     const openSideChat = useSetAtom(openSideChatAtom);
     const handleOpenSideChat = useCallback(() => {
       // Creator mode — the side chat exists to start/watch a session
       // without leaving the active tab.
       openSideChat(null);
     }, [openSideChat]);
-
-    const handleChatPanelCollabOrgCreated = useCallback(
-      (_result: CreatedOrgResult) => {
-        bumpProjectListRefresh((previous) => previous + 1);
-        handleReturnToSessionCreator();
-      },
-      [bumpProjectListRefresh, handleReturnToSessionCreator]
-    );
-
-    const handleStartPageAddApiKey = useCallback(() => {
-      const accountsPath = `${buildIntegrationsPath({ category: "models" })}?modelsTab=my-accounts`;
-      navigate(buildWizardPath(accountsPath, WIZARD_IDS.KEY_ADD));
-    }, [navigate]);
-
-    const handleStartPageInstallLatestUpdate = useCallback(() => {
-      void installAvailableAppUpdate();
-    }, []);
-    const handleShowRuntime = useCallback(() => {
-      openRuntimeTab(t("sessions:chat.startPage.tabs.runtime"));
-    }, [openRuntimeTab, t]);
-
-    const { createTargetOptions, handleCreateTargetChange } =
-      useChatPanelCreateTarget({
-        sessionCreatorAvailable: Boolean(SessionCreatorSlot),
-        setCollabOrgCreateIntent,
-        setCreateTarget,
-        setShowProjectAgentCreator,
-        setShowWorkItemAgentCreator,
-        setWorkItemCreateDraft,
-        t,
-      });
 
     const contentState = useChatPanelContentState({
       active,
@@ -457,46 +301,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         isChatFocus,
         startPageOpen,
       });
-
-    const setSelectedProject = useSetAtom(chatPanelSelectedProjectAtom);
-    const setSelectedWorkItem = useSetAtom(chatPanelSelectedWorkItemAtom);
-    const {
-      handleCancelCollabOrgCreate,
-      handleCancelProjectCreate,
-      handleCancelWorkItemCreate,
-      handleChatPanelProjectCreated,
-      handleChatPanelWorkItemCreated,
-      handleProjectAgentCreatorToggle,
-      handleWorkItemAgentCreatorToggle,
-    } = useProjectWorkItemHandlers({
-      bumpProjectListRefresh,
-      createProjectContext,
-      dispatchClearSession,
-      handleReturnToSessionCreator,
-      sessionCreatorAvailable: Boolean(SessionCreatorSlot),
-      setActiveSessionId,
-      setCreateTarget,
-      setSelectedProject,
-      setSelectedWorkItem,
-      setShowProjectAgentCreator,
-      setShowWorkItemAgentCreator,
-      setWorkItemCreateDraft,
-      setWorkstationActiveSessionId,
-    });
-    const {
-      defaultAiWorkItemExecutionTarget,
-      handleAiWorkItemSessionStart,
-      resolveAiWorkItemContext,
-    } = useAiWorkItemCreator({
-      allAgentDefs,
-      createProjectContext,
-      creatorState,
-      setActiveSessionId,
-      setSelectedProject,
-      setWorkItemCreateDraft,
-      setWorkstationActiveSessionId,
-      workItemCreateDraft,
-    });
 
     const {
       handleMoveToWorkstation,
@@ -524,41 +328,20 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     const useFullScreenCreator =
       isChatFocus || useExternalWidth || chatWidth >= chatMaxWidth;
     const creatorVariant = useFullScreenCreator ? "fullScreen" : "default";
-    const creatorClassName = "min-h-0 flex-1";
-    const emptyChatContent = (
-      <ChatPanelEmptyContent
-        createProjectContext={createProjectContext}
-        createTarget={createTarget}
-        createTargetOptions={createTargetOptions}
-        creatorClassName={creatorClassName}
-        creatorVariant={creatorVariant}
-        defaultAiWorkItemExecutionTarget={defaultAiWorkItemExecutionTarget}
-        handleAiWorkItemSessionStart={handleAiWorkItemSessionStart}
-        handleCancelWorkItemCreate={handleCancelWorkItemCreate}
-        handleCancelCollabOrgCreate={handleCancelCollabOrgCreate}
-        handleCancelProjectCreate={handleCancelProjectCreate}
-        handleCreateTargetChange={handleCreateTargetChange}
-        handleChatPanelProjectCreated={handleChatPanelProjectCreated}
-        handleChatPanelCollabOrgCreated={handleChatPanelCollabOrgCreated}
-        handleChatPanelWorkItemCreated={handleChatPanelWorkItemCreated}
-        handleOpenCliTerminal={handleOpenCliTerminal}
-        handleRegionNoticeChange={handleRegionNoticeChange}
-        handleStartPageAddApiKey={handleStartPageAddApiKey}
-        handleStartPageInstallLatestUpdate={handleStartPageInstallLatestUpdate}
-        handleStartPageShowRuntime={handleShowRuntime}
-        handleStartPageSessionStart={handleStartPageSessionStart}
-        handleProjectAgentCreatorToggle={handleProjectAgentCreatorToggle}
-        handleWorkItemAgentCreatorToggle={handleWorkItemAgentCreatorToggle}
-        resolveAiWorkItemContext={resolveAiWorkItemContext}
-        SessionCreatorSlot={SessionCreatorSlot}
-        setWorkItemCreateDraft={setWorkItemCreateDraft}
-        showStartPage={startPageOpen}
-        showProjectAgentCreator={showProjectAgentCreator}
-        showWorkItemAgentCreator={showWorkItemAgentCreator}
-        t={t}
-      />
-    );
-
+    const openRuntimeTab = useSetAtom(openRuntimeInChatPanelTabAtom);
+    const handleShowRuntime = useCallback(() => {
+      openRuntimeTab(t("sessions:chat.startPage.tabs.runtime"));
+    }, [openRuntimeTab, t]);
+    const emptyChatContent = useChatPanelCreationContent({
+      t,
+      startPageOpen,
+      sessionCreatorSlot: SessionCreatorSlot,
+      creatorVariant,
+      handleShowRuntime,
+      handleOpenLaunchpadTab,
+      handleOpenCliTerminal,
+      handleRegionNoticeChange,
+    });
     const tabStrip = <ChatPanelTabBar />;
 
     const tabStripPlus = (
@@ -567,8 +350,8 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
           onOpenLaunchpad={handleOpenLaunchpadTab}
           onOpenKanban={handleOpenKanbanTab}
           onOpenRuntime={handleShowRuntime}
-          onNewProject={handleStartPageNewProject}
-          onNewWorkItem={handleStartPageNewWorkItem}
+          onNewProject={openProjectCreate}
+          onNewWorkItem={openWorkItemCreate}
           onOpenSideChat={handleOpenSideChat}
         />
         {startPageOpen && !isStandaloneToolTabActive && (


### PR DESCRIPTION
## Problem

The chat host mixes layout/tab/session composition with creation workflows and membership-based access reconciliation. Its empty-content wiring exposes 32 feature props, keeping unrelated domain state and actions in the host.

## Solution

Move creation state/actions into useChatPanelCreationContent and the existing three access effects into useChatPanelAccessReconciliation. Both run unconditionally for the same chat-host lifetime, including when their content is hidden. The host passes eight presentation/chrome inputs, and the creation owner returns the existing ChatPanelEmptyContent element without an extra wrapper.

Reuse host translation, start-page state, and cloud selection so the extraction does not add subscriptions. Existing project/work-item/AI handlers, tab keep-alive policy, creation defaults, cancel/reset order, callbacks, view markup, copy, and styling remain unchanged.

## Potential risks

Moving creator state into conditional children would lose drafts; the hook stays mounted and hide/show regression tests check retained drafts and choices. Access reconciliation must remain active for hidden tabs and ignore outdated lookups; tests cover unknown/loaded rosters, scope changes, and unmount cancellation. Actual AI/session launch, native Tauri UI, pixel appearance, offline/reconnect, multi-instance behavior, and CPU/RSS were not exercised. Desktop computer control was not authorized. No runtime performance improvement is claimed.

No dependency, configuration, storage, API, IPC, or migration changes. Reverting the commit requires no data recovery.

## Verification

- `pnpm run typecheck --incremental --tsBuildInfoFile "$(git rev-parse --git-path chat-host-final.tsbuildinfo)"`: full-project check passed
- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.test.ts src/engines/ChatPanel/hooks/useProjectWorkItemHandlers.test.ts src/engines/ChatPanel/ChatPanelContent.test.ts --maxWorkers=2 --minWorkers=1`: 4 files / 14 tests passed
- `pnpm exec eslint src/engines/ChatPanel/index.tsx src/engines/ChatPanel/hooks/useChatPanelCreationContent.tsx src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.ts src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.test.ts --max-warnings 0`: passed
- `pnpm run check:circular`: passed, 6,344 modules
- `pnpm run check:test-placement`: passed, 439 directories
- `git diff --check`: passed
- One-off TypeScript AST-printer comparison: nine moved initializers/JSX, three feature-hook calls, and all three access effects match base
- Independent review checked unconditional lifetime, initial defaults, all emitted props, cancel/reset order, account/updater navigation, runtime actions, and access effects
- Full suite, live AI/session launch, and native screenshots/E2E not run; leaf widgets/network behavior are test seams, view markup is untouched, and desktop control was not authorized

Latest develop `55392aa43` was incorporated before this commit. Its new header actions menu and visibility guard are preserved; the focused tests and AST comparison were rerun against that version.

Normal repository hooks ran. Their worktree stats path did not append the usual commit trailer; nothing was bypassed or fabricated. The separate full-project check above is the compilation evidence.

## Audit

Architecture coverage and lifecycle evidence are included. UI audit: 0 fix / 4 keep with reason / 0 abstract. Runtime performance sign-off remains blocked by absent real-app measurements; no performance claim is made.

## Integration verification

All five independent pane-refactor branches also merged cleanly together in a temporary verification worktree based on develop `55392aa43`. The PRs remain separate; this checks their combined compatibility with the newly merged creator-layout work.

- Combined Vitest run below: **56 files / 337 tests passed**, including the project-pane snapshots
- `pnpm run typecheck --incremental --tsBuildInfoFile "$(git rev-parse --git-path pane-combined.tsbuildinfo)"`: full-project check passed
- `pnpm run check:circular`: passed, no cycles across 6,370 modules
- `pnpm run check:test-placement`: passed, 441 directories
- `git diff --cached --check`: passed

<details>
<summary>Exact combined test command</summary>

```sh
pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__ src/modules/MainApp/Integrations src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector src/scaffold/NavigationSidebar/connectors/useProjectsWorkItemMenuItems src/scaffold/NavigationSidebar/connectors/useSessionMenuItems src/scaffold/NavigationSidebar/connectors/__tests__/SidebarGuideButton.test.ts src/scaffold/NavigationSidebar/connectors/__tests__/workstationSidebarData.test.ts src/engines/ChatPanel/panels/ProjectPanelView.test.ts src/modules/ProjectManager/WorkItems/workItemSource.test.ts src/modules/ProjectManager/WorkItems/workItemPartialUpdate.test.ts src/modules/ProjectManager/WorkItems/workItemsViewModel.test.ts src/modules/ProjectManager/WorkItems/hooks/__tests__/workItemsData.test.ts src/modules/ProjectManager/ProjectManagerLayout/components/ProjectWorkItemsTabContentDataLoader.test.ts src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts src/engines/ChatPanel/hooks/useChatPanelAccessReconciliation.test.ts src/engines/ChatPanel/hooks/useProjectWorkItemHandlers.test.ts src/engines/ChatPanel/ChatPanelContent.test.ts --maxWorkers=2 --minWorkers=1
```

</details>
