### PR TITLE
fix(chat-history): count grouped events for collapse bars

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/components/PinnedTurnHeader.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/PinnedTurnHeader.tsx
@@ -47,6 +47,7 @@ function samePinnedMeta(
     left.turnId === right.turnId &&
     left.durationMs === right.durationMs &&
     left.itemCount === right.itemCount &&
+    left.bodyEventCount === right.bodyEventCount &&
     left.previewText === right.previewText &&
     left.startMs === right.startMs &&
     left.endMs === right.endMs &&

--- a/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 
+import { processChatItems } from "../../chatItemPipeline/pipeline";
 import type { OptimizedChatItem } from "../../chatItemPipeline/types";
 import { useChatGroups } from "../useChatGroups";
 import {
@@ -479,10 +480,14 @@ describe("useChatGroups collapse — terminal error survival", () => {
 
 describe("isTurnCollapseEligible — unloaded placeholder affordance", () => {
   function meta(overrides: Partial<ChatGroupMeta>): ChatGroupMeta {
+    const itemCount = overrides.itemCount ?? 0;
     return {
       turnId: "turn-1",
       durationMs: 0,
-      itemCount: 0,
+      itemCount,
+      // Ungrouped rows weigh one event each; tests that need the two to
+      // diverge pass `bodyEventCount` explicitly.
+      bodyEventCount: itemCount,
       previewText: "",
       startMs: null,
       endMs: null,
@@ -496,6 +501,28 @@ describe("isTurnCollapseEligible — unloaded placeholder affordance", () => {
       false
     );
     expect(isTurnCollapseEligible(meta({ itemCount: 2 }), 0, 3, {})).toBe(true);
+  });
+
+  it("measures the body in events, so one grouped row still collapses", () => {
+    // A round of shell commands renders as a single TerminalActivityGroup
+    // row. Counting rows called it trivial and withheld the bar.
+    expect(
+      isTurnCollapseEligible(
+        meta({ itemCount: 1, bodyEventCount: 2 }),
+        0,
+        3,
+        {}
+      )
+    ).toBe(true);
+    // A genuinely single-event body is still trivial.
+    expect(
+      isTurnCollapseEligible(
+        meta({ itemCount: 1, bodyEventCount: 1 }),
+        0,
+        3,
+        {}
+      )
+    ).toBe(false);
   });
 
   it("shows the bar for any unloaded turn with a nonzero body surrogate", () => {
@@ -536,6 +563,14 @@ describe("isTurnCollapseEligible — unloaded placeholder affordance", () => {
         tailTurnPhase: "complete",
       })
     ).toBe(false);
+  });
+
+  it("shows the completed tail bar for a single grouped tool row", () => {
+    expect(
+      isTurnCollapseEligible(meta({ itemCount: 1, bodyEventCount: 2 }), 2, 3, {
+        tailTurnPhase: "complete",
+      })
+    ).toBe(true);
   });
 
   it("resolves the shared default-collapse decision per phase", () => {
@@ -637,5 +672,82 @@ describe("projectChatGroups — completed tail turn", () => {
       "run_shell",
       "current reply",
     ]);
+  });
+});
+
+/**
+ * Regression: a round whose entire body is shell commands renders as ONE
+ * TerminalActivityGroup row, so the row-count threshold in
+ * `isTurnCollapseEligible` classified it as trivial and withheld the
+ * "Agent worked for X" bar no matter how many commands it ran.
+ */
+describe("projectChatGroups — grouped tool rows carry their event weight", () => {
+  function shellEvent(command: string): SessionEvent {
+    return makeEvent({
+      functionName: "run_shell",
+      uiCanonical: "run_shell",
+      actionType: "tool_call",
+      args: { command },
+      result: { success: true },
+      displayText: command,
+      displayVariant: "tool_call",
+    });
+  }
+
+  function shellOnlyTurn(commandCount: number) {
+    const events = [
+      makeEvent({
+        functionName: "user_message",
+        uiCanonical: "",
+        actionType: "raw",
+        source: "user",
+        displayText: "let's git pull first",
+        displayVariant: "message",
+      }),
+      ...Array.from({ length: commandCount }, (_, index) =>
+        shellEvent(`command-${index}`)
+      ),
+    ];
+    return processChatItems(events).items;
+  }
+
+  it("folds consecutive shell commands into a single row", () => {
+    const items = shellOnlyTurn(2);
+
+    // Header + one grouped row: the shape the bug depends on.
+    expect(items).toHaveLength(2);
+    expect(items[1].type).toBe("activityStackGroup");
+    expect(items[1].activityStackGroup?.events).toHaveLength(2);
+  });
+
+  it("reports the grouped row's events in the turn's body count", () => {
+    const result = projectChatGroups(shellOnlyTurn(2));
+    const [meta] = result.groupMeta;
+
+    expect(meta.itemCount).toBe(1);
+    expect(meta.bodyEventCount).toBe(2);
+  });
+
+  it("gives a completed shell-only tail turn its collapse bar", () => {
+    const result = projectChatGroups(shellOnlyTurn(2), {
+      tailTurnPhase: "complete",
+    });
+
+    expect(
+      isTurnCollapseEligible(result.groupMeta[0], 0, result.groupMeta.length, {
+        tailTurnPhase: "complete",
+      })
+    ).toBe(true);
+  });
+
+  it("keeps a one-command turn trivial", () => {
+    const result = projectChatGroups(shellOnlyTurn(1));
+
+    expect(result.groupMeta[0].bodyEventCount).toBe(1);
+    expect(
+      isTurnCollapseEligible(result.groupMeta[0], 0, result.groupMeta.length, {
+        tailTurnPhase: "complete",
+      })
+    ).toBe(false);
   });
 });

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatGroupsProjection.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatGroupsProjection.ts
@@ -20,7 +20,14 @@ export interface UnloadedTurnMeta {
 export interface ChatGroupMeta {
   turnId: string | null;
   durationMs: number;
+  /** Rendered rows in the turn body. A grouped stack counts as one row. */
   itemCount: number;
+  /**
+   * Session events the turn body stands for, expanding grouped rows. Always
+   * >= `itemCount`; the two differ whenever the item pipeline folded several
+   * tool calls into a single row.
+   */
+  bodyEventCount: number;
   previewText: string;
   startMs: number | null;
   endMs: number | null;
@@ -189,6 +196,41 @@ function parseEpochMs(iso: string | undefined): number | null {
   return Number.isFinite(ms) ? ms : null;
 }
 
+/**
+ * How many session events one rendered row stands for.
+ *
+ * The item pipeline folds consecutive tool calls into a SINGLE row —
+ * `readFileGroup`, `actionSummaryGroup`, and `activityStackGroup`, the last
+ * of which stacks terminal and edit activity from one event up
+ * (`minTerminalActivitiesToGroup: 1`). A round that ran nothing but shell
+ * commands therefore reaches the projection as one item, so counting rows
+ * alone reports a "trivial" body no matter how much work it holds.
+ *
+ * Floored at 1 so a row always weighs at least itself: this count only ever
+ * raises the old row count, never lowers it.
+ */
+function countItemBodyEvents(item: OptimizedChatItem): number {
+  if (item.readFileEvents) {
+    return Math.max(1, item.readFileEvents.length);
+  }
+  if (item.actionSummaryItems) {
+    return Math.max(1, item.actionSummaryItems.length);
+  }
+  if (item.actionSummaryEntries) {
+    return Math.max(
+      1,
+      item.actionSummaryEntries.reduce(
+        (total, entry) => total + entry.events.length,
+        0
+      )
+    );
+  }
+  if (item.activityStackGroup) {
+    return Math.max(1, item.activityStackGroup.events.length);
+  }
+  return 1;
+}
+
 export function isTurnCollapseEligible(
   meta: ChatGroupMeta | undefined,
   groupIndex: number,
@@ -199,9 +241,12 @@ export function isTurnCollapseEligible(
   } = {}
 ): boolean {
   if (!meta || meta.turnId === null) return false;
-  const bodyItemCount = meta.unloadedTurn?.bodyEventCount ?? meta.itemCount;
-  // Loaded turns render their items inline, so a trivial (≤1 item) body has
-  // nothing to collapse. An UNLOADED turn renders nothing inline — the
+  const bodyItemCount =
+    meta.unloadedTurn?.bodyEventCount ?? meta.bodyEventCount;
+  // Loaded turns render their items inline, so a trivial (≤1 event) body has
+  // nothing to collapse. Measured in EVENTS, not rendered rows: a round whose
+  // whole body is one grouped tool stack renders as a single row but still
+  // holds every command in it. An UNLOADED turn renders nothing inline — the
   // collapse bar is its only expand affordance (and, with turn pagination
   // off, the only way to fetch the body at all), so any nonzero count must
   // show it. Zero means the source measured a genuinely bodyless round.
@@ -293,6 +338,10 @@ export function projectChatGroups(
       turnId,
       durationMs: unloadedTurn?.durationMs ?? durationMs,
       itemCount: group.items.length,
+      bodyEventCount: group.items.reduce(
+        (total, item) => total + countItemBodyEvents(item),
+        0
+      ),
       previewText: headerEvent?.displayText ?? "",
       startMs: unloadedStartMs ?? startMs,
       endMs: unloadedEndMs ?? endMs,

--- a/src/engines/ChatPanel/ChatHistory/renderers/GroupHeaderRenderer.tsx
+++ b/src/engines/ChatPanel/ChatHistory/renderers/GroupHeaderRenderer.tsx
@@ -48,6 +48,7 @@ function sameMeta(
     left.turnId === right.turnId &&
     left.durationMs === right.durationMs &&
     left.itemCount === right.itemCount &&
+    left.bodyEventCount === right.bodyEventCount &&
     left.previewText === right.previewText &&
     left.startMs === right.startMs &&
     left.endMs === right.endMs &&


### PR DESCRIPTION
## Problem

Completed turns containing several shell or tool events can render as one grouped row. Collapse eligibility counted rendered rows, so these non-trivial turns were misclassified as single-item bodies and lost the “Agent worked for …” collapse bar.

## Solution

Project an explicit `bodyEventCount` from each grouped chat item’s authoritative event payload, use that count for collapse eligibility, and include it in memoized header comparisons. Regression coverage proves a two-command grouped row remains collapsible while a genuinely one-command turn stays trivial.

## Potential risks

The new count relies on the existing grouped-item payload shapes for read-file, action-summary, and activity-stack rows. Unknown future group types will conservatively count as one until their event payload is added. No persistence, IPC, wire format, or historical data cleanup is involved.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts` — passed, 1 file and 32 tests.
- `git diff --check` — passed.
- Pre-commit oxlint, ESLint, Prettier, and staged-file TypeScript check — passed.
- Rendered WDIO was not run; this source-level projection fix is covered at the producing boundary and desktop UI control was not authorized.
