### PR TITLE
fix(shortcuts): keep global shortcuts live inside CodeMirror

### DIFF
--- a/src/hooks/navigation/useGlobalShortcuts/__tests__/workstationEditorToolShortcut.test.ts
+++ b/src/hooks/navigation/useGlobalShortcuts/__tests__/workstationEditorToolShortcut.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWorkstationEditorToolShortcut } from "../workstationEditorToolShortcut";
+
+describe("resolveWorkstationEditorToolShortcut", () => {
+  it("claims the three editor-tool chords outside editable surfaces", () => {
+    expect(
+      resolveWorkstationEditorToolShortcut("KeyG", { editableTarget: false })
+    ).toBe("open_file_folder_tab");
+    expect(
+      resolveWorkstationEditorToolShortcut("KeyE", { editableTarget: false })
+    ).toBe("open_source_control_tab");
+    expect(
+      resolveWorkstationEditorToolShortcut("KeyJ", { editableTarget: false })
+    ).toBe("open_terminal_tab");
+  });
+
+  it("stays inert while an editable surface has focus (⌘G is find-next in CodeMirror)", () => {
+    for (const code of ["KeyG", "KeyE", "KeyJ"]) {
+      expect(
+        resolveWorkstationEditorToolShortcut(code, { editableTarget: true })
+      ).toBeNull();
+    }
+  });
+
+  // Regression: the old inline guard `return`ed out of the whole keydown
+  // handler for editable targets, so ⌘W never closed the tab while
+  // CodeMirror had focus. Not-ours keys must resolve to null (fall through
+  // to the global shortcuts) in BOTH focus states — never abort.
+  it("never claims foreign keys, regardless of focus", () => {
+    for (const editableTarget of [true, false]) {
+      for (const code of ["KeyW", "Digit1", "KeyN", "KeyP", "KeyT"]) {
+        expect(
+          resolveWorkstationEditorToolShortcut(code, { editableTarget })
+        ).toBeNull();
+      }
+    }
+  });
+});

--- a/src/hooks/navigation/useGlobalShortcuts/useGlobalKeydownShortcuts.ts
+++ b/src/hooks/navigation/useGlobalShortcuts/useGlobalKeydownShortcuts.ts
@@ -7,6 +7,7 @@ import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
 import { resolveDigitZeroShortcut } from "./digitZeroShortcut";
 import { isEditableElement, isEditableElementExtended } from "./types";
+import { resolveWorkstationEditorToolShortcut } from "./workstationEditorToolShortcut";
 
 function selectActiveTextControl(): boolean {
   const activeElement = document.activeElement;
@@ -251,31 +252,29 @@ export function useGlobalKeydownShortcuts(
         !event.altKey
       ) {
         const target = event.target;
-        if (
-          isEditableElementExtended(target) &&
-          !isTerminalShortcutTarget(target)
-        ) {
-          return;
-        }
-
-        if (event.code === "KeyG") {
+        // Editable focus (CodeMirror, chat input) only silences these three
+        // editor-tool chords — ⌘G is find-next inside CodeMirror. It must
+        // NOT abort the handler: ⌘W, ⌘1/2/3 and the global switch below
+        // still apply while typing.
+        const editorTool = resolveWorkstationEditorToolShortcut(event.code, {
+          editableTarget:
+            isEditableElementExtended(target) &&
+            !isTerminalShortcutTarget(target),
+        });
+        if (editorTool) {
           event.preventDefault();
           event.stopPropagation();
-          handleOpenCodeEditorFileFolder();
-          return;
-        }
-
-        if (event.code === "KeyE") {
-          event.preventDefault();
-          event.stopPropagation();
-          handleOpenCodeEditorSourceControl();
-          return;
-        }
-
-        if (event.code === "KeyJ") {
-          event.preventDefault();
-          event.stopPropagation();
-          handleOpenCodeEditorTerminal();
+          switch (editorTool) {
+            case "open_file_folder_tab":
+              handleOpenCodeEditorFileFolder();
+              break;
+            case "open_source_control_tab":
+              handleOpenCodeEditorSourceControl();
+              break;
+            case "open_terminal_tab":
+              handleOpenCodeEditorTerminal();
+              break;
+          }
           return;
         }
       }
@@ -438,12 +437,18 @@ export function useGlobalKeydownShortcuts(
           shortcutRegistry.dispatch("zoom_out");
           break;
 
-        case "/":
+        case "/": {
           if (event.shiftKey || event.altKey) return;
+          const target = event.target;
+          // ⌘/ toggles comments inside CodeMirror (defaultKeymap Mod-/).
+          if (target instanceof Element && target.closest(".cm-editor")) {
+            return;
+          }
           event.preventDefault();
           event.stopPropagation();
           shortcutRegistry.dispatch("open_model_selector");
           break;
+        }
 
         case "o": {
           if (!event.shiftKey) return;

--- a/src/hooks/navigation/useGlobalShortcuts/workstationEditorToolShortcut.ts
+++ b/src/hooks/navigation/useGlobalShortcuts/workstationEditorToolShortcut.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolves the workstation editor-tool chords ⌘G / ⌘E / ⌘J (open File
+ * Folder / Source Control / Terminal tab).
+ *
+ * The chords stay inert while an editable surface has focus because they
+ * carry editor-local meanings there — ⌘G is find-next in CodeMirror's
+ * search keymap, for example.
+ *
+ * Contract: this resolver only ever claims its own three chords. `null`
+ * means "not ours — keep processing the keydown", never "abort". The
+ * caller must fall through to the global shortcuts (⌘W close-tab,
+ * ⌘1/2/3 station switch, …) on `null`, regardless of focus.
+ */
+export type WorkstationEditorToolShortcut =
+  | "open_file_folder_tab"
+  | "open_source_control_tab"
+  | "open_terminal_tab";
+
+export function resolveWorkstationEditorToolShortcut(
+  code: string,
+  options: { editableTarget: boolean }
+): WorkstationEditorToolShortcut | null {
+  if (options.editableTarget) return null;
+  switch (code) {
+    case "KeyG":
+      return "open_file_folder_tab";
+    case "KeyE":
+      return "open_source_control_tab";
+    case "KeyJ":
+      return "open_terminal_tab";
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Problem

⌘W does not close the active tab while the CodeMirror editor has focus. The close handler lives in a capture-phase `document` keydown listener, so CodeMirror never even sees the event — the bug is upstream inside the handler: the workstation-route ⌘G/⌘E/⌘J block does a bare `return` when the event target is editable, and `isEditableElementExtended` explicitly matches `.cm-editor`/`.cm-content`. With editor focus the handler aborts before the `case "w"` branch — and also silently kills ⌘1/⌘2/⌘3 station switch, ⌘N, ⌘T, ⌘,, ⌘P, and zoom.

The editable guard itself is legitimate (⌘G is find-next in CM's `searchKeymap`); it was just scoped to the whole handler instead of the three chords it protects.

## Solution

- New pure resolver `workstationEditorToolShortcut.ts` (same extraction pattern as `digitZeroShortcut`): claims only ⌘G/⌘E/⌘J, returns `null` for them while an editable surface has focus, and never claims any other key. The handler dispatches on the resolver result and falls through on `null`, so ⌘W reaches `handleCloseCurrentTab` → `closeActiveWorkStationTabAtom` with editor focus. ⌘G/⌘E/⌘J behavior while typing is unchanged.
- `case "/"` now yields to CodeMirror (`.cm-editor` target): the buggy early-return was accidentally protecting CM's ⌘/ toggle-comment (`defaultKeymap` Mod-/), and without this guard the fix would have hijacked it into the model selector.

## Potential risks

- Previously-dead shortcuts now work with editor focus: ⌘1/⌘2/⌘3, ⌘N, ⌘P, ⇧⌘F search sidebar, ⇧⌘M maximize (the last shadows CM's rarely-used lint-panel binding). This matches how these shortcuts already behave in every other editable surface (e.g. chat input on non-workstation routes). ⌘A, ⌘F, and ⌘K keep their existing per-case editable guards.
- The full keydown handler is not unit-testable in this node-env vitest suite (hence the pure-resolver extraction); the handler restructuring itself is covered by typecheck + review only. No E2E was run and the change was not exercised in the running Tauri app.
- Keyboard-only change, nothing visual — no screenshots.

## Verification

Verified in a detached worktree at `origin/develop` (57c8ffd47) containing only this PR's three files (`node_modules` symlinked):

- `npx tsc --noEmit --pretty false -p tsconfig.json` — exit 0
- `npx vitest run --config config/vitest.config.ts src/hooks/navigation/useGlobalShortcuts/__tests__/workstationEditorToolShortcut.test.ts` — 3 tests pass, including the regression contract ("never claims foreign keys, regardless of focus")
- `npx eslint` over all three files — clean

Not run: E2E; manual ⌘W check in the running app. The commit was built with git plumbing from a live shared checkout, so git hooks did not run and the `Pre-commit hook ran.` trailer is absent — typecheck/lint/tests above were run manually instead.
