### PR TITLE
perf(hooks): stop pre-commit from stacking full-repo lint runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -457,15 +457,10 @@
   },
   "lint-staged": {
     "src/**/*.{ts,tsx,js,jsx}": [
-      "oxlint -c .oxlintrc.json --max-warnings 0",
-      "eslint --fix",
-      "prettier --write"
+      "oxlint -c .oxlintrc.json --max-warnings 0"
     ],
     "*.{ts,tsx,js,jsx}": [
       "eslint --fix",
-      "prettier --write"
-    ],
-    "src/**/*.{css,scss,md,json}": [
       "prettier --write"
     ],
     "*.{css,scss,md,json}": [

--- a/scripts/git/commit-stats-background.mjs
+++ b/scripts/git/commit-stats-background.mjs
@@ -4,13 +4,90 @@
  * Collects project-wide eslint/circular stats without blocking commits.
  */
 import { spawn } from "child_process";
-import { existsSync, writeFileSync } from "fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..", "..");
 const STATS_FILE = join(ROOT, ".git", "COMMIT_STATS.json");
+const LOCK_FILE = join(ROOT, ".git", "COMMIT_STATS.lock");
+
+function isAlive(pid) {
+  try {
+    // Signal 0 performs the permission/existence check without delivering.
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the pid exists but belongs to another user — still alive.
+    return err?.code === "EPERM";
+  }
+}
+
+/**
+ * Single-flight guard.
+ *
+ * This process is spawned detached and unref'd, and it runs a full-repo
+ * `eslint src/` plus madge — hundreds of MB and minutes of CPU. Without a
+ * lock, every commit started another one, so a few commits in quick
+ * succession (or several agent sessions sharing one checkout) stacked
+ * concurrent full-repo lints that outlived the commits that spawned them.
+ *
+ * Skipping is the right behavior rather than queueing: the run already in
+ * flight is reading a tree at least as new as ours, and prepare-commit-msg
+ * already tolerates trailing-by-one-commit numbers.
+ */
+function acquireLock() {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      // "wx" fails if the file exists, so creation is atomic between racing
+      // commits rather than a check-then-write window.
+      const fd = openSync(LOCK_FILE, "wx");
+      try {
+        writeSync(fd, String(process.pid));
+      } finally {
+        closeSync(fd);
+      }
+      return true;
+    } catch (err) {
+      // ENOENT/ENOTDIR: no .git directory to lock in (e.g. a linked worktree,
+      // where .git is a file). Nothing to collect into either — just bail.
+      if (err?.code !== "EEXIST") return false;
+
+      let holder = NaN;
+      try {
+        holder = Number.parseInt(readFileSync(LOCK_FILE, "utf8").trim(), 10);
+      } catch {
+        // Unreadable lock is treated as stale below.
+      }
+      if (Number.isInteger(holder) && isAlive(holder)) return false;
+
+      // Stale lock from a killed run — clear it and retry once.
+      try {
+        unlinkSync(LOCK_FILE);
+      } catch {
+        return false;
+      }
+    }
+  }
+  return false;
+}
+
+function releaseLock() {
+  try {
+    unlinkSync(LOCK_FILE);
+  } catch {
+    // Already gone.
+  }
+}
 
 function run(cmd, args) {
   return new Promise((resolve) => {
@@ -66,22 +143,40 @@ function countCircular(jsonStr) {
 }
 
 async function main() {
-  const [madgeOut, eslintOut] = await Promise.all([
-    run("node", ["scripts/quality/check-circular-dependencies.mjs", "--json"]),
-    run("npx", ["eslint", "src/", "--format", "json"]),
-  ]);
+  if (!acquireLock()) return;
 
-  const eslintCount = countEslint(eslintOut);
-  const circularCount = countCircular(madgeOut);
+  try {
+    const [madgeOut, eslintOut] = await Promise.all([
+      run("node", ["scripts/quality/check-circular-dependencies.mjs", "--json"]),
+      run("npx", ["eslint", "src/", "--format", "json"]),
+    ]);
 
-  const gitDir = join(ROOT, ".git");
-  if (existsSync(gitDir)) {
-    writeFileSync(
-      STATS_FILE,
-      JSON.stringify({ eslint: eslintCount, circular: circularCount }) + "\n",
-      "utf8"
-    );
+    const eslintCount = countEslint(eslintOut);
+    const circularCount = countCircular(madgeOut);
+
+    const gitDir = join(ROOT, ".git");
+    if (existsSync(gitDir)) {
+      writeFileSync(
+        STATS_FILE,
+        JSON.stringify({ eslint: eslintCount, circular: circularCount }) + "\n",
+        "utf8"
+      );
+    }
+  } finally {
+    releaseLock();
   }
 }
 
-main().catch(() => process.exit(0));
+// Release on abnormal termination too, so a killed run does not leave a lock
+// that blocks the next commit until the stale-pid check clears it.
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => {
+    releaseLock();
+    process.exit(0);
+  });
+}
+
+main().catch(() => {
+  releaseLock();
+  process.exit(0);
+});

--- a/scripts/git/commit-stats.mjs
+++ b/scripts/git/commit-stats.mjs
@@ -1,76 +1,24 @@
 #!/usr/bin/env node
 /**
- * Collects ESLint and circular dependency counts for commit messages.
+ * Kicks off project-wide ESLint/circular-dependency stats for the
+ * prepare-commit-msg trailer.
  *
- * FAST MODE (default): Only check staged files - blocks commit on errors.
- * Stats collection (eslint full src/, madge) runs async and doesn't block.
+ * This script does NOT gate the commit and does NOT lint. The staged-file
+ * ESLint gate is lint-staged, which runs earlier in .husky/pre-commit and
+ * aborts on any remaining error; this file used to re-lint the same staged
+ * files a third time in a fresh `npx eslint` process, which cost seconds of
+ * config/plugin-graph resolution and bought nothing.
  *
- * Ratchet is scoped to STAGED files only — unstaged WIP in the tree
- * won't block your commit as long as the files you're committing are clean.
+ * The project-wide counts are collected by commit-stats-background.mjs, which
+ * is spawned detached so the commit returns immediately.
  */
 import { execSync, spawn } from "child_process";
-import { existsSync, writeFileSync } from "fs";
+import { existsSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, "..", "..");
-const STATS_FILE = join(ROOT, ".git", "COMMIT_STATS.json");
-
-function run(cmd, args, opts = {}) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(cmd, args, {
-      cwd: ROOT,
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: true,
-      ...opts,
-    });
-    let stdout = "";
-    proc.stdout?.on("data", (chunk) => {
-      stdout += chunk;
-    });
-    proc.stderr?.on("data", () => {});
-    proc.on("close", () => {
-      resolve(stdout);
-    });
-    proc.on("error", reject);
-  });
-}
-
-function countEslint(jsonStr) {
-  try {
-    const results = JSON.parse(jsonStr);
-    if (!Array.isArray(results)) return 0;
-    return results.reduce((sum, file) => {
-      const messages = file.messages ?? [];
-      const isIgnoredFileOnly =
-        messages.length > 0 &&
-        messages.every((message) =>
-          Boolean(
-            message.message?.includes(
-              "ignored because of a matching ignore pattern",
-            ),
-          ),
-        );
-      if (isIgnoredFileOnly) {
-        return sum;
-      }
-      return sum + (file.errorCount ?? 0) + (file.warningCount ?? 0);
-    }, 0);
-  } catch {
-    return 0;
-  }
-}
-
-function countCircular(jsonStr) {
-  try {
-    const cycles = JSON.parse(jsonStr);
-    if (!Array.isArray(cycles)) return 0;
-    return cycles.length;
-  } catch {
-    return 0;
-  }
-}
 
 function getStagedSourceFiles() {
   try {
@@ -89,41 +37,16 @@ function getStagedSourceFiles() {
 
 async function main() {
   const stagedFiles = getStagedSourceFiles();
-
-  // ─────────────────────────────────────────────────────────────────────────
-  // CRITICAL PATH: Only check staged files (fast, gates commit)
-  // ─────────────────────────────────────────────────────────────────────────
-  let stagedEslintCount = 0;
-
-  if (stagedFiles.length > 0) {
-    const stagedEslintOut = await run("npx", [
-      "eslint",
-      ...stagedFiles,
-      "--format",
-      "json",
-    ]);
-    stagedEslintCount = countEslint(stagedEslintOut);
-
-    if (stagedEslintCount > 0) {
-      console.error(
-        `\n❌ ESLint errors in staged files: ${stagedEslintCount}`,
-      );
-      console.error("   Fix them before committing.");
-      console.error(`   Run:  npx eslint --fix ${stagedFiles.join(" ")}`);
-      console.error("   Skip: git commit --no-verify\n");
-      process.exit(2);
-    }
-  }
-
-  console.log(`📊 Staged files clean (${stagedFiles.length} checked)`);
+  console.log(
+    `📊 Staged files linted by lint-staged (${stagedFiles.length} files)`,
+  );
 
   // ─────────────────────────────────────────────────────────────────────────
   // NON-BLOCKING: Spawn detached process for project-wide stats
-  // These don't gate the commit, just write stats for prepare-commit-msg
+  // These don't gate the commit, just write stats for prepare-commit-msg.
+  // The child self-limits to one run at a time (see its lock), so committing
+  // repeatedly can no longer stack concurrent full-repo ESLint runs.
   // ─────────────────────────────────────────────────────────────────────────
-  
-  // Spawn a completely detached background process for stats collection
-  // This allows the commit to proceed immediately
   const bgScript = join(__dirname, "commit-stats-background.mjs");
   if (existsSync(bgScript)) {
     const child = spawn("node", [bgScript], {
@@ -133,11 +56,8 @@ async function main() {
     });
     child.unref(); // Don't wait for this process
   }
-  
+
   console.log("📊 Project stats: collecting in background...");
 }
 
-main().catch((err) => {
-  console.error("commit-stats:", err.message);
-  process.exit(1);
-});
+main().catch(() => process.exit(0));


### PR DESCRIPTION
## Problem

Committing spawns far more work than the change requires, and some of it outlives the commit.

1. **lint-staged ran `eslint --fix` and `prettier --write` twice on every staged file under `src/`.** lint-staged applies micromatch's `matchBase` to any pattern without a slash (`generateTasks.js`: `matchBase: !pattern.includes('/')`), so `"*.{ts,tsx,js,jsx}"` already matched `src/**` — and the `src/**` entry listed the same two commands again. Same duplication for `src/**/*.{css,scss,md,json}` vs `*.{css,scss,md,json}`.

2. **`commit-stats.mjs` re-linted the same staged files a third time** in a fresh `npx eslint` process, after lint-staged had already gated the commit on exactly those files.

3. **`commit-stats-background.mjs` could stack without limit.** It runs a full-repo `eslint src/` plus madge, and is spawned `detached` + `unref()`'d, so it survives the commit that started it. Nothing prevented concurrent runs: committing a few times in succession — or several agent sessions sharing one checkout — accumulated multiple full-repo ESLint runs holding hundreds of MB each. Observed live: two orphaned `eslint src/ --format json` runs still going 6+ minutes after their commits, alongside `tsgo` at 0.9 GB.

## Solution

- **lint-staged**: the `src/**` entry now carries only `oxlint` (which the bare pattern does not run); `eslint --fix` and `prettier --write` are left to the bare patterns, which already cover `src/**` via `matchBase`. The redundant `src/**/*.{css,scss,md,json}` entry is removed. Coverage is unchanged, each command runs once.
- **`commit-stats.mjs`**: drops the third ESLint pass and the helpers that existed only to serve it. It now only spawns the background collector. The staged-file gate remains lint-staged, which aborts the commit on any remaining error.
- **`commit-stats-background.mjs`**: takes an atomic single-flight lock — `openSync(..., "wx")` on `.git/COMMIT_STATS.lock`, so creation is atomic between racing commits rather than a check-then-write window — and exits immediately if a run is in flight. A lock left behind by a killed run is detected via a liveness check on the recorded pid and cleared; `SIGINT`/`SIGTERM`/`SIGHUP` handlers release it on the way out.

Skipping rather than queueing preserves existing semantics: the in-flight run is reading a tree at least as new as the one that would have queued, and `prepare-commit-msg` already tolerates numbers that trail by a commit (the file's own comments document staleness as an accepted mode).

## Potential risks

- **Formatting coverage is the main risk**, since it now rests entirely on `matchBase`. Verified two ways: read from lint-staged 15.5.2's source, and by running its own `generateTasks` over a representative staged set (see Verification). If lint-staged ever dropped `matchBase`, files outside `src/` would lose linting too — the bare patterns are pre-existing, so this is not a new dependency, but it is now load-bearing for `src/` as well.
- The trailer's project-wide numbers may now be skipped for a commit made while a previous collection is still running, where before a second collection was started. Already-possible staleness, made slightly more likely, in exchange for bounded memory.
- `.git/COMMIT_STATS.lock` is a new file under `.git/` (never committed). In a linked worktree, where `.git` is a file rather than a directory, lock creation fails and the collector exits — matching the existing behavior there, since it could not write `COMMIT_STATS.json` in a worktree either.
- Unchanged: the tsgo typecheck and scoped clippy tasks, and the trailer contract in `prepare-commit-msg`.

## Verification

- **Formatting coverage, via lint-staged's own `generateTasks`** over `src/**` code, `src/**` styles/JSON, root config, `config/`, `package.json`, and Markdown — old config vs new:
  - `src/components/Button/index.tsx`: was `oxlint,eslint,prettier,eslint,prettier` → now `oxlint,eslint,prettier`
  - `src/components/Table/index.scss`: was `prettier,prettier` → now `prettier`
  - `config/webpack.config.js`, `package.json`, `README.md`: unchanged
  - **No file lost any command; files running prettier twice: 4 → 0.**
- **Single-flight lock**, spawning three collectors simultaneously: 1 stays working, 2 exit early; lock file present while working; lock cleared after the winner is killed; a stale lock holding a dead pid is recovered and the next run proceeds.
- `node --check` on both edited scripts; `package.json` re-parsed as JSON, with a diff against `origin/develop` confirming `lint-staged` is the only top-level key that changed.
- Not run: a full end-to-end `git commit` on this branch, because the working checkout holds another session's uncommitted work; the commit was built with a temp index so that tree was never staged. The hook path itself is exercised by the two verifications above.
