### PR TITLE
fix(workspace-dropdown): move row paths from a second line to hover

### DIFF
--- a/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/WorkspaceDropdown.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/WorkspaceDropdown.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { REPO_KIND } from "@src/store/repo";
+
+import { WorkspaceDropdown } from "./WorkspaceDropdown";
+
+const EXTERNAL_RECENT_PATH = "/Users/tester/Documents/GitHub/business-plan";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/api/tauri/repo", () => ({
+  repoApi: { getRepoById: vi.fn() },
+}));
+
+vi.mock("@src/scaffold/GlobalSpotlight/hooks", () => ({
+  EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD: 5,
+  useSharedRepoList: () => ({
+    repos: [],
+    filteredRepos: [],
+    repoLoading: false,
+    refreshReposForce: vi.fn(),
+  }),
+  useExternalRecentPaths: () => ({
+    recentPathRepos: [
+      {
+        id: `external-recent:${EXTERNAL_RECENT_PATH}`,
+        name: "business-plan",
+        description: EXTERNAL_RECENT_PATH,
+        fs_uri: EXTERNAL_RECENT_PATH,
+        kind: REPO_KIND.FOLDER,
+      },
+    ],
+  }),
+  useWorkspaceSwitch: () => ({
+    workspaces: [],
+    activateWorkspace: vi.fn(),
+  }),
+}));
+
+vi.mock("@src/scaffold/GlobalSpotlight/hooks/forms", () => ({
+  useWorkspaceForm: () => ({ handleImportWorkspace: vi.fn() }),
+}));
+
+vi.mock("@src/hooks/dropdown", () => ({
+  useDropdownEngine: () => ({
+    isPositioned: true,
+    panelRef: createRef<HTMLDivElement>(),
+    panelPosition: { top: 100, bottom: undefined, left: 40, width: 320 },
+    keyboard: {
+      selectedIndex: -1,
+      setSelectedIndex: vi.fn(),
+      getItemProps: (index: number) => ({
+        "data-dropdown-item-index": index,
+        "aria-selected": false,
+        onMouseEnter: vi.fn(),
+        onClick: vi.fn(),
+      }),
+      handleKeyDown: vi.fn(),
+      keyboardNavigated: false,
+      clearKeyboardNavigation: vi.fn(),
+    },
+  }),
+}));
+
+describe("WorkspaceDropdown rows", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  const renderDropdown = () => {
+    act(() => {
+      root.render(
+        createElement(WorkspaceDropdown, {
+          isOpen: true,
+          onClose: vi.fn(),
+          onSelect: vi.fn(),
+          anchorRef: createRef<HTMLElement>(),
+        })
+      );
+    });
+  };
+
+  const externalRecentRow = () =>
+    document.querySelector<HTMLButtonElement>(
+      `[data-testid="repo-dropdown-row-external-recent:${EXTERNAL_RECENT_PATH}"]`
+    );
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps the path off the row instead of rendering it as a second line", () => {
+    renderDropdown();
+
+    const row = externalRecentRow();
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toBe("business-plan");
+    expect(row?.textContent).not.toContain(EXTERNAL_RECENT_PATH);
+  });
+
+  it("reveals the path in a tooltip while the row is hovered", () => {
+    renderDropdown();
+
+    const row = externalRecentRow();
+    expect(document.querySelector(".native-tooltip")).toBeNull();
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(document.querySelector(".native-tooltip")?.textContent).toBe(
+      EXTERNAL_RECENT_PATH
+    );
+
+    act(() => {
+      row?.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(document.querySelector(".native-tooltip")).toBeNull();
+  });
+
+  it("marks the panel as a menu so side tooltips clear its border", () => {
+    renderDropdown();
+
+    const panel = document.querySelector('[role="menu"]');
+    expect(panel).not.toBeNull();
+    expect(externalRecentRow()?.closest('[role="menu"]')).toBe(panel);
+  });
+});

--- a/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/WorkspaceDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/WorkspaceDropdown.tsx
@@ -28,6 +28,7 @@ import {
   DROPDOWN_ITEM,
   DROPDOWN_PANEL,
 } from "@src/components/Dropdown/tokens";
+import Tooltip from "@src/components/Tooltip";
 import {
   isSystemHomeRepoItem,
   isSystemPathRepoItem,
@@ -59,8 +60,9 @@ import { buildOpenPathItem } from "./pathActionItem";
 import { importWorkspacePath } from "./pathImport";
 
 const LIST_MAX_HEIGHT = 360;
-const VIEWPORT_MARGIN = 12;
 const MIN_DROPDOWN_WIDTH = 320;
+/** Long enough that scanning the list doesn't flash a popup on every row. */
+const ROW_DETAIL_TOOLTIP_DELAY = 200;
 
 type DropdownRepoItem =
   | { kind: "repo"; repo: RepoItem }
@@ -106,6 +108,43 @@ interface WorkspaceRowProps {
   keyboardProps: ReturnType<UseDropdownListNavigationReturn["getItemProps"]>;
 }
 
+interface RowDetailTooltipProps {
+  /** Secondary text to reveal on hover — a repo description, or the
+   *  filesystem path for externally-used and open-path rows. Rows without
+   *  one render bare. */
+  detail?: string;
+  children: React.ReactElement;
+}
+
+/**
+ * Reveals a row's secondary text on hover instead of on a second line.
+ *
+ * A second line overflows the token-fixed 32px row and pushes the list past
+ * its max height, so the detail moves into a framed side tooltip. Tooltip
+ * measures side placements from the enclosing `role="menu"` panel and offsets
+ * by `DROPDOWN_PANEL.submenuGap`, so the popup clears the panel border by the
+ * same distance a submenu would rather than landing on top of it.
+ */
+const RowDetailTooltip: React.FC<RowDetailTooltipProps> = ({
+  detail,
+  children,
+}) => {
+  if (!detail) return children;
+
+  return (
+    <Tooltip
+      content={detail}
+      position="right"
+      mouseEnterDelay={ROW_DETAIL_TOOLTIP_DELAY}
+      framedPanel
+      framedPanelWide
+      smartPlacement
+    >
+      {children}
+    </Tooltip>
+  );
+};
+
 const RepoRow: React.FC<RepoRowProps> = ({
   repo,
   isCurrent,
@@ -117,38 +156,35 @@ const RepoRow: React.FC<RepoRowProps> = ({
     : isSystemPath || repo.kind === REPO_KIND.FOLDER
       ? ICONS.folder
       : ICONS.repo;
-  const shouldShowDescription = Boolean(repo.description && !isSystemPath);
+  // System-path rows are self-describing ("Home"), so they keep no hover text.
+  const hoverDetail = isSystemPath ? undefined : repo.description;
 
   return (
-    <button
-      type="button"
-      data-testid={`repo-dropdown-row-${repo.id}`}
-      {...keyboardProps}
-      className={`${DROPDOWN_CLASSES.item} ${
-        isCurrent ? DROPDOWN_CLASSES.itemSelected : DROPDOWN_CLASSES.itemHover
-      } w-full justify-start`}
-    >
-      <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-        {isCurrent ? (
-          <HugeiconsIcon
-            icon={Tick01Icon}
-            data-icon="check"
-            size={DROPDOWN_ITEM.iconSize}
-            className="text-primary-6"
-          />
-        ) : (
-          <AnyIcon icon={Icon} size={DROPDOWN_ITEM.iconSize} />
-        )}
-      </span>
-      <div className="flex min-w-0 flex-1 flex-col items-start">
-        <span className="truncate">{repo.name}</span>
-        {shouldShowDescription && (
-          <span className="truncate text-[11px] text-text-3">
-            {repo.description}
-          </span>
-        )}
-      </div>
-    </button>
+    <RowDetailTooltip detail={hoverDetail}>
+      <button
+        type="button"
+        role="menuitem"
+        data-testid={`repo-dropdown-row-${repo.id}`}
+        {...keyboardProps}
+        className={`${DROPDOWN_CLASSES.item} ${
+          isCurrent ? DROPDOWN_CLASSES.itemSelected : DROPDOWN_CLASSES.itemHover
+        } w-full justify-start`}
+      >
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+          {isCurrent ? (
+            <HugeiconsIcon
+              icon={Tick01Icon}
+              data-icon="check"
+              size={DROPDOWN_ITEM.iconSize}
+              className="text-primary-6"
+            />
+          ) : (
+            <AnyIcon icon={Icon} size={DROPDOWN_ITEM.iconSize} />
+          )}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-left">{repo.name}</span>
+      </button>
+    </RowDetailTooltip>
   );
 };
 
@@ -161,6 +197,7 @@ const WorkspaceRow: React.FC<WorkspaceRowProps> = ({
   return (
     <button
       type="button"
+      role="menuitem"
       data-testid={`repo-dropdown-workspace-row-${workspace.workspaceId}`}
       {...keyboardProps}
       className={`${DROPDOWN_CLASSES.item} ${
@@ -190,22 +227,20 @@ const OpenPathRow: React.FC<OpenPathRowProps> = ({ item, keyboardProps }) => {
   const Icon = typeof item.icon === "string" ? ICONS.folder : item.icon;
 
   return (
-    <button
-      type="button"
-      data-testid="repo-dropdown-open-path-row"
-      {...keyboardProps}
-      className={`${DROPDOWN_CLASSES.item} ${DROPDOWN_CLASSES.itemHover} w-full justify-start`}
-    >
-      <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-        {Icon && <AnyIcon icon={Icon} size={DROPDOWN_ITEM.iconSize} />}
-      </span>
-      <div className="flex min-w-0 flex-1 flex-col items-start">
-        <span className="truncate">{item.label}</span>
-        {item.desc && (
-          <span className="truncate text-[11px] text-text-3">{item.desc}</span>
-        )}
-      </div>
-    </button>
+    <RowDetailTooltip detail={item.desc}>
+      <button
+        type="button"
+        role="menuitem"
+        data-testid="repo-dropdown-open-path-row"
+        {...keyboardProps}
+        className={`${DROPDOWN_CLASSES.item} ${DROPDOWN_CLASSES.itemHover} w-full justify-start`}
+      >
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+          {Icon && <AnyIcon icon={Icon} size={DROPDOWN_ITEM.iconSize} />}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-left">{item.label}</span>
+      </button>
+    </RowDetailTooltip>
   );
 };
 
@@ -631,14 +666,16 @@ export const WorkspaceDropdown: React.FC<WorkspaceDropdownProps> = ({
 
   const width = Math.max(MIN_DROPDOWN_WIDTH, panelPosition.width);
   const { width: vw } = getViewportSize();
+  const viewportMargin = DROPDOWN_PANEL.viewportPadding;
   const left = Math.max(
-    VIEWPORT_MARGIN,
-    Math.min(panelPosition.left, vw - VIEWPORT_MARGIN - width)
+    viewportMargin,
+    Math.min(panelPosition.left, vw - viewportMargin - width)
   );
 
   return createPortal(
     <div
       ref={panelRef}
+      role="menu"
       className={`${DROPDOWN_CLASSES.panel} fixed flex flex-col`}
       style={{
         top: panelPosition.top,


### PR DESCRIPTION
## Problem

Rows in the anchored workspace dropdown (the repo/workspace switcher on the
composer's `SessionInfoLine`) rendered their filesystem path on a second line.
`useExternalRecentPaths` sets `description` to the raw path, so every
"Used elsewhere" row printed one, and `buildOpenPathItem` did the same for the
open-path row.

`DROPDOWN_CLASSES.item` fixes the row at 32px (`h-8 min-h-8`), so a second line
overflowed the row and pushed the list past its `LIST_MAX_HEIGHT`. The row also
had no way to show a long path in full — the panel is 320px wide.

## Solution

The path moves out of the row and into a framed side tooltip on hover. A new
`RowDetailTooltip` wraps any row that has secondary text; rows without it render
bare. `RepoRow` and `OpenPathRow` collapse to a single truncating label, matching
`WorkspaceRow`, which puts all three row types back inside the token-fixed 32px
height.

Placement is the load-bearing detail. `Tooltip` measures side placements from
the enclosing `[role="menu"]` panel and offsets by `DROPDOWN_PANEL.submenuGap`,
so the popup clears the panel border the same distance a submenu would. Without
that anchor the tooltip would be positioned against the row's inset rect and land
~2px *inside* the panel — and since `.native-tooltip` is z-1060 against the
panel's z-10000, that overlap would be occluded. The panel therefore gains
`role="menu"` and the rows `role="menuitem"`, matching `PortsStatusMenu`
(the same search-panel shape) and `AddActionsDropdown`.

Two related token adoptions in the same file: the local `VIEWPORT_MARGIN = 12`
is replaced by `DROPDOWN_PANEL.viewportPadding`, and the removed second line
takes the arbitrary `text-[11px]` with it.

The tooltip carries the same content under the same condition as the old second
line — this relocates the information, it does not add or remove any.

## Potential risks

- **Discoverability.** A path that was always visible is now behind a 200ms
  hover. That is the intended trade (it was overflowing its row), but a
  pointer-only affordance is worse for keyboard navigation: arrowing onto a row
  does not open the tooltip. Keyboard users can still tell rows apart by name,
  and the spotlight variant keeps its explicit "Show path" footer toggle.
- **Positioning.** If neither side fits the viewport, `Tooltip` clamps rather
  than flips and the popup can land over the panel, where the z-index gap hides
  it. `smartPlacement` is on, so this needs a viewport narrower than
  panel + tooltip on both sides.
- **ARIA.** `role="menu"` + `role="menuitem"` is a net improvement over buttons
  in a bare `div`, but `getItemProps` still sets `aria-selected`, which
  `menuitem` does not support. That attribute was already there (equally
  unsupported on a bare `button`), so this is pre-existing, not a regression;
  fixing it means touching the shared `useDropdownListNavigation` used by ten
  components.
- **Not changed:** `LIST_MAX_HEIGHT` (360) and `MIN_DROPDOWN_WIDTH` (320) keep
  their local constants. The nearest tokens are 200 and 280, so adopting them
  would resize the panel.

## Verification

Run against this branch in an isolated worktree checked out at its own commit
(not the shared dirty checkout), with `node_modules` symlinked:

- `npx tsc --noEmit --pretty false -p tsconfig.json` — exit 0.
- `npx vitest run --config config/vitest.config.ts src/scaffold/GlobalSpotlight`
  — 28 files, 133 tests, all passing.
- `npx eslint src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/` — clean.
- `npx prettier --check` on the changed file — clean.
- `npm run check:test-placement` — clean (the directory colocates tests, and the
  new file is colocated).

New `WorkspaceDropdown.test.ts` covers the three behaviours: the row renders its
name only and not the path, hovering reveals the path in a tooltip and leaving
dismisses it, and the row resolves to a `[role="menu"]` ancestor so the tooltip
can clear the panel edge. Mutation-checked — restoring the second line, dropping
the tooltip, or removing `role="menu"` fails all three.

**Not run / not applicable:**

- **No screenshots.** ORG2 is a Tauri app with no browser-renderable entry
  point, so the dropdown cannot be captured without a full app launch. The
  hover behaviour is verified through jsdom rendering instead.
- **E2E** was not run; there is no rendered spec covering this dropdown.
- **No "Pre-commit hook ran." trailer.** The commit was built with plumbing
  (temp index + `commit-tree`) so the unrelated uncommitted work in the shared
  checkout could not enter it. Hooks were skipped, so typecheck, lint and tests
  were run by hand as listed above. Note the hook's TypeScript gate cannot fail
  a commit anyway (`TSC_OUTPUT=$(...) || true` then `$?` is always 0), so a green
  hook would not have been evidence.
- **Base.** Built on `origin/develop` (`aa17dccd7`). That commit's unused-export
  sweep (`export interface WorkspaceDropdownProps` to `interface ...`) is
  preserved rather than reverted — the local checkout predates it.
