### PR TITLE
fix(appearance): paint the editor gutter from the active skin

### DIFF
--- a/src/config/appearance/skins/deriveSkinTokens.ts
+++ b/src/config/appearance/skins/deriveSkinTokens.ts
@@ -164,6 +164,12 @@ export function deriveSkinTokens(
 
     // Editor
     "--cm-editor-background": editorSurface,
+    // Must be emitted alongside the editor background, not left to alias it.
+    // The base sheets declare `--cm-editor-gutter-bg: var(--cm-editor-background)`
+    // at `:root`, where it computes against `:root`'s value — skin tokens land on
+    // `<body>`, so the alias would keep the stylesheet's background and paint the
+    // line-number column in a different color than the code beside it.
+    "--cm-editor-gutter-bg": editorSurface,
     "--cm-editor-foreground": seed.ink,
     "--cm-editor-gutter-fg": fade(isLight ? 0.5 : 0.45),
     "--cm-editor-selection": tint(seed.accent, isLight ? 0.2 : 0.45),

--- a/src/config/appearance/skins/registry.test.ts
+++ b/src/config/appearance/skins/registry.test.ts
@@ -80,6 +80,33 @@ describe("skin registry", () => {
     }
   });
 
+  describe("label overrides", () => {
+    it("renames the Codex skin without touching its persisted id", () => {
+      const skin = getSkin("codex-codex");
+      expect(skin?.label).toBe("Constantly Reset");
+      // The id is what settings persist. Renaming it would reset every install
+      // that had this skin selected, because the settings enum would no longer
+      // accept the stored value.
+      expect(skin?.id).toBe("codex-codex");
+    });
+
+    it("leaves the generated data itself untouched", () => {
+      // The generated module stays a faithful record of what Codex ships, so a
+      // regeneration cannot revert the rename.
+      const generated = CODEX_SKINS.find((s) => s.id === "codex-codex");
+      expect(generated?.label).toBe("Codex");
+    });
+
+    it("keeps every other skin on its extracted label", () => {
+      for (const generated of CODEX_SKINS) {
+        if (generated.id === "codex-codex") continue;
+        expect(getSkin(generated.id)?.label, generated.id).toBe(
+          generated.label
+        );
+      }
+    });
+  });
+
   it("treats only the ORGII skin as baseline", () => {
     expect(isBaselineSkin(ORGII_SKIN_ID)).toBe(true);
     expect(isBaselineSkin("codex-dracula")).toBe(false);

--- a/src/config/appearance/skins/registry.ts
+++ b/src/config/appearance/skins/registry.ts
@@ -87,9 +87,29 @@ const ORGII_SKINS: readonly SkinDefinition[] = [
   },
 ];
 
+/**
+ * Display names ORGII shows in place of the extracted ones.
+ *
+ * `codexSkins.ts` is generated and records the labels Codex actually ships, so
+ * it stays a faithful account of the source and a regeneration cannot quietly
+ * revert an editorial choice made here. Renames therefore live in this file.
+ *
+ * Codex names its Claude-flavoured skin "Absolutely"; this returns the joke.
+ * Only the label changes — the id is what `general.lightSkin` / `general.darkSkin`
+ * persist, so renaming it would silently reset everyone who had it selected.
+ */
+const SKIN_LABEL_OVERRIDES: Readonly<Record<string, string>> = {
+  "codex-codex": "Constantly Reset",
+};
+
+function withLabelOverride(skin: SkinDefinition): SkinDefinition {
+  const label = SKIN_LABEL_OVERRIDES[skin.id];
+  return label ? { ...skin, label } : skin;
+}
+
 export const SKINS: readonly SkinDefinition[] = [
   ...ORGII_SKINS,
-  ...CODEX_SKINS,
+  ...CODEX_SKINS.map(withLabelOverride),
 ];
 
 const SKINS_BY_ID: ReadonlyMap<string, SkinDefinition> = new Map(

--- a/src/config/appearance/skins/rootAliasParity.test.ts
+++ b/src/config/appearance/skins/rootAliasParity.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Guards the one structural gap between where the base stylesheets declare a
+ * token and where a skin overrides it.
+ *
+ * Skin tokens are written as inline custom properties on `<body>`. A custom
+ * property declared at `:root` as an alias — `--a: var(--b)` — has its `var()`
+ * substituted against `:root`'s own properties, and descendants inherit the
+ * already-substituted result. So overriding `--b` on `<body>` does **not**
+ * move `--a`: it keeps whatever the stylesheet computed.
+ *
+ * That is invisible until two surfaces that are meant to share a color stop
+ * matching. It shipped once, as a line-number gutter that kept the base
+ * editor background while the code beside it took the skin's.
+ *
+ * Any `:root` alias whose referent a skin overrides must therefore be emitted
+ * by the skin too. This test reads the shipped stylesheets rather than a
+ * hand-maintained list, so a new alias is caught when it is added.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { SKIN_TOKEN_KEYS } from "./deriveSkinTokens";
+
+const STYLESHEETS = ["orgii_main.css", "orgii_dark.css"];
+
+interface Declarations {
+  root: Map<string, string>;
+  body: Set<string>;
+}
+
+function readStylesheet(name: string): Declarations {
+  const css = readFileSync(join(process.cwd(), "public", name), "utf8");
+  const block = (selector: string): string =>
+    new RegExp(`^${selector} \\{(.*?)^\\}`, "ms").exec(css)?.[1] ?? "";
+
+  const root = new Map<string, string>();
+  for (const match of block(":root").matchAll(
+    /^\s*(--[a-z0-9-]+):\s*([^;]*);/gms
+  )) {
+    root.set(match[1], match[2]);
+  }
+
+  const body = new Set<string>();
+  for (const match of block("body").matchAll(/^\s*(--[a-z0-9-]+):/gm)) {
+    body.add(match[1]);
+  }
+
+  return { root, body };
+}
+
+describe("root-scope alias parity", () => {
+  const skinTokens = new Set(SKIN_TOKEN_KEYS);
+
+  it.each(STYLESHEETS)(
+    "%s: every :root alias to a skin-owned token is itself skin-owned",
+    (name) => {
+      const { root, body } = readStylesheet(name);
+      const stale: string[] = [];
+
+      for (const [key, value] of root) {
+        // Redeclared on `body` — the body declaration wins for descendants and
+        // resolves against the skin's values, so the alias is not stale.
+        if (body.has(key)) continue;
+        if (skinTokens.has(key)) continue;
+
+        for (const [, referent] of value.matchAll(/var\((--[a-z0-9-]+)/g)) {
+          if (skinTokens.has(referent)) {
+            stale.push(`${key} -> var(${referent})`);
+          }
+        }
+      }
+
+      expect(
+        stale,
+        `These :root aliases point at tokens a skin overrides on <body>, so they ` +
+          `keep the stylesheet's value and drift out of sync. Emit them from ` +
+          `deriveSkinTokens, or move their declaration into the body scope.`
+      ).toEqual([]);
+    }
+  );
+
+  it("finds the declarations it is meant to be checking", () => {
+    // A regex that silently matched nothing would make this suite vacuous.
+    for (const name of STYLESHEETS) {
+      const { root, body } = readStylesheet(name);
+      expect(root.size, name).toBeGreaterThan(20);
+      expect(body.size, name).toBeGreaterThan(20);
+      expect(root.has("--cm-editor-gutter-bg"), name).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

On any non-baseline skin, the file viewer's line-number column kept the base
stylesheet's background while the code beside it took the skin's. Two surfaces
meant to share one colour visibly did not.

The base sheets declare, at `:root`:

```css
--cm-editor-gutter-bg: var(--cm-editor-background);
```

A custom property declared as an alias has its `var()` substituted **on the
element where it is declared** — here `:root` — and descendants inherit the
already-substituted result. Skin tokens are written as inline properties on
`<body>`, so overriding `--cm-editor-background` there never moved the gutter.

This is structural rather than a typo: it applies to any `:root` alias whose
referent a skin overrides, and it is invisible until someone notices a
mismatched strip on screen.

## Solution

Emit `--cm-editor-gutter-bg` from `deriveSkinTokens` alongside
`--cm-editor-background`, so both land in the same scope and move together.

Add `rootAliasParity.test.ts`, which parses the shipped stylesheets, finds every
`:root` declaration that aliases another token, and fails when the referent is
skin-owned but the alias is not — and is not redeclared in the `body` scope,
where it would resolve correctly anyway. Reading the stylesheets rather than a
hand-maintained list means the next such alias is caught when it is added.

Auditing the current sheets found exactly one offender. The other three aliases
(`--cm-font-family`, `--diff-added-chunk`, `--diff-deleted-chunk`) point at
tokens no skin overrides.

Also renames the Codex skin's display label to **Constantly Reset**, returning
the joke Codex makes with its Claude-flavoured "Absolutely". The rename lives in
a `SKIN_LABEL_OVERRIDES` map in the hand-written `registry.ts`, not in the
generated `codexSkins.ts`, for two reasons: the generated module stays a
faithful record of what Codex actually ships, so regenerating it cannot quietly
revert the label; and only the label changes. The id `codex-codex` is what
`general.lightSkin` / `general.darkSkin` persist, so renaming it would fail the
settings enum and silently reset every install that had this skin selected.

This PR carries a bug fix and a rename together at the author's request. They
are independent — the gutter fix stands whether or not the new name does.

## Potential risks

- **Baseline skins are unaffected.** They emit no tokens at all, so the shipped
  light and dark designs keep resolving the alias through the stylesheet exactly
  as before. The change is only observable on a Codex skin.
- The parity test reads `public/orgii_*.css` from disk. Moving or renaming those
  files breaks the test rather than failing silently, which is the intended
  direction, but it is a build-time coupling to a path.
- The test only understands `:root` and `body` scopes. An alias declared under a
  narrower selector would not be checked; none exist today.
- The rename is cosmetic and reversible in one line. It does change a
  user-visible label for anyone already running the Codex skin, who will see the
  entry rename itself without their selection changing.

## Verification

Verified in a clean `git worktree` checked out at `origin/develop` (`57c8ffd47`)
with only this branch's four files applied, rather than in the working checkout,
which carries unrelated in-flight work:

- `npx tsc --noEmit --pretty false` — exit 0
- `npx eslint src/config/appearance --ext .ts --max-warnings 0 --report-unused-disable-directives` — exit 0
- `npx vitest run --config config/vitest.config.ts src/config/appearance src/config/settingsSchema` — exit 0, 12 files / 83 tests passed

The new guard was checked for vacuity: reverting the one-line fix makes it fail
with `--cm-editor-gutter-bg -> var(--cm-editor-background)`, and restoring it
passes.

Not verified: no screenshot of the corrected gutter across skins, and the full
test suite was not re-run for this change — the diff is confined to the skin
registry and its own tests, and CI runs it.
