### PR TITLE
fix(settings): keep local writes authoritative over watcher echoes

### DIFF
--- a/src/store/settings/settingsAtom.ts
+++ b/src/store/settings/settingsAtom.ts
@@ -68,17 +68,110 @@ rawSettingsAtom.debugLabel = "rawSettingsAtom";
 
 let settingsWriteQueue: Promise<void> = Promise.resolve();
 
+/**
+ * Keys this window has written but has not yet seen echoed back by the file
+ * watcher.
+ *
+ * Writing a setting is a round trip: the atom updates immediately, the JSONC
+ * file is written asynchronously, and the OS watcher then reports the file as
+ * changed. That report is indistinguishable from a genuine external edit, so
+ * without this overlay a change could be reverted by the echo of an *earlier*
+ * write that had not yet included it — which is exactly what made the first
+ * change after launch appear to do nothing while a second one stuck. Startup
+ * makes this reliably reproducible: `initSettingsAtom` backfills every missing
+ * default, so the first user edit almost always races a write already in flight.
+ *
+ * An entry lives until the watcher confirms it (the file now holds the value we
+ * wrote) or until the grace window expires, so a watcher that never fires
+ * cannot pin a value forever.
+ */
+const pendingLocalWrites = new Map<
+  string,
+  { value: unknown; expiresAt: number }
+>();
+
+/**
+ * How long a settled write stays authoritative over incoming file state.
+ * Only needs to outlast the watcher's own debounce.
+ */
+const PENDING_WRITE_GRACE_MS = 5_000;
+
+function sameValue(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Local writes that should still win over whatever the file currently says.
+ * Expired entries are dropped as a side effect.
+ */
+function pendingWriteOverlay(): Record<string, unknown> {
+  const now = Date.now();
+  const overlay: Record<string, unknown> = {};
+  for (const [key, entry] of pendingLocalWrites) {
+    if (entry.expiresAt <= now) {
+      pendingLocalWrites.delete(key);
+      continue;
+    }
+    overlay[key] = entry.value;
+  }
+  return overlay;
+}
+
+/**
+ * Retire pending entries the incoming file state already agrees with. Anything
+ * still outstanding is a write the file has not caught up to yet.
+ */
+function confirmPendingWrites(rawSettings: Record<string, unknown>): void {
+  for (const [key, entry] of pendingLocalWrites) {
+    if (key in rawSettings && sameValue(rawSettings[key], entry.value)) {
+      pendingLocalWrites.delete(key);
+    }
+  }
+}
+
+/** Merge file state with any local write the file has not caught up to yet. */
+function mergeWithPendingWrites(
+  rawSettings: Record<string, unknown>
+): Record<string, unknown> {
+  confirmPendingWrites(rawSettings);
+  const overlay = pendingWriteOverlay();
+  return Object.keys(overlay).length > 0
+    ? { ...rawSettings, ...overlay }
+    : rawSettings;
+}
+
 function enqueueSettingsPartialWrite(
   partial: Record<string, unknown>
 ): Promise<void> {
+  // Claimed before the write starts: the atom has already published these
+  // values, so an echo arriving mid-flight must not undo them.
+  for (const [key, value] of Object.entries(partial)) {
+    pendingLocalWrites.set(key, { value, expiresAt: Number.POSITIVE_INFINITY });
+  }
+
+  const settle = () => {
+    const expiresAt = Date.now() + PENDING_WRITE_GRACE_MS;
+    for (const [key, value] of Object.entries(partial)) {
+      const entry = pendingLocalWrites.get(key);
+      // A newer write for the same key owns the entry now; leave it alone.
+      if (!entry || !sameValue(entry.value, value)) continue;
+      entry.expiresAt = expiresAt;
+    }
+  };
+
   const writePromise = settingsWriteQueue
     .catch(() => undefined)
     .then(() => settingsRpc.writePartial({ partial }));
-  settingsWriteQueue = writePromise.then(
-    () => undefined,
-    () => undefined
-  );
+  settingsWriteQueue = writePromise.then(settle, settle);
   return writePromise;
+}
+
+/** Test seam: drop all outstanding local writes. */
+export function __resetPendingSettingsWrites(): void {
+  pendingLocalWrites.clear();
 }
 
 // ============================================
@@ -221,8 +314,9 @@ export const initSettingsAtom = atom(null, async (_get, set) => {
   try {
     const rawSettings = await settingsRpc.read();
 
-    // Validate and merge with defaults
-    const validated = validateSettings(rawSettings);
+    // Validate and merge with defaults. A setting changed while this read was
+    // in flight must survive it — the read predates the change.
+    const validated = validateSettings(mergeWithPendingWrites(rawSettings));
     set(settingsAtom, validated);
     set(rawSettingsAtom, rawSettings);
     set(settingsLoadedAtom, true);
@@ -279,7 +373,10 @@ initSettingsAtom.debugLabel = "initSettingsAtom";
 export const handleExternalChangeAtom = atom(
   null,
   (_get, set, rawSettings: Record<string, unknown>) => {
-    const validated = validateSettings(rawSettings);
+    // The watcher cannot distinguish our own write from a genuine external
+    // edit, so anything this window wrote and has not seen echoed back yet
+    // stays authoritative.
+    const validated = validateSettings(mergeWithPendingWrites(rawSettings));
     set(settingsAtom, validated);
   }
 );

--- a/src/store/settings/settingsSync.ts
+++ b/src/store/settings/settingsSync.ts
@@ -10,7 +10,7 @@
 import { listen } from "@tauri-apps/api/event";
 import i18n from "i18next";
 import { useAtomValue, useSetAtom } from "jotai";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import {
   THEME_PREFERENCE,
@@ -62,8 +62,6 @@ export function useSettingsSync(): void {
   const settings = useAtomValue(settingsAtom);
   const setSystemColorScheme = useSetAtom(systemColorSchemeAtom);
 
-  const writingRef = useRef(false);
-
   useEffect(() => {
     let cancelled = false;
 
@@ -73,10 +71,9 @@ export function useSettingsSync(): void {
       SETTINGS_CHANGED_EVENT,
       (event) => {
         if (cancelled) return;
-        if (writingRef.current) {
-          writingRef.current = false;
-          return;
-        }
+        // Echoes of this window's own writes are neutralized inside
+        // `handleExternalChange`, which knows which keys are still in flight.
+        // A flag here could only ever suppress one event and was never armed.
         handleExternalChange(event.payload);
       }
     );
@@ -117,10 +114,17 @@ export function useSettingsSync(): void {
     const themePreference = normalizeGlobalThemePreference(
       settings["general.theme"]
     );
-    if (themePreference !== THEME_PREFERENCE.SYSTEM) return;
+    const followsSystem = themePreference === THEME_PREFERENCE.SYSTEM;
 
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const handleSystemThemeChange = () => {
+      // Track the OS scheme even on an explicit light/dark preference: the
+      // appearance picker labels its first entry "Follow system (Light|Dark)",
+      // and that label goes stale otherwise. Only the stylesheet swap is gated.
+      if (!followsSystem) {
+        setSystemColorScheme(getSystemColorScheme());
+        return;
+      }
       const resolvedThemeId = resolveGlobalThemePreference(themePreference);
       const selectedTheme = getGlobalTheme(resolvedThemeId);
       const cover = showThemeTransitionCover();
@@ -141,6 +145,10 @@ export function useSettingsSync(): void {
     // OS appearance twice.
     const resyncSystemTheme = () => {
       if (document.visibilityState === "hidden") return;
+      if (!followsSystem) {
+        setSystemColorScheme(getSystemColorScheme());
+        return;
+      }
       if (document.documentElement.dataset.theme === getSystemColorScheme()) {
         return;
       }

--- a/src/store/settings/settingsWatcherEcho.test.ts
+++ b/src/store/settings/settingsWatcherEcho.test.ts
@@ -1,0 +1,146 @@
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { settings as settingsProcedures } from "@src/api/tauri/rpc/procedures/settings";
+
+import {
+  __resetPendingSettingsWrites,
+  handleExternalChangeAtom,
+  initSettingsAtom,
+  settingsAtom,
+  updateSettingAtom,
+} from "./settingsAtom";
+
+const { rpcCallMock } = vi.hoisted(() => ({ rpcCallMock: vi.fn() }));
+
+vi.mock("@src/api/tauri/rpc/invoke", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@src/api/tauri/rpc/invoke")>();
+  return { ...actual, rpcCall: rpcCallMock };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * The write queue is module-global, so a test that leaves a write pending would
+ * stall every test after it. Each test registers its unresolved writes here.
+ */
+let pendingWrites: Array<() => void> = [];
+
+function stubRpc(read: Record<string, unknown> = {}) {
+  rpcCallMock.mockImplementation((procedure: unknown) => {
+    if (procedure === settingsProcedures.read) return Promise.resolve(read);
+    const write = deferred<void>();
+    pendingWrites.push(() => write.resolve());
+    return write.promise;
+  });
+}
+
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/**
+ * The settings file watcher cannot tell this window's own write apart from a
+ * genuine external edit, and reports it with whatever the file held when it
+ * read. Before these guards, an edit made while an earlier write was still in
+ * flight was reverted by that echo — the "first change does nothing, the second
+ * sticks" symptom.
+ */
+describe("settings watcher echoes", () => {
+  beforeEach(() => {
+    rpcCallMock.mockReset();
+    pendingWrites = [];
+    __resetPendingSettingsWrites();
+  });
+
+  afterEach(async () => {
+    pendingWrites.forEach((resolve) => resolve());
+    await flush();
+  });
+
+  it("keeps a local write that an in-flight echo has not caught up to", () => {
+    stubRpc();
+    const store = createStore();
+
+    store.set(updateSettingAtom, {
+      key: "general.iconStyle",
+      value: "monochrome",
+    });
+    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("monochrome");
+
+    // Watcher fires with file state that predates the write.
+    store.set(handleExternalChangeAtom, { "general.iconStyle": "colorful" });
+
+    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("monochrome");
+  });
+
+  it("keeps a local write that races the initial read", async () => {
+    stubRpc({ "general.iconStyle": "colorful" });
+    const store = createStore();
+
+    store.set(updateSettingAtom, {
+      key: "general.iconStyle",
+      value: "monochrome",
+    });
+    await store.set(initSettingsAtom);
+
+    // The read predates the change, so the change must survive it.
+    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("monochrome");
+  });
+
+  it("accepts a genuine external edit to an untouched key", () => {
+    stubRpc();
+    const store = createStore();
+
+    store.set(updateSettingAtom, {
+      key: "general.iconStyle",
+      value: "monochrome",
+    });
+    store.set(handleExternalChangeAtom, {
+      "general.iconStyle": "colorful",
+      "general.uiScale": 125,
+    });
+
+    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("monochrome");
+    expect(store.get(settingsAtom)["general.uiScale"]).toBe(125);
+  });
+
+  it("stops shadowing a key once the file agrees with what was written", async () => {
+    stubRpc();
+    const store = createStore();
+
+    store.set(updateSettingAtom, {
+      key: "general.iconStyle",
+      value: "monochrome",
+    });
+    pendingWrites.forEach((resolve) => resolve());
+    await flush();
+
+    // Confirming echo: the file now holds our value, so the claim is released.
+    store.set(handleExternalChangeAtom, { "general.iconStyle": "monochrome" });
+    // A later genuine external edit must now win.
+    store.set(handleExternalChangeAtom, { "general.iconStyle": "colorful" });
+
+    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("colorful");
+  });
+
+  it("lets the newest of two rapid writes to one key win", () => {
+    stubRpc();
+    const store = createStore();
+
+    store.set(updateSettingAtom, { key: "general.uiScale", value: 110 });
+    store.set(updateSettingAtom, { key: "general.uiScale", value: 125 });
+    store.set(handleExternalChangeAtom, { "general.uiScale": 100 });
+
+    expect(store.get(settingsAtom)["general.uiScale"]).toBe(125);
+  });
+});

--- a/src/store/settings/settingsWatcherEcho.test.ts
+++ b/src/store/settings/settingsWatcherEcho.test.ts
@@ -72,29 +72,37 @@ describe("settings watcher echoes", () => {
     const store = createStore();
 
     store.set(updateSettingAtom, {
-      key: "general.iconStyle",
-      value: "monochrome",
+      key: "general.spotlightPlacement",
+      value: "center",
     });
-    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("monochrome");
+    expect(store.get(settingsAtom)["general.spotlightPlacement"]).toBe(
+      "center"
+    );
 
     // Watcher fires with file state that predates the write.
-    store.set(handleExternalChangeAtom, { "general.iconStyle": "colorful" });
+    store.set(handleExternalChangeAtom, {
+      "general.spotlightPlacement": "top",
+    });
 
-    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("monochrome");
+    expect(store.get(settingsAtom)["general.spotlightPlacement"]).toBe(
+      "center"
+    );
   });
 
   it("keeps a local write that races the initial read", async () => {
-    stubRpc({ "general.iconStyle": "colorful" });
+    stubRpc({ "general.spotlightPlacement": "top" });
     const store = createStore();
 
     store.set(updateSettingAtom, {
-      key: "general.iconStyle",
-      value: "monochrome",
+      key: "general.spotlightPlacement",
+      value: "center",
     });
     await store.set(initSettingsAtom);
 
     // The read predates the change, so the change must survive it.
-    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("monochrome");
+    expect(store.get(settingsAtom)["general.spotlightPlacement"]).toBe(
+      "center"
+    );
   });
 
   it("accepts a genuine external edit to an untouched key", () => {
@@ -102,15 +110,17 @@ describe("settings watcher echoes", () => {
     const store = createStore();
 
     store.set(updateSettingAtom, {
-      key: "general.iconStyle",
-      value: "monochrome",
+      key: "general.spotlightPlacement",
+      value: "center",
     });
     store.set(handleExternalChangeAtom, {
-      "general.iconStyle": "colorful",
+      "general.spotlightPlacement": "top",
       "general.uiScale": 125,
     });
 
-    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("monochrome");
+    expect(store.get(settingsAtom)["general.spotlightPlacement"]).toBe(
+      "center"
+    );
     expect(store.get(settingsAtom)["general.uiScale"]).toBe(125);
   });
 
@@ -119,18 +129,22 @@ describe("settings watcher echoes", () => {
     const store = createStore();
 
     store.set(updateSettingAtom, {
-      key: "general.iconStyle",
-      value: "monochrome",
+      key: "general.spotlightPlacement",
+      value: "center",
     });
     pendingWrites.forEach((resolve) => resolve());
     await flush();
 
     // Confirming echo: the file now holds our value, so the claim is released.
-    store.set(handleExternalChangeAtom, { "general.iconStyle": "monochrome" });
+    store.set(handleExternalChangeAtom, {
+      "general.spotlightPlacement": "center",
+    });
     // A later genuine external edit must now win.
-    store.set(handleExternalChangeAtom, { "general.iconStyle": "colorful" });
+    store.set(handleExternalChangeAtom, {
+      "general.spotlightPlacement": "top",
+    });
 
-    expect(store.get(settingsAtom)["general.iconStyle"]).toBe("colorful");
+    expect(store.get(settingsAtom)["general.spotlightPlacement"]).toBe("top");
   });
 
   it("lets the newest of two rapid writes to one key win", () => {


### PR DESCRIPTION
## Problem

The settings file watcher cannot distinguish this window's own write from a
genuine external edit. It reports the file as it stood when it read, so an edit
made while an earlier write was still in flight was reverted by that echo.

This is why the first settings change after launch often appeared to do nothing
while a second attempt stuck. Startup makes it reliably reproducible:
`initSettingsAtom` backfills every missing default, so a user's first edit
almost always races a write already in flight — and any release that adds a new
settings key makes the backfill non-empty for every existing install.

`useSettingsSync` had a `writingRef` intended to suppress exactly this echo, but
nothing ever set it to `true`, so the suppression never ran. A single boolean
could only ever swallow one event anyway, while one write produces one echo per
watcher debounce window.

Separately, `systemColorSchemeAtom` was only updated while `general.theme` was
`system`. On an explicit light/dark preference it went stale, so the appearance
picker's first entry could read `Follow system (Light)` on a dark OS.

## Solution

Echo suppression moves into the store, which is the only layer that knows what
was written and when.

`enqueueSettingsPartialWrite` claims each key it is about to write. While a key
is claimed, `handleExternalChangeAtom` and `initSettingsAtom` overlay the local
value on top of whatever the file reports, so an echo cannot undo a change the
atom has already published. A claim is released as soon as the incoming file
state agrees with what was written, and otherwise expires after a 5s grace
window, so a watcher that never fires cannot pin a value forever. Keys nobody
wrote locally are untouched, so genuine external edits still win immediately.

The dead `writingRef` is removed.

`systemColorSchemeAtom` now tracks the OS scheme regardless of preference; only
the stylesheet swap stays gated on `system`.

## Potential risks

- **Grace window.** A genuine external edit to a key this window wrote within
  the preceding 5s is ignored. That is the intended trade: within that window
  the two writers are genuinely racing, and preferring the local edit matches
  what the user just did in the UI. Editing `settings.jsonc` by hand more than
  5s after an in-app change behaves exactly as before.
- **Claims are per window.** Each window suppresses only its own echoes, so a
  change made in one window still propagates to the others. Two windows editing
  the same key within the same 5s window resolve last-write-wins on disk, as
  they did before.
- **Memory.** Claims are bounded by the number of distinct settings keys and are
  dropped on expiry, so the map cannot grow unbounded.
- The system-scheme tracking change makes `systemColorSchemeAtom` update in a
  state where it previously never changed. Its only consumers are the appearance
  label and `resolvedGlobalThemeIdAtom`, and the latter reads it only when the
  preference is `system`.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — exit 0.
- `npx eslint src/ --ext .ts,.tsx,.js,.jsx --max-warnings 0` — exit 0.
- `npx vitest run --config config/vitest.config.ts` — exit 0, 1316 files /
  10330 tests passed.
- New `src/store/settings/settingsWatcherEcho.test.ts` covers the five cases
  that matter: an in-flight echo cannot revert a local write; a local write
  survives the initial read that predates it; an external edit to an untouched
  key still applies; a key stops being shadowed once the file agrees with it;
  and the newest of two rapid writes to one key wins.
- Not verified in a running app: the exact watcher debounce on each platform.
  The grace window only needs to outlast it, and the confirm-on-agreement path
  releases claims earlier than the timeout in the normal case.
