### PR TITLE
ci(typecheck): run tsgo in ci, keep tsc as nightly arbiter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Type check
-        run: pnpm typecheck
-        env:
-          NODE_OPTIONS: "--max-old-space-size=6144"
+      # tsgo (@typescript/native-preview): native full-project check,
+      # measured ~10s idle vs 65s warm-incremental / >10min cold for tsc on
+      # this codebase. tsc remains the arbiter in nightly-full-checks.yml —
+      # if the preview compiler ever disagrees, nightly surfaces it within
+      # 24h and this step can be pointed back at `pnpm typecheck`.
+      - name: Type check (tsgo)
+        run: pnpm typecheck:fast
 
       # Every rule in package.json#eslintConfig judges one file at a time, so a pull request
       # cannot make an untouched file newly non-compliant; whole-tree linting

--- a/.github/workflows/nightly-full-checks.yml
+++ b/.github/workflows/nightly-full-checks.yml
@@ -61,8 +61,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # tsc is the stable arbiter now that ci.yml type-checks with tsgo
+      # (a preview compiler): a nightly tsc pass catches any divergence
+      # between the two within 24h.
+      - name: Type check (tsc, arbiter)
+        run: pnpm typecheck
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
+
       # Whole tree, not a diff -- this is the coverage ci.yml gave up.
+      # `always()` so a typecheck failure still leaves lint/test results.
       - name: Lint (full tree)
+        if: always()
         run: pnpm lint
 
       # `always()` so a lint failure still leaves a test result to read; both


### PR DESCRIPTION
## Problem

CI's Type check step runs `tsc --noEmit` with a 6 GB heap allowance. On a runner there is no tsbuildinfo cache, so every PR pays the cold price — locally measured at **>10 minutes under load** and ~60 s of CI wall time today at ~3 GB peak RSS. Since #1193 the repo carries tsgo (`pnpm typecheck:fast`), verified zero-error-identical to tsc on the full 197k-LOC program, but CI has not used it.

## Solution

- **ci.yml**: the per-PR Type check step now runs `pnpm typecheck:fast` (tsgo). Measured on an idle machine: **9.9 s wall at 430% CPU, exit 0**, vs 65 s warm-incremental tsc. The `NODE_OPTIONS --max-old-space-size=6144` allowance is dropped from this step — tsgo is a native binary.
- **nightly-full-checks.yml**: adds a `Type check (tsc, arbiter)` step (with the heap allowance moved there). tsgo is a preview compiler (pinned `7.0.0-dev.20260707.2`), so tsc stays authoritative: any divergence between the two surfaces within 24h, same pattern as nightly's full-tree lint. The Lint step gets `if: always()` so a typecheck failure still leaves lint and test results to read — mirroring the existing unit-test step's rationale.

## Potential risks

- **A type error only tsc catches would land and surface next nightly, not at PR time.** The two compilers were verified identical on the current tree (zero errors both), and the pre-commit hook also runs tsgo — but implementation gaps in a preview compiler are the residual risk. Rollback is one line: point the CI step back at `pnpm typecheck`.
- The inverse (tsgo stricter than tsc) fails PRs tsc would pass; fix would be a mirror adjustment or a pin bump, both cheap.
- `typecheck:fast` resolves the tsgo binary from devDependencies via pnpm — CI installs with `--frozen-lockfile`, and the per-platform binaries (incl. linux-x64 for ubuntu runners) are already in the lockfile since #1193.
- Nightly gains ~1–4 min for the tsc arbiter step; acceptable for a daily job.

## Verification

- `pnpm typecheck:fast` on the current tree: **exit 0 in 9.9 s** (430% CPU, idle machine) — the exact command the new CI step runs.
- tsc/tsgo parity: both verified zero-error on the full program when #1193 landed; the tsconfig has not changed resolution semantics since.
- Workflow YAML changes reviewed in the diff; not run: an actual GitHub Actions execution of the modified workflows (first PR run of this branch exercises ci.yml itself; nightly runs on its schedule).
- No UI change; no screenshots applicable.