### PR TITLE
feat(chat): add display visibility controls

### DIFF
--- a/docs/frontend-ui-audit-2026-09-01/ChatPanelStartPage.md
+++ b/docs/frontend-ui-audit-2026-09-01/ChatPanelStartPage.md
@@ -1,0 +1,8 @@
+# ChatPanelStartPage UI audit
+
+| Line                                               | Element                             | Verdict          | Reason                                                                                                            | Suggested change |
+| -------------------------------------------------- | ----------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/engines/ChatPanel/ChatPanelStartPage.tsx:187` | Conditional launchpad quick actions | keep with reason | Visibility is applied before rendering, so hidden actions leave no empty wrapper or inaccessible controls behind. | None.            |
+| `src/engines/ChatPanel/ChatPanelStartPage.tsx:189` | Quick-action card/pill presentation | keep with reason | Continues to use the shared `LaunchpadActionCard` component for both existing responsive presentations.           | None.            |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-01/NewChatHeaderActionsMenu.md
+++ b/docs/frontend-ui-audit-2026-09-01/NewChatHeaderActionsMenu.md
@@ -1,0 +1,8 @@
+# NewChatHeaderActionsMenu UI audit
+
+| Line                                                                | Element                      | Verdict          | Reason                                                                                                                                              | Suggested change |
+| ------------------------------------------------------------------- | ---------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/engines/ChatPanel/components/NewChatHeaderActionsMenu.tsx:159` | Quick-actions visibility row | keep with reason | Reuses the shared dropdown control-row token and design-system `Switch`, including an accessible label and stable test selector.                    | None.            |
+| `src/engines/ChatPanel/components/NewChatHeaderActionsMenu.tsx:171` | Skills visibility row        | keep with reason | Reuses the same control-row and `Switch` pattern, shares the canonical persisted preference, and retains the product term “Skills” in every locale. | None.            |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-01/PinnedActionsBar.md
+++ b/docs/frontend-ui-audit-2026-09-01/PinnedActionsBar.md
@@ -1,0 +1,8 @@
+# PinnedActionsBar UI audit
+
+| Line                                                                                      | Element                        | Verdict          | Reason                                                                                                                                          | Suggested change |
+| ----------------------------------------------------------------------------------------- | ------------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/engines/ChatPanel/InputArea/components/PinnedActionsBar/LazyPinnedActionsBar.tsx:5`  | Lazy Skills component boundary | keep with reason | Uses the repository’s Webpack-compatible `React.lazy` and `Suspense` pattern, loading the existing design-system-backed surface only on opt-in. | None.            |
+| `src/engines/ChatPanel/InputArea/components/PinnedActionsBar/LazyPinnedActionsBar.tsx:20` | Inactive composer-control row  | keep with reason | Preserves the existing non-Skills leading/trailing control layout without rendering hidden interactive controls or an empty Skills wrapper.     | None.            |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-01/SessionHeaderActionsMenu.md
+++ b/docs/frontend-ui-audit-2026-09-01/SessionHeaderActionsMenu.md
@@ -1,0 +1,7 @@
+# SessionHeaderActionsMenu UI audit
+
+| Line                                                                | Element               | Verdict          | Reason                                                                                                                            | Suggested change |
+| ------------------------------------------------------------------- | --------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx:509` | Skills visibility row | keep with reason | Uses the existing UI-settings submenu structure and design-system `Switch`, with the same shared preference and accessible label. | None.            |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.

--- a/src/engines/ChatPanel/ChatPanelEmptyContent.tsx
+++ b/src/engines/ChatPanel/ChatPanelEmptyContent.tsx
@@ -245,7 +245,8 @@ export function ChatPanelEmptyContent({
     className: string,
     layout: "default" | "launchpad" = "default",
     heroFooterSlot?: React.ReactNode,
-    multiRunnerLauncher = false
+    multiRunnerLauncher = false,
+    hideWorkItemAttachmentControl = false
   ) =>
     SessionCreatorSlot ? (
       <SessionCreatorSlot
@@ -254,6 +255,7 @@ export function ChatPanelEmptyContent({
         layout={layout}
         heroFooterSlot={heroFooterSlot}
         hidePresenceButton
+        hideWorkItemAttachmentControl={hideWorkItemAttachmentControl}
         // Only the Parallel-run create target fans out. Every other launcher
         // — Session, work item, project — starts one agent.
         multiRunnerLauncher={multiRunnerLauncher}
@@ -346,8 +348,17 @@ export function ChatPanelEmptyContent({
   );
 
   if (showStartPage) {
-    const sessionLauncher = (heroFooterSlot: React.ReactNode) =>
-      renderSessionLauncher("h-full", "launchpad", heroFooterSlot);
+    const sessionLauncher = (
+      heroFooterSlot: React.ReactNode,
+      launchpadActionsVisible: boolean
+    ) =>
+      renderSessionLauncher(
+        "h-full",
+        "launchpad",
+        heroFooterSlot,
+        false,
+        !launchpadActionsVisible
+      );
     const moreCreateTarget =
       createTarget === CHAT_PANEL_CREATE_TARGET.PROJECT ||
       createTarget === CHAT_PANEL_CREATE_TARGET.PARALLEL_RUN ||

--- a/src/engines/ChatPanel/ChatPanelStartPage.test.ts
+++ b/src/engines/ChatPanel/ChatPanelStartPage.test.ts
@@ -1,8 +1,10 @@
 import type { TFunction } from "i18next";
+import { Provider, createStore } from "jotai";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
+import { creatorLaunchpadActionsVisibleAtom } from "@src/store/session/creatorLaunchpadActionsVisibleAtom";
 import { CHAT_PANEL_CREATE_TARGET } from "@src/store/ui/chatPanelAtom";
 
 import { ChatPanelStartPage } from "./ChatPanelStartPage";
@@ -226,6 +228,57 @@ describe("ChatPanelStartPage", () => {
     expect(markup).not.toContain("bg-bg-1");
     expect(markup).toContain("hover:bg-surface-hover");
     expect(markup).not.toContain("group-hover:bg-fill-3");
+  });
+
+  it("hides the complete launchpad quick-action group when disabled", () => {
+    mocks.useAvailableAppUpdate.mockReturnValue({
+      available: true,
+      version: "1.1.20",
+    });
+    const t = ((key: string) => key) as TFunction<
+      ["sessions", "common", "projects", "navigation"]
+    >;
+    const store = createStore();
+    store.set(creatorLaunchpadActionsVisibleAtom, false);
+    let receivedVisibility: boolean | undefined;
+
+    const markup = renderToStaticMarkup(
+      createElement(
+        Provider,
+        { store },
+        createElement(ChatPanelStartPage, {
+          ...createTargetProps,
+          createTarget: CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
+          sessionLauncher: (heroFooterSlot, launchpadActionsVisible) => {
+            receivedVisibility = launchpadActionsVisible;
+            return createElement(
+              "div",
+              {
+                "data-testid": "session-launcher",
+                "data-quick-actions-visible": String(launchpadActionsVisible),
+              },
+              heroFooterSlot
+            );
+          },
+          t,
+        })
+      )
+    );
+
+    expect(receivedVisibility).toBe(false);
+    expect(markup).toContain('data-quick-actions-visible="false"');
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-start-page-install-latest-update"'
+    );
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-start-page-import-session"'
+    );
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-start-page-add-api-key"'
+    );
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-start-page-show-runtime"'
+    );
   });
 
   it("renders the full work-item creator inside the Work Item tab", () => {

--- a/src/engines/ChatPanel/ChatPanelStartPage.tsx
+++ b/src/engines/ChatPanel/ChatPanelStartPage.tsx
@@ -22,6 +22,7 @@ import {
 import { CreatorContentLayout } from "@src/modules/shared/layouts/blocks";
 import { useAvailableAppUpdate } from "@src/scaffold/AppUpdater";
 import { creatorComposerPositionAtom } from "@src/store/session/creatorComposerPositionAtom";
+import { creatorLaunchpadActionsVisibleAtom } from "@src/store/session/creatorLaunchpadActionsVisibleAtom";
 import {
   CHAT_PANEL_CREATE_TARGET,
   type ChatPanelCreateTarget,
@@ -44,7 +45,10 @@ interface ChatPanelStartPageProps {
   onProjectAgentModeChange: (enabled: boolean) => void;
   onWorkItemAgentModeChange: (enabled: boolean) => void;
   projectAgentMode: boolean;
-  sessionLauncher?: (heroFooterSlot: React.ReactNode) => React.ReactNode;
+  sessionLauncher?: (
+    heroFooterSlot: React.ReactNode,
+    launchpadActionsVisible: boolean
+  ) => React.ReactNode;
   t: TFunction<["sessions", "common", "projects", "navigation"]>;
   workItemAgentMode: boolean;
   workItemLauncher?: (
@@ -100,6 +104,9 @@ export function ChatPanelStartPage({
   workItemLauncher,
 }: ChatPanelStartPageProps): React.ReactNode {
   const composerPosition = useAtomValue(creatorComposerPositionAtom);
+  const launchpadActionsVisible = useAtomValue(
+    creatorLaunchpadActionsVisibleAtom
+  );
   const [isImportSessionDialogOpen, setIsImportSessionDialogOpen] =
     useState(false);
   const availableUpdate = useAvailableAppUpdate();
@@ -177,15 +184,19 @@ export function ChatPanelStartPage({
       : createTarget === CHAT_PANEL_CREATE_TARGET.WORK_ITEM
         ? "work-item"
         : "more";
-  const suggestionActions = utilityActions.map((action) => (
-    <LaunchpadActionCard
-      key={action.id}
-      action={action}
-      presentation={
-        composerPosition === CREATOR_COMPOSER_POSITION.MIDDLE ? "pill" : "card"
-      }
-    />
-  ));
+  const suggestionActions = launchpadActionsVisible
+    ? utilityActions.map((action) => (
+        <LaunchpadActionCard
+          key={action.id}
+          action={action}
+          presentation={
+            composerPosition === CREATOR_COMPOSER_POSITION.MIDDLE
+              ? "pill"
+              : "card"
+          }
+        />
+      ))
+    : null;
   const manualMiddleContent = (
     <div
       className="flex w-full flex-col items-center justify-center gap-4"
@@ -216,7 +227,10 @@ export function ChatPanelStartPage({
       t={t}
     />
   );
-  const sessionLauncherContent = sessionLauncher?.(suggestionActions);
+  const sessionLauncherContent = sessionLauncher?.(
+    suggestionActions,
+    launchpadActionsVisible
+  );
   const workItemLauncherContent = workItemLauncher?.(
     manualMiddleContent,
     workItemModeControl

--- a/src/engines/ChatPanel/InputArea/components/InputAreaChrome.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/InputAreaChrome.test.ts
@@ -9,7 +9,7 @@ import { InputAreaTopRows } from "./InputAreaChrome";
 
 vi.mock("../ChatHeader", () => ({ default: () => null }));
 vi.mock("./PlanTodoPill", () => ({ default: () => null }));
-vi.mock("./PinnedActionsBar", async () => {
+vi.mock("./PinnedActionsBar/LazyPinnedActionsBar", async () => {
   const ReactModule = await import("react");
   return {
     default: ({ showPinnedActions }: { showPinnedActions?: boolean }) =>

--- a/src/engines/ChatPanel/InputArea/components/InputAreaChrome.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputAreaChrome.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+import type { ComposerInputRef } from "@src/components/ComposerInput";
 import { INPUT_AREA } from "@src/config/inputAreaTokens";
 import { ChatStatusSegmentedBar } from "@src/engines/ChatPanel/components/ChatStatusBanners";
 
 import ChatHeader from "../ChatHeader";
 import EditModeImageThumbnail from "./EditModeImageThumbnail";
 import ImageAttachmentPreview from "./ImageAttachmentPreview";
-import PinnedActionsBar from "./PinnedActionsBar";
+import LazyPinnedActionsBar from "./PinnedActionsBar/LazyPinnedActionsBar";
 import PlanTodoPill from "./PlanTodoPill";
 
 interface TopRowsProps {
@@ -15,9 +16,7 @@ interface TopRowsProps {
   omitChatHeader: boolean;
   topRowPills?: React.ReactNode;
   topRowTrailingContent?: React.ReactNode;
-  composerInputRef: React.ComponentProps<
-    typeof PinnedActionsBar
-  >["composerInputRef"];
+  composerInputRef: React.RefObject<ComposerInputRef | null>;
   sessionId?: string;
   showPinnedActions: boolean;
   skillWorkspacePaths?: string[];
@@ -38,7 +37,7 @@ export const InputAreaTopRows: React.FC<TopRowsProps> = ({
       {!isEditMode && !omitChatHeader && <ChatHeader />}
       {!isEditMode && (
         <div className="relative z-10 flex min-w-0 items-center gap-1 px-0.5 pb-1.5">
-          <PinnedActionsBar
+          <LazyPinnedActionsBar
             composerInputRef={composerInputRef}
             sessionId={sessionId}
             workspacePaths={skillWorkspacePaths ?? undefined}

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/LazyPinnedActionsBar.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/LazyPinnedActionsBar.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { ComposerInputRef } from "@src/components/ComposerInput";
+
+import LazyPinnedActionsBar from "./LazyPinnedActionsBar";
+
+const mocks = vi.hoisted(() => ({
+  moduleLoads: 0,
+}));
+
+vi.mock(".", async () => {
+  mocks.moduleLoads += 1;
+  const React = await import("react");
+  return {
+    default: () =>
+      React.createElement("div", {
+        "data-testid": "loaded-pinned-actions-bar",
+      }),
+  };
+});
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("LazyPinnedActionsBar", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    mocks.moduleLoads = 0;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps the skills chunk unloaded until visibility is enabled", async () => {
+    const composerInputRef = createRef<ComposerInputRef>();
+
+    act(() => {
+      root.render(
+        createElement(LazyPinnedActionsBar, {
+          composerInputRef,
+          leadingContent: createElement("span", null, "Plan controls"),
+          showPinnedActions: false,
+        })
+      );
+    });
+
+    expect(mocks.moduleLoads).toBe(0);
+    expect(container.textContent).toContain("Plan controls");
+    expect(
+      container.querySelector('[data-testid="loaded-pinned-actions-bar"]')
+    ).toBeNull();
+
+    await act(async () => {
+      root.render(
+        createElement(LazyPinnedActionsBar, {
+          composerInputRef,
+          leadingContent: createElement("span", null, "Plan controls"),
+          showPinnedActions: true,
+        })
+      );
+    });
+
+    expect(mocks.moduleLoads).toBe(1);
+    expect(
+      container.querySelector('[data-testid="loaded-pinned-actions-bar"]')
+    ).not.toBeNull();
+  });
+});

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/LazyPinnedActionsBar.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/LazyPinnedActionsBar.tsx
@@ -1,0 +1,72 @@
+import React, { Suspense, lazy } from "react";
+
+import type { PinnedActionsBarProps } from ".";
+
+const PinnedActionsBar = lazy(() => import("."));
+
+type InactivePinnedActionsRowProps = Pick<
+  PinnedActionsBarProps,
+  "leadingContent" | "manageButtonPlacement" | "trailingContent"
+>;
+
+/** Keep non-skill composer controls stable without loading the skills surface. */
+function InactivePinnedActionsRow({
+  leadingContent,
+  manageButtonPlacement = "after-actions",
+  trailingContent,
+}: InactivePinnedActionsRowProps): React.ReactNode {
+  const hasTrailingContent = Boolean(trailingContent);
+
+  return (
+    <div className="relative flex min-w-0 flex-1 items-center gap-1">
+      {manageButtonPlacement === "before-actions" ? (
+        <div className="scrollbar-hide flex min-w-0 flex-1 items-center gap-1 overflow-x-auto py-0.5">
+          <div className="flex shrink-0 items-center gap-1">
+            {leadingContent}
+            {trailingContent}
+          </div>
+        </div>
+      ) : manageButtonPlacement === "after-leading" ? (
+        <>
+          <div className="flex shrink-0 items-center gap-1">
+            {leadingContent}
+          </div>
+          {hasTrailingContent && (
+            <div aria-hidden className="mx-1 h-4 w-px shrink-0 bg-border-2" />
+          )}
+          <div className="scrollbar-hide flex min-w-0 flex-1 items-center gap-1 overflow-x-auto py-0.5">
+            {trailingContent}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="scrollbar-hide flex min-w-0 flex-1 items-center gap-1 overflow-x-auto py-0.5">
+            {leadingContent}
+          </div>
+          {hasTrailingContent && (
+            <div aria-hidden className="mx-1 h-4 w-px shrink-0 bg-border-2" />
+          )}
+          {trailingContent}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Defers the pinned skills/actions chunk until the shared visibility preference
+ * is enabled. The inactive row preserves non-skill composer controls.
+ */
+export default function LazyPinnedActionsBar(
+  props: PinnedActionsBarProps
+): React.ReactNode {
+  if (props.showPinnedActions === false) {
+    return <InactivePinnedActionsRow {...props} />;
+  }
+
+  return (
+    <Suspense fallback={<InactivePinnedActionsRow {...props} />}>
+      <PinnedActionsBar {...props} />
+    </Suspense>
+  );
+}

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
@@ -113,7 +113,7 @@ ActionPill.displayName = "ActionPill";
 
 // ── main component ────────────────────────────────────────────────────────────
 
-interface PinnedActionsBarProps {
+export interface PinnedActionsBarProps {
   /** Ref to the composer, used to insert content when a pill is clicked. */
   composerInputRef: React.RefObject<ComposerInputRef | null>;
   /**

--- a/src/engines/ChatPanel/components/NewChatHeaderActionsMenu.test.ts
+++ b/src/engines/ChatPanel/components/NewChatHeaderActionsMenu.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CREATOR_LAUNCHPAD_ACTIONS_VISIBLE_STORAGE_KEY,
+  creatorLaunchpadActionsVisibleAtom,
+} from "@src/store/session/creatorLaunchpadActionsVisibleAtom";
+import {
+  PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
+  pinnedActionsVisibleAtom,
+} from "@src/store/session/creatorPinnedActionsVisibleAtom";
+
+import { NewChatHeaderActionsMenu } from "./NewChatHeaderActionsMenu";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/hooks/dropdown", () => ({
+  getDropdownPanelStyle: () => ({}),
+  useDropdownEngine: () => ({
+    isOpen: true,
+    isPositioned: true,
+    toggle: vi.fn(),
+    close: vi.fn(),
+    triggerRef: { current: null },
+    panelRef: { current: null },
+    panelPosition: { left: 0, top: 0, width: 220 },
+  }),
+}));
+
+vi.mock("@src/components/Dropdown/ActionMenuSurface", async () => {
+  const React = await import("react");
+  return {
+    ActionMenuSurface: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    ActionSubmenu: ({
+      children,
+      dataTestId,
+    }: {
+      children: React.ReactNode;
+      dataTestId?: string;
+    }) => React.createElement("div", { "data-testid": dataTestId }, children),
+  };
+});
+
+describe("NewChatHeaderActionsMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    localStorage.removeItem(CREATOR_LAUNCHPAD_ACTIONS_VISIBLE_STORAGE_KEY);
+    localStorage.removeItem(PINNED_ACTIONS_VISIBLE_STORAGE_KEY);
+    store = createStore();
+    store.set(creatorLaunchpadActionsVisibleAtom, true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(NewChatHeaderActionsMenu)
+        )
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    vi.clearAllMocks();
+  });
+
+  it("toggles the persisted launchpad quick-action preference", () => {
+    const toggle = document.querySelector<HTMLButtonElement>(
+      '[data-testid="new-chat-show-quick-actions-toggle"]'
+    );
+
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("aria-label")).toBe(
+      "chat.startPage.showQuickActions"
+    );
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+
+    act(() => toggle?.click());
+
+    expect(store.get(creatorLaunchpadActionsVisibleAtom)).toBe(false);
+    expect(toggle?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("shows the skills toggle off by default and can enable pinned skills", () => {
+    const toggle = document.querySelector<HTMLButtonElement>(
+      '[data-testid="new-chat-show-skills-toggle"]'
+    );
+
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("aria-label")).toBe(
+      "chat.startPage.showSkills"
+    );
+    expect(toggle?.getAttribute("aria-checked")).toBe("false");
+
+    act(() => toggle?.click());
+
+    expect(store.get(pinnedActionsVisibleAtom)).toBe(true);
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+  });
+});

--- a/src/engines/ChatPanel/components/NewChatHeaderActionsMenu.tsx
+++ b/src/engines/ChatPanel/components/NewChatHeaderActionsMenu.tsx
@@ -22,6 +22,8 @@ import { getDropdownPanelStyle, useDropdownEngine } from "@src/hooks/dropdown";
 import { HugeiconsIcon, Layers01Icon, MoreHorizontalIcon } from "@src/icons";
 import { cliUpdateAlertsEnabledAtom } from "@src/store/session/cliUpdateAlertsAtom";
 import { creatorComposerPositionAtom } from "@src/store/session/creatorComposerPositionAtom";
+import { creatorLaunchpadActionsVisibleAtom } from "@src/store/session/creatorLaunchpadActionsVisibleAtom";
+import { pinnedActionsVisibleAtom } from "@src/store/session/creatorPinnedActionsVisibleAtom";
 import {
   changeCreatorComposerPositionAtom,
   creatorRepoChromePositionAtom,
@@ -36,6 +38,12 @@ export function NewChatHeaderActionsMenu(): React.ReactNode {
   const setComposerPosition = useSetAtom(changeCreatorComposerPositionAtom);
   const [trailPosition, setTrailPosition] = useAtom(
     creatorRepoChromePositionAtom
+  );
+  const [launchpadActionsVisible, setLaunchpadActionsVisible] = useAtom(
+    creatorLaunchpadActionsVisibleAtom
+  );
+  const [pinnedActionsVisible, setPinnedActionsVisible] = useAtom(
+    pinnedActionsVisibleAtom
   );
   const {
     isOpen,
@@ -53,6 +61,8 @@ export function NewChatHeaderActionsMenu(): React.ReactNode {
     autoKeyboardNavigation: false,
     closeOnEsc: false,
   });
+  const showQuickActionsLabel = t("chat.startPage.showQuickActions");
+  const showSkillsLabel = t("chat.startPage.showSkills");
   const showCliUpdateLabel = t("chat.startPage.showCliUpdate");
 
   return (
@@ -144,6 +154,30 @@ export function NewChatHeaderActionsMenu(): React.ReactNode {
                     },
                   ]}
                   onChange={setTrailPosition}
+                />
+              </div>
+              <div className={DROPDOWN_CLASSES.menuControlItem}>
+                <span className="min-w-0 flex-1 truncate">
+                  {showQuickActionsLabel}
+                </span>
+                <Switch
+                  checked={launchpadActionsVisible}
+                  onCheckedChange={setLaunchpadActionsVisible}
+                  size="small"
+                  ariaLabel={showQuickActionsLabel}
+                  dataTestId="new-chat-show-quick-actions-toggle"
+                />
+              </div>
+              <div className={DROPDOWN_CLASSES.menuControlItem}>
+                <span className="min-w-0 flex-1 truncate">
+                  {showSkillsLabel}
+                </span>
+                <Switch
+                  checked={pinnedActionsVisible}
+                  onCheckedChange={setPinnedActionsVisible}
+                  size="small"
+                  ariaLabel={showSkillsLabel}
+                  dataTestId="new-chat-show-skills-toggle"
                 />
               </div>
               <div className={DROPDOWN_CLASSES.menuControlItem}>

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts
@@ -29,6 +29,8 @@ const mocks = vi.hoisted(() => ({
   appOpenPlan: vi.fn(),
   openInApp: vi.fn(),
   messageError: vi.fn(),
+  pinnedActionsVisible: false,
+  setPinnedActionsVisible: vi.fn(),
 }));
 
 vi.mock("@src/api/tauri/externalHistory/appOpen", () => ({
@@ -46,6 +48,7 @@ vi.mock("@src/assets/modelIcons/openai.svg", () => ({
 }));
 vi.mock("jotai", async (importOriginal) => ({
   ...(await importOriginal<typeof import("jotai")>()),
+  useAtom: () => [mocks.pinnedActionsVisible, mocks.setPinnedActionsVisible],
   useAtomValue: () => mocks.session,
   useSetAtom: () => mocks.openWindow,
 }));
@@ -139,6 +142,7 @@ beforeEach(() => {
   ).IS_REACT_ACT_ENVIRONMENT = true;
   vi.clearAllMocks();
   mocks.eligible = true;
+  mocks.pinnedActionsVisible = false;
   mocks.appOpenPlan.mockResolvedValue(null);
   mocks.openInApp.mockResolvedValue(undefined);
   container = document.createElement("div");
@@ -397,7 +401,7 @@ describe("SessionHeaderActionsMenu", () => {
     expect(props.toggleHeaderActionsMenu).not.toHaveBeenCalled();
   });
 
-  it("nests the four display switches under UI settings without closing on toggle", () => {
+  it("nests the five display switches under UI settings without closing on toggle", () => {
     render();
     expect(document.querySelector('[role="switch"]')).toBeNull();
     expect(element("session-ui-settings-submenu").textContent).toBe(
@@ -410,6 +414,7 @@ describe("SessionHeaderActionsMenu", () => {
     expect(
       [...switches].map((control) => control.getAttribute("aria-label"))
     ).toEqual([
+      "chat.startPage.showSkills",
       "chat.showTokenUsage",
       "chat.showTurnMetadata",
       "common:pagination.title",
@@ -421,6 +426,10 @@ describe("SessionHeaderActionsMenu", () => {
     key("ArrowDown");
     expect(document.activeElement).toBe(switches[1]);
     act(() => switches.forEach((control) => control.click()));
+    expect(mocks.setPinnedActionsVisible).toHaveBeenCalledWith(
+      true,
+      expect.anything()
+    );
     expect(props.handleTokenUsageVisibleToggle).toHaveBeenCalledWith(
       true,
       expect.anything()

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import React from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
@@ -39,6 +39,7 @@ import {
   ThirdBracketIcon,
 } from "@src/icons";
 import { sessionByIdAtom, upsertSession } from "@src/store/session";
+import { pinnedActionsVisibleAtom } from "@src/store/session/creatorPinnedActionsVisibleAtom";
 import { openSessionInNewWindowAtom } from "@src/store/session/sessionTabPlacementAtom";
 import type { ChatHistoryDisplayMode } from "@src/store/ui/chatPanelAtom";
 import { isAgentSession } from "@src/util/session/sessionDispatch";
@@ -123,6 +124,10 @@ export const SessionHeaderActionsMenu: React.FC<
   const moveToWorkstation = moveTarget === "workstation";
 
   const currentSession = useAtomValue(sessionByIdAtom(currentSessionId ?? ""));
+  const [pinnedActionsVisible, setPinnedActionsVisible] = useAtom(
+    pinnedActionsVisibleAtom
+  );
+  const showSkillsLabel = t("chat.startPage.showSkills");
 
   // Track this / Convert to Project (orgtrack/v1 §7.2). Self-contained:
   // the backend command persists the switch + root WorkItem; only the
@@ -501,6 +506,18 @@ export const SessionHeaderActionsMenu: React.FC<
                   }
                   dataTestId="session-ui-settings-submenu"
                 >
+                  <div
+                    className={`${DROPDOWN_CLASSES.item} w-full justify-between text-left`}
+                  >
+                    <span className="flex-1 truncate">{showSkillsLabel}</span>
+                    <Switch
+                      checked={pinnedActionsVisible}
+                      onCheckedChange={setPinnedActionsVisible}
+                      size="small"
+                      ariaLabel={showSkillsLabel}
+                      dataTestId="session-menu-show-skills-toggle"
+                    />
+                  </div>
                   <div
                     className={`${DROPDOWN_CLASSES.item} w-full justify-between text-left`}
                   >

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -16,7 +16,7 @@ import {
 } from "@src/config/sessionCreatorConfig";
 import type { ScrollNavState } from "@src/engines/ChatPanel/ChatHistory";
 import CollapsedInlineRow from "@src/engines/ChatPanel/InputArea/components/CollapsedInlineRow";
-import PinnedActionsBar from "@src/engines/ChatPanel/InputArea/components/PinnedActionsBar";
+import LazyPinnedActionsBar from "@src/engines/ChatPanel/InputArea/components/PinnedActionsBar/LazyPinnedActionsBar";
 import { usePinnedActionsVisibilityContextMenu } from "@src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu";
 import type { SessionLaunchWorkItemContext } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
 import { LaunchpadActionGrid } from "@src/features/SessionCreator/components/LaunchpadActionGrid";
@@ -267,7 +267,7 @@ const SessionCreatorChatPanelView: React.FC<
       className={`mx-auto flex w-full items-center ${CHAT_PANEL_WIDTH_TOKENS.contentMaxWidth}`}
       onContextMenu={handlePinnedActionsContextMenu}
     >
-      <PinnedActionsBar
+      <LazyPinnedActionsBar
         composerInputRef={composerInputRef}
         manageButtonPlacement="before-actions"
         managePanelAlign="left"

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -885,6 +885,8 @@
       "positionUp": "Oben",
       "positionDown": "Unten",
       "uiControls": "UI-Steuerung",
+      "showQuickActions": "Schnellaktionen anzeigen",
+      "showSkills": "Skills anzeigen",
       "showCliUpdate": "CLI-Updates anzeigen",
       "title": "Was möchtest du tun?",
       "back": "Zurück zur Startseite",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -942,6 +942,8 @@
       "positionUp": "Up",
       "positionDown": "Down",
       "uiControls": "UI controls",
+      "showQuickActions": "Show quick actions",
+      "showSkills": "Show Skills",
       "showCliUpdate": "Show CLI update",
       "title": "What would you like to do?",
       "back": "Back to start page",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -887,6 +887,8 @@
       "positionUp": "Arriba",
       "positionDown": "Abajo",
       "uiControls": "Controles de interfaz",
+      "showQuickActions": "Mostrar acciones rápidas",
+      "showSkills": "Mostrar Skills",
       "showCliUpdate": "Mostrar actualizaciones de CLI",
       "title": "¿Qué quieres hacer?",
       "back": "Volver a la página inicial",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -887,6 +887,8 @@
       "positionUp": "Haut",
       "positionDown": "Bas",
       "uiControls": "Contrôles de l’interface",
+      "showQuickActions": "Afficher les actions rapides",
+      "showSkills": "Afficher Skills",
       "showCliUpdate": "Afficher les mises à jour CLI",
       "title": "Que voulez-vous faire ?",
       "back": "Retour à la page de départ",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -886,6 +886,8 @@
       "positionUp": "上",
       "positionDown": "下",
       "uiControls": "UI コントロール",
+      "showQuickActions": "クイックアクションを表示",
+      "showSkills": "Skills を表示",
       "showCliUpdate": "CLI の更新を表示",
       "title": "何をしますか？",
       "back": "スタートページに戻る",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -886,6 +886,8 @@
       "positionUp": "위",
       "positionDown": "아래",
       "uiControls": "UI 컨트롤",
+      "showQuickActions": "빠른 작업 표시",
+      "showSkills": "Skills 표시",
       "showCliUpdate": "CLI 업데이트 표시",
       "title": "무엇을 할까요?",
       "back": "시작 페이지로 돌아가기",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -888,6 +888,8 @@
       "positionUp": "Góra",
       "positionDown": "Dół",
       "uiControls": "Elementy interfejsu",
+      "showQuickActions": "Pokaż szybkie akcje",
+      "showSkills": "Pokaż Skills",
       "showCliUpdate": "Pokaż aktualizacje CLI",
       "title": "Co chcesz zrobić?",
       "back": "Wróć do strony startowej",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -886,6 +886,8 @@
       "positionUp": "Acima",
       "positionDown": "Abaixo",
       "uiControls": "Controles da interface",
+      "showQuickActions": "Mostrar ações rápidas",
+      "showSkills": "Mostrar Skills",
       "showCliUpdate": "Mostrar atualizações da CLI",
       "title": "O que você quer fazer?",
       "back": "Voltar à página inicial",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -891,6 +891,8 @@
       "positionUp": "Сверху",
       "positionDown": "Снизу",
       "uiControls": "Элементы интерфейса",
+      "showQuickActions": "Показывать быстрые действия",
+      "showSkills": "Показывать Skills",
       "showCliUpdate": "Показывать обновления CLI",
       "title": "Что вы хотите сделать?",
       "back": "Назад к стартовой странице",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -887,6 +887,8 @@
       "positionUp": "Üst",
       "positionDown": "Alt",
       "uiControls": "Arayüz kontrolleri",
+      "showQuickActions": "Hızlı eylemleri göster",
+      "showSkills": "Skills göster",
       "showCliUpdate": "CLI güncellemelerini göster",
       "title": "Ne yapmak istersiniz?",
       "back": "Başlangıç sayfasına dön",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -884,6 +884,8 @@
       "positionUp": "Trên",
       "positionDown": "Dưới",
       "uiControls": "Điều khiển giao diện",
+      "showQuickActions": "Hiển thị thao tác nhanh",
+      "showSkills": "Hiển thị Skills",
       "showCliUpdate": "Hiển thị bản cập nhật CLI",
       "title": "Bạn muốn làm gì?",
       "back": "Quay lại trang bắt đầu",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -901,6 +901,8 @@
       "positionUp": "上方",
       "positionDown": "下方",
       "uiControls": "介面控制",
+      "showQuickActions": "顯示快捷操作",
+      "showSkills": "顯示 Skills",
       "showCliUpdate": "顯示 CLI 更新",
       "title": "你想做什麼？",
       "back": "返回起始頁",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -933,6 +933,8 @@
       "positionUp": "上方",
       "positionDown": "下方",
       "uiControls": "界面控制",
+      "showQuickActions": "显示快捷操作",
+      "showSkills": "显示 Skills",
       "showCliUpdate": "显示 CLI 更新",
       "title": "你想做什么？",
       "back": "返回起始页",

--- a/src/store/session/__tests__/creatorLaunchpadActionsVisibleAtom.test.ts
+++ b/src/store/session/__tests__/creatorLaunchpadActionsVisibleAtom.test.ts
@@ -1,0 +1,45 @@
+import { createStore } from "jotai/vanilla";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CREATOR_LAUNCHPAD_ACTIONS_VISIBLE_STORAGE_KEY,
+  creatorLaunchpadActionsVisibleAtom,
+} from "../creatorLaunchpadActionsVisibleAtom";
+
+beforeEach(() => {
+  localStorage.removeItem(CREATOR_LAUNCHPAD_ACTIONS_VISIBLE_STORAGE_KEY);
+});
+
+function hydratedStore(): ReturnType<typeof createStore> {
+  const store = createStore();
+  store.sub(creatorLaunchpadActionsVisibleAtom, () => undefined);
+  return store;
+}
+
+describe("creatorLaunchpadActionsVisibleAtom", () => {
+  it("shows launchpad quick actions by default", () => {
+    expect(hydratedStore().get(creatorLaunchpadActionsVisibleAtom)).toBe(true);
+  });
+
+  it("persists a hidden choice and hydrates it in a new store", () => {
+    const firstStore = hydratedStore();
+    firstStore.set(creatorLaunchpadActionsVisibleAtom, false);
+
+    expect(
+      JSON.parse(
+        localStorage.getItem(CREATOR_LAUNCHPAD_ACTIONS_VISIBLE_STORAGE_KEY) ??
+          "null"
+      )
+    ).toBe(false);
+    expect(hydratedStore().get(creatorLaunchpadActionsVisibleAtom)).toBe(false);
+  });
+
+  it("falls back to visible for malformed persisted values", () => {
+    localStorage.setItem(
+      CREATOR_LAUNCHPAD_ACTIONS_VISIBLE_STORAGE_KEY,
+      JSON.stringify("hidden")
+    );
+
+    expect(hydratedStore().get(creatorLaunchpadActionsVisibleAtom)).toBe(true);
+  });
+});

--- a/src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts
+++ b/src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts
@@ -17,29 +17,29 @@ function hydratedStore(): ReturnType<typeof createStore> {
 }
 
 describe("pinnedActionsVisibleAtom", () => {
-  it("shows pinned actions by default", () => {
-    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(true);
+  it("hides pinned actions by default", () => {
+    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(false);
   });
 
-  it("persists a hidden choice and hydrates it in a new store", () => {
+  it("persists a visible choice and hydrates it in a new store", () => {
     const firstStore = hydratedStore();
-    firstStore.set(pinnedActionsVisibleAtom, false);
+    firstStore.set(pinnedActionsVisibleAtom, true);
 
     expect(
       JSON.parse(
         localStorage.getItem(PINNED_ACTIONS_VISIBLE_STORAGE_KEY) ?? "null"
       )
-    ).toBe(false);
+    ).toBe(true);
 
-    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(false);
+    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(true);
   });
 
-  it("falls back to visible for malformed persisted values", () => {
+  it("falls back to hidden for malformed persisted values", () => {
     localStorage.setItem(
       PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
       JSON.stringify("hidden")
     );
 
-    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(true);
+    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(false);
   });
 });

--- a/src/store/session/creatorLaunchpadActionsVisibleAtom.ts
+++ b/src/store/session/creatorLaunchpadActionsVisibleAtom.ts
@@ -1,0 +1,32 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+export const CREATOR_LAUNCHPAD_ACTIONS_VISIBLE_STORAGE_KEY =
+  "orgii:sessionCreator:launchpadActionsVisible";
+
+function normalizeCreatorLaunchpadActionsVisible(value: unknown): boolean {
+  return typeof value === "boolean" ? value : true;
+}
+
+const storedCreatorLaunchpadActionsVisibleAtom = atomWithStorage<unknown>(
+  CREATOR_LAUNCHPAD_ACTIONS_VISIBLE_STORAGE_KEY,
+  true,
+  undefined,
+  { getOnInit: true }
+);
+
+/**
+ * Whether the launchpad's quick-action group is shown. The preference only
+ * changes presentation; it does not disable any of the underlying actions.
+ */
+export const creatorLaunchpadActionsVisibleAtom = atom(
+  (get) =>
+    normalizeCreatorLaunchpadActionsVisible(
+      get(storedCreatorLaunchpadActionsVisibleAtom)
+    ),
+  (_get, set, visible: boolean) =>
+    set(storedCreatorLaunchpadActionsVisibleAtom, visible)
+);
+
+creatorLaunchpadActionsVisibleAtom.debugLabel =
+  "creatorLaunchpadActionsVisibleAtom";

--- a/src/store/session/creatorPinnedActionsVisibleAtom.ts
+++ b/src/store/session/creatorPinnedActionsVisibleAtom.ts
@@ -8,19 +8,20 @@ export const CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY =
   PINNED_ACTIONS_VISIBLE_STORAGE_KEY;
 
 function normalizePinnedActionsVisible(value: unknown): boolean {
-  return typeof value === "boolean" ? value : true;
+  return typeof value === "boolean" ? value : false;
 }
 
 const storedPinnedActionsVisibleAtom = atomWithStorage<unknown>(
   PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
-  true,
+  false,
   undefined,
   { getOnInit: true }
 );
 
 /**
  * Shared composer preference for showing pinned quick-action pills and their
- * management controls in the Session Creator and active sessions.
+ * management controls in the Session Creator and active sessions. Pinned
+ * actions are hidden by default until the user opts in.
  *
  * The preference does not delete or unpin actions. Compact and hidden-repo
  * creator surfaces ignore it because they do not expose the native menu that

--- a/src/store/session/index.ts
+++ b/src/store/session/index.ts
@@ -26,6 +26,7 @@ export * from "./recentModelEntriesAtom";
 export * from "./recentAgentSelectionsAtom";
 export * from "./creatorDefaultExecModeAtom";
 export * from "./creatorPinnedActionsVisibleAtom";
+export * from "./creatorLaunchpadActionsVisibleAtom";
 export * from "./creatorRepoChromePositionAtom";
 export * from "./cliUpdateAlertsAtom";
 


### PR DESCRIPTION
## Problem

The new-chat launchpad always rendered its utility quick-action group, while pinned Skills had no clear default-off control shared by new chats and active sessions. Even when pinned actions were visually disabled, the full PinnedActionsBar component could still be mounted, initializing its Skills-related state and cache hooks.

## Solution

- Add a persisted Show quick actions switch to the new-chat UI controls menu; it hides the entire launchpad action group while remaining enabled by default
- Add a shared persisted Show Skills switch to both new-chat and active-session UI controls; it defaults off and keeps explicit saved boolean choices
- Replace eager PinnedActionsBar mounts in the session creator and active composer with a React.lazy boundary
- Preserve non-Skills composer controls in a lightweight fallback row while the Skills surface is off or loading
- Keep the product term Skills literal in all 13 locale labels
- Add storage, menu, rendering, and module-load regression coverage

No pinned action data is deleted. The preferences only affect presentation and use existing local atom storage patterns.

## Potential risks

Users without an existing pinned-actions preference will now see pinned Skills hidden until they opt in. The first enable may briefly show the lightweight fallback while the async chunk resolves; subsequent enables reuse the loaded module. Existing stored true or false values remain compatible, and malformed values safely fall back to the new hidden default.

No dependency, lockfile, database, IPC, wire, or remote-data changes are included. Rollback is a revert of this commit; the stored boolean preferences are harmless if left behind.

Production bundle chunk output was not inspected because a full build did not complete in the earlier verification attempt. App screenshots were not captured because local computer control is explicit opt-in and was not requested.

## Verification

- pnpm exec vitest run --config config/vitest.config.ts with the eight affected suites: 8 files passed, 56 tests passed
- git diff --name-only origin/develop...HEAD -- '*.ts' '*.tsx' piped to pnpm exec eslint --max-warnings 0 --report-unused-disable-directives: passed
- pnpm exec tsgo --noEmit --pretty false: passed
- pnpm typecheck: attempted on the isolated commit for about 22 minutes with no diagnostics, then stopped because it did not terminate
- Locale JSON validation: all 13 sessions.json files parsed and every showSkills label retained the literal Skills term
- git diff --check origin/develop...HEAD: passed
- Latest origin/develop was inspected after it advanced; the branch is two commits behind with no merge conflict in the changed surface
- Full production build and rendered app screenshots were not completed

## Audit

Frontend UI audit totals across the four changed surfaces: 0 fix, 7 keep with reason, 0 abstract. The hidden-state performance review found no new timers, listeners, polling, scans, or retained caches; the module-load test confirms the full PinnedActionsBar import is not requested while Show Skills is off.