### PR TITLE
build(webpack): add flag-gated react compiler pipeline

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -52,6 +52,26 @@ module.exports = (env, argv) => {
   // depth for speed. Intended for local fast .app builds, not release builds.
   const useFastProd = isProduction && process.env.FAST_PROD === "true";
 
+  // ORGII_REACT_COMPILER=true: run React Compiler (babel-plugin-react-compiler)
+  // over src/**/*.tsx before swc transpiles it. Opt-in spike flag, default off.
+  // Only the SWC pipeline gets the pass — FAST_DEV / FAST_PROD / light-dev
+  // builds skip it, so a compiler-enabled build must not use those env flags.
+  const useReactCompiler = process.env.ORGII_REACT_COMPILER === "true";
+
+  // Babel runs ONLY the compiler transform. TS/JSX are enabled as parser
+  // plugins (parse-only, no preset), so type annotations and JSX survive
+  // into the output and swc stays the transpiler for types/JSX/target
+  // lowering, dev Fast Refresh included.
+  const reactCompilerLoader = {
+    loader: "babel-loader",
+    options: {
+      babelrc: false,
+      configFile: false,
+      parserOpts: { sourceType: "module", plugins: ["typescript", "jsx"] },
+      plugins: [["babel-plugin-react-compiler", { target: "19" }]],
+    },
+  };
+
   const isE2E = process.env.ORGII_E2E === "1";
   const devServerPort = Number.parseInt(
     process.env.WEBPACK_DEV_SERVER_PORT ?? process.env.PORT ?? "1998",
@@ -83,6 +103,13 @@ module.exports = (env, argv) => {
       // id (for example `__webpack_require__.j == 9121` while the emitted
       // runtime id is `49121`), which turns otherwise valid imports into
       // `undefined` only in the packaged app.
+      // React Compiler builds get their own cache DIRECTORY, not just a
+      // version bump: a version change invalidates the whole shared pack, so
+      // toggling the flag would wipe the warm non-compiler dev cache other
+      // sessions rely on. A separate name keeps both caches alive side by side.
+      ...(useReactCompiler
+        ? { name: `react-compiler-${isProduction ? "production" : "development"}` }
+        : {}),
       version: `${
         isProduction ? (useFastProd ? "prod-fast" : "prod") : "dev"
       }-11`,
@@ -230,22 +257,27 @@ module.exports = (env, argv) => {
                     jsx: "automatic",
                   },
                 }
-              : {
-                  // SWC: Fast Rust-based compiler with React Fast Refresh support
-                  loader: "swc-loader",
-                  options: {
-                    jsc: {
-                      target: "es2020",
-                      parser: { syntax: "typescript", tsx: true },
-                      transform: {
-                        react: {
-                          runtime: "automatic",
-                          refresh: !isProduction,
+              : [
+                  {
+                    // SWC: Fast Rust-based compiler with React Fast Refresh support
+                    loader: "swc-loader",
+                    options: {
+                      jsc: {
+                        target: "es2020",
+                        parser: { syntax: "typescript", tsx: true },
+                        transform: {
+                          react: {
+                            runtime: "automatic",
+                            refresh: !isProduction,
+                          },
                         },
                       },
                     },
                   },
-                },
+                  // Loaders run right-to-left: React Compiler sees the
+                  // original TSX, swc transpiles its output.
+                  ...(useReactCompiler ? [reactCompilerLoader] : []),
+                ],
         },
         {
           test: /\.ts$/,

--- a/docs/react-compiler-spike-2026-09-01/README.md
+++ b/docs/react-compiler-spike-2026-09-01/README.md
@@ -1,0 +1,98 @@
+# React Compiler spike — 2026-09-01
+
+Measured feasibility spike for adopting React Compiler (babel-plugin-react-compiler
+1.0.0) on React 19.2.6 with the existing swc-loader webpack pipeline. Everything
+below was measured on this repo at this date; nothing here is enabled by default.
+
+## How to run it
+
+```bash
+ORGII_REACT_COMPILER=true pnpm build          # production
+ORGII_REACT_COMPILER=true pnpm dev:frontend   # dev server (SWC pipeline only)
+```
+
+The flag chains a minimal Babel pass (only `babel-plugin-react-compiler`, TS/JSX
+enabled as parse-only parser plugins) in front of swc-loader for `src/**/*.tsx`.
+swc remains the transpiler — types, JSX lowering, and dev Fast Refresh are
+untouched. `FAST_DEV` / `FAST_PROD` / `ORGII_LIGHT_DEV` builds skip the pass
+entirely (esbuild branch), so a compiler-enabled build must not combine the flag
+with those. Compiler builds use their own webpack cache directory
+(`react-compiler-*`), so toggling the flag does not invalidate the warm
+non-compiler dev cache.
+
+## Coverage (standalone scan, all 4782 non-test `.ts`/`.tsx` files)
+
+| Metric | Value |
+| --- | --- |
+| Candidate functions (components + hooks, `compilationMode: infer`) | 3516 |
+| Compiled successfully | **2880 (81.9%)** |
+| — components in `.tsx` | 2225 |
+| — hooks in `.ts` | 655 |
+| Bailouts | 636 |
+
+The flag as wired compiles `.tsx` only (the 2225 components). Extending the same
+chain to the `.ts` rule would add the 655 hooks at roughly proportional build
+cost (~4400 more files through Babel).
+
+Bailout breakdown (a bailout means the function is left exactly as written —
+safe by construction):
+
+- **~490 compiler todos around `try`/`finally` and `try` without `catch`**
+  (`lowerStatement: Handle TryStatement with a finalizer`, etc.). Largest
+  unlock; shrinks as the upstream compiler adds support, no code change needed.
+- **45** dynamic `import()` inside component bodies (unsupported expression).
+- **26** "Cannot access refs during render" — real rule violations, e.g.
+  `src/components/Tooltip/index.tsx`, `src/components/VirtualizedStickyTree/index.tsx`,
+  `src/features/CodeMirror/Editor/index.tsx`. Worth fixing independently.
+- **23** components skipped because of `eslint-disable react-hooks/*`
+  suppressions (44 files carry such suppressions).
+- **8** "Use of incompatible library" warnings (memo-wrapped virtualization
+  components: `TurnPageList`, `ChannelMessageList`, `KanbanColumn`).
+
+## Build cost (M-series Mac, cold caches, prod cache dir wiped between runs)
+
+| Build | Baseline | With compiler | Delta |
+| --- | --- | --- | --- |
+| `pnpm build` (prod, SWC + Terser) | 65.9 s | 120.9 s | **+55 s (+83%)** |
+| One-shot dev build (SWC + Refresh) | 49.9 s | 92.5 s | **+43 s (+85%)** |
+| Total minified JS (prod) | 27.06 MB | 29.19 MB | **+2.13 MB (+7.9%)** |
+
+- Vendor chunks are byte-identical; the entire size delta is app chunks
+  (injected memo-cache slot logic; the sampled `settings-slot` chunk grew
+  687 → 921 KB). Gzip delta will be proportionally smaller — the cache-slot
+  code is highly repetitive.
+- The time delta is the single-threaded Babel parse+transform of 1706 `.tsx`
+  files. It is a **cold-build** cost; warm incremental rebuilds (HMR) only run
+  Babel on the edited file (~tens of ms per edit).
+- 3021 modules in the emitted dev bundle import `react/compiler-runtime`,
+  confirming compiled components actually ship.
+
+## Gotcha: Babel 8 silently cripples the compiler
+
+`pnpm add @babel/core` resolves to Babel **8**, and under Babel 8's AST,
+`babel-plugin-react-compiler@1.0.0` bails on every function whose parameters
+destructure with defaults (`({ size = 32 }) => …`) with
+`(BuildHIR::lowerAssignment) Expected object property value to be an LVal`.
+That idiom appears in 844 files here — coverage collapsed to 17% until
+`@babel/core` was pinned to `^7.29.0`. Do not bump it to 8 until the compiler
+declares support.
+
+## Verdict and suggested path
+
+The compiler compiles four fifths of the codebase today with zero source
+changes, and bailouts are safe (function left as written). Runtime perf was NOT
+measured in this spike — that needs the flag on in a real workload (June's
+re-render fan-out surfaces would be the target).
+
+1. Land the flag-gated wiring (this PR) — default off, zero impact.
+2. Dev-dogfood with `ORGII_REACT_COMPILER=true` on the dev server; watch for
+   behavioral regressions and measure re-renders on the known fan-out surfaces
+   (React DevTools profiler).
+3. Fix the 26 refs-during-render violations independently — they are latent
+   bugs regardless of the compiler.
+4. Decide default-on for prod after an E2E pass over a compiled build, and
+   decide whether `FAST_PROD` (esbuild path, used for local .app builds) must
+   also gain the pass to keep local and release builds behaviorally identical.
+5. Later: extend the pass to `.ts` (hooks, +655 functions), and only then
+   consider deleting hand-rolled `memo`/`useMemo`/`useCallback` sites — removal
+   before default-on would be a regression wherever the compiler bails.

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.0",
     "@commitlint/cli": "^19",
     "@commitlint/config-conventional": "^19",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.2",
@@ -180,6 +181,8 @@
     "@typescript-eslint/parser": "^6.16.0",
     "@vitest/coverage-v8": "^2.1.9",
     "autoprefixer": "^10.4.16",
+    "babel-loader": "^10.1.1",
+    "babel-plugin-react-compiler": "^1.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,10 +213,10 @@ importers:
         version: 7.0.5
       jotai:
         specifier: ^2.8.2
-        version: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.15)(react@19.2.6)
+        version: 2.18.1(@babel/core@7.29.0)(@babel/template@8.0.0)(@types/react@19.2.15)(react@19.2.6)
       jotai-family:
         specifier: ^1.0.2
-        version: 1.0.2(jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.15)(react@19.2.6))
+        version: 1.0.2(jotai@2.18.1(@babel/core@7.29.0)(@babel/template@8.0.0)(@types/react@19.2.15)(react@19.2.6))
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -296,6 +296,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@babel/core':
+        specifier: ^7.29.0
+        version: 7.29.0
       '@commitlint/cli':
         specifier: ^19
         version: 19.8.1(@types/node@20.19.37)(typescript@5.9.3)
@@ -344,6 +347,12 @@ importers:
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.27(postcss@8.5.8)
+      babel-loader:
+        specifier: ^10.1.1
+        version: 10.1.1(@babel/core@7.29.0)(webpack@5.105.4)
+      babel-plugin-react-compiler:
+        specifier: ^1.0.0
+        version: 1.0.0
       clean-webpack-plugin:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.105.4)
@@ -504,6 +513,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
@@ -591,6 +604,10 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
@@ -598,6 +615,10 @@ packages:
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
@@ -619,6 +640,11 @@ packages:
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5':
@@ -1060,6 +1086,10 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
@@ -1071,6 +1101,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -3136,6 +3170,19 @@ packages:
       react-native-b4a:
         optional: true
 
+  babel-loader@10.1.1:
+    resolution: {integrity: sha512-JwKSzk2kjIe7mgPK+/lyZ2QAaJcpahNAdM+hgR2HI8D0OJVkdj8Rl6J3kaLYki9pwF7P2iWnD8qVv80Lq1ABtg==}
+    engines: {node: ^18.20.0 || ^20.10.0 || >=22.0.0}
+    peerDependencies:
+      '@babel/core': ^7.12.0 || ^8.0.0-beta.1
+      '@rspack/core': ^1.0.0 || ^2.0.0-0
+      webpack: '>=5.61.0'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+
   babel-plugin-polyfill-corejs2@0.4.16:
     resolution: {integrity: sha512-xaVwwSfebXf0ooE11BJovZYKhFjIvQo7TsyVpETuIeH2JHv0k/T6Y5j22pPTvqYqmpkxdlPAJlyJ0tfOJAoMxw==}
     peerDependencies:
@@ -3150,6 +3197,9 @@ packages:
     resolution: {integrity: sha512-OTYbUlSwXhNgr4g6efMZgsO8//jA61P7ZbRX3iTT53VON8l+WQS8IAUEVo4a4cWknrg2W8Cj4gQhRYNCJ8GkAA==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -5337,6 +5387,9 @@ packages:
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5423,7 +5476,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lie@3.3.0:
@@ -8355,9 +8407,15 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
+
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+    optional: true
 
   '@babel/compat-data@7.29.0': {}
 
@@ -8368,10 +8426,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -8383,15 +8441,15 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -8437,14 +8495,14 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8452,14 +8510,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -8484,7 +8542,7 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -8492,9 +8550,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-string-parser@8.0.0':
+    optional: true
+
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    optional: true
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -8502,22 +8566,27 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.28.6':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
+    optional: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
     dependencies:
@@ -8757,7 +8826,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -8874,7 +8943,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9042,7 +9111,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
@@ -9073,17 +9142,24 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+    optional: true
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -9097,6 +9173,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+    optional: true
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -10127,7 +10209,7 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
@@ -11175,6 +11257,13 @@ snapshots:
 
   b4a@1.8.1: {}
 
+  babel-loader@10.1.1(@babel/core@7.29.0)(webpack@5.105.4):
+    dependencies:
+      '@babel/core': 7.29.0
+      find-up: 5.0.0
+    optionalDependencies:
+      webpack: 5.105.4(@swc/core@1.15.18)(webpack-cli@5.1.4)
+
   babel-plugin-polyfill-corejs2@0.4.16(@babel/core@7.29.0):
     dependencies:
       '@babel/compat-data': 7.29.0
@@ -11198,6 +11287,10 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.7(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.7
 
   bail@2.0.2: {}
 
@@ -13657,14 +13750,14 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jotai-family@1.0.2(jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.15)(react@19.2.6)):
+  jotai-family@1.0.2(jotai@2.18.1(@babel/core@7.29.0)(@babel/template@8.0.0)(@types/react@19.2.15)(react@19.2.6)):
     dependencies:
-      jotai: 2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.15)(react@19.2.6)
+      jotai: 2.18.1(@babel/core@7.29.0)(@babel/template@8.0.0)(@types/react@19.2.15)(react@19.2.6)
 
-  jotai@2.18.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.15)(react@19.2.6):
+  jotai@2.18.1(@babel/core@7.29.0)(@babel/template@8.0.0)(@types/react@19.2.15)(react@19.2.6):
     optionalDependencies:
       '@babel/core': 7.29.0
-      '@babel/template': 7.28.6
+      '@babel/template': 8.0.0
       '@types/react': 19.2.15
       react: 19.2.6
 
@@ -13672,6 +13765,9 @@ snapshots:
     optional: true
 
   js-base64@3.7.8: {}
+
+  js-tokens@10.0.0:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -13943,8 +14039,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -14849,7 +14945,7 @@ snapshots:
 
   node-source-walk@7.0.2:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
 
   non-layered-tidy-tree-layout@2.0.2: {}
 


### PR DESCRIPTION
## Problem

The June re-render fan-out in shared components has no durable fix: memoization is hand-rolled across the codebase (504 files use `memo`, 888 use `useMemo`/`useCallback`) and every gap re-surfaces as a new fan-out. React Compiler would subsume that layer, but the build has no Babel stage (swc-loader dev/prod, esbuild fast paths), so there was no way to even evaluate it — and no data on coverage, build cost, or bundle cost for this codebase.

## Solution

Flag-gated wiring plus a measured spike report; nothing changes by default.

- `ORGII_REACT_COMPILER=true` chains a minimal `babel-loader` pass (only `babel-plugin-react-compiler`, TS/JSX as parse-only parser plugins) in front of `swc-loader` for `src/**/*.tsx`. swc remains the transpiler; dev Fast Refresh is untouched. `FAST_DEV`/`FAST_PROD`/light-dev (esbuild branches) skip the pass.
- Compiler builds get their own webpack cache directory (`react-compiler-*`) so toggling the flag never invalidates the warm non-compiler dev cache.
- `@babel/core` pinned to `^7.29.0`: under Babel 8 (what a bare install resolves to today), compiler 1.0.0 bails on every component whose params destructure with defaults (844 files here) — coverage collapses from 82% to 17%.
- Measurements in `docs/react-compiler-spike-2026-09-01/README.md`: **81.9% of 3516 candidate functions compile** (2225 components + 655 hooks); cold builds get ~83% slower (prod 65.9s→120.9s, dev 49.9s→92.5s — cold only, HMR rebuilds pay ~tens of ms per edited file); minified JS +7.9% (27.06→29.19 MB, vendors byte-identical). Bailout inventory includes 26 real refs-during-render violations worth fixing regardless.

## Potential risks

- Default-off: zero behavior change for every existing build path and CI; the three new devDependencies are inert until the flag is set.
- With the flag on, compiled components change memoization behavior; components relying on unwritten rules violations the compiler cannot detect could regress. Runtime behavior of a compiled build has NOT been E2E-tested — that is the explicit next step before any default-on discussion.
- With the flag on, `FAST_PROD` local .app builds would silently skip the compiler and diverge behaviorally from a compiled release build; acceptable while the flag is a spike, must be resolved before default-on.
- Future `@babel/core` major bumps silently break coverage rather than erroring (see Babel 8 note); the caret pin guards this.

## Verification

- Standalone compiler scan over all 4782 non-test `src/**/*.{ts,tsx}` files: 2880/3516 functions compiled, 0 transform errors (script + per-shard results preserved in the spike report).
- `pnpm build` (baseline, cold prod cache): compiled in 65.9s, 27,059,002 bytes JS.
- `ORGII_REACT_COMPILER=true pnpm build` (cold cache): compiled in 120.9s, 29,192,685 bytes JS; vendor chunk sizes byte-identical to baseline.
- `ORGII_REACT_COMPILER=true npx webpack --mode development` (cold cache): compiled successfully in 92.5s; 3021 modules in emitted output import `react/compiler-runtime`, confirming compiled components ship. Baseline dev cold: 49.9s (measured with the shared dev cache set aside and restored).
- Dev server with the flag was not run interactively; HMR-latency claim is reasoning (per-file loader cost), not measurement.
- Not run: vitest/cargo/E2E — no source files changed; the webpack config change is exercised directly by the builds above.
