### PR TITLE
style(settings): remove redundant appearance descriptions

### DIFF
--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "Tiefe der Seitenleistenkante",
     "selectedItemTransparency": "Transparenz ausgewählter Elemente",
     "spotlightPlacement": "Spotlight-Position",
-    "spotlightPlacementDesc": "Wählen Sie, wo die Spotlight-Befehlspalette geöffnet wird",
     "spotlightPlacementOptions": {
       "top": "Oben",
       "center": "Seitenmitte"

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -168,7 +168,6 @@
     "sidebarEdgeDepth": "Sidebar edge depth",
     "selectedItemTransparency": "Selected item transparency",
     "spotlightPlacement": "Spotlight position",
-    "spotlightPlacementDesc": "Choose where the Spotlight command palette opens",
     "spotlightPlacementOptions": {
       "top": "Top",
       "center": "Page center"
@@ -221,7 +220,6 @@
     "darkSkin": "Dark skin",
     "lightAccent": "Light accent",
     "darkAccent": "Dark accent",
-    "accentDesc": "Match skin uses the accent the selected skin declares",
     "skinGroups": {
       "orgii": "ORGII",
       "codex": "Codex"
@@ -233,8 +231,6 @@
       "monochrome": "Monochrome"
     },
     "translucentSidebar": "Translucent sidebar",
-    "translucentSidebarDesc": "Let the sidebar blur and tint what sits behind it. Turn off for a solid panel",
-    "sidebarOpacityDesc": "How much of the background shows through",
     "skin": "Skin",
     "accent": "Accent",
     "linkSkinVariants": "Link light and dark",

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "Profundidad del borde de la barra lateral",
     "selectedItemTransparency": "Transparencia del elemento seleccionado",
     "spotlightPlacement": "Posición de Spotlight",
-    "spotlightPlacementDesc": "Elige dónde se abre la paleta de comandos Spotlight",
     "spotlightPlacementOptions": {
       "top": "Arriba",
       "center": "Centro de la página"

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "Profondeur du bord de la barre latérale",
     "selectedItemTransparency": "Transparence de l’élément sélectionné",
     "spotlightPlacement": "Position de Spotlight",
-    "spotlightPlacementDesc": "Choisissez où s’ouvre la palette de commandes Spotlight",
     "spotlightPlacementOptions": {
       "top": "Haut",
       "center": "Centre de la page"

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "サイドバー境界の奥行き",
     "selectedItemTransparency": "選択項目の透明度",
     "spotlightPlacement": "Spotlight の位置",
-    "spotlightPlacementDesc": "Spotlight コマンドパレットを開く位置を選択",
     "spotlightPlacementOptions": {
       "top": "上部",
       "center": "ページ中央"

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "사이드바 경계 깊이",
     "selectedItemTransparency": "선택한 항목 투명도",
     "spotlightPlacement": "Spotlight 위치",
-    "spotlightPlacementDesc": "Spotlight 명령 팔레트가 열릴 위치를 선택합니다",
     "spotlightPlacementOptions": {
       "top": "상단",
       "center": "페이지 중앙"

--- a/src/i18n/locales/pl/settings.json
+++ b/src/i18n/locales/pl/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "Głębia krawędzi paska bocznego",
     "selectedItemTransparency": "Przezroczystość wybranego elementu",
     "spotlightPlacement": "Pozycja Spotlight",
-    "spotlightPlacementDesc": "Wybierz, gdzie otwiera się paleta poleceń Spotlight",
     "spotlightPlacementOptions": {
       "top": "Góra",
       "center": "Środek strony"

--- a/src/i18n/locales/pt/settings.json
+++ b/src/i18n/locales/pt/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "Profundidade da borda da barra lateral",
     "selectedItemTransparency": "Transparência do item selecionado",
     "spotlightPlacement": "Posição do Spotlight",
-    "spotlightPlacementDesc": "Escolha onde a paleta de comandos Spotlight abre",
     "spotlightPlacementOptions": {
       "top": "Topo",
       "center": "Centro da página"

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "Глубина границы боковой панели",
     "selectedItemTransparency": "Прозрачность выбранного элемента",
     "spotlightPlacement": "Положение Spotlight",
-    "spotlightPlacementDesc": "Выберите, где открывается командная палитра Spotlight",
     "spotlightPlacementOptions": {
       "top": "Сверху",
       "center": "По центру страницы"

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "Kenar çubuğu kenar derinliği",
     "selectedItemTransparency": "Seçili öğe şeffaflığı",
     "spotlightPlacement": "Spotlight konumu",
-    "spotlightPlacementDesc": "Spotlight komut paletinin nerede açılacağını seçin",
     "spotlightPlacementOptions": {
       "top": "Üst",
       "center": "Sayfa merkezi"

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "Độ sâu cạnh thanh bên",
     "selectedItemTransparency": "Độ trong suốt của mục đã chọn",
     "spotlightPlacement": "Vị trí Spotlight",
-    "spotlightPlacementDesc": "Chọn nơi bảng lệnh Spotlight mở ra",
     "spotlightPlacementOptions": {
       "top": "Trên cùng",
       "center": "Giữa trang"

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -169,7 +169,6 @@
     "sidebarEdgeDepth": "側邊欄邊緣層次",
     "selectedItemTransparency": "選取項目透明度",
     "spotlightPlacement": "Spotlight 位置",
-    "spotlightPlacementDesc": "選擇 Spotlight 命令面板開啟的位置",
     "spotlightPlacementOptions": {
       "top": "頂部",
       "center": "頁面置中"

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -168,7 +168,6 @@
     "sidebarEdgeDepth": "侧边栏边缘层次",
     "selectedItemTransparency": "选中项目透明度",
     "spotlightPlacement": "Spotlight 位置",
-    "spotlightPlacementDesc": "选择 Spotlight 命令面板打开的位置",
     "spotlightPlacementOptions": {
       "top": "顶部",
       "center": "页面居中"
@@ -221,7 +220,6 @@
     "darkSkin": "深色皮肤",
     "lightAccent": "浅色强调色",
     "darkAccent": "深色强调色",
-    "accentDesc": "“跟随皮肤”会使用所选皮肤自带的强调色",
     "skinGroups": {
       "orgii": "ORGII",
       "codex": "Codex"
@@ -233,8 +231,6 @@
       "monochrome": "单色"
     },
     "translucentSidebar": "半透明侧边栏",
-    "translucentSidebarDesc": "让侧边栏模糊并透出背后的内容；关闭后为纯色面板",
-    "sidebarOpacityDesc": "背景透出的程度",
     "skin": "皮肤",
     "accent": "强调色",
     "linkSkinVariants": "统一浅色与深色",

--- a/src/modules/MainApp/Settings/sections/AppearanceSection.tsx
+++ b/src/modules/MainApp/Settings/sections/AppearanceSection.tsx
@@ -63,10 +63,7 @@ const SidebarOpacityRow: React.FC = () => {
   const [config, setConfig] = useAtom(backgroundConfigPersistAtom);
 
   return (
-    <SectionRow
-      label={t("background.sidebarOpacity")}
-      description={t("general.sidebarOpacityDesc")}
-    >
+    <SectionRow label={t("background.sidebarOpacity")}>
       <div className="min-w-0" style={SECTION_CONTROL_STYLE}>
         <Slider
           min={MIN_SIDEBAR_OPACITY}
@@ -181,10 +178,7 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
                     dataTestId="unified-skin-select"
                   />
                 </SectionRow>
-                <SectionRow
-                  label={t("general.accent")}
-                  description={t("general.accentDesc")}
-                >
+                <SectionRow label={t("general.accent")}>
                   <Select
                     value={unifiedAccent}
                     onChange={(value) =>
@@ -228,10 +222,7 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
                     dataTestId="dark-skin-select"
                   />
                 </SectionRow>
-                <SectionRow
-                  label={t("general.lightAccent")}
-                  description={t("general.accentDesc")}
-                >
+                <SectionRow label={t("general.lightAccent")}>
                   <Select
                     value={lightAccent}
                     onChange={(value) =>
@@ -320,10 +311,7 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
           </SectionContainer>
 
           <SectionContainer title={t("general.sidebar")}>
-            <SectionRow
-              label={t("general.translucentSidebar")}
-              description={t("general.translucentSidebarDesc")}
-            >
+            <SectionRow label={t("general.translucentSidebar")}>
               <Switch
                 checked={translucentSidebar}
                 onCheckedChange={setTranslucentSidebar}
@@ -358,10 +346,7 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
           </SectionContainer>
 
           <SectionContainer title={t("general.spotlight")}>
-            <SectionRow
-              label={t("general.spotlightPlacement")}
-              description={t("general.spotlightPlacementDesc")}
-            >
+            <SectionRow label={t("general.spotlightPlacement")}>
               <Select
                 value={spotlightPlacement}
                 onChange={(value) =>


### PR DESCRIPTION
## Problem

Several Appearance settings rows repeat descriptions that restate their labels or immediately visible controls. The extra copy makes the section denser without adding a separate decision or constraint.

## Solution

Remove the redundant descriptions from sidebar opacity, accent, translucent sidebar, and Spotlight placement rows, then delete the now-unused locale keys across the settings catalogs.

## Potential risks

The affected controls have less explanatory copy, so users must infer behavior from their labels and visible options. No control values, persistence, defaults, or settings behavior changed. Screenshots were not captured because desktop UI control was not authorized.

## Verification

- Parsed every `src/i18n/locales/*/settings.json` file with `JSON.parse` — passed.
- Repository sweep for `spotlightPlacementDesc`, `accentDesc`, `translucentSidebarDesc`, and `sidebarOpacityDesc` — zero remaining references.
- `git diff --check` — passed.
- Pre-commit oxlint, ESLint, Prettier, and staged-file TypeScript check — passed.
- Rendered visual verification was not run because desktop UI control requires explicit opt-in in this workspace.
