### PR TITLE
style(dropdown): remove duplicate control row hover

### DIFF
--- a/docs/frontend-ui-audit-2026-09-02/DropdownControlRows.md
+++ b/docs/frontend-ui-audit-2026-09-02/DropdownControlRows.md
@@ -1,0 +1,7 @@
+# Dropdown control rows UI audit
+
+| Line                                    | Element                     | Verdict | Reason                                                                                                                                                                        | Suggested change                                                                                                    |
+| --------------------------------------- | --------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `src/components/Dropdown/tokens.ts:391` | Shared dropdown control row | fix     | `menuControlItem` added a row-level hover fill around embedded pills, switches, and option controls across 13 call sites, duplicating the interactive control's own feedback. | Completed: remove the hover background from `menuControlItem`; keep hover feedback on `menuActionItem` action rows. |
+
+Verdict totals: **1 fix**, **0 keep with reason**, **0 abstract**.

--- a/src/components/Dropdown/tokens.test.ts
+++ b/src/components/Dropdown/tokens.test.ts
@@ -20,3 +20,10 @@ describe("dropdown section labels", () => {
     expect(DROPDOWN_CLASSES.sectionLabel).toContain("bg-bg-2");
   });
 });
+
+describe("dropdown control rows", () => {
+  it("leaves row hover styling to the embedded option control", () => {
+    expect(DROPDOWN_CLASSES.menuControlItem).not.toContain("hover:bg-");
+    expect(DROPDOWN_CLASSES.menuActionItem).toContain("hover:bg-");
+  });
+});

--- a/src/components/Dropdown/tokens.ts
+++ b/src/components/Dropdown/tokens.ts
@@ -384,7 +384,10 @@ export const DROPDOWN_CLASSES = {
     DROPDOWN_ITEM.hoverBgClass,
   ].join(" "),
 
-  /** 32px menu row for label + right-side control such as Switch. */
+  /**
+   * 32px menu row for a label + right-side control such as a Switch or pill.
+   * The embedded control owns its hover state; the containing row stays clear.
+   */
   menuControlItem: [
     "flex",
     "w-full",
@@ -401,7 +404,6 @@ export const DROPDOWN_CLASSES = {
     DROPDOWN_ITEM.fontSizeClass,
     DROPDOWN_ITEM.transitionClass,
     "text-text-1",
-    DROPDOWN_ITEM.hoverBgClass,
   ].join(" "),
 
   /** Inset rule between menu-item groups with a tight 2px local offset. */


### PR DESCRIPTION
## Problem

Dropdown rows that contain an interactive pill, switch, or option control add a second row-level hover fill around the control’s own feedback. The shared `menuControlItem` token caused this duplicated visual state across 13 call sites.

## Solution

Remove hover background styling from the shared control-row token while retaining it on action rows. Add a focused token test and document the design-system sweep result.

## Potential risks

Consumers that relied on the entire control row lighting up will now show feedback only on the embedded interactive control. This is the intended distinction between control rows and action rows. Rendered screenshots were not captured because desktop UI control was not authorized.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/components/Dropdown/tokens.test.ts` — passed, 1 file and 2 tests.
- `git diff --check` — passed.
- Pre-commit oxlint, ESLint, Prettier, and staged-file TypeScript check — passed.
- Rendered visual verification was not run because desktop UI control requires explicit opt-in in this workspace.

## Audit

Frontend UI verdict totals: **1 fix**, **0 keep with reason**, **0 abstract**.
