### PR TITLE
feat(sidebar): simplify appearance quick controls

### DIFF
--- a/docs/frontend-ui-audit-2026-09-02/SidebarAppearanceMenu.md
+++ b/docs/frontend-ui-audit-2026-09-02/SidebarAppearanceMenu.md
@@ -1,0 +1,9 @@
+# Sidebar appearance menu UI audit
+
+| Line                                                                        | Element                  | Verdict          | Reason                                                                                                                                                      | Suggested change |
+| --------------------------------------------------------------------------- | ------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx:102` | Theme mode icons         | keep with reason | Uses the shared Hugeicons wrapper and small-pill icon-size token; icon-only buttons retain translated accessible labels.                                    | None.            |
+| `src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx:125` | Theme segmented control  | keep with reason | Reuses `SegmentedTextPill`, matching the compact controls already established in the adjacent Layout submenu instead of rebuilding segmented-button styles. | None.            |
+| `src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx:136` | Modify appearance action | keep with reason | Reuses the shared `DropdownItem` action-row primitive and delegates navigation to the app's settings route helper.                                          | None.            |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.

--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -128,6 +128,7 @@
     },
     "settingsMenu": {
       "appearance": "Darstellung",
+      "modifyAppearance": "Darstellung ändern",
       "language": "Sprache",
       "viewRam": "RAM anzeigen",
       "tutorials": "Tutorials",

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -157,6 +157,7 @@
     },
     "settingsMenu": {
       "appearance": "Appearance",
+      "modifyAppearance": "Modify appearance",
       "language": "Language",
       "viewRam": "View RAM",
       "tutorials": "Tutorials",

--- a/src/i18n/locales/es/navigation.json
+++ b/src/i18n/locales/es/navigation.json
@@ -128,6 +128,7 @@
     },
     "settingsMenu": {
       "appearance": "Apariencia",
+      "modifyAppearance": "Modificar apariencia",
       "language": "Idioma",
       "viewRam": "Ver RAM",
       "tutorials": "Tutoriales",

--- a/src/i18n/locales/fr/navigation.json
+++ b/src/i18n/locales/fr/navigation.json
@@ -128,6 +128,7 @@
     },
     "settingsMenu": {
       "appearance": "Apparence",
+      "modifyAppearance": "Modifier l’apparence",
       "language": "Langue",
       "viewRam": "Voir la RAM",
       "tutorials": "Tutoriels",

--- a/src/i18n/locales/ja/navigation.json
+++ b/src/i18n/locales/ja/navigation.json
@@ -126,6 +126,7 @@
     },
     "settingsMenu": {
       "appearance": "外観",
+      "modifyAppearance": "外観を変更",
       "language": "言語",
       "viewRam": "RAM を表示",
       "tutorials": "チュートリアル",

--- a/src/i18n/locales/ko/navigation.json
+++ b/src/i18n/locales/ko/navigation.json
@@ -126,6 +126,7 @@
     },
     "settingsMenu": {
       "appearance": "모양",
+      "modifyAppearance": "모양 수정",
       "language": "언어",
       "viewRam": "RAM 보기",
       "tutorials": "튜토리얼",

--- a/src/i18n/locales/pl/navigation.json
+++ b/src/i18n/locales/pl/navigation.json
@@ -126,6 +126,7 @@
     },
     "settingsMenu": {
       "appearance": "Wygląd",
+      "modifyAppearance": "Zmień wygląd",
       "language": "Język",
       "viewRam": "Pokaż RAM",
       "tutorials": "Samouczki",

--- a/src/i18n/locales/pt/navigation.json
+++ b/src/i18n/locales/pt/navigation.json
@@ -128,6 +128,7 @@
     },
     "settingsMenu": {
       "appearance": "Aparência",
+      "modifyAppearance": "Modificar aparência",
       "language": "Idioma",
       "viewRam": "Ver RAM",
       "tutorials": "Tutoriais",

--- a/src/i18n/locales/ru/navigation.json
+++ b/src/i18n/locales/ru/navigation.json
@@ -126,6 +126,7 @@
     },
     "settingsMenu": {
       "appearance": "Внешний вид",
+      "modifyAppearance": "Изменить оформление",
       "language": "Язык",
       "viewRam": "Показать RAM",
       "tutorials": "Обучение",

--- a/src/i18n/locales/tr/navigation.json
+++ b/src/i18n/locales/tr/navigation.json
@@ -126,6 +126,7 @@
     },
     "settingsMenu": {
       "appearance": "Görünüm",
+      "modifyAppearance": "Görünümü değiştir",
       "language": "Dil",
       "viewRam": "RAM’i görüntüle",
       "tutorials": "Eğitimler",

--- a/src/i18n/locales/vi/navigation.json
+++ b/src/i18n/locales/vi/navigation.json
@@ -126,6 +126,7 @@
     },
     "settingsMenu": {
       "appearance": "Giao diện",
+      "modifyAppearance": "Thay đổi giao diện",
       "language": "Ngôn ngữ",
       "viewRam": "Xem RAM",
       "tutorials": "Hướng dẫn",

--- a/src/i18n/locales/zh-Hant/navigation.json
+++ b/src/i18n/locales/zh-Hant/navigation.json
@@ -127,6 +127,7 @@
     },
     "settingsMenu": {
       "appearance": "外觀",
+      "modifyAppearance": "修改外觀",
       "language": "語言",
       "viewRam": "查看 RAM",
       "tutorials": "教學",

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -127,6 +127,7 @@
     },
     "settingsMenu": {
       "appearance": "外观",
+      "modifyAppearance": "修改外观",
       "language": "语言",
       "viewRam": "查看 RAM",
       "tutorials": "教程",

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts
@@ -26,6 +26,7 @@ import SidebarSettingsMenuButton from "./SidebarSettingsMenuButton";
 const mocks = vi.hoisted(() => ({
   closeDropdown: vi.fn(),
   goToSettings: vi.fn(),
+  handleAppearanceModeChange: vi.fn().mockResolvedValue(undefined),
   navigateTo: vi.fn(),
 }));
 
@@ -79,11 +80,12 @@ vi.mock("@src/hooks/dropdown", () => ({
 vi.mock("@src/modules/MainApp/Settings/sections/useAppearanceState", () => ({
   useAppearanceState: () => ({
     appearanceMode: "system",
-    appearanceModeOptions: [],
-    activeSkinId: "orgii",
-    activeSkinOptions: [],
-    handleAppearanceModeChange: vi.fn(),
-    handleActiveSkinChange: vi.fn(),
+    appearanceModeOptions: [
+      { value: "system", label: "Follow system (Dark)" },
+      { value: "light", label: "Light" },
+      { value: "dark", label: "Dark" },
+    ],
+    handleAppearanceModeChange: mocks.handleAppearanceModeChange,
   }),
 }));
 
@@ -315,6 +317,76 @@ describe("SidebarSettingsMenuButton", () => {
     expect(
       document.body.querySelector('[role="switch"]')?.getAttribute("aria-label")
     ).toBe("layoutSettings.paginateChatHistory");
+  });
+
+  it("shows only the icon-only theme control in the appearance submenu", async () => {
+    const appearanceTrigger = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button")
+    ).find(
+      (button) => button.textContent === "sidebar.settingsMenu.appearance"
+    );
+
+    await act(async () => {
+      appearanceTrigger?.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true })
+      );
+    });
+
+    const themeControl = document.body.querySelector<HTMLElement>(
+      '[role="group"][aria-label="general.theme"]'
+    );
+    const themeButtons = Array.from(
+      themeControl?.querySelectorAll<HTMLButtonElement>("button") ?? []
+    );
+
+    expect(themeButtons).toHaveLength(3);
+    expect(
+      themeButtons.map((button) => button.getAttribute("aria-label"))
+    ).toEqual(["Follow system (Dark)", "Light", "Dark"]);
+    expect(themeButtons.map((button) => button.textContent)).toEqual([
+      "",
+      "",
+      "",
+    ]);
+    expect(
+      themeButtons.map((button) => button.getAttribute("aria-pressed"))
+    ).toEqual(["true", "false", "false"]);
+    expect(
+      themeButtons.map((button) =>
+        button.querySelector("[data-icon]")?.getAttribute("data-icon")
+      )
+    ).toEqual(["theme-system", "theme-light", "theme-dark"]);
+
+    expect(document.body.querySelector('[role="menuitemradio"]')).toBeNull();
+
+    await act(async () => themeButtons[2]?.click());
+    expect(mocks.handleAppearanceModeChange).toHaveBeenCalledWith("dark");
+  });
+
+  it("opens Appearance settings from Modify appearance", async () => {
+    const appearanceTrigger = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button")
+    ).find(
+      (button) => button.textContent === "sidebar.settingsMenu.appearance"
+    );
+
+    await act(async () => {
+      appearanceTrigger?.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true })
+      );
+    });
+
+    const modifyAppearance = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find(
+      (item) => item.textContent === "sidebar.settingsMenu.modifyAppearance"
+    );
+
+    expect(modifyAppearance).toBeDefined();
+    await act(async () => modifyAppearance?.click());
+
+    expect(mocks.goToSettings).toHaveBeenCalledWith({ section: "appearance" });
+    expect(mocks.closeDropdown).toHaveBeenCalledOnce();
   });
 
   it("aligns vertically to the row but measures the gap from the outer panel", async () => {

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -159,14 +159,8 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
     onOpenChange: handleSettingsMenuOpenChange,
     additionalInsideRefs: dropdownInsideRefs,
   });
-  const {
-    appearanceMode,
-    appearanceModeOptions,
-    activeSkinId,
-    activeSkinOptions,
-    handleAppearanceModeChange,
-    handleActiveSkinChange,
-  } = useAppearanceState();
+  const { appearanceMode, appearanceModeOptions, handleAppearanceModeChange } =
+    useAppearanceState();
 
   const openSettingsShortcut = getShortcutKeys("open_settings");
   const settingsButtonClassName = isOpen ? "text-text-1" : "text-text-2";
@@ -227,6 +221,11 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
     goToSettings();
   }, [closeAll, goToSettings]);
 
+  const handleModifyAppearance = useCallback(() => {
+    closeAll();
+    goToSettings({ section: "appearance" });
+  }, [closeAll, goToSettings]);
+
   const handleOpenUtilityPanel = useCallback(
     (panel: SettingsUtilityPanel) => {
       setActiveSubmenu(null);
@@ -260,14 +259,6 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
       closeAll();
     },
     [closeAll, handleAppearanceModeChange]
-  );
-
-  const handleSelectSkin = useCallback(
-    (skinId: string) => {
-      handleActiveSkinChange(skinId);
-      closeAll();
-    },
-    [closeAll, handleActiveSkinChange]
   );
 
   const handleSubmenuPointerDown = useCallback(
@@ -509,16 +500,14 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
       <SidebarSettingsMenuSubmenus
         activeSubmenu={activeSubmenu}
         appearanceMode={appearanceMode}
-        appearanceModeLabel={tSettings("general.appearanceMode")}
+        themeLabel={tSettings("general.theme")}
         appearanceModeOptions={appearanceModeOptions}
-        skinId={activeSkinId}
+        modifyAppearanceLabel={t("sidebar.settingsMenu.modifyAppearance")}
         submenuPanelRef={submenuPanelRef}
         submenuPosition={submenuPosition}
-        skinOptions={activeSkinOptions}
-        skinLabel={tSettings("general.skins")}
+        onModifyAppearance={handleModifyAppearance}
         onPresenceSelectionComplete={closeAll}
         onSelectAppearanceMode={(mode) => void handleSelectAppearanceMode(mode)}
-        onSelectSkin={handleSelectSkin}
         onSubmenuMouseDown={handleSubmenuMouseDown}
         onSubmenuPointerDown={handleSubmenuPointerDown}
       />

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx
@@ -1,13 +1,19 @@
 import React from "react";
 import { createPortal } from "react-dom";
 
-import DropdownSelectedCheck from "@src/components/Dropdown/DropdownSelectedCheck";
+import { PILL_SM_ICON_SIZE } from "@src/components/CompoundPill/config";
+import DropdownItem from "@src/components/Dropdown/DropdownItem";
 import type { SubmenuAnchor } from "@src/components/Dropdown/submenuLayout";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
-import type { AppearanceMode } from "@src/config/appearance/globalThemes";
+import SegmentedTextPill from "@src/components/SegmentedTextPill";
+import {
+  APPEARANCE_MODE,
+  type AppearanceMode,
+} from "@src/config/appearance/globalThemes";
+import { HugeiconsIcon, MonitorIcon, MoonIcon, Sun01Icon } from "@src/icons";
 
 import { PresenceMenuItems } from "./SidebarBottomBar";
 import { SidebarLayoutSettingsSubmenu } from "./SidebarLayoutSettingsSubmenu";
@@ -22,31 +28,17 @@ interface AppearanceOption {
   label: string;
 }
 
-interface SkinOption {
-  value: string | number;
-  label: React.ReactNode;
-  /** Swatch preview supplied by the skin registry. */
-  icon?: React.ReactNode;
-}
-
-interface SkinOptionGroup {
-  label: string;
-  options: SkinOption[];
-}
-
 interface SidebarSettingsMenuSubmenusProps {
   activeSubmenu: SettingsSubmenu | null;
   appearanceMode: AppearanceMode;
-  appearanceModeLabel: string;
+  themeLabel: string;
   appearanceModeOptions: readonly AppearanceOption[];
-  skinId: string;
+  modifyAppearanceLabel: string;
   submenuPanelRef: React.Ref<HTMLDivElement>;
   submenuPosition: SubmenuPosition | null;
-  skinOptions: readonly SkinOptionGroup[];
-  skinLabel: string;
+  onModifyAppearance: () => void;
   onPresenceSelectionComplete: () => void;
   onSelectAppearanceMode: (mode: AppearanceMode) => void;
-  onSelectSkin: (skinId: string) => void;
   onSubmenuMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
   onSubmenuPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
 }
@@ -54,16 +46,14 @@ interface SidebarSettingsMenuSubmenusProps {
 export function SidebarSettingsMenuSubmenus({
   activeSubmenu,
   appearanceMode,
-  appearanceModeLabel,
+  themeLabel,
   appearanceModeOptions,
-  skinId,
+  modifyAppearanceLabel,
   submenuPanelRef,
   submenuPosition,
-  skinOptions,
-  skinLabel,
+  onModifyAppearance,
   onPresenceSelectionComplete,
   onSelectAppearanceMode,
-  onSelectSkin,
   onSubmenuMouseDown,
   onSubmenuPointerDown,
 }: SidebarSettingsMenuSubmenusProps): React.ReactPortal | null {
@@ -97,6 +87,30 @@ export function SidebarSettingsMenuSubmenus({
   }
 
   if (activeSubmenu === "appearance") {
+    const appearanceModePillOptions = appearanceModeOptions.map((option) => {
+      const icon =
+        option.value === APPEARANCE_MODE.SYSTEM
+          ? MonitorIcon
+          : option.value === APPEARANCE_MODE.LIGHT
+            ? Sun01Icon
+            : MoonIcon;
+
+      return {
+        value: option.value,
+        ariaLabel: option.label,
+        label: (
+          <HugeiconsIcon
+            icon={icon}
+            data-icon={`theme-${option.value}`}
+            size={PILL_SM_ICON_SIZE}
+            strokeWidth={1.75}
+            className="block"
+            aria-hidden
+          />
+        ),
+      };
+    });
+
     return createPortal(
       <div
         ref={submenuPanelRef}
@@ -106,50 +120,27 @@ export function SidebarSettingsMenuSubmenus({
         onMouseDown={onSubmenuMouseDown}
       >
         <div
-          className={`${DROPDOWN_CLASSES.itemsColumnPadded} scrollbar-overlay max-h-[320px] overflow-y-auto`}
+          className={`${DROPDOWN_CLASSES.itemsColumnPadded} scrollbar-overlay max-h-80 overflow-y-auto`}
         >
-          <div className={DROPDOWN_CLASSES.sectionLabel}>
-            {appearanceModeLabel}
+          <div className={DROPDOWN_CLASSES.menuControlItem}>
+            <span className="min-w-0 flex-1 truncate">{themeLabel}</span>
+            <SegmentedTextPill
+              ariaLabel={themeLabel}
+              size="small"
+              value={appearanceMode}
+              options={appearanceModePillOptions}
+              onChange={onSelectAppearanceMode}
+            />
           </div>
-          {appearanceModeOptions.map((option) => {
-            const selected = appearanceMode === option.value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                className={`${DROPDOWN_CLASSES.menuActionItem} ${selected ? DROPDOWN_CLASSES.itemSelected : ""} justify-between`}
-                onClick={() => onSelectAppearanceMode(option.value)}
-                aria-selected={selected}
-              >
-                <span>{option.label}</span>
-                {selected && <DropdownSelectedCheck />}
-              </button>
-            );
-          })}
           <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
-          <div className={DROPDOWN_CLASSES.sectionLabel}>{skinLabel}</div>
-          {skinOptions.map((group) => (
-            <React.Fragment key={group.label}>
-              {group.options.map((skin) => {
-                const selected = skinId === skin.value;
-                return (
-                  <button
-                    key={skin.value}
-                    type="button"
-                    className={`${DROPDOWN_CLASSES.menuActionItem} ${selected ? DROPDOWN_CLASSES.itemSelected : ""} justify-between`}
-                    onClick={() => onSelectSkin(String(skin.value))}
-                    aria-selected={selected}
-                  >
-                    <span className="flex min-w-0 items-center gap-2">
-                      {skin.icon}
-                      <span className="truncate">{skin.label}</span>
-                    </span>
-                    {selected && <DropdownSelectedCheck />}
-                  </button>
-                );
-              })}
-            </React.Fragment>
-          ))}
+          <DropdownItem
+            fullWidth
+            tabIndex={0}
+            onClick={onModifyAppearance}
+            role="menuitem"
+          >
+            {modifyAppearanceLabel}
+          </DropdownItem>
         </div>
       </div>,
       document.body


### PR DESCRIPTION
## Problem

The sidebar Appearance submenu duplicates the full skin picker and presents theme modes as verbose rows, making a quick settings menu heavier than its purpose. It also lacks a direct route to the complete Appearance settings surface.

## Solution

Replace the submenu with a compact, icon-only system/light/dark segmented control and a translated “Modify appearance” action that opens the Appearance settings section. Remove the duplicate skin selection contract, preserve accessible labels and pressed state, and add focused interaction tests plus the required UI audit.

## Potential risks

Users can no longer change skins directly from the sidebar submenu; that selection now intentionally lives in full Appearance settings. Theme mode remains directly available. The translated action was added across all navigation locales, but rendered screenshots and keyboard traversal were not captured because desktop UI control was not authorized.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts` — passed, 1 file and 10 tests.
- `git diff --check` — passed.
- Pre-commit oxlint, ESLint, Prettier, and staged-file TypeScript check — passed.
- Rendered WDIO/visual verification was not run because desktop UI control requires explicit opt-in in this workspace.

## Audit

Frontend UI verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
