### PR TITLE
fix(markdown): reduce GitHub link icon size

### DIFF
--- a/src/components/MarkDown/MarkdownLinkIcon.test.ts
+++ b/src/components/MarkDown/MarkdownLinkIcon.test.ts
@@ -98,7 +98,7 @@ describe("MarkdownLinkIcon sizing", () => {
     path: "/repo/src/components/AttachPanel/index.tsx",
   };
 
-  it("gives both link-icon variants the same box", () => {
+  it("gives both link-icon variants the same intrinsic fallback box", () => {
     const github = renderIcon(githubHref, {
       kind: "browser",
       url: githubHref,
@@ -115,6 +115,25 @@ describe("MarkdownLinkIcon sizing", () => {
     expect(fileSize).toBeDefined();
     const { width, height } = SIZE_STYLES[fileSize!];
     expect(github).toContain(`data-box="${width}x${height}"`);
+  });
+
+  it("renders the optically dense GitHub mark smaller than file artwork", () => {
+    const github = renderIcon(githubHref, {
+      kind: "browser",
+      url: githubHref,
+    });
+    expect(github).toContain("markdown-link-icon-github");
+
+    const styles = readFileSync(
+      resolve(__dirname, "_base-elements.scss"),
+      "utf8"
+    );
+    const githubRule = styles.match(
+      /\.chat-markdown-body \.markdown-link-icon-github svg \{([\s\S]*?)\n\}/
+    )?.[1];
+
+    expect(githubRule).toMatch(/width: 1em/);
+    expect(githubRule).toMatch(/height: 1em/);
   });
 
   it("sizes the rendered icon in em so it tracks the chat font size", () => {

--- a/src/components/MarkDown/MarkdownLinkIcon.tsx
+++ b/src/components/MarkDown/MarkdownLinkIcon.tsx
@@ -13,16 +13,17 @@ interface MarkdownLinkIconProps {
 
 const ICON_WRAPPER_CLASS =
   "markdown-link-icon mr-1 inline-flex shrink-0 items-center justify-center leading-none";
+const GITHUB_ICON_WRAPPER_CLASS = `${ICON_WRAPPER_CLASS} markdown-link-icon-github`;
 
 /**
- * Nominal box for a markdown link's leading icon, shared by both variants so
- * a GitHub link and a file link never render at different sizes in the same
- * paragraph. `FileTypeIcon`'s "medium" token is the same 16px.
+ * Nominal box for a markdown link's leading icon. `FileTypeIcon`'s "medium"
+ * token is the same 16px; CSS makes the optically denser GitHub artwork a
+ * little smaller at rendered Markdown font sizes.
  *
- * The rendered size is re-stated in `em` by `.markdown-link-icon svg` in
- * `_base-elements.scss`: the markdown body inherits the chat font size, so a
- * fixed pixel box drifts out of proportion whenever the reader changes it.
- * These attributes are the intrinsic fallback and the aspect ratio.
+ * The rendered sizes are re-stated in `em` in `_base-elements.scss`: the
+ * markdown body inherits the chat font size, so a fixed pixel box drifts out
+ * of proportion whenever the reader changes it. These attributes are the
+ * intrinsic fallback and the aspect ratio.
  */
 const LINK_ICON_SIZE = 16;
 
@@ -51,7 +52,7 @@ const MarkdownLinkIcon: React.FC<MarkdownLinkIconProps> = ({
 }) => {
   if (isGitHubMarkdownHref(href)) {
     return (
-      <span aria-hidden="true" className={ICON_WRAPPER_CLASS}>
+      <span aria-hidden="true" className={GITHUB_ICON_WRAPPER_CLASS}>
         <GitHubIcon width={LINK_ICON_SIZE} height={LINK_ICON_SIZE} />
       </span>
     );

--- a/src/components/MarkDown/_base-elements.scss
+++ b/src/components/MarkDown/_base-elements.scss
@@ -69,6 +69,18 @@
   height: 1.15em;
 }
 
+// The GitHub mark fills its entire 24px viewBox, while file-type artwork has
+// built-in breathing room. Give the solid GitHub silhouette a smaller visual
+// box so it matches file links and cannot crowd the top of a Markdown line.
+.chat-markdown-body .markdown-link-icon-github {
+  vertical-align: -0.125em;
+}
+
+.chat-markdown-body .markdown-link-icon-github svg {
+  width: 1em;
+  height: 1em;
+}
+
 // Inline code used as a link label reads as a link, not as a code chip.
 // `.chat-markdown-body code` paints a fill-2 pill with text-1 text in the
 // monospace stack, so a commit/PR link written as


### PR DESCRIPTION
## Problem

GitHub link icons use the same nominal box as file-type icons, but the solid GitHub mark fills its viewBox while file artwork includes internal breathing room. In rendered Markdown the GitHub silhouette therefore appears larger and can crowd the line above it.

## Solution

Add a GitHub-specific wrapper class and size that dense artwork to `1em`, while preserving the existing 16px intrinsic fallback and the slightly larger file-artwork size. Add a regression test against the Markdown stylesheet contract.

## Potential risks

The optical adjustment is limited to GitHub Markdown links; other link icons retain their current sizing. The exact visual balance can vary with font size, and screenshots were not captured because desktop UI control was not authorized.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/components/MarkDown/MarkdownLinkIcon.test.ts` — passed, 1 file and 11 tests.
- `git diff --check` — passed.
- Pre-commit oxlint, ESLint, Prettier, and staged-file TypeScript check — passed.
- Rendered visual verification was not run because desktop UI control requires explicit opt-in in this workspace.
