### PR TITLE
fix(startup): isolate cross-version persistence

### DIFF
--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/mod.rs
@@ -54,8 +54,7 @@ pub use record::{
 pub use schema::init_schema;
 pub(crate) use schema::{create_schema, repair_dangling_materializations};
 pub(crate) use task_bindings::{
-    backfill_task_message_bindings, create_task_message_binding_schema,
-    oldest_unread_task_message_binding_with_connection,
+    create_task_message_binding_schema, oldest_unread_task_message_binding_with_connection,
 };
 
 /// Reserved sender id for system-generated agent inbox rows.

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/task_bindings.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/task_bindings.rs
@@ -160,62 +160,6 @@ pub(crate) fn oldest_unread_task_message_binding_with_connection(
     .map_err(|error| error.to_string())
 }
 
-/// One-time additive migration for releases that persisted the association
-/// only inside the exactly-once `org_send_message` receipt. The receipt's
-/// delivered Inbox id, related Task id, Coordinator Turn, recipient, and Task
-/// identity must all agree before a binding is reconstructed.
-pub(crate) fn backfill_task_message_bindings(conn: &Connection) -> rusqlite::Result<usize> {
-    let now = chrono::Utc::now().to_rfc3339();
-    conn.execute(
-        "INSERT OR IGNORE INTO agent_org_runtime_inbox_task_bindings (
-             inbox_id,org_run_id,task_id,recipient_member_id,binding_kind,
-             source_turn_intent_id,created_at
-         )
-         SELECT DISTINCT inbox.id,inbox.org_run_id,task.id,inbox.recipient_member_id,
-                         ?1,source_context.turn_intent_id,?2
-         FROM agent_org_runtime_tool_call_receipts receipt
-         JOIN agent_org_runtime_turn_contexts source_context
-           ON source_context.org_run_id=receipt.org_run_id
-          AND source_context.session_id=receipt.session_id
-          AND source_context.turn_intent_id=receipt.turn_intent_id
-          AND source_context.participant_id='coordinator'
-          AND source_context.turn_kind='coordinator'
-          AND source_context.source_kind IN ('root_turn','group_root')
-         JOIN json_each(
-             CASE WHEN json_valid(receipt.result_text)
-                  THEN receipt.result_text ELSE '{}' END,
-             '$.delivered'
-         ) delivered
-         JOIN agent_org_runtime_inbox inbox
-           ON inbox.org_run_id=receipt.org_run_id
-          AND inbox.id=json_extract(delivered.value,'$.inbox_id')
-          AND inbox.recipient_member_id=json_extract(
-              delivered.value,'$.recipient_member_id'
-          )
-          AND inbox.sender_member_id='coordinator'
-          AND inbox.delivery_class='formal_work'
-          AND inbox.payload_kind='plain'
-         JOIN agent_org_runtime_tasks task
-           ON task.org_run_id=inbox.org_run_id
-          AND task.id=json_extract(
-              CASE WHEN json_valid(receipt.result_text)
-                   THEN receipt.result_text ELSE '{}' END,
-              '$.related_task_id'
-          )
-          AND task.owner=inbox.recipient_member_id
-         WHERE receipt.tool_name='org_send_message'
-           AND receipt.operation='plain'
-           AND json_type(
-               CASE WHEN json_valid(receipt.result_text)
-                    THEN receipt.result_text ELSE '{}' END,
-               '$.related_task_id'
-           )='text'
-           AND json_type(delivered.value,'$.inbox_id')='integer'
-           AND json_type(delivered.value,'$.recipient_member_id')='text'",
-        params![BINDING_KIND, now],
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/mod.rs
@@ -631,13 +631,11 @@ pub fn new_task_id() -> String {
 pub fn init_schema(conn: &Connection) -> SqliteResult<()> {
     // Isolated Task test/sandbox entry points must include the completion
     // owner because every Task mutation now checks the certificate fence.
-    // Production still uses the canonical 23-table initializer, which calls
+    // Production still uses the canonical runtime initializer, which calls
     // `create_schema` directly in manifest order.
     super::agent_org_run_completion::create_schema(conn)?;
     create_schema(conn)
 }
-
-pub(crate) const HISTORY_PAGE_INDEX_NAME: &str = "idx_agent_org_runtime_tasks_history_page";
 
 pub(crate) fn create_history_page_index(conn: &Connection) -> SqliteResult<()> {
     conn.execute_batch(

--- a/src-tauri/crates/agent-core/src/core/coordination/fixtures/official_v1_3_0_agent_org.sql
+++ b/src-tauri/crates/agent-core/src/core/coordination/fixtures/official_v1_3_0_agent_org.sql
@@ -1,0 +1,301 @@
+-- Exact private Agent Org schema created by official ORGII v1.3.0.
+-- Keep this fixture release-shaped: it must not contain unpublished intermediate tables.
+
+CREATE TABLE agent_org_runs (
+    id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    coordinator_agent_id TEXT NOT NULL,
+    root_session_id TEXT,
+    org_snapshot_json TEXT,
+    entry_mode TEXT NOT NULL,
+    status TEXT NOT NULL,
+    work_item_id TEXT,
+    project_slug TEXT,
+    routine_fire_id TEXT,
+    summary TEXT,
+    last_error TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT
+);
+CREATE INDEX idx_agent_org_runs_org_updated
+    ON agent_org_runs(org_id, updated_at);
+CREATE INDEX idx_agent_org_runs_root_session
+    ON agent_org_runs(root_session_id);
+CREATE INDEX idx_agent_org_runs_work_item
+    ON agent_org_runs(work_item_id);
+CREATE INDEX idx_agent_org_runs_status
+    ON agent_org_runs(status);
+
+CREATE TABLE agent_org_run_progress (
+    org_run_id TEXT PRIMARY KEY,
+    work_revision INTEGER NOT NULL DEFAULT 0 CHECK(work_revision >= 0),
+    coordinator_presented_work_revision INTEGER,
+    coordinator_observed_work_revision INTEGER,
+    completion_requested INTEGER NOT NULL DEFAULT 0,
+    completion_requested_at TEXT,
+    completion_requested_work_revision INTEGER,
+    completion_summary TEXT,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
+);
+
+CREATE TABLE agent_org_plan_approvals (
+    approval_id TEXT PRIMARY KEY,
+    plan_revision_id TEXT NOT NULL UNIQUE,
+    request_id TEXT NOT NULL UNIQUE,
+    org_run_id TEXT NOT NULL,
+    source_task_id TEXT NOT NULL,
+    source_member_id TEXT NOT NULL,
+    source_session_id TEXT NOT NULL,
+    root_session_id TEXT NOT NULL,
+    policy TEXT NOT NULL,
+    status TEXT NOT NULL,
+    plan_title TEXT NOT NULL,
+    plan_path TEXT NOT NULL,
+    plan_content TEXT NOT NULL,
+    decision_by TEXT,
+    feedback TEXT,
+    created_at TEXT NOT NULL,
+    resolved_at TEXT
+);
+CREATE INDEX idx_agent_org_plan_approvals_run_status
+    ON agent_org_plan_approvals(org_run_id, status, created_at);
+CREATE INDEX idx_agent_org_plan_approvals_task
+    ON agent_org_plan_approvals(org_run_id, source_task_id, created_at);
+
+CREATE TABLE agent_org_recovery_attempts (
+    org_run_id TEXT NOT NULL,
+    action_kind TEXT NOT NULL,
+    target_key TEXT NOT NULL,
+    reason_fingerprint TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_allowed_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    reservation_token TEXT,
+    PRIMARY KEY (org_run_id, action_kind, target_key)
+);
+CREATE INDEX idx_agent_org_recovery_attempts_run
+    ON agent_org_recovery_attempts(org_run_id);
+
+CREATE TABLE agent_org_tasks (
+    id TEXT NOT NULL,
+    org_run_id TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    active_form TEXT,
+    owner TEXT,
+    status TEXT NOT NULL,
+    blocks_json TEXT NOT NULL DEFAULT '[]',
+    blocked_by_json TEXT NOT NULL DEFAULT '[]',
+    metadata_json TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (org_run_id, id)
+);
+CREATE INDEX idx_agent_org_tasks_status
+    ON agent_org_tasks(org_run_id, status, owner);
+CREATE INDEX idx_agent_org_tasks_owner
+    ON agent_org_tasks(org_run_id, owner);
+
+CREATE TABLE agent_org_task_events (
+    id TEXT PRIMARY KEY,
+    org_run_id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    previous_owner TEXT,
+    next_owner TEXT,
+    previous_status TEXT,
+    next_status TEXT,
+    actor_member_id TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX idx_agent_org_task_events_run
+    ON agent_org_task_events(org_run_id, created_at, id);
+CREATE INDEX idx_agent_org_task_events_task
+    ON agent_org_task_events(org_run_id, task_id, created_at, id);
+
+CREATE TABLE agent_org_task_run_schema_migrations (
+    name TEXT NOT NULL,
+    org_run_id TEXT NOT NULL,
+    applied_at TEXT NOT NULL,
+    PRIMARY KEY (name, org_run_id)
+);
+
+CREATE TABLE agent_inbox (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recipient_agent_id TEXT NOT NULL,
+    recipient_member_id TEXT,
+    sender_agent_id TEXT NOT NULL,
+    sender_member_id TEXT,
+    org_run_id TEXT,
+    payload_kind TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    request_id TEXT,
+    created_at TEXT NOT NULL,
+    read_at TEXT,
+    causation_inbox_id INTEGER,
+    display_text TEXT
+);
+CREATE INDEX idx_agent_inbox_recipient_member_unread
+    ON agent_inbox(recipient_member_id, read_at, created_at);
+CREATE INDEX idx_agent_inbox_recipient_unread
+    ON agent_inbox(recipient_agent_id, read_at, created_at);
+CREATE INDEX idx_agent_inbox_org_run
+    ON agent_inbox(org_run_id, created_at);
+CREATE INDEX idx_agent_inbox_org_run_id
+    ON agent_inbox(org_run_id, id);
+CREATE INDEX idx_agent_inbox_run_unread_recipient
+    ON agent_inbox(org_run_id, recipient_member_id, recipient_agent_id, id)
+    WHERE read_at IS NULL;
+CREATE INDEX idx_agent_inbox_run_kind_id
+    ON agent_inbox(org_run_id, payload_kind, id);
+CREATE INDEX idx_agent_inbox_run_task_assignment_v4
+    ON agent_inbox(
+        org_run_id,
+        recipient_member_id,
+        json_extract(
+            CASE WHEN length(CAST(payload_json AS BLOB))<=262144
+                           AND json_valid(payload_json)
+                 THEN payload_json ELSE '{}' END,
+            '$.task_id'
+        )
+    )
+    WHERE payload_kind='task_assigned'
+      AND CASE WHEN length(CAST(payload_json AS BLOB))<=262144
+               THEN json_valid(payload_json) ELSE 0 END
+      AND json_type(
+            CASE WHEN length(CAST(payload_json AS BLOB))<=262144
+                           AND json_valid(payload_json)
+                 THEN payload_json ELSE '{}' END,
+            '$.task_id'
+          )='text';
+CREATE INDEX idx_agent_inbox_request_id
+    ON agent_inbox(request_id);
+CREATE UNIQUE INDEX idx_agent_inbox_causation_recipient_once
+    ON agent_inbox(
+        causation_inbox_id,
+        payload_kind,
+        recipient_agent_id,
+        COALESCE(recipient_member_id, '')
+    )
+    WHERE causation_inbox_id IS NOT NULL;
+
+CREATE TABLE agent_inbox_materializations (
+    inbox_id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    transcript_message_id TEXT NOT NULL,
+    transcript_intent_id TEXT NOT NULL,
+    materialized_at TEXT NOT NULL
+);
+CREATE INDEX idx_agent_inbox_materializations_session
+    ON agent_inbox_materializations(session_id, inbox_id);
+
+CREATE TABLE agent_inbox_delivery_resolutions (
+    inbox_id INTEGER PRIMARY KEY,
+    org_run_id TEXT NOT NULL,
+    resolution_kind TEXT NOT NULL
+        CHECK(resolution_kind IN ('cancelled', 'superseded')),
+    resolved_by_member_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    replacement_inbox_id INTEGER,
+    replacement_task_id TEXT,
+    created_at TEXT NOT NULL,
+    CHECK(
+        (resolution_kind='cancelled'
+            AND replacement_inbox_id IS NULL
+            AND replacement_task_id IS NULL)
+        OR
+        (resolution_kind='superseded'
+            AND ((replacement_inbox_id IS NOT NULL)
+                 <> (replacement_task_id IS NOT NULL)))
+    )
+);
+CREATE INDEX idx_agent_inbox_delivery_resolutions_run
+    ON agent_inbox_delivery_resolutions(org_run_id, inbox_id);
+
+CREATE TABLE agent_member_interventions (
+    org_run_id TEXT NOT NULL,
+    member_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    reason TEXT,
+    entered_at TEXT NOT NULL,
+    last_user_activity_at TEXT NOT NULL,
+    resume_after TEXT NOT NULL,
+    cleared_at TEXT,
+    PRIMARY KEY (org_run_id, member_id)
+);
+CREATE INDEX idx_agent_member_interventions_session
+    ON agent_member_interventions(session_id);
+CREATE INDEX idx_agent_member_interventions_active
+    ON agent_member_interventions(org_run_id, cleared_at, resume_after);
+
+INSERT INTO agent_org_runs (
+    id, org_id, coordinator_agent_id, root_session_id, org_snapshot_json,
+    entry_mode, status, created_at, updated_at
+) VALUES (
+    'official-run', 'official-org', 'official-coordinator', 'ordinary-session',
+    '{"id":"official-org","children":[]}', 'standalone_session', 'idle',
+    '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z'
+);
+INSERT INTO agent_org_run_progress (org_run_id, updated_at)
+VALUES ('official-run', '2026-08-01T00:00:00Z');
+INSERT INTO agent_org_plan_approvals (
+    approval_id, plan_revision_id, request_id, org_run_id, source_task_id,
+    source_member_id, source_session_id, root_session_id, policy, status,
+    plan_title, plan_path, plan_content, created_at
+) VALUES (
+    'official-approval', 'official-revision', 'official-request', 'official-run',
+    'official-task', 'official-member', 'ordinary-session', 'ordinary-session',
+    'coordinator', 'pending', 'Official plan', '/tmp/official-plan', '# Plan',
+    '2026-08-01T00:00:00Z'
+);
+INSERT INTO agent_org_recovery_attempts (
+    org_run_id, action_kind, target_key, reason_fingerprint, next_allowed_at, updated_at
+) VALUES (
+    'official-run', 'member_rewake', 'official-member', 'official-fingerprint',
+    '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z'
+);
+INSERT INTO agent_org_tasks (
+    id, org_run_id, subject, status, created_at, updated_at
+) VALUES (
+    'official-task', 'official-run', 'Official task', 'pending',
+    '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z'
+);
+INSERT INTO agent_org_task_events (
+    id, org_run_id, task_id, event_type, actor_member_id, created_at
+) VALUES (
+    'official-event', 'official-run', 'official-task', 'created', 'official-member',
+    '2026-08-01T00:00:00Z'
+);
+INSERT INTO agent_org_task_run_schema_migrations (name, org_run_id, applied_at)
+VALUES ('canonical_blocked_by_v1', 'official-run', '2026-08-01T00:00:00Z');
+INSERT INTO agent_inbox (
+    recipient_agent_id, recipient_member_id, sender_agent_id, sender_member_id,
+    org_run_id, payload_kind, payload_json, request_id, created_at
+) VALUES (
+    'official-agent', 'official-member', 'official-coordinator', 'coordinator',
+    'official-run', 'plain', '{"kind":"plain","text":"official"}',
+    'official-inbox-request', '2026-08-01T00:00:00Z'
+);
+INSERT INTO agent_inbox_materializations (
+    inbox_id, session_id, transcript_message_id, transcript_intent_id, materialized_at
+) VALUES (
+    1, 'ordinary-session', 'ordinary-message', 'ordinary-intent',
+    '2026-08-01T00:00:00Z'
+);
+INSERT INTO agent_inbox_delivery_resolutions (
+    inbox_id, org_run_id, resolution_kind, resolved_by_member_id, reason, created_at
+) VALUES (
+    2, 'official-run', 'cancelled', 'official-member', 'official fixture',
+    '2026-08-01T00:00:00Z'
+);
+INSERT INTO agent_member_interventions (
+    org_run_id, member_id, agent_id, session_id, status, entered_at,
+    last_user_activity_at, resume_after
+) VALUES (
+    'official-run', 'official-member', 'official-agent', 'ordinary-session', 'active',
+    '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', '2026-08-01T00:05:00Z'
+);

--- a/src-tauri/crates/agent-core/src/core/coordination/schema.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/schema.rs
@@ -9,6 +9,7 @@
 use std::collections::BTreeMap;
 
 use rusqlite::{ffi, Connection, Error as SqliteError, Result as SqliteResult};
+use sha2::{Digest, Sha256};
 
 use super::{
     agent_inbox, agent_member_interventions, agent_org_archive, agent_org_final_summary,
@@ -54,11 +55,87 @@ const RUNTIME_TABLES: [&str; 33] = [
     "agent_org_runtime_tool_call_receipts",
 ];
 
-const LEGACY_TABLES: [&str; 13] = [
+const RUNTIME_INDEXES: [&str; 70] = [
+    "idx_agent_org_final_summary_one_active",
+    "idx_agent_org_final_summary_public_timeline",
+    "idx_agent_org_final_summary_run_current",
+    "idx_agent_org_final_summary_turn",
+    "idx_agent_org_formal_trigger_attempt_turn",
+    "idx_agent_org_formal_trigger_missing_doorbell",
+    "idx_agent_org_formal_trigger_one_active_attempt",
+    "idx_agent_org_formal_trigger_pending",
+    "idx_agent_org_formal_trigger_task",
+    "idx_agent_org_member_intervention_active",
+    "idx_agent_org_member_intervention_continuation",
+    "idx_agent_org_member_intervention_public_timeline",
+    "idx_agent_org_member_intervention_return_request",
+    "idx_agent_org_member_intervention_session",
+    "idx_agent_org_member_intervention_turn_queue",
+    "idx_agent_org_runtime_archive_pending",
+    "idx_agent_org_runtime_archive_teardown_pending",
+    "idx_agent_org_runtime_inbox_causation_recipient_once",
+    "idx_agent_org_runtime_inbox_delivery_resolutions_run",
+    "idx_agent_org_runtime_inbox_materializations_session",
+    "idx_agent_org_runtime_inbox_org_run",
+    "idx_agent_org_runtime_inbox_org_run_id",
+    "idx_agent_org_runtime_inbox_recipient_member_unread",
+    "idx_agent_org_runtime_inbox_recipient_unread",
+    "idx_agent_org_runtime_inbox_request_id",
+    "idx_agent_org_runtime_inbox_run_kind_id",
+    "idx_agent_org_runtime_inbox_run_task_assignment_v4",
+    "idx_agent_org_runtime_inbox_run_unread_recipient",
+    "idx_agent_org_runtime_inbox_task_bindings_wake",
+    "idx_agent_org_runtime_inbox_user_message_once",
+    "idx_agent_org_runtime_initial_inputs_dispatch",
+    "idx_agent_org_runtime_member_materializations_pending",
+    "idx_agent_org_runtime_pause_capture",
+    "idx_agent_org_runtime_pause_dispatch",
+    "idx_agent_org_runtime_pause_drain",
+    "idx_agent_org_runtime_pause_one_active",
+    "idx_agent_org_runtime_pause_public_timeline",
+    "idx_agent_org_runtime_pause_request",
+    "idx_agent_org_runtime_plan_decisions_status",
+    "idx_agent_org_runtime_plan_revisions_path",
+    "idx_agent_org_runtime_plan_revisions_run_task",
+    "idx_agent_org_runtime_plan_revisions_source_session_turn",
+    "idx_agent_org_runtime_recovery_attempts_run",
+    "idx_agent_org_runtime_resume_public_timeline",
+    "idx_agent_org_runtime_run_completion_certificates_turn",
+    "idx_agent_org_runtime_run_completion_public_timeline",
+    "idx_agent_org_runtime_runs_org_updated",
+    "idx_agent_org_runtime_runs_root_session",
+    "idx_agent_org_runtime_runs_status",
+    "idx_agent_org_runtime_runs_work_item",
+    "idx_agent_org_runtime_task_annotations_page",
+    "idx_agent_org_runtime_task_events_run",
+    "idx_agent_org_runtime_task_events_task",
+    "idx_agent_org_runtime_task_execution_handoffs_replacement",
+    "idx_agent_org_runtime_task_execution_handoffs_run",
+    "idx_agent_org_runtime_tasks_history_page",
+    "idx_agent_org_runtime_tasks_owner",
+    "idx_agent_org_runtime_tasks_page",
+    "idx_agent_org_runtime_tasks_replacement",
+    "idx_agent_org_runtime_turn_contexts_group_root_session",
+    "idx_agent_org_runtime_turn_contexts_member_sequence",
+    "idx_agent_org_runtime_turn_contexts_public_timeline",
+    "idx_agent_org_runtime_turn_contexts_source",
+    "idx_agent_org_runtime_udw_coordinator_pending",
+    "idx_agent_org_runtime_udw_member_fifo",
+    "idx_agent_org_runtime_udw_pending_recovery",
+    "idx_agent_org_runtime_udw_source_inbox",
+    "idx_agent_org_runtime_work_episode_tasks_episode",
+    "idx_agent_org_runtime_work_episodes_active",
+    "idx_agent_org_runtime_work_episodes_current",
+];
+
+const RUNTIME_TRIGGERS: [&str; 1] = ["trg_agent_org_runtime_plan_revisions_immutable"];
+const RUNTIME_MANIFEST_SHA256: &str =
+    "ca0b99fc4d60fe4a4d691c405114d7e48009b8b86fdeec78cf1a0f82998cd352";
+
+/// Exact private Agent Org tables created by official v1.3.0 and v1.2.6.
+const LEGACY_TABLES: [&str; 11] = [
     "agent_org_runs",
     "agent_org_run_progress",
-    "agent_org_member_materializations",
-    "agent_org_initial_inputs",
     "agent_org_plan_approvals",
     "agent_org_recovery_attempts",
     "agent_org_tasks",
@@ -86,8 +163,6 @@ const DROP_LEGACY_SCHEMA: &str = "DROP TABLE IF EXISTS agent_inbox_materializati
      DROP TABLE IF EXISTS agent_org_plan_approvals;
      DROP TABLE IF EXISTS agent_org_recovery_attempts;
      DROP TABLE IF EXISTS agent_member_interventions;
-     DROP TABLE IF EXISTS agent_org_initial_inputs;
-     DROP TABLE IF EXISTS agent_org_member_materializations;
      DROP TABLE IF EXISTS agent_org_run_progress;
      DROP TABLE IF EXISTS agent_org_runs;";
 
@@ -98,44 +173,11 @@ pub(super) fn initialize(conn: &Connection) -> SqliteResult<()> {
     let tx = database::db::begin_immediate(conn)?;
     let runtime_table_count = count_known_tables(&tx, &RUNTIME_TABLES)?;
 
-    let (fresh, migrated_task_bindings, migrated_task_history_index) =
-        match runtime_table_count {
-        0 => (true, false, false),
+    let fresh = match runtime_table_count {
+        0 => true,
         count if count == RUNTIME_TABLES.len() => {
-            let missing_task_history_index = !object_exists_with_connection(
-                &tx,
-                "index",
-                agent_org_tasks::HISTORY_PAGE_INDEX_NAME,
-            )?;
-            if missing_task_history_index {
-                verify_previous_manifest(&tx, &expected, false, true)?;
-                agent_org_tasks::create_history_page_index(&tx)?;
-                verify_manifest(&tx, &expected)?;
-            } else {
-                verify_manifest(&tx, &expected)?;
-            }
-            (false, false, missing_task_history_index)
-        }
-        count if count + 1 == RUNTIME_TABLES.len()
-            && !object_exists_with_connection(
-                &tx,
-                "table",
-                "agent_org_runtime_inbox_task_bindings",
-            )? =>
-        {
-            let missing_task_history_index = !object_exists_with_connection(
-                &tx,
-                "index",
-                agent_org_tasks::HISTORY_PAGE_INDEX_NAME,
-            )?;
-            verify_previous_manifest(&tx, &expected, true, missing_task_history_index)?;
-            agent_inbox::create_task_message_binding_schema(&tx)?;
-            agent_inbox::backfill_task_message_bindings(&tx)?;
-            if missing_task_history_index {
-                agent_org_tasks::create_history_page_index(&tx)?;
-            }
             verify_manifest(&tx, &expected)?;
-            (false, true, missing_task_history_index)
+            false
         }
         count => {
             return Err(schema_error(format!(
@@ -169,49 +211,10 @@ pub(super) fn initialize(conn: &Connection) -> SqliteResult<()> {
         legacy_table_count,
         legacy_object_count,
         fresh,
-        migrated_task_bindings,
-        migrated_task_history_index,
         idempotent = !fresh,
         "initialized isolated Agent Org runtime schema"
     );
     Ok(())
-}
-
-fn verify_previous_manifest(
-    conn: &Connection,
-    expected: &SchemaManifest,
-    without_task_bindings: bool,
-    without_task_history_index: bool,
-) -> SqliteResult<()> {
-    let mut previous = expected.clone();
-    if without_task_bindings {
-        previous.retain(|(_object_type, name), (table_name, _sql)| {
-            name != "agent_org_runtime_inbox_task_bindings"
-                && name != "idx_agent_org_runtime_inbox_task_bindings_wake"
-                && table_name != "agent_org_runtime_inbox_task_bindings"
-        });
-    }
-    if without_task_history_index {
-        previous.remove(&(
-            "index".to_string(),
-            agent_org_tasks::HISTORY_PAGE_INDEX_NAME.to_string(),
-        ));
-    }
-    verify_manifest(conn, &previous)
-}
-
-fn object_exists_with_connection(
-    conn: &Connection,
-    object_type: &str,
-    name: &str,
-) -> SqliteResult<bool> {
-    conn.query_row(
-        "SELECT EXISTS(
-             SELECT 1 FROM sqlite_master WHERE type=?1 AND name=?2
-         )",
-        rusqlite::params![object_type, name],
-        |row| row.get(0),
-    )
 }
 
 fn create_runtime_schema(conn: &Connection) -> SqliteResult<()> {
@@ -237,7 +240,64 @@ fn expected_manifest() -> SqliteResult<SchemaManifest> {
     let expected = Connection::open_in_memory()?;
     expected.execute_batch("PRAGMA foreign_keys=ON;")?;
     create_runtime_schema(&expected)?;
-    read_manifest(&expected)
+    let manifest = read_manifest(&expected)?;
+    verify_frozen_runtime_contract(&manifest)?;
+    Ok(manifest)
+}
+
+fn manifest_object_names(manifest: &SchemaManifest, object_type: &str) -> Vec<String> {
+    manifest
+        .keys()
+        .filter(|(kind, _)| kind == object_type)
+        .map(|(_, name)| name.clone())
+        .collect()
+}
+
+fn sorted_names(names: &[&str]) -> Vec<String> {
+    let mut names = names
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    names
+}
+
+fn manifest_snapshot(manifest: &SchemaManifest) -> String {
+    manifest
+        .iter()
+        .map(|((object_type, name), (table_name, sql))| {
+            format!(
+                "{object_type}|{name}|{table_name}|{:x}\n",
+                Sha256::digest(sql.as_bytes())
+            )
+        })
+        .collect()
+}
+
+fn verify_frozen_runtime_contract(manifest: &SchemaManifest) -> SqliteResult<()> {
+    let tables = manifest_object_names(manifest, "table");
+    let indexes = manifest_object_names(manifest, "index");
+    let triggers = manifest_object_names(manifest, "trigger");
+    let digest = format!(
+        "{:x}",
+        Sha256::digest(manifest_snapshot(manifest).as_bytes())
+    );
+    if tables == sorted_names(&RUNTIME_TABLES)
+        && indexes == sorted_names(&RUNTIME_INDEXES)
+        && triggers == sorted_names(&RUNTIME_TRIGGERS)
+        && digest == RUNTIME_MANIFEST_SHA256
+    {
+        return Ok(());
+    }
+    Err(schema_error(format!(
+        "compiled Agent Org runtime schema differs from the frozen final compatibility contract; tables={}/{}, indexes={}/{}, triggers={}/{}, digest={digest}",
+        tables.len(),
+        RUNTIME_TABLES.len(),
+        indexes.len(),
+        RUNTIME_INDEXES.len(),
+        triggers.len(),
+        RUNTIME_TRIGGERS.len(),
+    )))
 }
 
 fn verify_manifest(conn: &Connection, expected: &SchemaManifest) -> SqliteResult<()> {
@@ -376,111 +436,16 @@ mod tests {
         .unwrap_or_else(|error| panic!("count {table}: {error}"))
     }
 
-    fn create_legacy_fixture(conn: &Connection, table_count: usize, unknown_column: bool) {
-        assert!(matches!(table_count, 5 | 9 | 11 | 13));
-        let extra = if unknown_column {
-            ", local_develop_column BLOB"
-        } else {
-            ""
-        };
-        conn.execute_batch(&format!(
-            "CREATE TABLE agent_org_runs (id INTEGER PRIMARY KEY, payload TEXT{extra});
-             INSERT INTO agent_org_runs VALUES (1, 'legacy-0'{unknown_value});
-             CREATE TABLE agent_org_tasks (
-                 id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                 FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-             );
-             INSERT INTO agent_org_tasks VALUES (1, 1, 'legacy-1');
-             CREATE TABLE agent_org_task_events (
-                 id INTEGER PRIMARY KEY, task_id INTEGER NOT NULL, payload TEXT,
-                 FOREIGN KEY(task_id) REFERENCES agent_org_tasks(id) ON DELETE CASCADE
-             );
-             INSERT INTO agent_org_task_events VALUES (1, 1, 'legacy-2');
-             CREATE TABLE agent_inbox (
-                 id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                 FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-             );
-             INSERT INTO agent_inbox VALUES (1, 1, 'legacy-3');
-             CREATE TABLE agent_member_interventions (
-                 id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                 FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-             );
-             INSERT INTO agent_member_interventions VALUES (1, 1, 'legacy-4');",
-            unknown_value = if unknown_column { ", x'0102'" } else { "" },
-        ))
-        .expect("create five-table legacy fixture");
-        if table_count >= 9 {
-            conn.execute_batch(
-                "CREATE TABLE agent_org_run_progress (
-                     id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                     FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_org_run_progress VALUES (1, 1, 'legacy-5');
-                 CREATE TABLE agent_org_plan_approvals (
-                     id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                     FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_org_plan_approvals VALUES (1, 1, 'legacy-6');
-                 CREATE TABLE agent_org_recovery_attempts (
-                     id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                     FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_org_recovery_attempts VALUES (1, 1, 'legacy-7');
-                 CREATE TABLE agent_inbox_materializations (
-                     id INTEGER PRIMARY KEY, inbox_id INTEGER NOT NULL, payload TEXT,
-                     FOREIGN KEY(inbox_id) REFERENCES agent_inbox(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_inbox_materializations VALUES (1, 1, 'legacy-8');",
-            )
-            .expect("create nine-table legacy fixture");
-        }
-        if table_count >= 11 {
-            conn.execute_batch(
-                "CREATE TABLE agent_inbox_delivery_resolutions (
-                     id INTEGER PRIMARY KEY, inbox_id INTEGER NOT NULL, payload TEXT,
-                     FOREIGN KEY(inbox_id) REFERENCES agent_inbox(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_inbox_delivery_resolutions VALUES (1, 1, 'legacy-9');
-                 CREATE TABLE agent_org_task_run_schema_migrations (
-                     id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                     FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_org_task_run_schema_migrations VALUES (1, 1, 'legacy-10');",
-            )
-            .expect("create eleven-table legacy fixture");
-        }
-        if table_count >= 13 {
-            conn.execute_batch(
-                "CREATE TABLE agent_org_member_materializations (
-                     id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                     FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_org_member_materializations VALUES (1, 1, 'legacy-11');
-                 CREATE TABLE agent_org_initial_inputs (
-                     id INTEGER PRIMARY KEY, org_run_id INTEGER NOT NULL, payload TEXT,
-                     FOREIGN KEY(org_run_id) REFERENCES agent_org_runs(id) ON DELETE CASCADE
-                 );
-                 INSERT INTO agent_org_initial_inputs VALUES (1, 1, 'legacy-12');",
-            )
-            .expect("create thirteen-table legacy fixture");
-        }
-        conn.execute_batch(
-            "CREATE INDEX idx_legacy_agent_org_runs_payload ON agent_org_runs(payload);
-             CREATE TRIGGER trg_legacy_agent_org_runs_touch
-             AFTER UPDATE ON agent_org_runs BEGIN SELECT 1; END;",
-        )
-        .expect("legacy index and trigger");
+    fn create_official_v1_3_0_fixture(conn: &Connection) {
+        conn.execute_batch(include_str!("fixtures/official_v1_3_0_agent_org.sql"))
+            .expect("create exact official v1.3.0 Agent Org fixture");
     }
 
     fn seed_shared_sentinels(conn: &Connection) {
+        crate::persistence::session_snapshots::ensure_tables_with(conn)
+            .expect("create production Session/message schema");
         conn.execute_batch(
-            "CREATE TABLE agent_sessions (
-                 id TEXT PRIMARY KEY, session_id TEXT UNIQUE, payload BLOB, org_member_id TEXT
-             );
-             CREATE TABLE agent_messages (
-                 id TEXT PRIMARY KEY, session_id TEXT, payload BLOB
-             );
-             CREATE TABLE code_sessions (
+            "CREATE TABLE code_sessions (
                  id TEXT PRIMARY KEY, session_id TEXT UNIQUE, payload BLOB, org_member_id TEXT
              );
              CREATE TABLE session_turn_intents (id TEXT PRIMARY KEY, payload BLOB, org_run_id TEXT);
@@ -488,8 +453,18 @@ mod tests {
              CREATE TABLE work_items (id TEXT PRIMARY KEY, payload BLOB);
              CREATE TABLE routines (id TEXT PRIMARY KEY, payload BLOB);
              CREATE TABLE usage_events (id TEXT PRIMARY KEY, payload BLOB);
-             INSERT INTO agent_sessions VALUES ('rust', 'rust-session', x'000102', 'member-a');
-             INSERT INTO agent_messages VALUES ('message', 'rust-session', x'030405');
+             INSERT INTO agent_sessions (
+                 session_id,name,status,user_input,created_at,updated_at
+             ) VALUES (
+                 'ordinary-session','Ordinary SDE','idle','ordinary sentinel',
+                 '2026-08-01T00:00:00Z','2026-08-01T00:00:00Z'
+             );
+             INSERT INTO agent_messages (
+                 id,session_id,role,content,sequence,created_at
+             ) VALUES (
+                 'ordinary-message','ordinary-session','assistant',
+                 'ordinary message sentinel',1,'2026-08-01T00:00:00Z'
+             );
              INSERT INTO code_sessions VALUES ('cli', 'cli-session', x'060708', 'member-b');
              INSERT INTO session_turn_intents VALUES ('intent', x'090A0B', 'run-a');
              INSERT INTO projects VALUES ('project', x'0C0D0E');
@@ -502,25 +477,41 @@ mod tests {
 
     fn shared_sentinel_fingerprint(conn: &Connection) -> Vec<(String, String)> {
         [
-            "agent_sessions",
-            "agent_messages",
-            "code_sessions",
-            "session_turn_intents",
-            "projects",
-            "work_items",
-            "routines",
-            "usage_events",
+            (
+                "agent_sessions",
+                "SELECT session_id || '|' || name || '|' || status || '|' || user_input
+                 FROM agent_sessions WHERE session_id='ordinary-session'",
+            ),
+            (
+                "agent_messages",
+                "SELECT id || '|' || session_id || '|' || role || '|' || content || '|' || sequence
+                 FROM agent_messages WHERE id='ordinary-message'",
+            ),
+            ("code_sessions", "SELECT hex(payload) FROM code_sessions"),
+            (
+                "session_turn_intents",
+                "SELECT hex(payload) FROM session_turn_intents",
+            ),
+            ("projects", "SELECT hex(payload) FROM projects"),
+            ("work_items", "SELECT hex(payload) FROM work_items"),
+            ("routines", "SELECT hex(payload) FROM routines"),
+            ("usage_events", "SELECT hex(payload) FROM usage_events"),
         ]
         .into_iter()
-        .map(|table| {
+        .map(|(table, query)| {
             let fingerprint = conn
-                .query_row(&format!("SELECT hex(payload) FROM {table}"), [], |row| {
-                    row.get::<_, String>(0)
-                })
+                .query_row(query, [], |row| row.get::<_, String>(0))
                 .unwrap_or_else(|error| panic!("fingerprint {table}: {error}"));
             (table.to_string(), fingerprint)
         })
         .collect()
+    }
+
+    #[test]
+    fn final_runtime_manifest_matches_the_frozen_release_contract() {
+        let manifest = expected_manifest().expect("final manifest");
+        assert_eq!(manifest.len(), 104);
+        verify_frozen_runtime_contract(&manifest).expect("frozen final runtime contract");
     }
 
     #[test]
@@ -565,36 +556,28 @@ mod tests {
     }
 
     #[test]
-    fn retires_every_historical_namespace_shape_without_touching_shared_data() {
-        for (table_count, unknown_column) in
-            [(5, false), (9, false), (11, false), (13, false), (13, true)]
-        {
-            let conn = connection();
-            create_legacy_fixture(&conn, table_count, unknown_column);
-            seed_shared_sentinels(&conn);
-            let shared_before = shared_sentinel_fingerprint(&conn);
-
-            initialize(&conn).expect("retire legacy namespace");
-
-            for table in LEGACY_TABLES {
-                assert!(!object_exists(&conn, "table", table), "retained {table}");
-            }
-            for table in RUNTIME_TABLES {
-                assert!(object_exists(&conn, "table", table), "missing {table}");
-                assert_eq!(row_count(&conn, table), 0, "fresh {table} not empty");
-            }
-            assert!(!object_exists(
-                &conn,
-                "index",
-                "idx_legacy_agent_org_runs_payload"
-            ));
-            assert!(!object_exists(
-                &conn,
-                "trigger",
-                "trg_legacy_agent_org_runs_touch"
-            ));
-            assert_eq!(shared_sentinel_fingerprint(&conn), shared_before);
+    fn exact_official_v1_3_0_home_initializes_final_without_touching_shared_data() {
+        let conn = connection();
+        create_official_v1_3_0_fixture(&conn);
+        seed_shared_sentinels(&conn);
+        let shared_before = shared_sentinel_fingerprint(&conn);
+        assert_eq!(count_known_tables(&conn, &LEGACY_TABLES).unwrap(), 11);
+        for table in LEGACY_TABLES {
+            assert_eq!(row_count(&conn, table), 1, "fixture row missing in {table}");
         }
+
+        initialize(&conn).expect("upgrade exact official v1.3.0 home");
+
+        for table in LEGACY_TABLES {
+            assert!(!object_exists(&conn, "table", table), "retained {table}");
+        }
+        for table in RUNTIME_TABLES {
+            assert!(object_exists(&conn, "table", table), "missing {table}");
+            assert_eq!(row_count(&conn, table), 0, "fresh {table} not empty");
+        }
+        verify_manifest(&conn, &expected_manifest().expect("final manifest"))
+            .expect("exact final manifest");
+        assert_eq!(shared_sentinel_fingerprint(&conn), shared_before);
     }
 
     #[test]
@@ -684,7 +667,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         for _ in 0..2 {
-            create_legacy_fixture(&conn, 13, true);
+            create_official_v1_3_0_fixture(&conn);
             initialize(&conn).expect("re-upgrade cleanup");
             assert_eq!(
                 RUNTIME_TABLES
@@ -709,7 +692,7 @@ mod tests {
     }
 
     #[test]
-    fn exact_previous_manifest_adds_history_page_index_without_touching_data() {
+    fn unpublished_runtime_without_history_index_is_rejected_without_touching_data() {
         let conn = connection();
         initialize(&conn).expect("create current runtime");
         conn.execute_batch(
@@ -730,20 +713,15 @@ mod tests {
              );
              DROP INDEX idx_agent_org_runtime_tasks_history_page;",
         )
-        .expect("simulate exact previous manifest");
+        .expect("simulate unpublished runtime without the final history index");
 
-        initialize(&conn).expect("upgrade history page index");
-        assert!(object_exists(
-            &conn,
-            "index",
-            agent_org_tasks::HISTORY_PAGE_INDEX_NAME
-        ));
+        let error = initialize(&conn).expect_err("intermediate runtime must be rejected");
+        assert!(error.to_string().contains("Agent Org runtime schema"));
         assert_eq!(row_count(&conn, "agent_org_runtime_tasks"), 1);
-        initialize(&conn).expect("upgraded history index remains idempotent");
     }
 
     #[test]
-    fn exact_previous_manifest_adds_and_backfills_task_message_bindings() {
+    fn unpublished_runtime_without_task_bindings_is_rejected_without_backfill() {
         let conn = connection();
         conn.execute_batch(
             "CREATE TABLE session_turn_intents (
@@ -831,35 +809,17 @@ mod tests {
             "DROP TABLE agent_org_runtime_inbox_task_bindings;
              DROP INDEX idx_agent_org_runtime_tasks_history_page;",
         )
-        .expect("simulate exact previous runtime manifest");
+        .expect("simulate unpublished runtime without final task bindings");
         assert_eq!(
             count_known_tables(&conn, &RUNTIME_TABLES).unwrap(),
             RUNTIME_TABLES.len() - 1
         );
 
-        initialize(&conn).expect("upgrade exact previous manifest");
-        assert!(object_exists(
-            &conn,
-            "index",
-            agent_org_tasks::HISTORY_PAGE_INDEX_NAME
-        ));
-        let binding: (String, String, String) = conn
-            .query_row(
-                "SELECT task_id,recipient_member_id,source_turn_intent_id
-                 FROM agent_org_runtime_inbox_task_bindings WHERE inbox_id=?1",
-                [inbox_id],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-            )
-            .expect("backfilled exact task message binding");
-        assert_eq!(
-            binding,
-            (
-                "task-upgrade".to_string(),
-                "member-a".to_string(),
-                "root-reply-turn".to_string()
-            )
-        );
-        initialize(&conn).expect("upgraded manifest remains idempotent");
+        let error = initialize(&conn).expect_err("intermediate runtime must be rejected");
+        assert!(error
+            .to_string()
+            .contains("partial Agent Org runtime schema"));
+        assert_eq!(row_count(&conn, "agent_org_runtime_tool_call_receipts"), 1);
     }
 
     #[test]
@@ -936,7 +896,7 @@ mod tests {
     #[test]
     fn create_failure_rolls_back_every_legacy_drop() {
         let conn = connection();
-        create_legacy_fixture(&conn, 13, false);
+        create_official_v1_3_0_fixture(&conn);
         conn.execute_batch("CREATE VIEW agent_org_runtime_runs AS SELECT 1 AS id;")
             .expect("runtime name conflict");
 
@@ -1020,7 +980,7 @@ mod tests {
             initialize(&conn).expect("canonical no-op init");
             no_op.push(started.elapsed());
 
-            create_legacy_fixture(&conn, 13, true);
+            create_official_v1_3_0_fixture(&conn);
             let started = Instant::now();
             initialize(&conn).expect("legacy cleanup init");
             cleanup.push(started.elapsed());
@@ -1034,7 +994,7 @@ mod tests {
         let (no_op_median, no_op_max) = summary(&mut no_op);
         let (cleanup_median, cleanup_max) = summary(&mut cleanup);
         eprintln!(
-            "Agent Org schema init, {SAMPLES} samples: fresh median={fresh_median:?} max={fresh_max:?}; canonical no-op median={no_op_median:?} max={no_op_max:?}; 13-table cleanup median={cleanup_median:?} max={cleanup_max:?}"
+            "Agent Org schema init, {SAMPLES} samples: fresh median={fresh_median:?} max={fresh_max:?}; canonical no-op median={no_op_median:?} max={no_op_max:?}; official-v1.3.0 cleanup median={cleanup_median:?} max={cleanup_max:?}"
         );
     }
 }

--- a/src-tauri/crates/agent-core/src/core/definitions/orgs.rs
+++ b/src-tauri/crates/agent-core/src/core/definitions/orgs.rs
@@ -1223,6 +1223,9 @@ mod tests {
         let new_path = storage_path();
         let new_bytes = std::fs::read(&new_path).expect("canonical bytes");
         let legacy_path = app_paths::agent_orgs();
+        let settings_path = app_paths::settings();
+        let settings_bytes = br#"{"general":{"theme":"dark"}}"#;
+        std::fs::write(&settings_path, settings_bytes).expect("settings sentinel");
         std::fs::write(&legacy_path, br#"[{"id":"downgrade-team"}]"#)
             .expect("downgrade legacy file");
 
@@ -1232,6 +1235,10 @@ mod tests {
         assert_eq!(
             std::fs::read(&new_path).expect("new bytes after cleanup"),
             new_bytes
+        );
+        assert_eq!(
+            std::fs::read(settings_path).expect("settings after Team cleanup"),
+            settings_bytes
         );
         assert_eq!(restarted.get(&org.id).expect("preserved Team"), org);
     }

--- a/src/store/workstation/tabRegistry/atoms.test.ts
+++ b/src/store/workstation/tabRegistry/atoms.test.ts
@@ -13,7 +13,7 @@ import {
   workstationTabsStateAtom,
 } from "@src/store/workstation/tabs";
 import {
-  WORKSTATION_V3_SHARED_KEY,
+  WORKSTATION_V4_SHARED_KEY,
   emptyWorkstationTabsState,
 } from "@src/store/workstation/tabs/storage";
 import { workstationNewBrowserSessionRequestAtom } from "@src/store/workstation/workstationTabBarAtoms";
@@ -215,7 +215,7 @@ describe("live shared-resource close semantics", () => {
     ]);
     expect(next.sessionWorkspaces.B.tabOrder).toEqual([]);
     expect(
-      JSON.parse(localStorage.getItem(WORKSTATION_V3_SHARED_KEY) ?? "null")
+      JSON.parse(localStorage.getItem(WORKSTATION_V4_SHARED_KEY) ?? "null")
     ).toEqual({ tabs: [] });
 
     expect(store.get(recentWorkstationTabsAtom)).toEqual([browser]);

--- a/src/store/workstation/tabs/__tests__/storage.test.ts
+++ b/src/store/workstation/tabs/__tests__/storage.test.ts
@@ -8,6 +8,10 @@ import {
   WORKSTATION_V3_LEGACY_SEED_KEY,
   WORKSTATION_V3_MANIFEST_KEY,
   WORKSTATION_V3_SHARED_KEY,
+  WORKSTATION_V4_GLOBAL_KEY,
+  WORKSTATION_V4_LEGACY_SEED_KEY,
+  WORKSTATION_V4_MANIFEST_KEY,
+  WORKSTATION_V4_SHARED_KEY,
   deletePersistedWorkstationWorkspace,
   emptyWorkstationTabsState,
   loadWorkstationTabsState,
@@ -21,7 +25,8 @@ import type {
   WorkstationWorkspaceState,
 } from "../types";
 
-const SESSION_PREFIX = "workstation:tabs:v3:session:";
+const V3_SESSION_PREFIX = "workstation:tabs:v3:session:";
+const V4_SESSION_PREFIX = "workstation:tabs:v4:session:";
 
 function tab(
   id: string,
@@ -53,8 +58,12 @@ function workspace(
   };
 }
 
-function sessionKey(sessionId: string): string {
-  return `${SESSION_PREFIX}${encodeURIComponent(sessionId)}`;
+function v3SessionKey(sessionId: string): string {
+  return `${V3_SESSION_PREFIX}${encodeURIComponent(sessionId)}`;
+}
+
+function v4SessionKey(sessionId: string): string {
+  return `${V4_SESSION_PREFIX}${encodeURIComponent(sessionId)}`;
 }
 
 beforeEach(() => {
@@ -157,8 +166,9 @@ describe("v2 migration", () => {
       { partition: "shared", tabId: "browser:resource" },
     ]);
     expect(localStorage.getItem(LAYOUT_STORAGE_KEY)).not.toBeNull();
-    expect(localStorage.getItem(WORKSTATION_V3_MANIFEST_KEY)).not.toBeNull();
-    expect(localStorage.getItem(WORKSTATION_V3_LEGACY_SEED_KEY)).not.toBeNull();
+    expect(localStorage.getItem(WORKSTATION_V4_MANIFEST_KEY)).not.toBeNull();
+    expect(localStorage.getItem(WORKSTATION_V4_LEGACY_SEED_KEY)).not.toBeNull();
+    expect(localStorage.getItem(WORKSTATION_V3_MANIFEST_KEY)).toBeNull();
   });
 
   it("does not expose a seed when v2 contains only shared resources", () => {
@@ -179,9 +189,9 @@ describe("v2 migration", () => {
     expect(localStorage.getItem(LAYOUT_STORAGE_KEY)).toBeNull();
   });
 
-  it("prefers committed v3 state over a leftover v2 recovery source", () => {
+  it("prefers committed v4 state over a leftover v2 recovery source", () => {
     const state = emptyWorkstationTabsState();
-    state.globalWorkspace = workspace([tab("file:/v3.ts")]);
+    state.globalWorkspace = workspace([tab("file:/v4.ts")]);
     expect(persistWorkstationTabsState(state)).toBe(true);
     localStorage.setItem(
       LAYOUT_STORAGE_KEY,
@@ -194,13 +204,13 @@ describe("v2 migration", () => {
     );
 
     expect(loadWorkstationTabsState().globalWorkspace.tabs).toEqual([
-      tab("file:/v3.ts", "file", { hasUnsavedChanges: false }),
+      tab("file:/v4.ts", "file", { hasUnsavedChanges: false }),
     ]);
   });
 });
 
-describe("v3 persistence keys", () => {
-  it("discards legacy Team snapshots without replacing them with empty members", () => {
+describe("v3 upgrade and v4 persistence keys", () => {
+  it("migrates v3 without changing any v3 bytes and discards stale Team snapshots", () => {
     const legacyOrgTab = tab(
       "agent-config:org:default:sde-feature-team",
       "agent-config",
@@ -245,14 +255,31 @@ describe("v3 persistence keys", () => {
 
     localStorage.setItem(
       WORKSTATION_V3_MANIFEST_KEY,
-      JSON.stringify({ version: 3, sessionIds: [] })
+      JSON.stringify({ version: 3, sessionIds: ["ordinary/session"] })
     );
     localStorage.setItem(
       WORKSTATION_V3_SHARED_KEY,
       JSON.stringify({ tabs: [legacyOrgTab, currentOrgTab] })
     );
+    localStorage.setItem(
+      WORKSTATION_V3_GLOBAL_KEY,
+      JSON.stringify(workspace([tab("file:/official-v3.ts")]))
+    );
+    localStorage.setItem(WORKSTATION_V3_LEGACY_SEED_KEY, "null");
+    localStorage.setItem(
+      v3SessionKey("ordinary/session"),
+      JSON.stringify(workspace([tab("file:/ordinary-session.ts")]))
+    );
+    localStorage.setItem(v3SessionKey("downgrade"), "official-v3-session");
+    localStorage.setItem("browser:unrelated-sentinel", "keep-browser-state");
+    const v3BytesBefore = Object.fromEntries(
+      Object.keys(localStorage)
+        .filter((key) => key.startsWith("workstation:tabs:v3:"))
+        .map((key) => [key, localStorage.getItem(key)])
+    );
 
-    const loadedTabs = loadWorkstationTabsState().shared.tabs;
+    const loaded = loadWorkstationTabsState();
+    const loadedTabs = loaded.shared.tabs;
     const loadedLegacyData = loadedTabs.find(
       (item) => item.id === legacyOrgTab.id
     )?.data;
@@ -267,6 +294,37 @@ describe("v3 persistence keys", () => {
     });
     expect(loadedLegacyData).not.toHaveProperty("entitySnapshot");
     expect(loadedCurrentData?.entitySnapshot).toEqual(currentOrgSnapshot);
+    expect(loaded.version).toBe(4);
+    expect(loaded.globalWorkspace.tabs[0]?.id).toBe("file:/official-v3.ts");
+    expect(loaded.sessionWorkspaces["ordinary/session"]?.tabs[0]?.id).toBe(
+      "file:/ordinary-session.ts"
+    );
+    expect(
+      JSON.parse(localStorage.getItem(WORKSTATION_V4_MANIFEST_KEY)!)
+    ).toEqual({ version: 4, sessionIds: ["ordinary/session"] });
+    expect(
+      Object.fromEntries(
+        Object.keys(localStorage)
+          .filter((key) => key.startsWith("workstation:tabs:v3:"))
+          .map((key) => [key, localStorage.getItem(key)])
+      )
+    ).toEqual(v3BytesBefore);
+    expect(localStorage.getItem("browser:unrelated-sentinel")).toBe(
+      "keep-browser-state"
+    );
+
+    loaded.globalWorkspace = workspace([tab("file:/changed-in-v4.ts")]);
+    expect(persistWorkstationTabsState(loaded)).toBe(true);
+    expect(
+      JSON.parse(localStorage.getItem(WORKSTATION_V4_GLOBAL_KEY)!).tabs[0].id
+    ).toBe("file:/changed-in-v4.ts");
+    expect(
+      Object.fromEntries(
+        Object.keys(localStorage)
+          .filter((key) => key.startsWith("workstation:tabs:v3:"))
+          .map((key) => [key, localStorage.getItem(key)])
+      )
+    ).toEqual(v3BytesBefore);
 
     const legacySnapshot = legacyOrgTab.data.entitySnapshot;
     expect(
@@ -307,17 +365,21 @@ describe("v3 persistence keys", () => {
     expect(persistWorkstationTabsState(state)).toBe(true);
 
     expect(
-      JSON.parse(localStorage.getItem(WORKSTATION_V3_MANIFEST_KEY)!)
-    ).toEqual({ version: 3, sessionIds: ["agent/a b"] });
+      JSON.parse(localStorage.getItem(WORKSTATION_V4_MANIFEST_KEY)!)
+    ).toEqual({ version: 4, sessionIds: ["agent/a b"] });
     expect(
-      JSON.parse(localStorage.getItem(WORKSTATION_V3_SHARED_KEY)!)
+      JSON.parse(localStorage.getItem(WORKSTATION_V4_SHARED_KEY)!)
     ).toEqual(state.shared);
     expect(
-      JSON.parse(localStorage.getItem(WORKSTATION_V3_GLOBAL_KEY)!)
+      JSON.parse(localStorage.getItem(WORKSTATION_V4_GLOBAL_KEY)!)
     ).toEqual(state.globalWorkspace);
-    expect(JSON.parse(localStorage.getItem(sessionKey("agent/a b"))!)).toEqual(
-      state.sessionWorkspaces["agent/a b"]
-    );
+    expect(
+      JSON.parse(localStorage.getItem(v4SessionKey("agent/a b"))!)
+    ).toEqual(state.sessionWorkspaces["agent/a b"]);
+    expect(localStorage.getItem(WORKSTATION_V3_MANIFEST_KEY)).toBeNull();
+    expect(localStorage.getItem(WORKSTATION_V3_SHARED_KEY)).toBeNull();
+    expect(localStorage.getItem(WORKSTATION_V3_GLOBAL_KEY)).toBeNull();
+    expect(localStorage.getItem(v3SessionKey("agent/a b"))).toBeNull();
     expect(workstationWorkspaceId({ kind: "global" })).toBe("global");
     expect(
       workstationWorkspaceId({ kind: "session", sessionId: "agent/a b" })
@@ -346,20 +408,47 @@ describe("v3 persistence keys", () => {
     expect(loaded.sessionWorkspaces.B.tabs[0].data).toEqual({ owner: "B" });
   });
 
-  it("removes only the requested persisted session workspace", () => {
-    localStorage.setItem(sessionKey("A"), "A");
-    localStorage.setItem(sessionKey("B"), "B");
+  it("keeps committed v4 canonical after a downgraded app changes v3", () => {
+    localStorage.setItem(
+      WORKSTATION_V3_MANIFEST_KEY,
+      JSON.stringify({ version: 3, sessionIds: [] })
+    );
+    localStorage.setItem(
+      WORKSTATION_V3_GLOBAL_KEY,
+      JSON.stringify(workspace([tab("file:/before-downgrade.ts")]))
+    );
+    expect(loadWorkstationTabsState().globalWorkspace.tabs[0]?.id).toBe(
+      "file:/before-downgrade.ts"
+    );
+
+    localStorage.setItem(
+      WORKSTATION_V3_GLOBAL_KEY,
+      JSON.stringify(workspace([tab("file:/written-by-v1.3.0.ts")]))
+    );
+
+    expect(loadWorkstationTabsState().globalWorkspace.tabs[0]?.id).toBe(
+      "file:/before-downgrade.ts"
+    );
+  });
+
+  it("removes only the requested v4 session and leaves downgrade data alone", () => {
+    localStorage.setItem(v4SessionKey("A"), "v4-A");
+    localStorage.setItem(v4SessionKey("B"), "v4-B");
+    localStorage.setItem(v3SessionKey("A"), "v3-A");
+    localStorage.setItem(v3SessionKey("B"), "v3-B");
 
     deletePersistedWorkstationWorkspace("A");
 
-    expect(localStorage.getItem(sessionKey("A"))).toBeNull();
-    expect(localStorage.getItem(sessionKey("B"))).toBe("B");
+    expect(localStorage.getItem(v4SessionKey("A"))).toBeNull();
+    expect(localStorage.getItem(v4SessionKey("B"))).toBe("v4-B");
+    expect(localStorage.getItem(v3SessionKey("A"))).toBe("v3-A");
+    expect(localStorage.getItem(v3SessionKey("B"))).toBe("v3-B");
   });
 
   it("does not commit the manifest when a scoped write fails", () => {
     const original = localStorage.setItem.bind(localStorage);
     vi.spyOn(localStorage, "setItem").mockImplementation((key, value) => {
-      if (key === WORKSTATION_V3_GLOBAL_KEY) throw new Error("quota");
+      if (key === WORKSTATION_V4_GLOBAL_KEY) throw new Error("quota");
       original(key, value);
     });
 
@@ -367,7 +456,7 @@ describe("v3 persistence keys", () => {
     state.globalWorkspace = workspace([tab("file:/global.ts")]);
 
     expect(persistWorkstationTabsState(state)).toBe(false);
-    expect(localStorage.getItem(WORKSTATION_V3_MANIFEST_KEY)).toBeNull();
+    expect(localStorage.getItem(WORKSTATION_V4_MANIFEST_KEY)).toBeNull();
   });
 });
 
@@ -404,7 +493,7 @@ describe("retired editor settings tabs", () => {
       JSON.stringify(savedWorkspace("file:/global.ts"))
     );
     localStorage.setItem(
-      sessionKey("A"),
+      v3SessionKey("A"),
       JSON.stringify(savedWorkspace("file:/session.ts"))
     );
     localStorage.setItem(

--- a/src/store/workstation/tabs/__tests__/workspaceState.test.ts
+++ b/src/store/workstation/tabs/__tests__/workspaceState.test.ts
@@ -22,7 +22,7 @@ import {
   type WorkStationTab,
   type WorkStationTabType,
   type WorkstationTabOwnership,
-  type WorkstationTabsStateV3,
+  type WorkstationTabsStateV4,
   type WorkstationWorkspaceState,
   closesSharedResourceOnDismiss,
   getWorkstationTabOwnership,
@@ -90,7 +90,7 @@ function workspace(
   };
 }
 
-function stateWithWorkspaces(): WorkstationTabsStateV3 {
+function stateWithWorkspaces(): WorkstationTabsStateV4 {
   const state = emptyWorkstationTabsState();
   state.globalWorkspace = workspace([tab("file:/global.ts")]);
   state.sessionWorkspaces = {

--- a/src/store/workstation/tabs/atoms.ts
+++ b/src/store/workstation/tabs/atoms.ts
@@ -26,7 +26,7 @@ import {
   type WorkStationLayoutState,
   type WorkStationTab,
   type WorkstationTabRef,
-  type WorkstationTabsStateV3,
+  type WorkstationTabsStateV4,
   type WorkstationWorkspaceKey,
   type WorkstationWorkspaceState,
   closesSharedResourceOnDismiss,
@@ -70,13 +70,13 @@ export const recentWorkstationTabsAtom = atom((get) => {
 recentWorkstationTabsAtom.debugLabel = "recentWorkstationTabsAtom";
 
 /** Canonical persisted state. Feature code writes through scoped actions below. */
-export const workstationTabsStateAtom = atom<WorkstationTabsStateV3>(
+export const workstationTabsStateAtom = atom<WorkstationTabsStateV4>(
   loadWorkstationTabsState()
 );
 workstationTabsStateAtom.debugLabel = "workstationTabsStateAtom";
 
 function workspaceFor(
-  state: WorkstationTabsStateV3,
+  state: WorkstationTabsStateV4,
   key: WorkstationWorkspaceKey
 ): WorkstationWorkspaceState {
   if (key.kind === "global") return state.globalWorkspace;
@@ -88,7 +88,7 @@ function refIdentity(ref: WorkstationTabRef): string {
 }
 
 function composePanel(
-  state: WorkstationTabsStateV3,
+  state: WorkstationTabsStateV4,
   key: WorkstationWorkspaceKey
 ): PanelState {
   const workspace = workspaceFor(state, key);
@@ -131,10 +131,10 @@ function composePanel(
 }
 
 function splitPanel(
-  previous: WorkstationTabsStateV3,
+  previous: WorkstationTabsStateV4,
   key: WorkstationWorkspaceKey,
   panel: PanelState
-): WorkstationTabsStateV3 {
+): WorkstationTabsStateV4 {
   const sharedTabs: WorkStationTab[] = [];
   const localTabs: WorkStationTab[] = [];
   const tabOrder: WorkstationTabRef[] = [];
@@ -184,9 +184,9 @@ function splitPanel(
 function setAndPersist(
   set: (
     atom: typeof workstationTabsStateAtom,
-    value: WorkstationTabsStateV3
+    value: WorkstationTabsStateV4
   ) => void,
-  next: WorkstationTabsStateV3
+  next: WorkstationTabsStateV4
 ): void {
   set(workstationTabsStateAtom, next);
   persistWorkstationTabsState(next);
@@ -262,7 +262,7 @@ export const claimLegacyWorkstationSeedAtom = atom(null, (get, set) => {
   if (key.kind !== "session") return;
   const state = get(workstationTabsStateAtom);
   if (!state.legacySeed || state.sessionWorkspaces[key.sessionId]) return;
-  const next: WorkstationTabsStateV3 = {
+  const next: WorkstationTabsStateV4 = {
     ...state,
     sessionWorkspaces: {
       ...state.sessionWorkspaces,
@@ -311,10 +311,10 @@ export interface CloseWorkstationTabsRequest {
 }
 
 function updateScopedPanel(
-  state: WorkstationTabsStateV3,
+  state: WorkstationTabsStateV4,
   workspace: WorkstationWorkspaceKey,
   updater: (panel: PanelState) => PanelState
-): WorkstationTabsStateV3 {
+): WorkstationTabsStateV4 {
   return splitPanel(state, workspace, updater(composePanel(state, workspace)));
 }
 
@@ -332,9 +332,9 @@ export const openWorkstationTabAtom = atom(
 openWorkstationTabAtom.debugLabel = "openWorkstationTabAtom";
 
 function removeSharedTabsFromState(
-  state: WorkstationTabsStateV3,
+  state: WorkstationTabsStateV4,
   tabIds: ReadonlySet<string>
-): WorkstationTabsStateV3 {
+): WorkstationTabsStateV4 {
   if (
     tabIds.size === 0 ||
     !state.shared.tabs.some((tab) => tabIds.has(tab.id))
@@ -610,7 +610,7 @@ openEditorFilePathsAtom.debugLabel = "openEditorFilePathsAtom";
 
 /** Read a workspace without changing the presented WorkStation selection. */
 export function selectWorkstationPanel(
-  state: WorkstationTabsStateV3,
+  state: WorkstationTabsStateV4,
   key: WorkstationWorkspaceKey
 ): PanelState {
   return composePanel(state, key);

--- a/src/store/workstation/tabs/index.ts
+++ b/src/store/workstation/tabs/index.ts
@@ -18,6 +18,14 @@ export type {
   PanelState,
   WorkStationLayoutState,
   WorkstationWorkspaceKey,
+  WorkstationWorkspaceId,
+  WorkstationTabPartition,
+  WorkstationTabRef,
+  WorkstationWorkspaceState,
+  WorkstationSharedState,
+  WorkstationTabsStateV4,
+  WorkstationTabOwnership,
+  TimelineDiffCommitInfo,
   // Editor cache types
   EditorRepoCache,
 } from "./types";

--- a/src/store/workstation/tabs/storage.ts
+++ b/src/store/workstation/tabs/storage.ts
@@ -5,7 +5,7 @@ import {
   type WorkStationTab,
   type WorkStationTabType,
   type WorkstationTabRef,
-  type WorkstationTabsStateV3,
+  type WorkstationTabsStateV4,
   type WorkstationWorkspaceId,
   type WorkstationWorkspaceKey,
   type WorkstationWorkspaceState,
@@ -14,13 +14,19 @@ import {
 
 const log = createLogger("workStationTabs");
 
-/** Legacy single-pane key, read only by the v2 -> v3 migrator. */
+/** Legacy single-pane key, read only by the v2 -> v4 migrator. */
 export const LAYOUT_STORAGE_KEY = "workstation:layout-v2";
+/** Official v1.2.6/v1.3.0 keys. They are a read-only upgrade source. */
 export const WORKSTATION_V3_MANIFEST_KEY = "workstation:tabs:v3:manifest";
 export const WORKSTATION_V3_SHARED_KEY = "workstation:tabs:v3:shared";
 export const WORKSTATION_V3_GLOBAL_KEY = "workstation:tabs:v3:global";
 export const WORKSTATION_V3_LEGACY_SEED_KEY = "workstation:tabs:v3:legacy-seed";
 const WORKSTATION_V3_SESSION_PREFIX = "workstation:tabs:v3:session:";
+export const WORKSTATION_V4_MANIFEST_KEY = "workstation:tabs:v4:manifest";
+export const WORKSTATION_V4_SHARED_KEY = "workstation:tabs:v4:shared";
+export const WORKSTATION_V4_GLOBAL_KEY = "workstation:tabs:v4:global";
+export const WORKSTATION_V4_LEGACY_SEED_KEY = "workstation:tabs:v4:legacy-seed";
+const WORKSTATION_V4_SESSION_PREFIX = "workstation:tabs:v4:session:";
 
 const VALID_WORKSTATION_TAB_TYPES = new Set<WorkStationTabType>([
   "file",
@@ -66,8 +72,8 @@ const EMPTY_WORKSPACE: WorkstationWorkspaceState = {
   tabOrder: [],
 };
 
-interface ManifestV3 {
-  version: 3;
+interface ManifestV4 {
+  version: 4;
   sessionIds: string[];
 }
 
@@ -204,13 +210,17 @@ export function workstationWorkspaceId(
   return key.kind === "global" ? "global" : `session:${key.sessionId}`;
 }
 
-function sessionStorageKey(sessionId: string): string {
+function v3SessionStorageKey(sessionId: string): string {
   return `${WORKSTATION_V3_SESSION_PREFIX}${encodeURIComponent(sessionId)}`;
 }
 
-export function emptyWorkstationTabsState(): WorkstationTabsStateV3 {
+function v4SessionStorageKey(sessionId: string): string {
+  return `${WORKSTATION_V4_SESSION_PREFIX}${encodeURIComponent(sessionId)}`;
+}
+
+export function emptyWorkstationTabsState(): WorkstationTabsStateV4 {
   return {
-    version: 3,
+    version: 4,
     shared: { tabs: [] },
     globalWorkspace: { ...EMPTY_WORKSPACE },
     sessionWorkspaces: {},
@@ -218,7 +228,7 @@ export function emptyWorkstationTabsState(): WorkstationTabsStateV3 {
   };
 }
 
-function migrateLegacyV2(): WorkstationTabsStateV3 {
+function migrateLegacyV2(): WorkstationTabsStateV4 {
   const state = emptyWorkstationTabsState();
   const legacy = readJson(LAYOUT_STORAGE_KEY);
   if (!isPlainObject(legacy) || !isPlainObject(legacy.mainPane)) return state;
@@ -256,54 +266,84 @@ function migrateLegacyV2(): WorkstationTabsStateV3 {
   return state;
 }
 
-export function loadWorkstationTabsState(): WorkstationTabsStateV3 {
-  if (!hasLocalStorage()) return emptyWorkstationTabsState();
-  const manifest = readJson(WORKSTATION_V3_MANIFEST_KEY);
-  if (!isPlainObject(manifest) || manifest.version !== 3) {
-    return migrateLegacyV2();
+function readPersistedState(
+  manifest: Record<string, unknown>,
+  keys: {
+    shared: string;
+    global: string;
+    legacySeed: string;
+    session: (sessionId: string) => string;
   }
+): WorkstationTabsStateV4 {
   const sessionIds = Array.isArray(manifest.sessionIds)
     ? manifest.sessionIds.filter((id): id is string => typeof id === "string")
     : [];
   const sessionWorkspaces: Record<string, WorkstationWorkspaceState> = {};
   for (const sessionId of sessionIds) {
     sessionWorkspaces[sessionId] = sanitizeWorkspaceState(
-      readJson(sessionStorageKey(sessionId))
+      readJson(keys.session(sessionId))
     );
   }
-  const rawLegacySeed = readJson(WORKSTATION_V3_LEGACY_SEED_KEY);
+  const rawLegacySeed = readJson(keys.legacySeed);
   return {
-    version: 3,
-    shared: { tabs: sanitizeSharedTabs(readJson(WORKSTATION_V3_SHARED_KEY)) },
-    globalWorkspace: sanitizeWorkspaceState(
-      readJson(WORKSTATION_V3_GLOBAL_KEY)
-    ),
+    version: 4,
+    shared: { tabs: sanitizeSharedTabs(readJson(keys.shared)) },
+    globalWorkspace: sanitizeWorkspaceState(readJson(keys.global)),
     sessionWorkspaces,
     legacySeed: rawLegacySeed ? sanitizeWorkspaceState(rawLegacySeed) : null,
   };
 }
 
+export function loadWorkstationTabsState(): WorkstationTabsStateV4 {
+  if (!hasLocalStorage()) return emptyWorkstationTabsState();
+
+  const v4Manifest = readJson(WORKSTATION_V4_MANIFEST_KEY);
+  if (isPlainObject(v4Manifest) && v4Manifest.version === 4) {
+    return readPersistedState(v4Manifest, {
+      shared: WORKSTATION_V4_SHARED_KEY,
+      global: WORKSTATION_V4_GLOBAL_KEY,
+      legacySeed: WORKSTATION_V4_LEGACY_SEED_KEY,
+      session: v4SessionStorageKey,
+    });
+  }
+
+  const v3Manifest = readJson(WORKSTATION_V3_MANIFEST_KEY);
+  if (isPlainObject(v3Manifest) && v3Manifest.version === 3) {
+    const migrated = readPersistedState(v3Manifest, {
+      shared: WORKSTATION_V3_SHARED_KEY,
+      global: WORKSTATION_V3_GLOBAL_KEY,
+      legacySeed: WORKSTATION_V3_LEGACY_SEED_KEY,
+      session: v3SessionStorageKey,
+    });
+    // v3 belongs to official downgrade targets. Never mutate or delete it.
+    persistWorkstationTabsState(migrated);
+    return migrated;
+  }
+
+  return migrateLegacyV2();
+}
+
 export function persistWorkstationTabsState(
-  state: WorkstationTabsStateV3
+  state: WorkstationTabsStateV4
 ): boolean {
   if (!hasLocalStorage()) return false;
   const sessionIds = Object.keys(state.sessionWorkspaces);
   const writes = [
-    writeJson(WORKSTATION_V3_SHARED_KEY, state.shared),
-    writeJson(WORKSTATION_V3_GLOBAL_KEY, state.globalWorkspace),
+    writeJson(WORKSTATION_V4_SHARED_KEY, state.shared),
+    writeJson(WORKSTATION_V4_GLOBAL_KEY, state.globalWorkspace),
     state.legacySeed
-      ? writeJson(WORKSTATION_V3_LEGACY_SEED_KEY, state.legacySeed)
+      ? writeJson(WORKSTATION_V4_LEGACY_SEED_KEY, state.legacySeed)
       : (() => {
-          localStorage.removeItem(WORKSTATION_V3_LEGACY_SEED_KEY);
+          localStorage.removeItem(WORKSTATION_V4_LEGACY_SEED_KEY);
           return true;
         })(),
     ...sessionIds.map((id) =>
-      writeJson(sessionStorageKey(id), state.sessionWorkspaces[id])
+      writeJson(v4SessionStorageKey(id), state.sessionWorkspaces[id])
     ),
   ];
   if (writes.some((ok) => !ok)) return false;
-  const manifest: ManifestV3 = { version: 3, sessionIds };
-  const committed = writeJson(WORKSTATION_V3_MANIFEST_KEY, manifest);
+  const manifest: ManifestV4 = { version: 4, sessionIds };
+  const committed = writeJson(WORKSTATION_V4_MANIFEST_KEY, manifest);
   // Keep v2 as a recovery source until its workspace-local seed has been
   // successfully claimed by an explicit session.
   if (committed && state.legacySeed === null) {
@@ -314,5 +354,5 @@ export function persistWorkstationTabsState(
 
 export function deletePersistedWorkstationWorkspace(sessionId: string): void {
   if (!hasLocalStorage()) return;
-  localStorage.removeItem(sessionStorageKey(sessionId));
+  localStorage.removeItem(v4SessionStorageKey(sessionId));
 }

--- a/src/store/workstation/tabs/types.ts
+++ b/src/store/workstation/tabs/types.ts
@@ -183,9 +183,9 @@ export interface WorkstationSharedState {
   tabs: WorkStationTab[];
 }
 
-/** Persisted v3 state. Runtime storage splits this document into per-scope keys. */
-export interface WorkstationTabsStateV3 {
-  version: 3;
+/** Persisted v4 state. Runtime storage splits this document into per-scope keys. */
+export interface WorkstationTabsStateV4 {
+  version: 4;
   shared: WorkstationSharedState;
   globalWorkspace: WorkstationWorkspaceState;
   sessionWorkspaces: Record<string, WorkstationWorkspaceState>;


### PR DESCRIPTION
## Problem

Fixes #840

The redesigned Team experience and official v1.3.0/v1.2.6 releases could read and write overlapping startup persistence. WorkStation layouts shared the v3 local-storage namespace even though the Team snapshot shape changed, so reopening an older release after leaving a redesigned Team tab active could feed it data it could not understand. The old and redesigned Agent Org SQLite schemas also occupied the same database without a frozen ownership contract, making downgrade cleanup vulnerable to deleting or reshaping the wrong objects.

## Solution

WorkStation now writes only a v4 namespace. Startup prefers committed v4 state, otherwise performs a one-time sanitized copy from v3, then falls back to v2. The importer keeps ordinary tabs, removes only incompatible Agent Org snapshots, and never changes or deletes v3 bytes, so official older releases retain their own readable layout.

Agent Org startup now freezes both sides of the database boundary: the exact 11 private tables created by official v1.3.0/v1.2.6 and the exact final manifest of 33 tables, 69 indexes, and one trigger. Initialization accepts either an empty redesigned namespace or that complete manifest, removes only the known official legacy objects in the same transaction, and fails closed before cleanup when it sees a partial or unknown redesigned schema. An exact official-v1.3 fixture and rollback/concurrency tests cover that contract. The obsolete intermediate backfill path was removed because unpublished schemas are no longer silently upgraded.

Redesigned Team definitions remain in their separate file. Recreated legacy definition files are retired without changing the redesigned file or unrelated settings.

## Potential risks

- This intentionally changes persistence behavior: after v4 has been created, later WorkStation layout changes made by an older release remain in v3 and are not merged back into v4. This prevents an older release from overwriting redesigned state, but means layout changes are version-local.
- Startup now rejects partial or unknown redesigned Agent Org schemas instead of guessing how to repair them. That is safer for data, but a developer or unpublished intermediate build may need to copy aside its isolated test database and recreate it before starting this version.
- The exact official legacy Agent Org tables are deleted on each redesigned startup. Official older releases can recreate that legacy namespace after downgrade, while redesigned runtime tables and shared session/settings data remain untouched. Rolling back this commit restores the previous heuristic behavior; recovery for an unexpected database is to preserve the database file and start with an isolated home rather than deleting unknown objects.
- The complete signed-old-release matrix ran before PR #1153 was rebased. After integrating the new PR #1153 head, all deterministic checks and BuildFast packaging were rerun, but the entire Computer Use downgrade/re-upgrade UI matrix was not repeated on that rebuilt binary.
- No dependency, lockfile, public API, IPC, or wire-format change is included. Visual screenshots are not useful because this PR intentionally changes startup and persistence behavior without changing the rendered UI.

## Verification

- `pnpm install --frozen-lockfile` — synchronized dependencies for the latest PR #1153 base; the lockfile was unchanged.
- `pnpm exec prettier --check src/store/workstation/tabRegistry/atoms.test.ts src/store/workstation/tabs/__tests__/storage.test.ts src/store/workstation/tabs/__tests__/workspaceState.test.ts src/store/workstation/tabs/atoms.ts src/store/workstation/tabs/index.ts src/store/workstation/tabs/storage.ts src/store/workstation/tabs/types.ts` — passed.
- `rustfmt --edition 2021 --check <changed Rust files>` — passed for every Rust file changed by this PR.
- `pnpm typecheck` — passed.
- `pnpm run lint` — passed with zero warnings.
- `pnpm run check:circular` — passed across 6,402 modules.
- `pnpm exec vitest run --config config/vitest.config.ts src/store/workstation/tabs/__tests__/storage.test.ts src/store/workstation/tabs/__tests__/workspaceState.test.ts src/store/workstation/tabRegistry/atoms.test.ts` — 32/32 tests passed.
- `cargo test --manifest-path src-tauri/Cargo.toml -p agent_core core::coordination::schema::tests` — 12/12 tests passed.
- `cargo test --manifest-path src-tauri/Cargo.toml -p agent_core downgrade_recreated_legacy_file_is_deleted_without_changing_new_bytes` — passed.
- `cargo test --manifest-path src-tauri/Cargo.toml -p agent_core core::session::persistence::crud::ops_tests` — 5/5 tests passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` — passed.
- `ORGII_AGENT_ORG_REDESIGN=1 pnpm run tauri:build:fast` — passed on PR #1153 head `af65cf920`; binary SHA-256 `8df6d507c333b505fe9eca28392713ed2aa71c703e78877c1413eda1c0756bf8`.
- Packaged matrix A, official v1.3.0 → redesigned final: ordinary Provider session remained usable; a real Team delegated implementation and verification, created the exact 22-byte proof file, produced Delivered reports, and survived restart.
- Packaged matrix B, redesigned final → official v1.3.0 twice → redesigned final: both old starts succeeded, an existing ordinary Provider session sent successfully, redesigned database/Team/settings fingerprints survived, exact legacy objects were retired on re-upgrade, and a new Team follow-up completed with Delivered.
- Packaged matrix C, redesigned final left on a Team → signed official v1.2.6 twice → redesigned final: both old starts reached the main UI without white screen or crash, and the final build reopened the complete Team history.
- Direct SQLite readback after the matrix: `PRAGMA quick_check` returned `ok`; redesigned Agent Org objects were exactly 33 tables, 69 indexes, and one trigger; all 11 known legacy tables were absent.
- Full `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` was also run and reports pre-existing formatting differences in unrelated PR #1153 base files. Those files are outside this diff and were not reformatted here.

## Audit

The architecture review covered ownership, type/schema contracts, transformation boundaries, write paths, initialization parity, downgrade/restart lifecycle, persistence authority, failure atomicity, legacy cleanup, and deterministic/real-app evidence. Frontend UI and performance audits were not applicable because this PR changes no React component and adds no polling, timer, cache, subscription, worker, or background lifecycle.
