### PR TITLE
ci(rust-scope): gate rust jobs on rust-relevant paths only

### DIFF
--- a/scripts/ci/detect-rust-changes.cjs
+++ b/scripts/ci/detect-rust-changes.cjs
@@ -2,74 +2,48 @@
 
 const fs = require("node:fs");
 
-// Keep the skip rules deliberately narrow. Rust may be skipped only when
-// every changed file is frontend-only or documentation with no Rust inputs.
-const FRONTEND_ONLY_PREFIXES = Object.freeze([
-  "assets/",
-  "build/",
-  "public/",
-  "src/",
-  "tests/",
+// The Rust jobs (clippy + workspace tests) read a bounded set of inputs, so
+// the gate enumerates those inputs and fires only when the diff touches one.
+// Everything else — frontend code, configs, docs, agent skills, unrelated
+// tooling — skips the macOS runner. This replaces the old inverted rule
+// ("skip only when every path is on a frontend/docs allowlist"), which ran
+// ~30 min of clippy for any path the allowlist had never heard of.
+//
+// If the Rust build grows a new out-of-tree input (a codegen script, a shared
+// fixture directory), it must be added here in the same change.
+const RUST_RELEVANT_PREFIXES = Object.freeze([
+  // The entire workspace: crates, Cargo.toml/Cargo.lock, .cargo/, tauri
+  // configs, capabilities, icons bundled into the binary.
+  "src-tauri/",
+  // Schemas and fixtures read by Rust protocol-conformance tests; the whole
+  // contract stays in Rust scope, including its Markdown.
+  "docs/orgtrack-pm-protocol/",
+  // The Rust CI job shells out to these before building (sidecar prep, build
+  // helpers), so their behavior is part of the build.
+  "scripts/tauri/",
+  // Workflow definitions and composite actions decide how (and whether) the
+  // Rust jobs run.
+  ".github/workflows/",
+  ".github/actions/",
 ]);
 
-const FRONTEND_ONLY_FILES = new Set([
-  "config/commitlint.config.cjs",
-  "config/postcss.config.js",
-  "config/vitest.config.ts",
-  "config/webpack.config.js",
-  "commitlint.config.cjs",
-  "package.json",
-  "pnpm-lock.yaml",
-  "pnpm-workspace.yaml",
-  "postcss.config.js",
-  "tsconfig.json",
-  "vitest.config.ts",
-  "webpack.config.js",
+const RUST_RELEVANT_FILES = new Set([
+  // The gate itself and its test: a diff that edits the detector must not be
+  // trusted to scope itself.
+  "scripts/ci/detect-rust-changes.cjs",
+  "scripts/ci/detect-rust-changes.test.cjs",
 ]);
 
-const DOCUMENTATION_FILES = new Set([
-  ".claude/CLAUDE.md",
-  ".github/CODE_OF_CONDUCT.md",
-  ".github/CONTRIBUTING.md",
-  ".github/PR_RULES.md",
-  ".github/SECURITY.md",
-  "AGENTS.md",
-  "CLAUDE.md",
-  "CODE_OF_CONDUCT.md",
-  "CONTRIBUTING.md",
-  "PR_RULES.md",
-  "README.md",
-  "SECURITY.md",
-]);
-
-function isFrontendOnlyPath(filePath) {
+function isRustRelevantPath(filePath) {
   return (
-    FRONTEND_ONLY_FILES.has(filePath) ||
-    FRONTEND_ONLY_PREFIXES.some((prefix) => filePath.startsWith(prefix))
-  );
-}
-
-function isDocumentationOnlyPath(filePath) {
-  // The PM protocol directory contains schemas and fixtures read by Rust
-  // conformance tests. Keep the entire contract in Rust scope, including
-  // its Markdown docs; do not exempt arbitrary files under docs/.
-  return (
-    DOCUMENTATION_FILES.has(filePath) ||
-    (filePath.startsWith("docs/") &&
-      filePath.endsWith(".md") &&
-      !filePath.startsWith("docs/orgtrack-pm-protocol/"))
+    RUST_RELEVANT_FILES.has(filePath) ||
+    RUST_RELEVANT_PREFIXES.some((prefix) => filePath.startsWith(prefix))
   );
 }
 
 function requiresRust(filePaths) {
   // Fail closed when diff discovery yields nothing unexpectedly.
-  return (
-    filePaths.length === 0 ||
-    filePaths.some(
-      (filePath) =>
-        !isFrontendOnlyPath(filePath) && !isDocumentationOnlyPath(filePath)
-    )
-  );
+  return filePaths.length === 0 || filePaths.some(isRustRelevantPath);
 }
 
 function parseNullDelimitedPaths(input) {
@@ -82,7 +56,7 @@ if (require.main === module) {
 }
 
 module.exports = {
-  isFrontendOnlyPath,
+  isRustRelevantPath,
   parseNullDelimitedPaths,
   requiresRust,
 };

--- a/scripts/ci/detect-rust-changes.test.cjs
+++ b/scripts/ci/detect-rust-changes.test.cjs
@@ -4,7 +4,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
-  isFrontendOnlyPath,
+  isRustRelevantPath,
   parseNullDelimitedPaths,
   requiresRust,
 } = require("./detect-rust-changes.cjs");
@@ -37,33 +37,25 @@ test("frontend configs, assets, and repository tests skip Rust", () => {
   );
 });
 
-test("frontend changes with supporting Markdown docs skip Rust", () => {
-  assert.equal(
-    requiresRust([
-      "src/icons.ts",
-      "src/config/segmentRegistry.ts",
-      "docs/hugeicons-migration/icon-mapping.md",
-    ]),
-    false
-  );
-});
-
-test("ordinary Markdown documentation alone skips Rust", () => {
+test("documentation, agent tooling, and unknown paths skip Rust", () => {
+  // The gate enumerates the Rust build's inputs; anything outside that set
+  // skips the macOS runner, including paths no allowlist has heard of. The
+  // old fail-closed-on-unknown rule burned ~30 min of clippy for changes
+  // like a deleted frontend config or an .orgii skill edit.
   for (const filePath of [
     ".claude/CLAUDE.md",
-    ".github/CODE_OF_CONDUCT.md",
-    ".github/CONTRIBUTING.md",
     ".github/PR_RULES.md",
-    ".github/SECURITY.md",
-    "AGENTS.md",
-    "CLAUDE.md",
-    "CODE_OF_CONDUCT.md",
-    "CONTRIBUTING.md",
-    "PR_RULES.md",
+    ".orgii/skills/frontend-ui-audit/SKILL.md",
     "README.md",
-    "SECURITY.md",
     "docs/frontend-ui-audit-2026-08-31/Icons.md",
     "docs/development/build notes.md",
+    "docs/examples/main.rs",
+    "config/tailwind.config.js",
+    "scripts/ci/select-lint-targets.cjs",
+    "scripts/dev/webpack-server.js",
+    "tools/org2-diagnostics/cli.mjs",
+    "unknown.md",
+    "README.md.backup",
   ]) {
     assert.equal(requiresRust([filePath]), false, filePath);
   }
@@ -71,6 +63,9 @@ test("ordinary Markdown documentation alone skips Rust", () => {
 
 test("Rust and mixed changes run Rust", () => {
   assert.equal(requiresRust(["src-tauri/src/lib.rs"]), true);
+  assert.equal(requiresRust(["src-tauri/Cargo.toml"]), true);
+  assert.equal(requiresRust(["src-tauri/tauri.conf.json"]), true);
+  assert.equal(requiresRust(["src-tauri/README.md"]), true);
   assert.equal(
     requiresRust(["src/components/Button.tsx", "src-tauri/Cargo.lock"]),
     true
@@ -84,36 +79,33 @@ test("Rust and mixed changes run Rust", () => {
   );
 });
 
-test("workflow, script, and protocol changes run Rust conservatively", () => {
+test("build machinery the Rust job invokes stays in Rust scope", () => {
   assert.equal(requiresRust([".github/workflows/ci.yml"]), true);
-  assert.equal(requiresRust([".github/actions/build/README.md"]), true);
+  assert.equal(requiresRust([".github/workflows/warm-rust-cache.yml"]), true);
+  assert.equal(requiresRust([".github/actions/setup/action.yml"]), true);
   assert.equal(requiresRust(["scripts/tauri/prepare-sidecars.cjs"]), true);
-  assert.equal(requiresRust(["docs/orgtrack-pm-protocol/README.md"]), true);
 });
 
-test("Rust contracts and non-Markdown documentation inputs stay in Rust scope", () => {
+test("the gate cannot scope a diff that edits the gate itself", () => {
+  assert.equal(requiresRust(["scripts/ci/detect-rust-changes.cjs"]), true);
+  assert.equal(requiresRust(["scripts/ci/detect-rust-changes.test.cjs"]), true);
+});
+
+test("the PM protocol contract stays in Rust scope, including its Markdown", () => {
   for (const filePath of [
+    "docs/orgtrack-pm-protocol/README.md",
     "docs/orgtrack-pm-protocol/decisions.md",
     "docs/orgtrack-pm-protocol/schemas/common.schema.json",
     "docs/orgtrack-pm-protocol/fixtures/routine-spec.json",
-    "docs/examples/Cargo.lock",
-    "docs/examples/main.rs",
-    "docs/fixtures/example.json",
-    "src-tauri/README.md",
   ]) {
     assert.equal(requiresRust([filePath]), true, filePath);
   }
 });
 
-test("empty or unknown diffs fail closed", () => {
+test("empty diffs fail closed", () => {
   assert.equal(requiresRust([]), true);
-  assert.equal(requiresRust(["unknown.md"]), true);
-  assert.equal(requiresRust(["README.md.backup"]), true);
-  assert.equal(requiresRust([".github/SECURITY.md.backup"]), true);
-  assert.equal(requiresRust(["docs/notes.md.backup"]), true);
-  assert.equal(isFrontendOnlyPath("package.json.backup"), false);
-  assert.equal(requiresRust(["config/webpack.config.js.backup"]), true);
-  assert.equal(requiresRust(["config/rust-build.json"]), true);
+  assert.equal(isRustRelevantPath("src-tauri"), false);
+  assert.equal(isRustRelevantPath("src-tauri/"), true);
 });
 
 test("NUL-delimited paths preserve whitespace and drive the CLI", () => {


### PR DESCRIPTION
## Problem

`Detect CI scope` gates the Rust jobs with a fail-closed rule: Rust is skipped only when every changed path is on a frontend/documentation allowlist, and *any* path the allowlist has never heard of buys ~30 minutes of clippy on a macOS runner. That fires constantly for changes with zero Rust impact — PR #1198 (a pure frontend Tailwind migration) ran the full Rust job three separate ways: it edited the CI scripts' path lists, touched an `.orgii/` skill doc, and deleted `config/tailwind.config.js` (whose allowlist entry the same PR removed). The allowlist also rots: every new frontend config or tooling path must be registered just to avoid a Rust run.

## Solution

Invert the gate to enumerate what the Rust jobs actually read, mirroring the bounded-inputs approach `detect-audit-changes.cjs` already uses. `requiresRust` now fires only when the diff touches:

- `src-tauri/` — the entire workspace (crates, Cargo files, `.cargo/`, tauri configs, capabilities, bundled assets);
- `docs/orgtrack-pm-protocol/` — schemas and fixtures read by Rust conformance tests (whole contract, including its Markdown, unchanged from before);
- `scripts/tauri/` — the Rust CI job shells out to `prepare-sidecars.cjs` before building;
- `.github/workflows/` and `.github/actions/` — they define how the Rust jobs run;
- `scripts/ci/detect-rust-changes.cjs` + its test — a diff that edits the gate must not be trusted to scope itself.

Everything else — frontend code and configs, docs, agent skills, unrelated tooling, and paths that do not exist yet — skips the runner. Empty diffs still fail closed (`true`). The frontend/documentation allowlists are deleted outright, ending their maintenance burden. The stdin/stdout contract is unchanged, so both callers (`ci.yml`, `warm-rust-cache.yml`) need no edits, and the required `Rust (clippy)` check still reports skipped-as-success exactly as before.

## Potential risks

- **A future out-of-tree Rust input would be silently missed** (a codegen script outside `scripts/tauri/`, a fixture directory outside the protocol dir). This is the inherent trade of allowlisting inputs over allowlisting non-inputs; the header comment instructs that new inputs be registered in the same change, and `nightly-full-checks.yml` still runs the full matrix unconditionally, so a missed input is caught by the clock rather than never.
- Paths that previously ran Rust "by accident" (e.g. `docs/**/*.json`, `*.md.backup`, unknown roots) now skip it. The new test suite pins this loosening explicitly.
- The exported helper renamed `isFrontendOnlyPath` → `isRustRelevantPath`; repo-wide grep shows no consumers outside the module and its test.

## Verification

- `node --test scripts/ci/detect-rust-changes.test.cjs` — 9/9 pass, including pins for: self-edit conservatism, protocol-contract retention, workflow/action machinery, the unknown-path inversion, and the empty-diff fail-closed stance.
- `node --test scripts/ci/detect-audit-changes.test.cjs scripts/ci/select-lint-targets.test.cjs` — 13/13 pass (no stale imports of the renamed helper; grep confirms no other consumers).
- CLI contract smoke-tested via the NUL-delimited spawn test (unchanged `true\n`/`false\n` output).
- This PR itself is the conservative case: it edits the gate, so its own CI run must (and will) execute the Rust jobs.
