### PR TITLE
fix(model-pill): unify the placeholder across model selector pills

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/ModelPill.tsx
+++ b/src/engines/ChatPanel/InputArea/components/ModelPill.tsx
@@ -253,7 +253,7 @@ const ModelPill: React.FC = memo(() => {
     <ModelSelectorPill
       ref={modelSegmentRef}
       selection={lastModel}
-      defaultLabel={t("sessions:creator.selectModel")}
+      defaultLabel={t("sessions:creator.model")}
       active={isModelOpen}
       className="max-w-[360px]"
       onClick={handleOpenModelSelector}

--- a/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/AgentControlInputTrailing.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/AgentControlInputTrailing.tsx
@@ -7,6 +7,10 @@ import { AgentControlSubmitButton } from "./AgentControlSubmitButton";
 
 interface AgentControlInputTrailingProps {
   selection: LastModelSelection | null;
+  /** Placeholder shown until a model is picked. Names the thing ("Model"),
+   *  matching every other ModelSelectorPill and the hook's own fallback. */
+  modelLabel: string;
+  /** Accessible name. Names the action ("Select model"). */
   selectModelLabel: string;
   modelSelectorActive: boolean;
   onOpenModelSelector: () => void;
@@ -18,6 +22,7 @@ export const AgentControlInputTrailing: React.FC<
   AgentControlInputTrailingProps
 > = ({
   selection,
+  modelLabel,
   selectModelLabel,
   modelSelectorActive,
   onOpenModelSelector,
@@ -28,7 +33,7 @@ export const AgentControlInputTrailing: React.FC<
     <div className="flex items-center gap-2">
       <ModelSelectorPill
         selection={selection}
-        defaultLabel={selectModelLabel}
+        defaultLabel={modelLabel}
         active={modelSelectorActive}
         className="h-[28px] max-w-[180px] shrink-0 text-[13px]"
         dataTestId="agent-control-model-pill"

--- a/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/index.tsx
@@ -142,6 +142,7 @@ export const AgentControlPalette: React.FC<AgentControlPaletteProps> = ({
   const inputTrailingSlot = (
     <AgentControlInputTrailing
       selection={palette.creatorDefaultLastModel}
+      modelLabel={palette.modelLabel}
       selectModelLabel={palette.selectModelLabel}
       modelSelectorActive={isModelOpen}
       onOpenModelSelector={handleOpenModelSelector}

--- a/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/useAgentControlPalette.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/useAgentControlPalette.ts
@@ -377,6 +377,7 @@ export function useAgentControlPalette({
     isModelOpen: false,
     items,
     kernel,
+    modelLabel: t("sessions:creator.model"),
     modePath,
     pendingProposal,
     placeholder: t("adeManager.inputPlaceholder"),


### PR DESCRIPTION
## Problem

`ModelSelectorPill`'s `defaultLabel` is the placeholder shown until a model is
picked. Eight surfaces render one, and they disagreed:

| Surface | key | en / zh |
| --- | --- | --- |
| SessionCreator `ControlButtons` | `sessions:creator.model` | Model / 模型 |
| SessionCreator `RunnerRow` | `sessions:creator.model` | Model / 模型 |
| `Install`, `SessionCreatorOrgMembersPanel`, `AgentLauncherSection`, `RunGroupRunRow` | `sessions:creator.model` | Model / 模型 |
| ChatPanel `ModelPill` | `sessions:creator.selectModel` | Select model / 选择模型 |
| `AgentControlInputTrailing` | `common:adeManager.selectModel` | Select model / 选择模型 |

So the same control introduced itself two different ways depending on where it
was rendered. The six that say "Model" also agree with `useModelPillLabel`'s own
built-in fallback, which is the literal `"Model"` — the two outliers were passing
the *action* string where the *placeholder* belongs.

`AgentControlInputTrailing` made it worse by feeding one string to both
`defaultLabel` and `ariaLabel`, collapsing the two roles into a single prop.

## Solution

All eight `defaultLabel`s now resolve `sessions:creator.model` — **Model / 模型**.

Accessible names are deliberately untouched: every pill still announces "Select
model" / 选择模型, so `sessions:creator.selectModel` and
`common:adeManager.selectModel` both stay live. The result is a consistent split
that `ControlButtons` was already using — the visible placeholder names the
*thing*, the accessible name names the *action*.

Keeping that split in the Agent Control palette required separating the two
props, which is why this touches four files for a two-line behavioural change:
`AgentControlInputTrailing` takes a new `modelLabel` alongside `selectModelLabel`,
and `useAgentControlPalette` exposes it.

Cross-namespace `t("sessions:creator.model")` from a `common`-namespace hook
matches what the neighbouring `ModelPill` already does for model-picker copy.

## Potential risks

- **Copy change, two locales.** `sessions:creator.model` exists only in `en` and
  `zh` — the same coverage the strings it replaces had, so no locale loses a
  translation. The other eleven locales fall back exactly as before.
- **"Model" is less instructive than "Select model"** for a first-time user
  looking at an unfilled pill. The accessible name still carries the verb, and
  the pill's affordance (chevron, click target) carries the rest. This is the
  trade the six existing surfaces already made.
- **No behaviour change.** `defaultLabel` is only read when there is no model
  selection; every pill with a selection renders the model name and is
  unaffected.
- **`common:adeManager.selectModel` is now aria-only.** It is still referenced,
  so it is not dead, but its sole remaining use is an accessible name — worth
  knowing if someone later greps for visible uses.

## Verification

Run against this branch in an isolated worktree checked out at its own commit
(not the shared dirty checkout), with `node_modules` symlinked:

- `npx tsc --noEmit --pretty false -p tsconfig.json` — exit 0.
- `npx vitest run --config config/vitest.config.ts src/scaffold/GlobalSpotlight src/engines/ChatPanel/InputArea src/features/SessionCreator src/components/ModelSelectorPill`
  — 79 files, 452 tests, all passing.
- `npx eslint src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/ src/engines/ChatPanel/InputArea/components/ModelPill.tsx` — clean.
- `npx prettier --check` on the changed files — clean.
- Audited every `defaultLabel=` and `useModelPillLabel(` call site in `src/` to
  confirm all eight now resolve the same key, and that
  `sessions:creator.selectModel` / `common:adeManager.selectModel` still have
  live `ariaLabel` consumers.

**Not run / not applicable:**

- **No new test.** This is a one-token key swap per call site with no branching,
  and the existing suites already render both pills. A reviewer who wants drift
  protection could ask for an assertion pinning the placeholder key — say so and
  I will add it.
- **No screenshots.** ORG2 is a Tauri app with no browser-renderable entry point;
  the change is a string swap with no layout effect.
- **No "Pre-commit hook ran." trailer.** The commit was built with plumbing
  (temp index + `commit-tree`) so the unrelated uncommitted work in the shared
  checkout could not enter it. Hooks were skipped, so typecheck, lint and tests
  were run by hand as listed above. The hook's TypeScript gate cannot fail a
  commit anyway (`TSC_OUTPUT=$(...) || true` then `$?` is always 0).
- **Base.** Built on `origin/develop` (`aa17dccd7`). That commit's unused-export
  sweep on `AgentControlInputTrailingProps` and `AgentControlPaletteProps` is
  preserved rather than reverted — the local checkout predates it.
