### PR TITLE
fix(splash): move the splash preflight reset into @layer base

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -387,6 +387,14 @@
       })();
     </script>
     <style nonce="orgii-codemirror-style">
+      /*
+       * Everything here lives in `@layer base` so Tailwind v4 utilities
+       * (which are emitted in `@layer utilities`) keep beating the splash
+       * preflight. Unlayered, the `* { margin: 0; padding: 0 }` reset
+       * below would override every padding/margin utility in the app —
+       * unlayered author styles always beat layered ones.
+       */
+      @layer base {
       :root {
         --border-radius-window: 10px;
         /*
@@ -599,6 +607,7 @@
       #splash-text .dots::after {
         content: ".";
         animation: dots 1.5s steps(1) infinite;
+      }
       }
     </style>
   </head>


### PR DESCRIPTION
## Problem

After the Tailwind v4 migration (#1198), the running app rendered "vandalized": paddings and margins collapsed app-wide, chrome flat and cramped — while the compiled CSS was verifiably complete and correct.

Root cause: the inline splash-preflight `<style>` in `public/index.html` declares a universal reset (`* { margin: 0; padding: 0; box-sizing: border-box; user-select: none }`). In v3 this was harmless — utilities beat a zero-specificity `*` on specificity. In v4, utilities are emitted inside `@layer utilities`, and **unlayered author styles beat layered styles regardless of specificity**, so the splash reset silently overrode every padding/margin/user-select utility in the app. The migration layered all of `src/index.scss`'s resets but missed this one because it lives in an HTML template, not a stylesheet.

Diagnosed live against the dev server: a probe element with `p-4` computed `padding: 0px` while `gap-2` (not touched by the reset) computed correctly; rule-walking `document.styleSheets` pinned the winner to the unlayered `*` rule in the splash `<style>` block.

## Solution

Wrap the entire splash `<style>` block in `@layer base`, with a comment explaining why. This restores the v3 cascade relationship: the splash reset still overrides Tailwind's preflight (later in the same layer by document order... it precedes it, and preflight wins ties exactly as the main stylesheet did in v3) and still applies during the splash window, but loses to utilities.

Layer-order note: this sheet loads before Tailwind's output, so it creates the `base` layer first; Tailwind's `@layer theme, base, components, utilities;` statement then appends the remaining layers after it. `base` stays below `utilities` (the property that matters), and `theme` ordering is irrelevant here since the splash block defines only `--splash-*` / `--border-radius-window`, which no other layer touches.

## Potential risks

- The block's `!important` rules (input `user-select`, fullscreen `border-radius: 0`) move from unlayered-important to layered-important, which is *stronger* under important-inversion — but each has an identical-value twin in `src/index.scss`, so the computed result is unchanged.
- Splash-only selectors (`#splash`, its animation) become layered and thus weaker against unlayered app CSS; nothing in the app targets splash elements, and they are removed at boot.
- Browsers without `@layer` support would drop the whole splash style block — the app already hard-requires `@layer` (all Tailwind v4 output is layered), so this adds no new floor.

## Verification

- Live before/after on the dev server (rspack, :1998) via browser probe: `p-4` computed `0px` before, `16px` after; `select-text` computed `none` before, `text` after; `mt-1` = 4px; `gap-2` unchanged at 8px.
- Rule-walk of `document.styleSheets` after the fix shows every margin/padding-zeroing rule (splash + app resets) inside `@layer base`, with `.p-4` in `@layer utilities` winning.
- Full app visual check in the Tauri webview after reload (dev flow).
- Not run: production build (template change is bundler-agnostic; HtmlPlugin inlines the same file in both webpack and rspack).
