### PR TITLE
feat(session-sidebar): add quick navigation controls

### DIFF
--- a/docs/frontend-ui-audit-2026-09-01/SidebarSessionsHeader.md
+++ b/docs/frontend-ui-audit-2026-09-01/SidebarSessionsHeader.md
@@ -1,0 +1,10 @@
+# Sidebar first history header UI audit
+
+| Line                            | Element                        | Verdict          | Reason                                                                                                           | Suggested change |
+| ------------------------------- | ------------------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `sidebarMenuCollections.ts:141` | First generated session header | keep with reason | Skips Pinned and decorates the first regular time, agent, or workspace section instead of adding another heading | None             |
+| `sidebarMenuCollections.ts:152` | Search header action           | keep with reason | Reuses the existing `NavigationMenuRowActionButton` and `Search01Icon` contract                                  | None             |
+| `sidebarMenuCollections.ts:160` | Refresh header action          | keep with reason | Uses the existing `NavigationMenuRowActionButton` contract and shared `Refresh04Icon`/`useRefreshSpin` behavior  | None             |
+| `NavigationSidebar.tsx:460`     | Inline session search          | keep with reason | Reuses the shared `SidebarMenuSearchInput`; autofocus is opt-in and fixed navigation remains visible             | None             |
+
+Verdict totals: **0 fix**, **4 keep with reason**, **0 abstract**.

--- a/src/scaffold/NavigationSidebar/blocks/SidebarMenuSearchInput.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarMenuSearchInput.tsx
@@ -8,38 +8,42 @@ interface SidebarMenuSearchInputProps {
   onChange: (value: string) => void;
   placeholder?: string;
   compact?: boolean;
+  autoFocus?: boolean;
 }
 
 /** Shared ghost search field used around navigation sidebar menu content. */
 const SidebarMenuSearchInput: React.FC<SidebarMenuSearchInputProps> =
-  React.memo(({ value, onChange, placeholder, compact = false }) => {
-    const height = compact ? 28 : 36;
+  React.memo(
+    ({ value, onChange, placeholder, compact = false, autoFocus = false }) => {
+      const height = compact ? 28 : 36;
 
-    return (
-      <Input
-        type="search"
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        appearance="bare"
-        autoHeight
-        allowClear
-        prefix={
-          <HugeiconsIcon
-            icon={Search01Icon}
-            data-icon="search"
-            size={14}
-            strokeWidth={2}
-            className="text-text-3"
-          />
-        }
-        className={`${compact ? "h-7 [&_.input-inner]:!h-7" : "h-9 [&_.input-inner]:!h-9"} rounded-lg text-text-1 [&_.input-inner]:gap-3 [&_.input-inner]:!px-2 [&_.input-prefix]:mr-0`}
-        inputClassName={`${compact ? "text-[12px]" : "text-[13px]"} font-normal placeholder:text-text-3`}
-        style={{ height }}
-        inputStyle={{ transform: "none" }}
-      />
-    );
-  });
+      return (
+        <Input
+          type="search"
+          autoFocus={autoFocus}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          appearance="bare"
+          autoHeight
+          allowClear
+          prefix={
+            <HugeiconsIcon
+              icon={Search01Icon}
+              data-icon="search"
+              size={14}
+              strokeWidth={2}
+              className="text-text-3"
+            />
+          }
+          className={`${compact ? "h-7 [&_.input-inner]:!h-7" : "h-9 [&_.input-inner]:!h-9"} rounded-lg text-text-1 [&_.input-inner]:gap-3 [&_.input-inner]:!px-2 [&_.input-prefix]:mr-0`}
+          inputClassName={`${compact ? "text-[12px]" : "text-[13px]"} font-normal placeholder:text-text-3`}
+          style={{ height }}
+          inputStyle={{ transform: "none" }}
+        />
+      );
+    }
+  );
 
 SidebarMenuSearchInput.displayName = "SidebarMenuSearchInput";
 

--- a/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
@@ -25,13 +25,17 @@ import IconButton from "@src/components/IconButton";
 import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import {
+  Infinity01Icon,
   ArrowRight01Icon,
   ArrowUpRight01Icon,
+  Clock01Icon,
   FilterMailIcon,
   FolderInputIcon,
+  FolderOpenIcon,
   FolderOutputIcon,
   FolderSymlinkIcon,
   HugeiconsIcon,
+  type IconSvgElement,
   Layers01Icon,
   ListChevronsDownUpIcon,
   Refresh04Icon,
@@ -44,6 +48,14 @@ import HoverAnimatedIcon, {
   triggerIconAnimation,
 } from "../components/HoverAnimatedIcon";
 import { GROUP_BY_MODES } from "./types";
+
+const GROUP_BY_MODE_ICONS: Readonly<
+  Partial<Record<string, { icon: IconSvgElement; name: string }>>
+> = {
+  byTime: { icon: Clock01Icon, name: "clock" },
+  byWorkspace: { icon: FolderOpenIcon, name: "folder-open" },
+  byAgent: { icon: Infinity01Icon, name: "infinity" },
+};
 
 interface SessionFilterButtonProps {
   groupByMode: string;
@@ -495,16 +507,30 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
               onMouseDown={handleSubmenuMouseDown}
             >
               <div className={DROPDOWN_CLASSES.itemsColumnPadded}>
-                {groupByModes.map((mode) => (
-                  <DropdownItem
-                    key={mode}
-                    dataTestId={`sidebar-group-by-${mode}`}
-                    selected={mode === groupByMode}
-                    onClick={() => handleSelect(mode)}
-                  >
-                    {resolveGroupByLabel(mode)}
-                  </DropdownItem>
-                ))}
+                {groupByModes.map((mode) => {
+                  const iconConfig = GROUP_BY_MODE_ICONS[mode];
+
+                  return (
+                    <DropdownItem
+                      key={mode}
+                      dataTestId={`sidebar-group-by-${mode}`}
+                      icon={
+                        iconConfig ? (
+                          <HugeiconsIcon
+                            icon={iconConfig.icon}
+                            data-icon={iconConfig.name}
+                            size={DROPDOWN_ITEM.iconSize}
+                            strokeWidth={2}
+                          />
+                        ) : undefined
+                      }
+                      selected={mode === groupByMode}
+                      onClick={() => handleSelect(mode)}
+                    >
+                      {resolveGroupByLabel(mode)}
+                    </DropdownItem>
+                  );
+                })}
               </div>
             </DropdownPanel>,
             document.body

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -52,6 +52,7 @@ import { useWorkstationSidebarRevealRequestState } from "./sidebarConnector.reve
 import { useWorkstationSidebarScopeAndPagination } from "./sidebarConnector.scopeAndPagination";
 import { useWorkstationSidebarSelectionAndCollapse } from "./sidebarConnector.selectionAndCollapse";
 import { useWorkstationSidebarSessionInteractionHandlers } from "./sidebarConnector.sessionInteractionHandlers";
+import { useSidebarSessionRefreshAction } from "./sidebarSessionRefresh";
 import { SidebarSearchShortcutTooltip } from "./sidebarTabs";
 import type { WorkstationSidebarKey } from "./types";
 import { useSessionSidebarRowActions } from "./useSessionSidebarRowActions";
@@ -96,6 +97,8 @@ export const WorkstationSidebarConnector: React.FC = () => {
     promoteActiveSessionCreatorDraftAtom
   );
   const deleteSessionCreatorDraft = useSetAtom(deleteSessionCreatorDraftAtom);
+  const { refreshSpinClass, handleRefreshSessions } =
+    useSidebarSessionRefreshAction();
 
   const {
     chatPanelContentMode,
@@ -127,6 +130,11 @@ export const WorkstationSidebarConnector: React.FC = () => {
   const { goToNewSession, navigateTo } = useAppNavigation();
   const [activeSidebarKey, setActiveSidebarKey] =
     useState<WorkstationSidebarKey>("workstation");
+  const [sessionSearchQuery, setSessionSearchQuery] = useState("");
+  const [sessionSearchVisible, setSessionSearchVisible] = useState(false);
+  const handleOpenSessionSearch = useCallback(() => {
+    setSessionSearchVisible(true);
+  }, []);
   const [channelsOpen, setChannelsOpen] = useState(false);
   const [workItemsOpen, setWorkItemsOpen] = useState(false);
   const workItemsContentVisible =
@@ -321,7 +329,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     repoPathToName,
     groupByMode,
     untitledSession,
-    searchQuery: "",
+    searchQuery: sessionSearchQuery,
     selectedOrgIds: sessionFilterOrgIds,
     extraSessionIds: cloudScopedExtraSessionIds,
     excludedSessionIds: sessionListExcludedIds,
@@ -347,6 +355,11 @@ export const WorkstationSidebarConnector: React.FC = () => {
     menuItems,
     sessionCreatorDrafts,
     activeViewKey,
+    sessionSearchLabel: t("sidebar.search.sessions"),
+    sessionRefreshLabel: tCommon("actions.refresh"),
+    sessionRefreshIconClassName: refreshSpinClass,
+    onSessionSearch: handleOpenSessionSearch,
+    onSessionRefresh: handleRefreshSessions,
     createProjectLabel,
     createWorkItemLabel,
     importGithubIssuesLabel,
@@ -551,6 +564,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
       projectsWorkItemsLoading: workItems.loading,
       projectsSidebarMenuItems: workItems.menuItems,
       sessionsLoading,
+      handleRefreshSessions,
       openRuntimeTab,
       runtimeLabel,
       groupByMode,
@@ -589,19 +603,39 @@ export const WorkstationSidebarConnector: React.FC = () => {
         macTopBarFollowingContent={
           <div className="shrink-0 px-3 pt-1">{sidebarOrgSelector}</div>
         }
+        search={
+          activeViewKey === "sessions" && sessionSearchVisible
+            ? {
+                value: sessionSearchQuery,
+                onChange: setSessionSearchQuery,
+                placeholder: t("sidebar.search.sessions"),
+                noResultsTitle: t("sidebar.empty.noResultsFor", {
+                  query: sessionSearchQuery,
+                }),
+                autoFocus: true,
+                filterPinnedItems: false,
+              }
+            : undefined
+        }
         preListContent={
           <WorkstationSidebarViewSwitcher
             activeKey={activeViewKey}
             onChange={handleViewChange}
           />
         }
-        onAddNew={handleOpenSpotlight}
+        onAddNew={
+          activeViewKey === "sessions"
+            ? handleOpenSessionSearch
+            : handleOpenSpotlight
+        }
         addIcon={Search01Icon}
         addLabel={tCommon("actions.search")}
         addTooltipContent={
-          <SidebarSearchShortcutTooltip
-            searchLabel={tCommon("actions.search")}
-          />
+          activeViewKey === "sessions" ? undefined : (
+            <SidebarSearchShortcutTooltip
+              searchLabel={tCommon("actions.search")}
+            />
+          )
         }
         listTopPadding
         bottomContent={

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.bottomActions.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.bottomActions.ts
@@ -7,7 +7,6 @@
 import { useSetAtom } from "jotai";
 import { useCallback, useMemo } from "react";
 
-import { createLogger } from "@src/hooks/logger";
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import { type Session, markAllSessionsVisited } from "@src/store/session";
 import {
@@ -18,10 +17,7 @@ import {
 import { getAllSectionIds } from "../workstationSidebarData";
 import { useSidebarBottomRightActions } from "./bottomActions";
 import { useWorkstationSidebarMemory } from "./sidebarMemory";
-import { rescanSidebarSessions } from "./sidebarSessionRefresh";
 import type { WorkstationSidebarKey } from "./types";
-
-const logger = createLogger("WorkstationSidebar");
 
 export function resolveSidebarSelectedMenuItemId({
   activeSidebarKey,
@@ -64,6 +60,7 @@ interface UseWorkstationSidebarBottomActionsParams {
   projectsWorkItemsLoading: boolean;
   projectsSidebarMenuItems: NavigationMenuItem[];
   sessionsLoading: boolean;
+  handleRefreshSessions: () => void;
   openRuntimeTab: (title: string) => void;
   runtimeLabel: string;
   groupByMode: BottomRightActionsParams["groupByMode"];
@@ -87,6 +84,7 @@ export function useWorkstationSidebarBottomActions({
   projectsWorkItemsLoading,
   projectsSidebarMenuItems,
   sessionsLoading,
+  handleRefreshSessions,
   openRuntimeTab,
   runtimeLabel,
   groupByMode,
@@ -109,11 +107,6 @@ export function useWorkstationSidebarBottomActions({
   const handleMarkAllRead = useCallback(() => {
     markAllSessionsVisited(sessions.map((session) => session.session_id));
   }, [sessions]);
-  const handleRefreshSessions = useCallback(() => {
-    void rescanSidebarSessions().catch((error) => {
-      logger.warn("Failed to rescan sidebar sessions:", error);
-    });
-  }, []);
   const setRuntimeNavigationIntent = useSetAtom(runtimeNavigationIntentAtom);
   // The sidebar's include-external toggle is all-or-nothing; per-source
   // visibility is owned by Runtime → Scanning, so the menu links there instead

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.pinnedAndRevealData.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.pinnedAndRevealData.ts
@@ -28,6 +28,11 @@ interface UseWorkstationSidebarPinnedAndRevealDataParams {
   menuItems: readonly NavigationMenuItem[];
   sessionCreatorDrafts: readonly SessionCreatorDraft[];
   activeViewKey: WorkstationSidebarViewKey;
+  sessionSearchLabel: string;
+  sessionRefreshLabel: string;
+  sessionRefreshIconClassName?: string;
+  onSessionSearch: () => void;
+  onSessionRefresh: () => void;
   createProjectLabel: string;
   createWorkItemLabel: string;
   importGithubIssuesLabel: string;
@@ -45,6 +50,11 @@ export function useWorkstationSidebarPinnedAndRevealData({
   menuItems,
   sessionCreatorDrafts,
   activeViewKey,
+  sessionSearchLabel,
+  sessionRefreshLabel,
+  sessionRefreshIconClassName,
+  onSessionSearch,
+  onSessionRefresh,
   createProjectLabel,
   createWorkItemLabel,
   importGithubIssuesLabel,
@@ -93,6 +103,11 @@ export function useWorkstationSidebarPinnedAndRevealData({
   const sessionSidebarMenuItems = useSessionSidebarMenuItems({
     menuItems,
     sessionCreatorDrafts,
+    searchLabel: sessionSearchLabel,
+    refreshLabel: sessionRefreshLabel,
+    refreshIconClassName: sessionRefreshIconClassName,
+    onSearch: onSessionSearch,
+    onRefresh: onSessionRefresh,
     t,
   });
   const loadedCloudMySessionRowCount = useMemo(

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.test.ts
@@ -1,0 +1,109 @@
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
+
+import { addActionsToFirstSessionSection } from "./sidebarMenuCollections";
+
+describe("addActionsToFirstSessionSection", () => {
+  it("adds search before refresh on the first regular session header only", () => {
+    const onSearch = vi.fn();
+    const onRefresh = vi.fn();
+    const existingAction = vi.fn();
+    const items: NavigationMenuItem[] = [
+      {
+        id: "separator-pinned",
+        key: "separator-pinned",
+        label: "Pinned",
+      },
+      { id: "session-pinned", key: "session-pinned", label: "Pinned session" },
+      {
+        id: "separator-today",
+        key: "separator-today",
+        label: "Today",
+        rowActions: [{ label: "Existing", onClick: existingAction }],
+      },
+      { id: "session-1", key: "session-1", label: "First" },
+      {
+        id: "separator-yesterday",
+        key: "separator-yesterday",
+        label: "Yesterday",
+      },
+    ];
+
+    const result = addActionsToFirstSessionSection({
+      menuItems: items,
+      searchLabel: "Search sessions",
+      refreshLabel: "Refresh",
+      refreshIconClassName: "animate-spin",
+      onSearch,
+      onRefresh,
+    });
+
+    expect(result[0]?.rowActions).toBeUndefined();
+    expect(result[2]).toMatchObject({
+      id: "separator-today",
+      rowActions: [
+        expect.objectContaining({
+          label: "Search sessions",
+          dataIcon: "search",
+          dataTestId: "sidebar-sessions-search",
+        }),
+        expect.objectContaining({
+          label: "Refresh",
+          dataIcon: "refresh-cw",
+          iconClassName: "animate-spin",
+          dataTestId: "sidebar-sessions-refresh",
+        }),
+        expect.objectContaining({ label: "Existing" }),
+      ],
+    });
+    expect(result[4]?.rowActions).toBeUndefined();
+
+    result[2]?.rowActions?.[0]?.onClick(
+      {} as React.MouseEvent<HTMLButtonElement>
+    );
+    expect(onSearch).toHaveBeenCalledOnce();
+    result[2]?.rowActions?.[1]?.onClick(
+      {} as React.MouseEvent<HTMLButtonElement>
+    );
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a pinned-only session list unchanged", () => {
+    const items: NavigationMenuItem[] = [
+      {
+        id: "separator-pinned",
+        key: "separator-pinned",
+        label: "Pinned",
+      },
+      { id: "session-pinned", key: "session-pinned", label: "Pinned session" },
+    ];
+
+    expect(
+      addActionsToFirstSessionSection({
+        menuItems: items,
+        searchLabel: "Search sessions",
+        refreshLabel: "Refresh",
+        onSearch: vi.fn(),
+        onRefresh: vi.fn(),
+      })
+    ).toBe(items);
+  });
+
+  it("keeps a headerless session list unchanged", () => {
+    const items: NavigationMenuItem[] = [
+      { id: "session-1", key: "session-1", label: "First" },
+    ];
+
+    expect(
+      addActionsToFirstSessionSection({
+        menuItems: items,
+        searchLabel: "Search sessions",
+        refreshLabel: "Refresh",
+        onSearch: vi.fn(),
+        onRefresh: vi.fn(),
+      })
+    ).toBe(items);
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.ts
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { getTerminalDisplayTitle } from "@src/engines/TerminalCore/types";
-import { SquareTerminalIcon } from "@src/icons";
+import { Refresh04Icon, Search01Icon, SquareTerminalIcon } from "@src/icons";
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import { chatPanelTabsAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { terminalSessionsAtom } from "@src/store/chatPanel/chatPanelTerminalAtom";
@@ -19,6 +19,8 @@ import {
   buildProjectsPinnedMenuItems,
 } from "../workstationSidebarMenuItems";
 import type { WorkstationSidebarViewKey } from "./WorkstationSidebarViewSwitcher";
+
+const PINNED_SESSION_SEPARATOR_ID = "separator-pinned";
 
 interface UsePinnedMenuItemsParams {
   activeViewKey: WorkstationSidebarViewKey;
@@ -121,13 +123,76 @@ export function usePinnedMenuItems({
   return { pinnedMenuItems };
 }
 
+export function addActionsToFirstSessionSection({
+  menuItems,
+  searchLabel,
+  refreshLabel,
+  refreshIconClassName,
+  onSearch,
+  onRefresh,
+}: {
+  menuItems: readonly NavigationMenuItem[];
+  searchLabel: string;
+  refreshLabel: string;
+  refreshIconClassName?: string;
+  onSearch: () => void;
+  onRefresh: () => void;
+}): readonly NavigationMenuItem[] {
+  const sectionIndex = menuItems.findIndex(
+    (item) =>
+      item.id.startsWith("separator-") &&
+      item.id !== PINNED_SESSION_SEPARATOR_ID &&
+      item.label.length > 0
+  );
+  if (sectionIndex < 0) return menuItems;
+
+  const section = menuItems[sectionIndex];
+  const sectionWithActions: NavigationMenuItem = {
+    ...section,
+    rowActions: [
+      {
+        icon: Search01Icon,
+        dataIcon: "search",
+        label: searchLabel,
+        dataTestId: "sidebar-sessions-search",
+        onClick: onSearch,
+      },
+      {
+        icon: Refresh04Icon,
+        dataIcon: "refresh-cw",
+        iconClassName: refreshIconClassName,
+        label: refreshLabel,
+        dataTestId: "sidebar-sessions-refresh",
+        onClick: onRefresh,
+      },
+      ...(section.rowActions ?? []),
+    ],
+  };
+
+  return [
+    ...menuItems.slice(0, sectionIndex),
+    sectionWithActions,
+    ...menuItems.slice(sectionIndex + 1),
+  ];
+}
+
 export function useSessionSidebarMenuItems({
   menuItems,
   sessionCreatorDrafts,
+  searchLabel,
+  refreshLabel,
+  refreshIconClassName,
+  onSearch,
+  onRefresh,
   t,
 }: {
   menuItems: readonly NavigationMenuItem[];
   sessionCreatorDrafts: readonly SessionCreatorDraft[];
+  searchLabel: string;
+  refreshLabel: string;
+  refreshIconClassName?: string;
+  onSearch: () => void;
+  onRefresh: () => void;
   t: TFunction<"navigation">;
 }): NavigationMenuItem[] {
   const draftMenuItems = useMemo<NavigationMenuItem[]>(
@@ -180,9 +245,29 @@ export function useSessionSidebarMenuItems({
     return items;
   }, [terminalTabs, t]);
 
+  const sessionMenuItems = useMemo(
+    () =>
+      addActionsToFirstSessionSection({
+        menuItems,
+        searchLabel,
+        refreshLabel,
+        refreshIconClassName,
+        onSearch,
+        onRefresh,
+      }),
+    [
+      menuItems,
+      onRefresh,
+      onSearch,
+      refreshIconClassName,
+      refreshLabel,
+      searchLabel,
+    ]
+  );
+
   return useMemo(
-    () => [...draftMenuItems, ...terminalMenuItems, ...menuItems],
-    [draftMenuItems, terminalMenuItems, menuItems]
+    () => [...draftMenuItems, ...terminalMenuItems, ...sessionMenuItems],
+    [draftMenuItems, terminalMenuItems, sessionMenuItems]
   );
 }
 

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.test.ts
@@ -77,4 +77,35 @@ describe("rescanSidebarSessions", () => {
       forceRefresh: true,
     });
   });
+
+  it("shares one in-flight rescan across repeated refresh actions", async () => {
+    let resolveScan: ((value: undefined) => void) | undefined;
+    mocks.externalHistoryRescanSources.mockReturnValue(
+      new Promise<undefined>((resolve) => {
+        resolveScan = resolve;
+      })
+    );
+
+    const first = rescanSidebarSessions();
+    const second = rescanSidebarSessions();
+
+    expect(second).toBe(first);
+    expect(mocks.externalHistoryRescanSources).toHaveBeenCalledTimes(1);
+
+    resolveScan?.(undefined);
+    await Promise.all([first, second]);
+    expect(mocks.loadSessionRoster).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a new refresh after an in-flight rescan fails", async () => {
+    mocks.externalHistoryRescanSources
+      .mockRejectedValueOnce(new Error("scan failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(rescanSidebarSessions()).rejects.toThrow("scan failed");
+    await rescanSidebarSessions();
+
+    expect(mocks.externalHistoryRescanSources).toHaveBeenCalledTimes(2);
+    expect(mocks.loadSessionRoster).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.ts
@@ -1,9 +1,11 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import {
   IMPORTED_HISTORY_SOURCE_DESCRIPTORS,
   externalHistoryRescanSources,
 } from "@src/api/tauri/externalHistory";
+import { createLogger } from "@src/hooks/logger";
+import { useRefreshSpin } from "@src/hooks/ui";
 import {
   loadSessionRoster,
   refreshRecentNativeSessions,
@@ -21,8 +23,11 @@ import {
   SIDEBAR_SESSION_IDLE_REFRESH_INTERVAL_MS,
 } from "../sidebarConnectorUtils";
 
+const logger = createLogger("WorkstationSidebar");
+let sidebarSessionRescanInFlight: Promise<void> | null = null;
+
 /** Rescan every enabled external source, then refresh the canonical roster. */
-export async function rescanSidebarSessions(): Promise<void> {
+async function performSidebarSessionRescan(): Promise<void> {
   const store = getInstrumentedStore();
   if (!store.get(externalSessionsEnabledAtom)) {
     // External sessions are switched off entirely — nothing to rescan, and
@@ -56,6 +61,44 @@ export async function rescanSidebarSessions(): Promise<void> {
     }
     return next;
   });
+}
+
+/** Share one manual rescan across the header and overflow-menu refresh actions. */
+export function rescanSidebarSessions(): Promise<void> {
+  if (sidebarSessionRescanInFlight) return sidebarSessionRescanInFlight;
+
+  const request = performSidebarSessionRescan().finally(() => {
+    if (sidebarSessionRescanInFlight === request) {
+      sidebarSessionRescanInFlight = null;
+    }
+  });
+  sidebarSessionRescanInFlight = request;
+  return request;
+}
+
+export function useSidebarSessionRefreshAction(): {
+  refreshSpinClass: string | undefined;
+  handleRefreshSessions: () => void;
+} {
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshSessions = useCallback(() => {
+    setRefreshing(true);
+    void rescanSidebarSessions()
+      .catch((error) => {
+        logger.warn("Failed to rescan sidebar sessions:", error);
+      })
+      .finally(() => {
+        setRefreshing(false);
+      });
+  }, []);
+  const { spinClass: refreshSpinClass, handleClick: handleRefreshSessions } =
+    useRefreshSpin(
+      refreshSessions,
+      refreshing,
+      "workstation-sidebar-session-refresh"
+    );
+
+  return { refreshSpinClass, handleRefreshSessions };
 }
 
 export function useSidebarSessionRefreshEffects(): void {

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts
@@ -131,7 +131,21 @@ describe("SessionFilterButton", () => {
     expect(
       queryTestId("sidebar-group-by-byWorkspace")?.getAttribute("aria-selected")
     ).toBe("false");
-    expect(queryTestId("sidebar-group-by-byAgent")).not.toBeNull();
+    expect(
+      queryTestId("sidebar-group-by-byTime")?.querySelector(
+        '[data-icon="clock"]'
+      )
+    ).not.toBeNull();
+    expect(
+      queryTestId("sidebar-group-by-byWorkspace")?.querySelector(
+        '[data-icon="folder-open"]'
+      )
+    ).not.toBeNull();
+    expect(
+      queryTestId("sidebar-group-by-byAgent")?.querySelector(
+        '[data-icon="infinity"]'
+      )
+    ).not.toBeNull();
   });
 
   it("opens the second level on click, for pointerless interaction", async () => {

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts
@@ -85,6 +85,82 @@ describe("NavigationSidebar", () => {
     expect(markup).not.toContain('data-test-menu-item="projects"');
   });
 
+  it("renders actions on an existing session section header", () => {
+    const markup = renderToStaticMarkup(
+      createElement(NavigationSidebar, {
+        items: [],
+        activeKey: "",
+        onChange: vi.fn(),
+        menuItems: [
+          {
+            id: "separator-today",
+            key: "separator-today",
+            label: "Today",
+            rowActions: [
+              {
+                label: "Search sessions",
+                dataTestId: "sidebar-sessions-search",
+                onClick: vi.fn(),
+              },
+              {
+                label: "Refresh",
+                dataTestId: "sidebar-sessions-refresh",
+                onClick: vi.fn(),
+              },
+            ],
+          },
+          { id: "session-1", key: "session-1", label: "First session" },
+        ],
+        collapsibleSections: true,
+      })
+    );
+
+    expect(markup).toContain('data-sidebar-section-toggle="today"');
+    expect(markup).toContain(">Today</span>");
+    expect(markup).toContain('data-testid="sidebar-sessions-search"');
+    expect(markup).toContain('title="Search sessions"');
+    expect(markup).toContain('data-testid="sidebar-sessions-refresh"');
+    expect(markup).toContain('title="Refresh"');
+    expect(
+      markup.indexOf('data-testid="sidebar-sessions-search"')
+    ).toBeLessThan(markup.indexOf('data-testid="sidebar-sessions-refresh"'));
+  });
+
+  it("autofocuses inline search while keeping fixed navigation visible", () => {
+    const markup = renderToStaticMarkup(
+      createElement(NavigationSidebar, {
+        items: [],
+        activeKey: "",
+        onChange: vi.fn(),
+        pinnedMenuItems: [
+          { id: "new-session", key: "new-session", label: "New session" },
+        ],
+        menuItems: [
+          {
+            id: "separator-today",
+            key: "separator-today",
+            label: "Today",
+          },
+          { id: "match", key: "match", label: "Matching session" },
+          { id: "other", key: "other", label: "Unrelated task" },
+        ],
+        search: {
+          value: "matching",
+          onChange: vi.fn(),
+          placeholder: "Search sessions...",
+          autoFocus: true,
+          filterPinnedItems: false,
+        },
+      })
+    );
+
+    expect(markup).toContain('placeholder="Search sessions..."');
+    expect(markup).toContain('autofocus=""');
+    expect(markup).toContain('data-test-menu-item="new-session"');
+    expect(markup).toContain('data-test-menu-item="match"');
+    expect(markup).not.toContain('data-test-menu-item="other"');
+  });
+
   it("renders surface-specific skeleton content while loading", () => {
     const markup = renderToStaticMarkup(
       createElement(NavigationSidebar, {

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -46,6 +46,10 @@ interface NavigationSidebarSearchConfig {
   noResultsTitle?: string;
   /** Keep filtering active while a caller renders the shared input elsewhere. */
   showInput?: boolean;
+  /** Focus the shared input when it mounts. */
+  autoFocus?: boolean;
+  /** Whether the query also filters the fixed navigation rows. */
+  filterPinnedItems?: boolean;
 }
 
 export interface NavigationSidebarProps {
@@ -286,9 +290,13 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
       () => normalizeSearchValue(search?.filterValue ?? search?.value ?? ""),
       [search?.filterValue, search?.value]
     );
+    const shouldFilterPinnedMenuItems = search?.filterPinnedItems !== false;
     const filteredPinnedMenuItems = useMemo(
-      () => filterMenuItems(pinnedMenuItems, normalizedSearchQuery),
-      [normalizedSearchQuery, pinnedMenuItems]
+      () =>
+        shouldFilterPinnedMenuItems
+          ? filterMenuItems(pinnedMenuItems, normalizedSearchQuery)
+          : [...pinnedMenuItems],
+      [normalizedSearchQuery, pinnedMenuItems, shouldFilterPinnedMenuItems]
     );
     const filteredMenuItems = useMemo(
       () => filterMenuItems(menuItems, normalizedSearchQuery),
@@ -455,6 +463,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
               value={search.value}
               onChange={search.onChange}
               placeholder={search.placeholder}
+              autoFocus={search.autoFocus}
             />
           </div>
         )}
@@ -541,7 +550,9 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
           scrollContainerRef={menuRevealRootRef}
         >
           {hasSearchInput &&
-          filteredPinnedMenuItems.length === 0 &&
+          (shouldFilterPinnedMenuItems
+            ? filteredPinnedMenuItems.length === 0
+            : true) &&
           sections.length === 0 ? (
             <Placeholder
               variant="no-results"


### PR DESCRIPTION
## Problem

Frequently used session-sidebar controls are split across separate surfaces: session search opens a Spotlight layer instead of filtering in place, manual refresh lives in the overflow menu, and grouping choices are text-only. The first regular history section already provides the right contextual header, but it has no quick actions; putting global actions on Pinned would also give a user-curated section unrelated responsibilities.

## Solution

- Add Search followed by Refresh to the first regular session section header while explicitly skipping Pinned and preserving existing workspace-header actions.
- Make both the top search control and the section Search action reveal the shared inline sidebar input with autofocus. The query filters session rows through the existing session-menu search path while fixed navigation remains visible.
- Share one manual refresh owner between the header and overflow menu, including the existing refresh animation and a single-flight rescan that clears after both success and failure.
- Add semantic icons to grouping choices: clock for time, folder for workspace, and infinity for Agent.
- Add focused tests for action ordering, Pinned exclusion, inline filtering/autofocus, grouping icons, refresh deduplication, and retry after failure.

## Potential risks

- Workspace headers already have contextual actions, so adding Search and Refresh increases hover-action density at narrow sidebar widths. The change reuses the existing hover-only row-action component, but rendered spacing was not manually verified.
- Inline search evaluates the existing memoized session filter as the user types. Session groups remain bounded by existing pagination outside search, and search uses the existing loaded-session path; no runtime profiling was performed, so this PR does not claim a responsiveness improvement or justify virtualization.
- A slow manual scan now causes repeated refresh clicks to share the same promise by design. Failure clears that promise so the next click can retry.
- No persistence, schema, backend, IPC, wire, dependency, or configuration format changes are included. Rollback is a direct revert of the single commit.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.test.ts src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts` — 4 files, 18 tests passed after rebasing onto current `origin/develop`.
- `pnpm run typecheck` — passed after rebase.
- `pnpm exec eslint src/scaffold/NavigationSidebar/blocks/SidebarMenuSearchInput.tsx src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.bottomActions.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.pinnedAndRevealData.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.test.ts src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts --max-warnings 0 --report-unused-disable-directives` — passed after rebase.
- `pnpm run check:test-placement` — passed across 445 directories.
- `pnpm run check:circular` — no circular dependencies across 6,406 modules.
- `git diff --check origin/develop...HEAD` — passed.
- Normal commit hooks ran successfully: lint-staged formatting/lint and scoped TypeScript checks passed; no Rust files were staged.
- Full `pnpm test`, rendered Tauri/WebDriver E2E, and post-change screenshots were not run. The focused owning-boundary tests cover behavior, while repository instructions prohibit desktop computer control without explicit opt-in; visual spacing, themes, and live autofocus remain unverified in the real app.

## Audit

Frontend UI audit: **0 fix**, **4 keep with reason**, **0 abstract**. The implementation reuses the shared sidebar input, row-action component, icon system, and refresh animation rather than introducing new visual primitives.

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | fix | Header and overflow refresh previously had separate callback ownership | One shared manual action and one single-flight rescan; existing visibility-aware background timer lifecycle is unchanged | Concurrent-click and failure/retry unit tests |
| Memory | keep | One module-level in-flight promise, cleared in `finally` | Retention is bounded to one settling request | Success and rejection tests |
| Scope/isolation | keep | Manual refresh reads the current local source configuration and updates the app-wide session roster | No auth-, endpoint-, org-, or provider-identity cache was added | Existing source-selection test plus typecheck |
| Rendering/hot path | keep | Inline query uses existing memoized filtering and session pagination/search mode | No speculative virtualization, debounce, or new dependency without runtime evidence | Inline filter/autofocus static render test |

Provider parsing, identity, sync, and topology matrices are not applicable because this PR does not change provider ingestion or transport behavior.

Performance verdict: **pass** for the applicable lifecycle invariants. No runtime performance improvement is claimed.
