### PR TITLE
fix(dropdown): keep section labels visible while scrolling

### DIFF
--- a/docs/frontend-ui-audit-2026-09-01/DropdownStickySectionLabels.md
+++ b/docs/frontend-ui-audit-2026-09-01/DropdownStickySectionLabels.md
@@ -1,0 +1,8 @@
+# Dropdown sticky section labels UI audit
+
+| Line                                 | Element                             | Verdict          | Reason                                                                                                      | Suggested change                                                              |
+| ------------------------------------ | ----------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `Dropdown/tokens.ts:467`             | Shared dropdown section-label token | fix              | Section headings scrolled away with their rows even though every grouped dropdown already shares this token | Add token-backed sticky positioning, stacking, and an opaque panel background |
+| `SlashCommandPortal/MenuRows.tsx:47` | Slash-command menu section heading  | keep with reason | Reuses the shared dropdown section-label contract, so it inherits the behavior without a local style fork   | None                                                                          |
+
+Verdict totals: **1 fix**, **1 keep with reason**, **0 abstract**.

--- a/src/components/Dropdown/tokens.test.ts
+++ b/src/components/Dropdown/tokens.test.ts
@@ -10,3 +10,13 @@ describe("dropdown menu group spacing", () => {
     expect(DROPDOWN_CLASSES.menuGroupSeparator).not.toContain("my-1");
   });
 });
+
+describe("dropdown section labels", () => {
+  it("pins the current section over scrolling menu rows", () => {
+    expect(DROPDOWN_CLASSES.sectionLabel).toContain("sticky");
+    expect(DROPDOWN_CLASSES.sectionLabel).toContain("-top-1");
+    expect(DROPDOWN_CLASSES.sectionLabel).not.toContain("top-0");
+    expect(DROPDOWN_CLASSES.sectionLabel).toContain("z-10");
+    expect(DROPDOWN_CLASSES.sectionLabel).toContain("bg-bg-2");
+  });
+});

--- a/src/components/Dropdown/tokens.ts
+++ b/src/components/Dropdown/tokens.ts
@@ -459,9 +459,18 @@ export const DROPDOWN_CLASSES = {
     DROPDOWN_PANEL.paddingClass,
   ].join(" "),
 
-  /** Section / group label inside a dropdown (non-interactive). */
-  sectionLabel:
+  /**
+   * Section / group label inside a dropdown (non-interactive). Labels pin to
+   * the top of their nearest scrolling menu until the next section replaces
+   * them, so the current group stays identifiable in long lists.
+   */
+  sectionLabel: [
+    "sticky",
+    "-top-1",
+    "z-10",
+    DROPDOWN_PANEL.bgClass,
     "px-1.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-text-3",
+  ].join(" "),
 
   /** Bordered dropdown section wrapper for grouped controls above/between lists. */
   sectionContainer: [


### PR DESCRIPTION
## Problem

Grouped dropdowns lose their current section heading as long menus scroll, so users can no longer tell which category the visible rows belong to. The shared section-label token had no sticky positioning or opaque panel background.

## Solution

Make the shared dropdown section-label token sticky at the menu’s inset top, give it the panel background and stacking order, and add a token regression test. All grouped dropdown consumers inherit the behavior through the existing design-system token.

## Potential risks

Sticky positioning depends on the nearest scrolling ancestor and could expose clipping or stacking differences in unusual dropdown hosts. The change is centralized and covered at the token boundary, but rendered screenshots were not captured because desktop UI control was not authorized.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/components/Dropdown/tokens.test.ts` — passed, 1 file and 2 tests.
- `git diff --check` — passed.
- Pre-commit oxlint, ESLint, Prettier, and staged-file TypeScript check — passed.
- Rendered WDIO/visual verification was not run because desktop UI control requires explicit opt-in in this workspace.

## Audit

Frontend UI verdict totals: **1 fix**, **1 keep with reason**, **0 abstract**.
