### PR TITLE
feat(workstation-tabs): retire the Files tab when a file opens

### DIFF
--- a/src/store/workstation/tabs/__tests__/tabMutations.test.ts
+++ b/src/store/workstation/tabs/__tests__/tabMutations.test.ts
@@ -45,6 +45,13 @@ function tab(
 
 const empty: PanelState = { tabs: [], activeTabId: null };
 
+// The Explorer ("Files") tab is a transient picker — opening a file retires it.
+const explorerTab = tab({
+  id: "explorer:main",
+  type: "explorer",
+  title: "Files",
+});
+
 describe("openTab", () => {
   it("appends a new tab and activates it", () => {
     const next = openTab(empty, tab({ id: "file:a.ts" }));
@@ -73,6 +80,57 @@ describe("openTab", () => {
     );
     expect(next.tabs[0].data.targetLine).toBe(42);
     expect(next.activeTabId).toBe("file:a.ts");
+  });
+
+  it("replaces the Explorer tab in place when a file tab is opened", () => {
+    const state: PanelState = {
+      tabs: [explorerTab, tab({ id: "terminal:main", type: "terminal" })],
+      activeTabId: "explorer:main",
+    };
+    const next = openTab(state, tab({ id: "file:a.ts" }));
+    expect(next.tabs.map((item) => item.id)).toEqual([
+      "file:a.ts",
+      "terminal:main",
+    ]);
+    expect(next.activeTabId).toBe("file:a.ts");
+  });
+
+  it("retires the Explorer tab when an already-open file tab is reopened", () => {
+    const state: PanelState = {
+      tabs: [tab({ id: "file:a.ts" }), explorerTab],
+      activeTabId: "explorer:main",
+    };
+    const next = openTab(state, tab({ id: "file:a.ts" }));
+    expect(next.tabs.map((item) => item.id)).toEqual(["file:a.ts"]);
+    expect(next.activeTabId).toBe("file:a.ts");
+  });
+
+  it("keeps the Explorer tab when a non-file tab is opened", () => {
+    const state: PanelState = {
+      tabs: [explorerTab],
+      activeTabId: "explorer:main",
+    };
+    const next = openTab(
+      state,
+      tab({ id: "search:1", type: "search", title: "Search" })
+    );
+    expect(next.tabs.map((item) => item.id)).toEqual([
+      "explorer:main",
+      "search:1",
+    ]);
+    expect(next.activeTabId).toBe("search:1");
+  });
+
+  it("keeps a pinned Explorer fixture when a file tab is opened", () => {
+    const state: PanelState = {
+      tabs: [{ ...explorerTab, pinned: true }],
+      activeTabId: "explorer:main",
+    };
+    const next = openTab(state, tab({ id: "file:a.ts" }));
+    expect(next.tabs.map((item) => item.id)).toEqual([
+      "explorer:main",
+      "file:a.ts",
+    ]);
   });
 });
 

--- a/src/store/workstation/tabs/tabMutations.ts
+++ b/src/store/workstation/tabs/tabMutations.ts
@@ -52,28 +52,66 @@ function mergeReopenedTab(
 }
 
 /**
+ * The Explorer ("Files") tab is a transient picker: it exists so the user can
+ * browse the tree and pick something to edit. Once a file tab is opened it has
+ * served its purpose, so the incoming file tab takes over its slot in the strip
+ * instead of stacking next to it.
+ *
+ * Returns the index of the Explorer tab to retire, or `-1` when nothing should
+ * be retired (the incoming tab is not a file, no Explorer tab is open, or the
+ * Explorer tab has been configured as a protected fixture).
+ */
+function findRetiringExplorerIndex(
+  tabs: WorkStationTab[],
+  incoming: WorkStationTab
+): number {
+  if (incoming.type !== "file") return -1;
+  return tabs.findIndex(
+    (tabItem) =>
+      tabItem.type === "explorer" &&
+      !tabItem.pinned &&
+      tabItem.closable !== false
+  );
+}
+
+/**
  * Open or switch to a tab
  */
 export function openTab(state: PanelState, tab: WorkStationTab): PanelState {
   // Safety check for uninitialized state
   const tabs = state?.tabs ?? [];
   const existingIndex = tabs.findIndex((tabItem) => tabItem.id === tab.id);
+  const explorerIndex = findRetiringExplorerIndex(tabs, tab);
 
   if (existingIndex !== -1) {
     const mergedTab = mergeReopenedTab(tabs[existingIndex], tab);
-    if (mergedTab === tabs[existingIndex] && state?.activeTabId === tab.id) {
+    if (
+      mergedTab === tabs[existingIndex] &&
+      state?.activeTabId === tab.id &&
+      explorerIndex === -1
+    ) {
       return state;
     }
 
     const updatedTabs = [...tabs];
     updatedTabs[existingIndex] = mergedTab;
+    if (explorerIndex !== -1) updatedTabs.splice(explorerIndex, 1);
     return {
       tabs: updatedTabs,
       activeTabId: tab.id,
     };
   }
 
-  // Create new tab
+  // Create new tab — replacing the Explorer tab in place when one is open.
+  if (explorerIndex !== -1) {
+    const updatedTabs = [...tabs];
+    updatedTabs.splice(explorerIndex, 1, tab);
+    return {
+      tabs: updatedTabs,
+      activeTabId: tab.id,
+    };
+  }
+
   return {
     tabs: [...tabs, tab],
     activeTabId: tab.id,


### PR DESCRIPTION
## Problem

The Explorer ("Files") tab is a transient picker: it exists so the user can browse the tree and open a file. But after a file was opened, the Files tab stayed in the strip next to the new file tab. Every browse-then-open flow left a stale Files tab behind that the user had to close by hand.

## Solution

`openTab` in `src/store/workstation/tabs/tabMutations.ts` now retires an open Explorer tab whenever a `file` tab is opened:

- A newly created file tab is spliced into the Explorer's slot, so the strip position is preserved (a genuine replace, not close-then-append).
- Re-activating an already-open file also retires the Explorer tab, so clicking an open file from the tree behaves identically.
- Non-file tabs (search, terminal, source-control, browser, directory listings) leave the Explorer alone.
- A `pinned` or `closable: false` Explorer is treated as a protected fixture and never retired (currently unused — `usePinnedTabs` is wired `enabled: false` — but keeps the fixture contract).

The fix lives in the single pure mutation that every open path funnels through (file-tree click, chat path references, spotlight, `EditorTabService`, agent-driven opens), rather than being patched per call site.

## Potential risks

- Behavior change applies in every station mode, not just my-station — the tab strip is a single shared pool, and gating a pure mutation on `stationModeAtom` would thread store state into it. Scoping it per mode is possible as a follow-up if wanted.
- Once a file is open, ⌘G focuses the last file rather than reopening Files (pre-existing `EditorTabService.getLastFileOrExplorerTabId` preference); Files stays reachable via the Launchpad / `+` menu, or ⌘G with no file tabs open.
- The Explorer tab is `workspace-local`, so removal flows through the normal `splitPanel` persistence with no shared-resource teardown; no migration concerns.
- Tab lifecycle only, no visual restyle — screenshots would show an unchanged tab strip, so none are attached. The change was not exercised in the running Tauri app.

## Verification

Verified in a detached worktree at `origin/develop` (57c8ffd47) containing only this PR's two files (`node_modules` symlinked), so the diff compiles and passes against the base alone:

- `npx tsc --noEmit --pretty false -p tsconfig.json` — exit 0
- `npx vitest run --config config/vitest.config.ts src/store/workstation/tabs/__tests__/tabMutations.test.ts` — 19 tests pass (4 new: replace-in-place, reopen-retires, non-file untouched, pinned protected)
- `npx eslint` over both files — clean

On the dev checkout, the broader sweep `vitest src/store/workstation src/hooks/tabHost src/modules/WorkStation src/services/workStation` — 144 files / 1050 tests pass.

Not run: E2E; manual check in the running app. The commit was built with git plumbing from a live shared checkout, so git hooks did not run and the `Pre-commit hook ran.` trailer is absent — typecheck/lint/tests above were run manually instead.
