### PR TITLE
fix(sidebar): align the top bar with the sidebar list padding

### DIFF
--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -288,7 +288,12 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
           style={
             {
               height: `${SIDEBAR_STYLE.topBarHeight}px`,
-              paddingLeft: IS_WINDOWS_HOST
+              // Only macOS needs an inline reserve for the traffic lights.
+              // Windows/Linux (and browser mode, which resolves to Linux) must
+              // fall through to the alignment class above — an inline `0px`
+              // would beat `pl-3` and pull the top bar flush to the sidebar
+              // edge, out of line with the list rows below it.
+              paddingLeft: IS_WINDOWS_OR_LINUX_HOST
                 ? undefined
                 : `${trafficLightPadding}px`,
               WebkitAppRegion: IS_WINDOWS_HOST ? "no-drag" : "drag",


### PR DESCRIPTION
## Problem

In the navigation sidebar, the top bar (org selector on Windows/Linux, the "ORG2" wordmark when a variant supplies no leading content) sits flush against the sidebar's left edge, while everything below it — the tab row, the nav list rows, and the account footer — is inset 12px. The result is a visibly ragged left margin on Linux.

Cause: `renderTrafficLightsSpace` in `SidebarBase.tsx` reserves room for the macOS traffic lights with an **inline** `paddingLeft`, computed as `0` on every non-macOS host. The same element already carries a Tailwind alignment class (`pl-3` with leading content, `pl-5` without), and an inline declaration always beats a class — so on Linux the inline `0px` silently cancelled `pl-3`. Windows was already exempted from the inline style (`IS_WINDOWS_HOST ? undefined : …`) and therefore looked correct; Linux fell through the exemption.

## Solution

Widen the exemption from `IS_WINDOWS_HOST` to `IS_WINDOWS_OR_LINUX_HOST`, so both hosts fall through to the alignment class instead of receiving an inline zero. The top bar then honors `pl-3` (12px) and lines up with the list container's `px-3` and the footer's `px-3`.

macOS is untouched: it still receives the inline `SIDEBAR_STYLE.trafficLightsPadding` (80px) reserve, and `0` in fullscreen where the lights are hidden and the class list carries no `pl-*` anyway. The `WebkitAppRegion` drag behavior on the same element is a separate ternary and is not changed.

## Potential risks

- **Linux is the only platform whose rendering changes.** The top bar shifts right by 12px (or 20px in the no-leading-content variant, which uses `pl-5`). That variant is not reachable from the shipped sidebars — `WorkstationSidebarConnector` passes the org selector and `SettingsSidebar` passes the return item — but if a future variant omits leading content, its wordmark will sit 8px further in than the list rows. Left as-is rather than silently restyling a surface this change does not otherwise touch.
- No behavior change for macOS or Windows; no change to drag regions, height, or the fullscreen path.
- Purely presentational: no state, IPC, or persistence surface is involved.

## Verification

- Measured in a live render against the running dev server, offsets relative to the sidebar's left edge:

  | Element | Before | After |
  | --- | --- | --- |
  | Org selector row | 0px | 12px |
  | Tab icon row | 12px | 12px |
  | Nav list rows | 12px | 12px |
  | Account footer | 12px | 12px |

  Confirmed the computed `padding-left` on the top bar is now `12px` and its inline `style` attribute no longer carries a `padding-left` declaration (only `height` and `app-region`).
- Visual check of the rendered sidebar before/after.
- `SidebarBase` has no test pinning the top-bar padding (repo-wide grep for `trafficLightsPadding` / `pl-5 pr-2` / `pl-3 pr-2` in `*.test.ts` returns nothing), so no test updates were required and none were added — this is a one-line cascade fix whose evidence is the measured layout above.
- Not run: the macOS and Windows paths were reasoned about from the diff rather than executed, since the change only widens an existing exemption those hosts already sat on either side of.
