### PR TITLE
test(rust): cover five crates that had no Rust tests

### DIFF
--- a/src-tauri/crates/app-platform/src/lib.rs
+++ b/src-tauri/crates/app-platform/src/lib.rs
@@ -38,3 +38,41 @@ pub fn hide_console(command: &mut std::process::Command) {
     #[cfg(not(windows))]
     let _ = command;
 }
+
+#[cfg(test)]
+mod tests {
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn hide_console_leaves_the_command_runnable() {
+        // On Windows this sets CREATE_NO_WINDOW; everywhere else it is a
+        // no-op. Either way the command must still spawn and capture output —
+        // this is the shim every subprocess in the app passes through.
+        let mut command = Command::new("echo");
+        command.arg("orgii").stdout(Stdio::piped());
+
+        super::hide_console(&mut command);
+
+        let output = command.output().expect("spawn echo");
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "orgii");
+    }
+
+    #[test]
+    fn hide_console_can_be_applied_more_than_once() {
+        let mut command = Command::new("echo");
+        command.arg("twice").stdout(Stdio::piped());
+
+        super::hide_console(&mut command);
+        super::hide_console(&mut command);
+
+        let output = command.output().expect("spawn echo");
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "twice");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn create_no_window_matches_the_win32_constant() {
+        assert_eq!(super::CREATE_NO_WINDOW, 0x0800_0000);
+    }
+}

--- a/src-tauri/crates/app-platform/src/objc_bridge/mod.rs
+++ b/src-tauri/crates/app-platform/src/objc_bridge/mod.rs
@@ -69,3 +69,65 @@ pub fn with_objc_catch<T, F: FnOnce() -> T>(label: &str, f: F) -> Result<T, Stri
         None => Err(format!("{}: trampoline did not run", label)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn returns_the_closure_value_when_nothing_throws() {
+        assert_eq!(with_objc_catch("add", || 1 + 1), Ok(2));
+    }
+
+    #[test]
+    fn carries_non_copy_values_back_across_the_c_trampoline() {
+        // The result travels through a heap box behind a `*mut c_void`, so a
+        // type that owns an allocation is the interesting case.
+        let value = with_objc_catch("build", || vec!["a".to_string(), "b".to_string()])
+            .expect("no exception");
+
+        assert_eq!(value, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn runs_the_closure_exactly_once() {
+        static CALLS: AtomicUsize = AtomicUsize::new(0);
+
+        with_objc_catch("count", || {
+            CALLS.fetch_add(1, Ordering::SeqCst);
+        })
+        .expect("no exception");
+
+        assert_eq!(CALLS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn converts_a_rust_panic_into_an_err_instead_of_unwinding_into_objc() {
+        // Unwinding across the `extern "C"` trampoline would abort the
+        // process, which is exactly what this bridge exists to prevent.
+        let result: Result<(), String> =
+            with_objc_catch("explode", || panic!("boom inside the trampoline"));
+
+        let err = result.unwrap_err();
+        assert_eq!(err, "explode: Rust panic during ObjC call");
+        // The label is the only breadcrumb in the log, so it has to survive.
+        assert!(err.starts_with("explode:"));
+    }
+
+    #[test]
+    fn a_panic_in_one_call_does_not_poison_the_next() {
+        let _: Result<(), String> = with_objc_catch("first", || panic!("boom"));
+
+        assert_eq!(with_objc_catch("second", || "still works"), Ok("still works"));
+    }
+
+    #[test]
+    fn moves_captured_state_into_the_closure() {
+        let owned = String::from("captured");
+
+        let result = with_objc_catch("move", move || owned.len()).expect("no exception");
+
+        assert_eq!(result, 8);
+    }
+}

--- a/src-tauri/crates/bin-provider-key-check/src/main.rs
+++ b/src-tauri/crates/bin-provider-key-check/src/main.rs
@@ -149,3 +149,89 @@ async fn run() -> Result<(), String> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> Result<ConfigFile, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn a_minimal_entry_needs_only_the_agent_type_and_key_env() {
+        // Everything else is `#[serde(default)]` so a CI config can stay as
+        // small as the provider allows.
+        let config = parse(
+            r#"{ "checks": [ { "agent_type": "openai", "api_key_env": "OPENAI_API_KEY" } ] }"#,
+        )
+        .expect("parse");
+
+        let entry = &config.checks[0];
+        assert_eq!(entry.agent_type, "openai");
+        assert_eq!(entry.api_key_env, "OPENAI_API_KEY");
+        assert_eq!(entry.base_url, None);
+        assert_eq!(entry.base_url_env, None);
+        assert_eq!(entry.session_token_env, None);
+        assert_eq!(entry.test_model, None);
+        assert_eq!(entry.protocol, None);
+    }
+
+    #[test]
+    fn every_optional_field_round_trips() {
+        let config = parse(
+            r#"{ "checks": [ {
+                   "agent_type": "cursor",
+                   "api_key_env": "CURSOR_KEY",
+                   "base_url": "https://api.example.com",
+                   "base_url_env": "CURSOR_BASE_URL",
+                   "session_token_env": "CURSOR_SESSION",
+                   "test_model": "gpt-4o-mini",
+                   "protocol": "openai"
+                 } ] }"#,
+        )
+        .expect("parse");
+
+        let entry = &config.checks[0];
+        assert_eq!(entry.base_url.as_deref(), Some("https://api.example.com"));
+        assert_eq!(entry.base_url_env.as_deref(), Some("CURSOR_BASE_URL"));
+        assert_eq!(entry.session_token_env.as_deref(), Some("CURSOR_SESSION"));
+        assert_eq!(entry.test_model.as_deref(), Some("gpt-4o-mini"));
+        assert_eq!(entry.protocol.as_deref(), Some("openai"));
+    }
+
+    #[test]
+    fn a_missing_required_field_fails_the_parse() {
+        // `agent_type` and `api_key_env` have no default; a config missing
+        // either would otherwise validate nothing and still exit 0.
+        assert!(parse(r#"{ "checks": [ { "agent_type": "openai" } ] }"#).is_err());
+        assert!(parse(r#"{ "checks": [ { "api_key_env": "KEY" } ] }"#).is_err());
+        assert!(parse(r#"{ "entries": [] }"#).is_err(), "`checks` is required");
+    }
+
+    #[test]
+    fn an_empty_checks_array_parses_and_is_rejected_later_by_run() {
+        // Parsing succeeds; `run` turns this into the "empty `checks` array"
+        // error so the operator sees why nothing was validated.
+        let config = parse(r#"{ "checks": [] }"#).expect("parse");
+        assert!(config.checks.is_empty());
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored_rather_than_rejected() {
+        // No `deny_unknown_fields`: a typo like `api_key_ENV` does not fail
+        // the parse, it fails later as a missing required field. A typo in an
+        // *optional* key is silently dropped.
+        let config = parse(
+            r#"{ "checks": [ {
+                   "agent_type": "openai",
+                   "api_key_env": "OPENAI_API_KEY",
+                   "test_modell": "gpt-4o-mini"
+                 } ], "note": "ignored" }"#,
+        )
+        .expect("parse");
+
+        assert_eq!(config.checks.len(), 1);
+        assert_eq!(config.checks[0].test_model, None);
+    }
+}

--- a/src-tauri/crates/bin-telegram-smoke/src/main.rs
+++ b/src-tauri/crates/bin-telegram-smoke/src/main.rs
@@ -177,3 +177,87 @@ fn build_echo_reply(msg: &InboundMessage) -> String {
     }
     format!("echo ({}): {}", msg.channel, msg.content)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------- token redaction ----------
+
+    #[test]
+    fn token_preview_keeps_the_bot_id_and_drops_the_secret() {
+        // The preview is logged at startup, so the secret half must never
+        // survive into a log file or a pasted terminal transcript.
+        let preview = token_preview("123456789:AAHrandom-secret-material");
+
+        assert_eq!(preview, "123456789:***");
+        assert!(!preview.contains("AAHrandom-secret-material"));
+    }
+
+    #[test]
+    fn token_preview_redacts_everything_when_the_shape_is_unfamiliar() {
+        // A token that is not `<bot_id>:<secret>` might be entirely secret,
+        // so nothing is echoed rather than guessing which half is safe.
+        assert_eq!(token_preview("AAHrandom-secret-material"), "***");
+        assert_eq!(token_preview(""), "***");
+    }
+
+    #[test]
+    fn token_preview_splits_on_the_first_colon_only() {
+        // `split_once` keeps later colons inside the redacted half.
+        assert_eq!(token_preview("123:secret:with:colons"), "123:***");
+    }
+
+    // ---------- allow-list parsing ----------
+
+    #[test]
+    fn allow_from_is_empty_when_unset_and_trims_and_drops_blank_entries() {
+        // One test because the env var is process-wide.
+        std::env::remove_var("ORGII_TELEGRAM_ALLOW_FROM");
+        assert!(load_allow_from().is_empty(), "unset means no restriction");
+
+        std::env::set_var("ORGII_TELEGRAM_ALLOW_FROM", " 111 , 222,,333 ,");
+        assert_eq!(load_allow_from(), vec!["111", "222", "333"]);
+
+        // A value of only separators must not produce an allow-list of one
+        // empty string, which would match nobody and look like a lockout.
+        std::env::set_var("ORGII_TELEGRAM_ALLOW_FROM", " , , ");
+        assert!(load_allow_from().is_empty());
+
+        std::env::remove_var("ORGII_TELEGRAM_ALLOW_FROM");
+    }
+
+    // ---------- echo replies ----------
+
+    #[test]
+    fn start_command_gets_the_liveness_banner() {
+        let msg = InboundMessage::new("telegram", "42", "chat-1", "/start");
+
+        let reply = build_echo_reply(&msg);
+        assert!(reply.contains("smoke-test is alive"));
+        assert!(!reply.starts_with("echo ("));
+    }
+
+    #[test]
+    fn start_command_matches_by_prefix_so_arguments_are_accepted() {
+        // Telegram appends a payload to deep links (`/start ref=abc`).
+        let msg = InboundMessage::new("telegram", "42", "chat-1", "/start ref=abc");
+
+        assert!(build_echo_reply(&msg).contains("smoke-test is alive"));
+    }
+
+    #[test]
+    fn any_other_message_is_echoed_with_its_channel() {
+        let msg = InboundMessage::new("telegram", "42", "chat-1", "hello there");
+
+        assert_eq!(build_echo_reply(&msg), "echo (telegram): hello there");
+    }
+
+    #[test]
+    fn a_message_merely_mentioning_start_is_still_echoed() {
+        // The check is a prefix test, not a substring test.
+        let msg = InboundMessage::new("telegram", "42", "chat-1", "please /start it");
+
+        assert_eq!(build_echo_reply(&msg), "echo (telegram): please /start it");
+    }
+}

--- a/src-tauri/crates/db-browser/Cargo.toml
+++ b/src-tauri/crates/db-browser/Cargo.toml
@@ -21,3 +21,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tauri = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.13"

--- a/src-tauri/crates/db-browser/src/ops.rs
+++ b/src-tauri/crates/db-browser/src/ops.rs
@@ -419,3 +419,531 @@ pub fn is_valid_sqlite_file(path: &str) -> Result<bool, String> {
     }
     Ok(&header[..15] == b"SQLite format 3")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// In-memory DB with a small fixture table. Every test gets its own.
+    fn fixture() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute_batch(
+            "CREATE TABLE users (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 name TEXT NOT NULL,
+                 nickname TEXT DEFAULT 'anon',
+                 score REAL,
+                 avatar BLOB
+             );
+             CREATE VIEW active_users AS SELECT * FROM users;
+             INSERT INTO users (name, nickname, score, avatar) VALUES
+                 ('carol', 'cc', 3.5, x'0a0b'),
+                 ('alice', NULL, 1.0, NULL),
+                 ('bob',   'bb', 2.25, NULL);",
+        )
+        .expect("seed fixture");
+        conn
+    }
+
+    fn map(pairs: &[(&str, serde_json::Value)]) -> ColumnValueMap {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), value.clone()))
+            .collect()
+    }
+
+    // ---------- row serialization ----------
+
+    #[test]
+    fn query_maps_every_sqlite_storage_class_to_json() {
+        let conn = fixture();
+        let result = query(
+            &conn,
+            "SELECT 1, 2.5, 'text', NULL, x'0a0b' FROM users LIMIT 1",
+        )
+        .expect("query");
+
+        assert_eq!(result.row_count, 1);
+        assert_eq!(
+            result.values[0],
+            vec![
+                json!(1),
+                json!(2.5),
+                json!("text"),
+                serde_json::Value::Null,
+                // Blobs are hex-encoded so they survive the JSON round-trip
+                // to the frontend, which has no binary channel.
+                json!("0x0a0b"),
+            ]
+        );
+    }
+
+    #[test]
+    fn query_reports_column_names_and_leaves_total_count_unset() {
+        let conn = fixture();
+        let result = query(&conn, "SELECT name, score FROM users ORDER BY name").expect("query");
+
+        assert_eq!(result.columns, vec!["name", "score"]);
+        assert_eq!(result.row_count, 3);
+        // `total_count` is a pagination concept; the free-form query path
+        // must not invent one.
+        assert_eq!(result.total_count, None);
+    }
+
+    #[test]
+    fn query_propagates_sql_errors_as_err() {
+        let conn = fixture();
+        // Unlike `execute`, `query` surfaces failures as `Err`, not as an
+        // `ExecuteResult { success: false }`.
+        assert!(query(&conn, "SELECT * FROM missing_table").is_err());
+    }
+
+    // ---------- schema introspection ----------
+
+    #[test]
+    fn get_tables_lists_tables_and_views_sorted_and_skips_sqlite_internals() {
+        let conn = fixture();
+        // `sqlite_sequence` exists because of AUTOINCREMENT and must stay hidden.
+        let tables = get_tables(&conn).expect("get tables");
+
+        let names: Vec<&str> = tables.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, vec!["active_users", "users"]);
+
+        assert_eq!(tables[0].kind, "view");
+        assert_eq!(tables[1].kind, "table");
+        assert!(tables[1].sql.as_deref().unwrap().contains("CREATE TABLE"));
+        // Row counts are deliberately not computed here — counting every
+        // table on open would be O(rows) per file.
+        assert!(tables.iter().all(|t| t.row_count.is_none()));
+    }
+
+    #[test]
+    fn get_table_schema_reports_nullability_primary_key_and_defaults() {
+        let conn = fixture();
+        let cols = get_table_schema(&conn, "users").expect("schema");
+
+        let names: Vec<&str> = cols.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["id", "name", "nickname", "score", "avatar"]);
+
+        let id = &cols[0];
+        assert_eq!(id.col_type, "INTEGER");
+        assert!(id.primary_key);
+        assert!(id.auto_increment);
+
+        let name = &cols[1];
+        assert!(!name.nullable, "NOT NULL column must report nullable=false");
+        assert!(!name.primary_key);
+        assert!(!name.auto_increment);
+        assert_eq!(name.default_value, None);
+
+        let nickname = &cols[2];
+        assert!(nickname.nullable);
+        // PRAGMA returns the default as raw SQL text, so a string default
+        // keeps its SQL quotes and then picks up JSON quotes on top.
+        assert_eq!(nickname.default_value.as_deref(), Some("\"'anon'\""));
+    }
+
+    #[test]
+    fn get_table_schema_marks_integer_primary_key_without_autoincrement_as_not_auto() {
+        let conn = fixture();
+        conn.execute_batch("CREATE TABLE plain (id INTEGER PRIMARY KEY, label TEXT)")
+            .expect("create table");
+
+        let cols = get_table_schema(&conn, "plain").expect("schema");
+        assert!(cols[0].primary_key);
+        assert!(
+            !cols[0].auto_increment,
+            "rowid alias without AUTOINCREMENT must not be reported as auto-increment"
+        );
+    }
+
+    #[test]
+    fn get_table_schema_returns_empty_for_unknown_table() {
+        let conn = fixture();
+        // PRAGMA table_info on a missing table is not an error in SQLite —
+        // it just yields no rows.
+        assert!(get_table_schema(&conn, "missing").expect("schema").is_empty());
+    }
+
+    // ---------- paginated table data ----------
+
+    #[test]
+    fn get_table_data_defaults_to_first_page_and_reports_total_count() {
+        let conn = fixture();
+        let result = get_table_data(&conn, "users", None).expect("table data");
+
+        assert_eq!(result.row_count, 3);
+        assert_eq!(result.total_count, Some(3));
+        assert_eq!(result.columns[1], "name");
+    }
+
+    #[test]
+    fn get_table_data_paginates_with_offset_and_keeps_total_count_whole() {
+        let conn = fixture();
+        let options = QueryOptions {
+            page: Some(2),
+            page_size: Some(2),
+            order_by: Some("name".to_string()),
+            order_direction: None,
+        };
+
+        let result = get_table_data(&conn, "users", Some(&options)).expect("table data");
+
+        assert_eq!(result.row_count, 1, "page 2 of size 2 over 3 rows");
+        assert_eq!(result.values[0][1], json!("carol"));
+        // `total_count` is the table total, not the page total — the UI needs
+        // it to render the pager.
+        assert_eq!(result.total_count, Some(3));
+    }
+
+    #[test]
+    fn get_table_data_orders_ascending_by_default_and_descending_on_request() {
+        let conn = fixture();
+        let ascending = QueryOptions {
+            page: None,
+            page_size: None,
+            order_by: Some("name".to_string()),
+            order_direction: None,
+        };
+        let descending = QueryOptions {
+            order_direction: Some("DESC".to_string()),
+            ..ascending.clone()
+        };
+
+        let asc = get_table_data(&conn, "users", Some(&ascending)).expect("asc");
+        let desc = get_table_data(&conn, "users", Some(&descending)).expect("desc");
+
+        assert_eq!(
+            asc.values.iter().map(|r| r[1].clone()).collect::<Vec<_>>(),
+            vec![json!("alice"), json!("bob"), json!("carol")]
+        );
+        // Direction matching is case-insensitive.
+        assert_eq!(
+            desc.values.iter().map(|r| r[1].clone()).collect::<Vec<_>>(),
+            vec![json!("carol"), json!("bob"), json!("alice")]
+        );
+    }
+
+    #[test]
+    fn get_table_data_treats_unrecognized_direction_as_ascending() {
+        let conn = fixture();
+        let options = QueryOptions {
+            page: None,
+            page_size: None,
+            order_by: Some("name".to_string()),
+            // Anything that is not "desc" must not be spliced into the SQL
+            // as-is; it falls back to ASC.
+            order_direction: Some("desc; DROP TABLE users".to_string()),
+        };
+
+        let result = get_table_data(&conn, "users", Some(&options)).expect("table data");
+        assert_eq!(result.values[0][1], json!("alice"));
+        assert_eq!(
+            get_table_data(&conn, "users", None).expect("table intact").row_count,
+            3
+        );
+    }
+
+    #[test]
+    fn get_table_data_clamps_non_positive_page_and_page_size() {
+        let conn = fixture();
+        let options = QueryOptions {
+            page: Some(0),
+            page_size: Some(-5),
+            order_by: None,
+            order_direction: None,
+        };
+
+        // Without clamping this builds `LIMIT -5 OFFSET 5` — SQLite reads a
+        // negative LIMIT as "no limit", which would silently return the whole
+        // table instead of one page.
+        let result = get_table_data(&conn, "users", Some(&options)).expect("table data");
+        assert_eq!(result.row_count, 1);
+    }
+
+    #[test]
+    fn get_table_data_quotes_identifiers_containing_spaces_and_keywords() {
+        let conn = fixture();
+        conn.execute_batch(
+            "CREATE TABLE \"order details\" (\"select\" TEXT); \
+             INSERT INTO \"order details\" VALUES ('kept')",
+        )
+        .expect("create quoted table");
+
+        let options = QueryOptions {
+            page: None,
+            page_size: None,
+            order_by: Some("select".to_string()),
+            order_direction: None,
+        };
+        let result = get_table_data(&conn, "order details", Some(&options)).expect("table data");
+
+        assert_eq!(result.columns, vec!["select"]);
+        assert_eq!(result.values[0][0], json!("kept"));
+    }
+
+    #[test]
+    fn get_table_data_reports_zero_total_count_when_the_table_is_missing() {
+        let conn = fixture();
+        // The page query fails, so the call is an `Err`; the `COUNT(*)`
+        // fallback only matters for tables that vanish between the two
+        // statements.
+        assert!(get_table_data(&conn, "missing", None).is_err());
+    }
+
+    // ---------- execute ----------
+
+    #[test]
+    fn execute_runs_a_batch_and_reports_the_last_insert_id() {
+        let conn = fixture();
+        let result = execute(
+            &conn,
+            "INSERT INTO users (name) VALUES ('dave'); \
+             INSERT INTO users (name) VALUES ('erin');",
+        )
+        .expect("execute");
+
+        assert!(result.success);
+        assert_eq!(result.error, None);
+        assert_eq!(result.last_insert_id, Some(5));
+        // `execute_batch` reports the changes of the *last* statement only.
+        assert_eq!(result.rows_affected, 1);
+    }
+
+    #[test]
+    fn execute_returns_a_failed_result_instead_of_err_on_bad_sql() {
+        let conn = fixture();
+        // The frontend renders the SQL error inline, so a syntax error must
+        // come back as a successful call carrying `success: false`.
+        let result = execute(&conn, "NOT SQL AT ALL").expect("execute must not be Err");
+
+        assert!(!result.success);
+        assert_eq!(result.rows_affected, 0);
+        assert_eq!(result.last_insert_id, None);
+        assert!(result.error.is_some());
+    }
+
+    // ---------- insert / update / delete ----------
+
+    #[test]
+    fn insert_binds_every_json_type_as_a_parameter() {
+        let conn = fixture();
+        let result = insert(
+            &conn,
+            "users",
+            &map(&[
+                ("name", json!("dave")),
+                ("nickname", serde_json::Value::Null),
+                ("score", json!(9.5)),
+            ]),
+        )
+        .expect("insert");
+
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(result.rows_affected, 1);
+        assert_eq!(result.last_insert_id, Some(4));
+
+        let row = query(&conn, "SELECT nickname, score FROM users WHERE name = 'dave'")
+            .expect("read back");
+        assert_eq!(row.values[0], vec![serde_json::Value::Null, json!(9.5)]);
+    }
+
+    #[test]
+    fn insert_coerces_bool_and_composite_json_values() {
+        let conn = fixture();
+        conn.execute_batch("CREATE TABLE misc (flag, blob_ish, nested)")
+            .expect("create table");
+
+        let result = insert(
+            &conn,
+            "misc",
+            &map(&[
+                ("flag", json!(true)),
+                ("blob_ish", json!(7)),
+                // Arrays and objects have no SQLite storage class, so they are
+                // stored as their JSON text.
+                ("nested", json!({"a": 1})),
+            ]),
+        )
+        .expect("insert");
+        assert!(result.success, "{:?}", result.error);
+
+        let row = query(&conn, "SELECT flag, blob_ish, nested FROM misc").expect("read back");
+        assert_eq!(
+            row.values[0],
+            vec![json!(1), json!(7), json!("{\"a\":1}")]
+        );
+    }
+
+    #[test]
+    fn insert_treats_a_string_value_as_data_not_sql() {
+        let conn = fixture();
+        let result = insert(
+            &conn,
+            "users",
+            &map(&[("name", json!("'); DROP TABLE users; --"))]),
+        )
+        .expect("insert");
+
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(
+            query(&conn, "SELECT COUNT(*) FROM users").expect("count").values[0][0],
+            json!(4)
+        );
+    }
+
+    #[test]
+    fn insert_returns_a_failed_result_when_a_constraint_rejects_the_row() {
+        let conn = fixture();
+        // `name` is NOT NULL.
+        let result = insert(&conn, "users", &map(&[("score", json!(1))])).expect("insert");
+
+        assert!(!result.success);
+        assert_eq!(result.rows_affected, 0);
+        assert!(result.error.unwrap().contains("NOT NULL"));
+    }
+
+    #[test]
+    fn update_applies_only_to_rows_matching_every_where_column() {
+        let conn = fixture();
+        let result = update(
+            &conn,
+            "users",
+            &map(&[("score", json!(10.0)), ("nickname", json!("zz"))]),
+            &map(&[("name", json!("alice"))]),
+        )
+        .expect("update");
+
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(result.rows_affected, 1);
+        // UPDATE does not produce a new rowid.
+        assert_eq!(result.last_insert_id, None);
+
+        let rows = query(&conn, "SELECT name, score, nickname FROM users ORDER BY name")
+            .expect("read back");
+        assert_eq!(rows.values[0], vec![json!("alice"), json!(10.0), json!("zz")]);
+        assert_eq!(rows.values[1][1], json!(2.25), "other rows untouched");
+    }
+
+    #[test]
+    fn update_combines_multiple_where_columns_with_and() {
+        let conn = fixture();
+        let result = update(
+            &conn,
+            "users",
+            &map(&[("score", json!(0.0))]),
+            &map(&[("name", json!("alice")), ("nickname", json!("bb"))]),
+        )
+        .expect("update");
+
+        assert!(result.success, "{:?}", result.error);
+        // No row has name='alice' AND nickname='bb'.
+        assert_eq!(result.rows_affected, 0);
+    }
+
+    #[test]
+    fn update_matches_a_null_where_value_against_no_rows() {
+        let conn = fixture();
+        let result = update(
+            &conn,
+            "users",
+            &map(&[("score", json!(0.0))]),
+            &map(&[("nickname", serde_json::Value::Null)]),
+        )
+        .expect("update");
+
+        assert!(result.success, "{:?}", result.error);
+        // `"nickname" = NULL` is never true in SQL, even for the row whose
+        // nickname *is* NULL. Editing a row through a NULL cell silently
+        // does nothing rather than updating the wrong row.
+        assert_eq!(result.rows_affected, 0);
+    }
+
+    #[test]
+    fn delete_removes_only_the_matching_rows() {
+        let conn = fixture();
+        let result = delete(&conn, "users", &map(&[("name", json!("bob"))])).expect("delete");
+
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(result.rows_affected, 1);
+        assert_eq!(
+            query(&conn, "SELECT COUNT(*) FROM users").expect("count").values[0][0],
+            json!(2)
+        );
+    }
+
+    #[test]
+    fn delete_with_an_unknown_where_column_silently_matches_nothing() {
+        let conn = fixture();
+        let result =
+            delete(&conn, "users", &map(&[("nope", json!(1))])).expect("delete must not be Err");
+
+        // SQLite's double-quote fallback turns the unresolvable identifier
+        // `"nope"` into the *string literal* 'nope', so the predicate is
+        // `'nope' = 1` — false for every row. The call therefore reports
+        // success with zero rows rather than "no such column". Callers must
+        // treat `rows_affected == 0` as "nothing matched", not as "deleted".
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(result.rows_affected, 0);
+        assert_eq!(
+            query(&conn, "SELECT COUNT(*) FROM users").expect("count").values[0][0],
+            json!(3)
+        );
+    }
+
+    #[test]
+    fn update_returns_a_failed_result_for_an_unknown_set_column() {
+        let conn = fixture();
+        // Unlike a WHERE column, a SET target has no string-literal fallback,
+        // so a stale column name does surface as an error here.
+        let result = update(
+            &conn,
+            "users",
+            &map(&[("nope", json!(1))]),
+            &map(&[("name", json!("alice"))]),
+        )
+        .expect("update must not be Err");
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("no such column"));
+    }
+
+    // ---------- file validation ----------
+
+    #[test]
+    fn is_valid_sqlite_file_accepts_a_real_database() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("real.sqlite");
+        let conn = Connection::open(&path).expect("create db");
+        conn.execute_batch("CREATE TABLE t (a)").expect("write header");
+        drop(conn);
+
+        assert_eq!(
+            is_valid_sqlite_file(path.to_str().unwrap()),
+            Ok(true)
+        );
+    }
+
+    #[test]
+    fn is_valid_sqlite_file_rejects_other_files_without_erroring() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let text = dir.path().join("notes.txt");
+        std::fs::write(&text, "this is definitely not a database file").expect("write");
+        assert_eq!(is_valid_sqlite_file(text.to_str().unwrap()), Ok(false));
+
+        // Shorter than the 16-byte header read.
+        let stub = dir.path().join("stub.bin");
+        std::fs::write(&stub, b"SQLite format").expect("write");
+        assert_eq!(is_valid_sqlite_file(stub.to_str().unwrap()), Ok(false));
+
+        // A missing path is "not a database", not an error — the picker
+        // calls this on arbitrary user selections.
+        let missing = dir.path().join("nope.sqlite");
+        assert_eq!(is_valid_sqlite_file(missing.to_str().unwrap()), Ok(false));
+
+        // A directory is also just "false".
+        assert_eq!(is_valid_sqlite_file(dir.path().to_str().unwrap()), Ok(false));
+    }
+}

--- a/src-tauri/crates/db-browser/src/pool.rs
+++ b/src-tauri/crates/db-browser/src/pool.rs
@@ -69,3 +69,114 @@ where
         .ok_or_else(|| format!("DB connection not found: {}", connection_id))?;
     func(conn).map_err(|e| e.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a real SQLite file the pool can open read-write.
+    fn seeded_db(dir: &std::path::Path, name: &str) -> String {
+        let path = dir.join(name);
+        let conn = Connection::open(&path).expect("create db");
+        conn.execute_batch("CREATE TABLE t (a); INSERT INTO t VALUES (1)")
+            .expect("seed");
+        drop(conn);
+        path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn open_derives_the_connection_id_from_the_file_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = seeded_db(dir.path(), "ids.sqlite");
+
+        let id = open(&path).expect("open");
+        assert_eq!(id, format!("db:{path}"));
+        close(&id);
+    }
+
+    #[test]
+    fn open_is_idempotent_and_reuses_the_pooled_connection() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = seeded_db(dir.path(), "idempotent.sqlite");
+
+        let first = open(&path).expect("first open");
+        let second = open(&path).expect("second open");
+        assert_eq!(first, second);
+
+        // The second call must not have replaced the live connection: a
+        // temp table created through the first handle is still visible.
+        with(&first, |conn| {
+            conn.execute_batch("CREATE TEMP TABLE marker (x)")
+        })
+        .expect("create temp table");
+        let seen = with(&second, |conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM temp.sqlite_master WHERE name = 'marker'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+        })
+        .expect("read temp table");
+        assert_eq!(seen, 1);
+
+        close(&first);
+    }
+
+    #[test]
+    fn open_fails_for_a_path_that_does_not_exist() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("nope.sqlite");
+
+        // The pool opens READ_WRITE without CREATE, so browsing must never
+        // conjure an empty database at a mistyped path.
+        assert!(open(missing.to_str().unwrap()).is_err());
+        assert!(!missing.exists());
+    }
+
+    #[test]
+    fn with_runs_the_closure_against_the_pooled_connection() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = seeded_db(dir.path(), "with.sqlite");
+        let id = open(&path).expect("open");
+
+        let count = with(&id, |conn| {
+            conn.query_row("SELECT COUNT(*) FROM t", [], |row| row.get::<_, i64>(0))
+        })
+        .expect("with");
+        assert_eq!(count, 1);
+
+        close(&id);
+    }
+
+    #[test]
+    fn with_reports_the_missing_connection_id_after_close() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = seeded_db(dir.path(), "closed.sqlite");
+        let id = open(&path).expect("open");
+        close(&id);
+
+        let err = with(&id, |conn| conn.query_row("SELECT 1", [], |_| Ok(()))).unwrap_err();
+        assert!(err.contains("DB connection not found"));
+        assert!(err.contains(&id), "the error names the id the caller sent");
+    }
+
+    #[test]
+    fn close_is_a_no_op_for_an_unknown_connection_id() {
+        close("db:/never/opened.sqlite");
+    }
+
+    #[test]
+    fn with_surfaces_closure_errors_as_strings() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = seeded_db(dir.path(), "err.sqlite");
+        let id = open(&path).expect("open");
+
+        let err = with(&id, |conn| {
+            conn.query_row("SELECT * FROM missing", [], |_| Ok(()))
+        })
+        .unwrap_err();
+        assert!(err.contains("missing"), "got {err}");
+
+        close(&id);
+    }
+}

--- a/src-tauri/crates/db-clients/src/commands.rs
+++ b/src-tauri/crates/db-clients/src/commands.rs
@@ -455,3 +455,182 @@ pub async fn db_sql_get_table_schema(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every command in this module resolves a pooled connection first, so a
+    /// test only needs an id that was never connected.
+    fn unconnected_id(name: &str) -> String {
+        format!("db-clients-test-never-connected-{name}")
+    }
+
+    /// The result payloads are plain serde DTOs without `Debug`, so unwrap the
+    /// error side by hand rather than widening the production derives.
+    fn err_of<T>(result: Result<T, String>) -> String {
+        match result {
+            Ok(_) => panic!("expected an error, got Ok"),
+            Err(err) => err,
+        }
+    }
+
+    // ---------- connection lifecycle ----------
+
+    #[tokio::test]
+    async fn connect_rejects_an_unknown_engine_without_dialling_out() {
+        let err = db_sql_connect(
+            unconnected_id("engine"),
+            "sqlite".to_string(),
+            "sqlite:///tmp/whatever.db".to_string(),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err, "Unsupported db_type: sqlite");
+        // A rejected engine must not leave a half-registered pool entry
+        // behind for later commands to find.
+        assert!(POOLS.lock().await.get(&unconnected_id("engine")).is_none());
+    }
+
+    #[tokio::test]
+    async fn connect_engine_name_matching_is_exact_and_case_sensitive() {
+        for engine in ["Postgres", "POSTGRES", "postgresql", "MySQL", ""] {
+            let err = db_sql_connect(
+                unconnected_id("case"),
+                engine.to_string(),
+                "ignored".to_string(),
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(err, format!("Unsupported db_type: {engine}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn disconnect_is_a_no_op_for_an_unknown_connection() {
+        // The frontend calls disconnect on teardown paths that may never have
+        // connected; that must not surface an error to the user.
+        assert_eq!(db_sql_disconnect(unconnected_id("disconnect")).await, Ok(()));
+    }
+
+    // ---------- unresolved-connection guards ----------
+
+    #[tokio::test]
+    async fn query_requires_an_established_connection() {
+        let id = unconnected_id("query");
+        let err = err_of(db_sql_query(id.clone(), "SELECT 1".to_string()).await);
+
+        assert_eq!(err, format!("No connection found for: {id}"));
+    }
+
+    #[tokio::test]
+    async fn execute_requires_an_established_connection() {
+        let id = unconnected_id("execute");
+        let err = err_of(db_sql_execute(id.clone(), "DELETE FROM t".to_string()).await);
+
+        // The guard runs before the SQL is handed to any driver, so a
+        // destructive statement against a dead connection is never sent.
+        assert_eq!(err, format!("No connection found for: {id}"));
+    }
+
+    #[tokio::test]
+    async fn get_tables_requires_an_established_connection() {
+        let id = unconnected_id("tables");
+        let err = err_of(db_sql_get_tables(id.clone()).await);
+
+        assert_eq!(err, format!("No connection found for: {id}"));
+    }
+
+    #[tokio::test]
+    async fn get_table_schema_requires_an_established_connection() {
+        let id = unconnected_id("schema");
+        let err = err_of(db_sql_get_table_schema(id.clone(), "users".to_string()).await);
+
+        assert_eq!(err, format!("No connection found for: {id}"));
+    }
+
+    // ---------- wire contract ----------
+    //
+    // These structs cross the Tauri boundary with **no** `rename_all`, so the
+    // JSON keys stay snake_case. `DatabaseCore`'s `PostgresProvider` /
+    // `MySQLProvider` read `table_type`, `row_count`, `data_type`,
+    // `primary_key`, `default_value` and `auto_increment` verbatim. Adding
+    // `#[serde(rename_all = "camelCase")]` here — as the sibling `db_browser`
+    // crate does — would silently produce `undefined` in both providers, so
+    // the field names are pinned.
+
+    /// Field names in sorted order — JSON object key order is not part of the
+    /// contract, the set of names is.
+    fn field_names(value: &serde_json::Value) -> Vec<&str> {
+        let mut names: Vec<&str> = value
+            .as_object()
+            .expect("serializes to a JSON object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        names.sort_unstable();
+        names
+    }
+
+    #[test]
+    fn query_result_serializes_with_snake_case_keys() {
+        let json = serde_json::to_value(QueryResult {
+            columns: vec!["id".to_string()],
+            rows: vec![vec![serde_json::json!(1)]],
+            row_count: 1,
+        })
+        .expect("serialize");
+
+        assert_eq!(field_names(&json), vec!["columns", "row_count", "rows"]);
+        assert_eq!(json["rows"][0][0], serde_json::json!(1));
+    }
+
+    #[test]
+    fn execute_result_serializes_with_snake_case_keys() {
+        let json = serde_json::to_value(ExecuteResult { rows_affected: 7 }).expect("serialize");
+
+        assert_eq!(field_names(&json), vec!["rows_affected"]);
+        assert_eq!(json["rows_affected"], serde_json::json!(7));
+    }
+
+    #[test]
+    fn table_info_serializes_with_snake_case_keys_and_nullable_row_count() {
+        let json = serde_json::to_value(TableInfo {
+            name: "users".to_string(),
+            table_type: "VIEW".to_string(),
+            row_count: None,
+        })
+        .expect("serialize");
+
+        assert_eq!(field_names(&json), vec!["name", "row_count", "table_type"]);
+        // The providers map `row_count ?? undefined`, so `null` must be sent
+        // rather than the field being skipped.
+        assert_eq!(json["row_count"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn column_info_serializes_with_snake_case_keys() {
+        let json = serde_json::to_value(ColumnInfo {
+            name: "id".to_string(),
+            data_type: "INT4".to_string(),
+            nullable: false,
+            primary_key: true,
+            default_value: Some("nextval('users_id_seq')".to_string()),
+            auto_increment: true,
+        })
+        .expect("serialize");
+
+        assert_eq!(
+            field_names(&json),
+            vec![
+                "auto_increment",
+                "data_type",
+                "default_value",
+                "name",
+                "nullable",
+                "primary_key",
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Five workspace crates shipped with no Rust tests at all — not a single
`#[cfg(test)]` module between them:

| Crate | LOC | Tests |
| --- | --- | --- |
| `db-browser` | 727 | 0 |
| `db-clients` | 479 | 0 |
| `app-platform` | 111 | 0 |
| `bin-telegram-smoke` | 179 | 0 |
| `bin-provider-key-check` | 151 | 0 |

The gap matters most in `db-browser`, which builds SQL against **arbitrary
user SQLite files** and performs row-level insert/update/delete on them, and
in `app-platform::objc_bridge`, whose whole reason to exist is turning an
ObjC exception into an `Err` instead of aborting the process. Neither had a
single assertion. `bin-telegram-smoke::token_preview` redacts a bot token
before it is logged, and nothing pinned that the secret half is dropped.

## Solution

67 inline unit tests, following the repo convention of `#[cfg(test)] mod
tests` in the source file. **No production code was changed** — the diff is
purely additive (`+1091`, `-0`), plus one `tempfile` dev-dependency.

- **`db-browser` (35)** — `ops.rs`: storage-class→JSON mapping including
  blob hex encoding, schema introspection (nullability, PK, AUTOINCREMENT
  detection, SQL-text defaults), pagination/order-by construction, identifier
  quoting for names with spaces and keywords, insert/update/delete parameter
  binding, and `is_valid_sqlite_file` header sniffing. `pool.rs`: connection-id
  derivation, idempotent open, read-write-without-create, lifecycle errors.
- **`db-clients` (11)** — engine rejection without dialling out, the
  unresolved-connection guard on all four query paths, and the snake_case
  serde wire contract the `PostgresProvider` / `MySQLProvider` read verbatim.
- **`app-platform` (8)** — `with_objc_catch` returns closure values across the
  `extern "C"` trampoline, converts a Rust panic into `Err` rather than
  unwinding into ObjC, and stays usable after one; `hide_console` leaves a
  command spawnable.
- **`bin-telegram-smoke` (8)** — token redaction (both shapes), allow-list
  trimming, echo/`/start` dispatch.
- **`bin-provider-key-check` (5)** — CI config parse contract.

Two behaviours the tests pinned deliberately, because they surprised me:

1. `db-browser`'s `delete`/`update` with an unknown **WHERE** column matches
   nothing and reports `success: true, rows_affected: 0`. SQLite's
   double-quote fallback turns the unresolvable `"nope"` into the string
   literal `'nope'`. A SET column has no such fallback and does error.
2. `update` with a `NULL` WHERE value matches zero rows — `"col" = NULL` is
   never true — so editing a row through a NULL cell is a silent no-op.

Both are pre-existing behaviour, unchanged here; the tests record them so the
next reader does not have to rediscover them.

## Potential risks

Low. Nothing outside `#[cfg(test)]` changed, so no runtime behaviour moves and
there is nothing to roll back beyond reverting the commit.

- `db-browser` gains a `tempfile` dev-dependency. Dev-only; it is already the
  workspace-wide convention (13 other crates pin `tempfile = "3.13"`) and does
  not enter the shipped binary.
- Two tests mutate a process-wide env var (`ORGII_GPU_LAYERS` is not among
  them; `ORGII_TELEGRAM_ALLOW_FROM` is). Each keeps all its cases in a single
  `#[test]` and restores the variable, so parallel execution is safe as long as
  no future test in the same binary reads the same variable.
- `db-clients` tests touch the global `POOLS` map, but only via ids that are
  never connected, so they cannot evict or observe a real pool.
- `objc_bridge` tests are macOS-only (the module is already
  `#[cfg(target_os = "macos")]`). CI runs on `macos-latest`, so they execute.

Three defects were found while writing these and are **not** fixed here, to
keep this PR to one responsibility:

- Neither `db-browser::pool` nor `db_clients::db_sql_connect` evicts FIFO
  despite the comment saying so — `HashMap::keys().next()` is arbitrary order,
  so at capacity a randomly chosen live connection is dropped. `db-clients`
  additionally evicts *before* validating `db_type`, so an unsupported-engine
  call at capacity kills a working pool. Not covered: reproducing needs 16/20
  live connections.
- `db_sql_connect` interpolates the driver error into its message, and a sqlx
  connection error can carry the connection string, so a bad password can
  surface a DSN in the UI.

## Verification

Run from `src-tauri/`:

- `cargo test -p db_browser --lib` → **35 passed**, 0 failed
- `cargo test -p db_clients --lib` → **11 passed**, 0 failed
- `cargo test -p app_platform -p bin_provider_key_check -p bin_telegram_smoke`
  → **8 + 5 + 8 = 21 passed**, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` → clean (this is the
  exact CI gate; it lints test targets too)

Not run, and why:

- Full `cargo test --workspace` was not run end-to-end on this branch; the five
  crates above were run individually and the workspace clippy build covers
  compilation of every other test target.
- No UI changes, so no screenshots apply.
- The commit was built with a temporary index from a shared working tree that
  holds unrelated in-progress work, so **git hooks did not run** and the
  `Pre-commit hook ran.` trailer is absent. Clippy and the test runs above were
  executed by hand instead.
