### PR TITLE
fix(chat-panel): preserve composer across target switch

### DIFF
--- a/docs/frontend-ui-audit-2026-09-02/SessionWorkItemComposer.md
+++ b/docs/frontend-ui-audit-2026-09-02/SessionWorkItemComposer.md
@@ -1,0 +1,10 @@
+# Session / Work Item composer UI audit
+
+| Line                                                           | Element                            | Verdict          | Reason                                                                                                                                                                           | Suggested change |
+| -------------------------------------------------------------- | ---------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/engines/ChatPanel/ChatPanelStartPage.tsx:236`             | Shared agent-launcher selection    | keep with reason | Session and agent-assisted Work Item now use one launcher seam, while the manual Work Item path retains its purpose-built Markdown editor and save controls.                     | None.            |
+| `src/engines/ChatPanel/ChatPanelStartPage.tsx:366`             | Persistent creator layout          | keep with reason | Both agent targets occupy the same `CreatorContentLayout` and DOM wrapper position, preserving the composer instance without introducing a parallel shell.                       | None.            |
+| `src/engines/ChatPanel/StartPageAgentComposer.tsx:88`          | Layout-neutral portal hosts        | keep with reason | These non-interactive `contents` containers are mount targets for lazy Work Item chrome; no design-system primitive represents this structural role.                             | None.            |
+| `src/engines/ChatPanel/StartPageWorkItemComposerChrome.tsx:79` | Work Item title and property slots | keep with reason | The portaled content reuses `CreateComposerHeader` and `CreateComposerPinnedActions`, preserving the established title divider, property-pill treatment, and dropdown direction. | None.            |
+
+Verdict totals: **0 fix**, **4 keep with reason**, **0 abstract**.

--- a/src/engines/ChatPanel/ChatPanelEmptyContent.tsx
+++ b/src/engines/ChatPanel/ChatPanelEmptyContent.tsx
@@ -23,6 +23,10 @@ import {
 import { STORY_PERSONAL_ORG_FILTER_ID } from "@src/store/workstation/tabs";
 
 import { ChatPanelStartPage } from "./ChatPanelStartPage";
+import {
+  type DefaultAiWorkItemExecutionTarget,
+  StartPageAgentComposer,
+} from "./StartPageAgentComposer";
 import type { ChatPanelProps, ChatPanelRegionNotice } from "./types";
 
 const CreateProjectView = React.lazy(
@@ -42,13 +46,6 @@ interface EmbeddedAgentComposerOptions {
   onSessionStart: NonNullable<SessionCreatorSlotProps["onSessionStart"]>;
   resolveWorkItemContext?: SessionCreatorSlotProps["resolveWorkItemContext"];
   workItemContext?: SessionCreatorSlotProps["workItemContext"];
-}
-
-interface DefaultAiWorkItemExecutionTarget {
-  id: string;
-  name: string;
-  type: "agent" | "org";
-  agentDefinitionId?: string;
 }
 
 interface WorkspaceScopedCreateContext {
@@ -301,17 +298,6 @@ export function ChatPanelEmptyContent({
   };
 
   if (showStartPage) {
-    const sessionLauncher = (
-      heroFooterSlot: React.ReactNode,
-      launchpadActionsVisible: boolean
-    ) =>
-      renderSessionLauncher(
-        "h-full",
-        "launchpad",
-        heroFooterSlot,
-        false,
-        !launchpadActionsVisible
-      );
     const moreCreateTarget =
       createTarget === CHAT_PANEL_CREATE_TARGET.PROJECT ||
       createTarget === CHAT_PANEL_CREATE_TARGET.PARALLEL_RUN
@@ -327,6 +313,35 @@ export function ChatPanelEmptyContent({
 
     return (
       <ChatPanelStartPage
+        agentLauncher={
+          SessionCreatorSlot
+            ? ({
+                createTarget: agentCreateTarget,
+                heroFooterSlot,
+                launchpadActionsVisible,
+                workItemModeControl,
+              }) => (
+                <StartPageAgentComposer
+                  createTarget={agentCreateTarget}
+                  creatorModeControl={workItemModeControl}
+                  creatorVariant={creatorVariant}
+                  defaultAiWorkItemExecutionTarget={
+                    defaultAiWorkItemExecutionTarget
+                  }
+                  handleAiWorkItemSessionStart={handleAiWorkItemSessionStart}
+                  handleOpenCliTerminal={handleOpenCliTerminal}
+                  handleRegionNoticeChange={handleRegionNoticeChange}
+                  handleStartPageSessionStart={handleStartPageSessionStart}
+                  heroFooterSlot={heroFooterSlot}
+                  launchpadActionsVisible={launchpadActionsVisible}
+                  onDraftChange={setWorkItemCreateDraft}
+                  orgId={createProjectContext?.orgId}
+                  resolveAiWorkItemContext={resolveAiWorkItemContext}
+                  SessionCreatorSlot={SessionCreatorSlot}
+                />
+              )
+            : undefined
+        }
         className={creatorClassName}
         createTarget={createTarget}
         createTargetOptions={createTargetOptions}
@@ -337,11 +352,10 @@ export function ChatPanelEmptyContent({
         onProjectAgentModeChange={handleProjectAgentCreatorToggle}
         onWorkItemAgentModeChange={handleWorkItemAgentCreatorToggle}
         moreLauncher={moreLauncher}
-        sessionLauncher={sessionLauncher}
         t={t}
         projectAgentMode={showProjectAgentCreator}
         workItemAgentMode={showWorkItemAgentCreator}
-        workItemLauncher={(manualMiddleContent, creatorModeControl) =>
+        manualWorkItemLauncher={(manualMiddleContent, creatorModeControl) =>
           renderWorkItemCreator(manualMiddleContent, creatorModeControl)
         }
       />

--- a/src/engines/ChatPanel/ChatPanelStartPage.lifecycle.test.ts
+++ b/src/engines/ChatPanel/ChatPanelStartPage.lifecycle.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { Provider } from "jotai";
+import {
+  type ComponentProps,
+  act,
+  createElement,
+  useEffect,
+  useState,
+} from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CHAT_PANEL_CREATE_TARGET,
+  type ChatPanelCreateTarget,
+} from "@src/store/ui/chatPanelAtom";
+
+import { ChatPanelStartPage } from "./ChatPanelStartPage";
+
+const mocks = vi.hoisted(() => ({
+  mounts: vi.fn(),
+  unmounts: vi.fn(),
+  useAvailableAppUpdate: vi.fn(),
+}));
+
+vi.mock("@src/scaffold/AppUpdater", () => ({
+  useAvailableAppUpdate: mocks.useAvailableAppUpdate,
+}));
+
+const t = ((key: string) => key) as ComponentProps<
+  typeof ChatPanelStartPage
+>["t"];
+
+function TrackedAgentComposer({
+  createTarget,
+}: {
+  createTarget: ChatPanelCreateTarget;
+}) {
+  useEffect(() => {
+    mocks.mounts();
+    return () => mocks.unmounts();
+  }, []);
+
+  return createElement("textarea", {
+    "data-create-target": createTarget,
+    "data-testid": "tracked-agent-composer",
+    defaultValue: "draft",
+  });
+}
+
+function Harness() {
+  const [createTarget, setCreateTarget] = useState<ChatPanelCreateTarget>(
+    CHAT_PANEL_CREATE_TARGET.AGENT_SESSION
+  );
+
+  return createElement(ChatPanelStartPage, {
+    agentLauncher: ({ createTarget: agentCreateTarget }) =>
+      createElement(TrackedAgentComposer, {
+        createTarget: agentCreateTarget,
+      }),
+    createTarget,
+    createTargetOptions: [
+      { value: CHAT_PANEL_CREATE_TARGET.PROJECT, label: "Create project" },
+    ],
+    onAddApiKey: vi.fn(),
+    onCreateTarget: (target) =>
+      setCreateTarget(target as ChatPanelCreateTarget),
+    onInstallLatestUpdate: vi.fn(),
+    onProjectAgentModeChange: vi.fn(),
+    onShowRuntime: vi.fn(),
+    onWorkItemAgentModeChange: vi.fn(),
+    projectAgentMode: true,
+    t,
+    workItemAgentMode: true,
+  });
+}
+
+describe("ChatPanelStartPage agent composer lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    mocks.useAvailableAppUpdate.mockReturnValue(null);
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps the agent composer mounted when Session changes to Work Item", () => {
+    act(() => {
+      root.render(createElement(Provider, null, createElement(Harness)));
+    });
+
+    const composer = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="tracked-agent-composer"]'
+    );
+    expect(composer).not.toBeNull();
+    expect(mocks.mounts).toHaveBeenCalledTimes(1);
+    composer!.value = "unfinished prompt";
+
+    const workItemTab = container.querySelector<HTMLElement>(
+      '[data-testid="chat-panel-start-page-tab-work-item"]'
+    );
+    expect(workItemTab).not.toBeNull();
+    act(() => {
+      workItemTab!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const workItemComposer = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="tracked-agent-composer"]'
+    );
+    expect(workItemComposer).toBe(composer);
+    expect(workItemComposer?.value).toBe("unfinished prompt");
+    expect(workItemComposer?.dataset.createTarget).toBe(
+      CHAT_PANEL_CREATE_TARGET.WORK_ITEM
+    );
+    expect(mocks.mounts).toHaveBeenCalledTimes(1);
+    expect(mocks.unmounts).not.toHaveBeenCalled();
+  });
+});

--- a/src/engines/ChatPanel/ChatPanelStartPage.test.ts
+++ b/src/engines/ChatPanel/ChatPanelStartPage.test.ts
@@ -136,7 +136,7 @@ describe("ChatPanelStartPage", () => {
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
         createTarget: CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
-        sessionLauncher: (heroFooterSlot) =>
+        agentLauncher: ({ heroFooterSlot }) =>
           createElement("div", null, "Session launcher", heroFooterSlot),
         t,
       })
@@ -193,7 +193,7 @@ describe("ChatPanelStartPage", () => {
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
         createTarget: CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
-        sessionLauncher: (heroFooterSlot) =>
+        agentLauncher: ({ heroFooterSlot }) =>
           createElement("div", null, "Session launcher", heroFooterSlot),
         t,
       })
@@ -245,7 +245,7 @@ describe("ChatPanelStartPage", () => {
         createElement(ChatPanelStartPage, {
           ...createTargetProps,
           createTarget: CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
-          sessionLauncher: (heroFooterSlot, launchpadActionsVisible) => {
+          agentLauncher: ({ heroFooterSlot, launchpadActionsVisible }) => {
             receivedVisibility = launchpadActionsVisible;
             return createElement(
               "div",
@@ -292,7 +292,7 @@ describe("ChatPanelStartPage", () => {
         createTarget: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
         t,
         workItemAgentMode: false,
-        workItemLauncher: (manualMiddleContent, modeControl) =>
+        manualWorkItemLauncher: (manualMiddleContent, modeControl) =>
           createElement(
             "div",
             { "data-testid": "full-work-item-creator" },
@@ -377,7 +377,7 @@ describe("ChatPanelStartPage", () => {
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
         createTarget: CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
-        sessionLauncher: (heroFooterSlot) =>
+        agentLauncher: ({ heroFooterSlot }) =>
           createElement("div", null, "Session launcher", heroFooterSlot),
         t,
       })

--- a/src/engines/ChatPanel/ChatPanelStartPage.tsx
+++ b/src/engines/ChatPanel/ChatPanelStartPage.tsx
@@ -30,7 +30,17 @@ import {
 
 type StartPageView = "session" | "work-item" | "more";
 
+interface StartPageAgentLauncherOptions {
+  createTarget:
+    | typeof CHAT_PANEL_CREATE_TARGET.AGENT_SESSION
+    | typeof CHAT_PANEL_CREATE_TARGET.WORK_ITEM;
+  heroFooterSlot: React.ReactNode;
+  launchpadActionsVisible: boolean;
+  workItemModeControl: React.ReactNode;
+}
+
 interface ChatPanelStartPageProps {
+  agentLauncher?: (options: StartPageAgentLauncherOptions) => React.ReactNode;
   className?: string;
   createTarget: ChatPanelCreateTarget;
   createTargetOptions: SelectOption[];
@@ -45,13 +55,9 @@ interface ChatPanelStartPageProps {
   onProjectAgentModeChange: (enabled: boolean) => void;
   onWorkItemAgentModeChange: (enabled: boolean) => void;
   projectAgentMode: boolean;
-  sessionLauncher?: (
-    heroFooterSlot: React.ReactNode,
-    launchpadActionsVisible: boolean
-  ) => React.ReactNode;
   t: TFunction<["sessions", "common", "projects", "navigation"]>;
   workItemAgentMode: boolean;
-  workItemLauncher?: (
+  manualWorkItemLauncher?: (
     manualMiddleContent: React.ReactNode,
     creatorModeControl: React.ReactNode
   ) => React.ReactNode;
@@ -87,6 +93,7 @@ function StartPageCreatorModeToggle({
 }
 
 export function ChatPanelStartPage({
+  agentLauncher,
   className,
   createTarget,
   createTargetOptions,
@@ -98,10 +105,9 @@ export function ChatPanelStartPage({
   onProjectAgentModeChange,
   onWorkItemAgentModeChange,
   projectAgentMode,
-  sessionLauncher,
   t,
   workItemAgentMode,
-  workItemLauncher,
+  manualWorkItemLauncher,
 }: ChatPanelStartPageProps): React.ReactNode {
   const composerPosition = useAtomValue(creatorComposerPositionAtom);
   const launchpadActionsVisible = useAtomValue(
@@ -227,14 +233,22 @@ export function ChatPanelStartPage({
       t={t}
     />
   );
-  const sessionLauncherContent = sessionLauncher?.(
-    suggestionActions,
-    launchpadActionsVisible
-  );
-  const workItemLauncherContent = workItemLauncher?.(
-    manualMiddleContent,
-    workItemModeControl
-  );
+  const showManualWorkItem = activeView === "work-item" && !workItemAgentMode;
+  const agentLauncherContent =
+    activeView !== "more" && !showManualWorkItem
+      ? agentLauncher?.({
+          createTarget:
+            activeView === "work-item"
+              ? CHAT_PANEL_CREATE_TARGET.WORK_ITEM
+              : CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
+          heroFooterSlot: suggestionActions,
+          launchpadActionsVisible,
+          workItemModeControl,
+        })
+      : null;
+  const manualWorkItemLauncherContent = showManualWorkItem
+    ? manualWorkItemLauncher?.(manualMiddleContent, workItemModeControl)
+    : null;
   const moreLauncherContent = moreLauncher?.(
     manualMiddleContent,
     createTarget === CHAT_PANEL_CREATE_TARGET.PROJECT
@@ -334,12 +348,12 @@ export function ChatPanelStartPage({
         </div>
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
-        {activeView === "work-item" ? (
+        {showManualWorkItem ? (
           <div
             className="flex h-full min-h-0 w-full"
             data-testid="chat-panel-start-page-work-item-launcher"
           >
-            {workItemLauncherContent}
+            {manualWorkItemLauncherContent}
           </div>
         ) : activeView === "more" ? (
           <div
@@ -351,14 +365,22 @@ export function ChatPanelStartPage({
         ) : (
           <CreatorContentLayout
             placement="fill"
-            contentDataTestId="chat-panel-start-page-session-content"
+            contentDataTestId={
+              activeView === "work-item"
+                ? "chat-panel-start-page-work-item-content"
+                : "chat-panel-start-page-session-content"
+            }
           >
-            {sessionLauncherContent ? (
+            {agentLauncherContent ? (
               <div
                 className="h-full w-full"
-                data-testid="chat-panel-start-page-session-launcher"
+                data-testid={
+                  activeView === "work-item"
+                    ? "chat-panel-start-page-work-item-launcher"
+                    : "chat-panel-start-page-session-launcher"
+                }
               >
-                {sessionLauncherContent}
+                {agentLauncherContent}
               </div>
             ) : null}
           </CreatorContentLayout>

--- a/src/engines/ChatPanel/StartPageAgentComposer.test.ts
+++ b/src/engines/ChatPanel/StartPageAgentComposer.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { Provider } from "jotai";
+import { type ComponentProps, act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SESSION_CREATOR_LAUNCH_MODE } from "@src/features/SessionCreator/types";
+import { CHAT_PANEL_CREATE_TARGET } from "@src/store/ui/chatPanelAtom";
+
+import { StartPageAgentComposer } from "./StartPageAgentComposer";
+import type { ChatPanelProps } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  captureSlotProps: vi.fn(),
+  mounts: vi.fn(),
+  unmounts: vi.fn(),
+}));
+
+vi.mock("./StartPageWorkItemComposerChrome", () => ({
+  default: () => null,
+}));
+
+const SessionCreatorSlot: NonNullable<ChatPanelProps["sessionCreatorSlot"]> = (
+  props
+) => {
+  useEffect(() => {
+    mocks.captureSlotProps(props);
+  });
+  useEffect(() => {
+    mocks.mounts();
+    return () => mocks.unmounts();
+  }, []);
+  return createElement(
+    "div",
+    { "data-testid": "session-creator-slot" },
+    props.composerHeaderContent,
+    props.pinnedActionsContent
+  );
+};
+
+const baseProps = {
+  creatorModeControl: createElement("div", null, "mode"),
+  creatorVariant: "fullScreen" as const,
+  defaultAiWorkItemExecutionTarget: null,
+  handleAiWorkItemSessionStart: vi.fn(),
+  handleOpenCliTerminal: vi.fn(),
+  handleRegionNoticeChange: vi.fn(),
+  handleStartPageSessionStart: vi.fn(),
+  heroFooterSlot: createElement("div", null, "suggestions"),
+  launchpadActionsVisible: true,
+  onDraftChange: vi.fn(),
+  resolveAiWorkItemContext: vi.fn(),
+  SessionCreatorSlot,
+} satisfies Omit<ComponentProps<typeof StartPageAgentComposer>, "createTarget">;
+
+function latestSlotProps(): Record<string, unknown> {
+  return mocks.captureSlotProps.mock.lastCall?.[0] as Record<string, unknown>;
+}
+
+describe("StartPageAgentComposer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  async function render(
+    createTarget: ComponentProps<typeof StartPageAgentComposer>["createTarget"]
+  ) {
+    await act(async () => {
+      root.render(
+        createElement(
+          Provider,
+          null,
+          createElement(StartPageAgentComposer, {
+            ...baseProps,
+            createTarget,
+          })
+        )
+      );
+    });
+  }
+
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("changes only composer chrome and launch semantics for Work Item", async () => {
+    await render(CHAT_PANEL_CREATE_TARGET.AGENT_SESSION);
+
+    expect(latestSlotProps().composerHeaderContent).toBeUndefined();
+    expect(latestSlotProps().pinnedActionsContent).toBeUndefined();
+    expect(latestSlotProps().heroFooterSlot).toBe(baseProps.heroFooterSlot);
+    expect(latestSlotProps().onSessionStart).toBe(
+      baseProps.handleStartPageSessionStart
+    );
+    expect(mocks.mounts).toHaveBeenCalledTimes(1);
+
+    await render(CHAT_PANEL_CREATE_TARGET.WORK_ITEM);
+
+    expect(latestSlotProps().composerHeaderContent).toBeDefined();
+    expect(latestSlotProps().pinnedActionsContent).toBeDefined();
+    expect(latestSlotProps().heroFooterSlot).toBeUndefined();
+    expect(latestSlotProps().hideWorkItemAttachmentControl).toBe(true);
+    expect(latestSlotProps().includeHumanSession).toBe(false);
+    expect(latestSlotProps().launchMode).toBe(
+      SESSION_CREATOR_LAUNCH_MODE.START_BACKGROUND
+    );
+    expect(latestSlotProps().launchpadIntent).toBe("plan");
+    expect(latestSlotProps().onSessionStart).toBe(
+      baseProps.handleAiWorkItemSessionStart
+    );
+    expect(latestSlotProps().resolveWorkItemContext).toBe(
+      baseProps.resolveAiWorkItemContext
+    );
+    expect(mocks.mounts).toHaveBeenCalledTimes(1);
+    expect(mocks.unmounts).not.toHaveBeenCalled();
+  });
+});

--- a/src/engines/ChatPanel/StartPageAgentComposer.tsx
+++ b/src/engines/ChatPanel/StartPageAgentComposer.tsx
@@ -1,0 +1,136 @@
+import React, { Suspense, useCallback, useState } from "react";
+
+import { SESSION_CREATOR_LAUNCH_MODE } from "@src/features/SessionCreator/types";
+import { CHAT_PANEL_CREATE_TARGET } from "@src/store/ui/chatPanelAtom";
+import type { WorkItemDraft } from "@src/store/workstation/projectManager";
+
+import type { ChatPanelProps, ChatPanelRegionNotice } from "./types";
+
+const StartPageWorkItemComposerChrome = React.lazy(
+  () => import("./StartPageWorkItemComposerChrome")
+);
+
+type SessionCreatorSlot = NonNullable<ChatPanelProps["sessionCreatorSlot"]>;
+type SessionCreatorSlotProps = React.ComponentProps<SessionCreatorSlot>;
+
+type StartPageAgentCreateTarget =
+  | typeof CHAT_PANEL_CREATE_TARGET.AGENT_SESSION
+  | typeof CHAT_PANEL_CREATE_TARGET.WORK_ITEM;
+
+export interface DefaultAiWorkItemExecutionTarget {
+  id: string;
+  name: string;
+  type: "agent" | "org";
+  agentDefinitionId?: string;
+}
+
+interface StartPageAgentComposerProps {
+  createTarget: StartPageAgentCreateTarget;
+  creatorModeControl: React.ReactNode;
+  creatorVariant: "default" | "fullScreen";
+  defaultAiWorkItemExecutionTarget: DefaultAiWorkItemExecutionTarget | null;
+  handleAiWorkItemSessionStart: NonNullable<
+    SessionCreatorSlotProps["onSessionStart"]
+  >;
+  handleOpenCliTerminal: NonNullable<
+    SessionCreatorSlotProps["onOpenCliTerminal"]
+  >;
+  handleRegionNoticeChange: (notice: ChatPanelRegionNotice | null) => void;
+  handleStartPageSessionStart: NonNullable<
+    SessionCreatorSlotProps["onSessionStart"]
+  >;
+  heroFooterSlot: React.ReactNode;
+  launchpadActionsVisible: boolean;
+  onDraftChange: (draft: WorkItemDraft) => void;
+  orgId?: string;
+  resolveAiWorkItemContext: NonNullable<
+    SessionCreatorSlotProps["resolveWorkItemContext"]
+  >;
+  SessionCreatorSlot: SessionCreatorSlot;
+}
+
+/**
+ * One stable SessionCreator owner for the Session and agent-assisted Work Item
+ * tabs. Switching targets changes only the launch contract and composer chrome;
+ * the editor, draft restoration, repository state, and creator hooks stay
+ * mounted at the same React position.
+ */
+export function StartPageAgentComposer({
+  createTarget,
+  creatorModeControl,
+  creatorVariant,
+  defaultAiWorkItemExecutionTarget,
+  handleAiWorkItemSessionStart,
+  handleOpenCliTerminal,
+  handleRegionNoticeChange,
+  handleStartPageSessionStart,
+  heroFooterSlot,
+  launchpadActionsVisible,
+  onDraftChange,
+  orgId,
+  resolveAiWorkItemContext,
+  SessionCreatorSlot,
+}: StartPageAgentComposerProps): React.ReactNode {
+  const isWorkItem = createTarget === CHAT_PANEL_CREATE_TARGET.WORK_ITEM;
+  const [headerHost, setHeaderHost] = useState<HTMLDivElement | null>(null);
+  const [pinnedActionsHost, setPinnedActionsHost] =
+    useState<HTMLDivElement | null>(null);
+  const handleHeaderHostRef = useCallback((node: HTMLDivElement | null) => {
+    setHeaderHost(node);
+  }, []);
+  const handlePinnedActionsHostRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setPinnedActionsHost(node);
+    },
+    []
+  );
+
+  const composerHeaderContent = isWorkItem ? (
+    <div ref={handleHeaderHostRef} className="contents" />
+  ) : undefined;
+  const pinnedActionsContent = isWorkItem ? (
+    <div ref={handlePinnedActionsHostRef} className="contents" />
+  ) : undefined;
+
+  return (
+    <>
+      <SessionCreatorSlot
+        className="h-full min-h-0 flex-1"
+        variant={creatorVariant}
+        layout="launchpad"
+        launchpadIntent={isWorkItem ? "plan" : "build"}
+        composerHeaderContent={composerHeaderContent}
+        heroFooterSlot={isWorkItem ? undefined : heroFooterSlot}
+        pinnedActionsContent={pinnedActionsContent}
+        hidePresenceButton
+        hideWorkItemAttachmentControl={isWorkItem || !launchpadActionsVisible}
+        includeHumanSession={isWorkItem ? false : undefined}
+        launchMode={
+          isWorkItem ? SESSION_CREATOR_LAUNCH_MODE.START_BACKGROUND : undefined
+        }
+        onOpenCliTerminal={handleOpenCliTerminal}
+        onRegionNoticeChange={handleRegionNoticeChange}
+        onSessionStart={
+          isWorkItem
+            ? handleAiWorkItemSessionStart
+            : handleStartPageSessionStart
+        }
+        resolveWorkItemContext={
+          isWorkItem ? resolveAiWorkItemContext : undefined
+        }
+      />
+      {isWorkItem ? (
+        <Suspense fallback={null}>
+          <StartPageWorkItemComposerChrome
+            creatorModeControl={creatorModeControl}
+            defaultAiWorkItemExecutionTarget={defaultAiWorkItemExecutionTarget}
+            headerHost={headerHost}
+            onDraftChange={onDraftChange}
+            orgId={orgId}
+            pinnedActionsHost={pinnedActionsHost}
+          />
+        </Suspense>
+      ) : null}
+    </>
+  );
+}

--- a/src/engines/ChatPanel/StartPageWorkItemComposerChrome.test.ts
+++ b/src/engines/ChatPanel/StartPageWorkItemComposerChrome.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { Provider } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_ORCHESTRATOR_CONFIG } from "@src/modules/ProjectManager/WorkItems/constants";
+
+import StartPageWorkItemComposerChrome from "./StartPageWorkItemComposerChrome";
+
+const mocks = vi.hoisted(() => ({
+  updateDraft: vi.fn(),
+}));
+
+vi.mock(
+  "@src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/InlineCreateWorkItemFields",
+  () => ({
+    useInlineCreateWorkItemFields: () => ({
+      draft: {
+        name: "",
+        description: "",
+        status: "todo",
+        priority: "medium",
+        labelIds: [],
+      },
+      inlinePropertyPills: "properties",
+      titleSection: "title",
+      updateDraft: mocks.updateDraft,
+      workItemProjectPill: "project",
+    }),
+  })
+);
+
+describe("StartPageWorkItemComposerChrome", () => {
+  let container: HTMLDivElement;
+  let headerHost: HTMLDivElement;
+  let pinnedActionsHost: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.clearAllMocks();
+    container = document.createElement("div");
+    headerHost = document.createElement("div");
+    pinnedActionsHost = document.createElement("div");
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("portals Work Item-only controls into the persistent composer", () => {
+    act(() => {
+      root.render(
+        createElement(
+          Provider,
+          null,
+          createElement(StartPageWorkItemComposerChrome, {
+            creatorModeControl: createElement("span", null, "mode"),
+            defaultAiWorkItemExecutionTarget: {
+              id: "agent-1",
+              name: "Agent",
+              type: "agent",
+              agentDefinitionId: "agent-def-1",
+            },
+            headerHost,
+            onDraftChange: vi.fn(),
+            pinnedActionsHost,
+          })
+        )
+      );
+    });
+
+    expect(headerHost.textContent).toContain("title");
+    expect(pinnedActionsHost.textContent).toContain("mode");
+    expect(pinnedActionsHost.textContent).toContain("project");
+    expect(pinnedActionsHost.textContent).toContain("properties");
+    expect(mocks.updateDraft).toHaveBeenCalledWith({
+      orchestratorConfig: {
+        ...DEFAULT_ORCHESTRATOR_CONFIG,
+        agent_definition_id: "agent-def-1",
+        org_id: undefined,
+      },
+    });
+  });
+});

--- a/src/engines/ChatPanel/StartPageWorkItemComposerChrome.tsx
+++ b/src/engines/ChatPanel/StartPageWorkItemComposerChrome.tsx
@@ -1,0 +1,101 @@
+import { useAtomValue } from "jotai";
+import React, { useEffect } from "react";
+import { createPortal } from "react-dom";
+
+import { useInlineCreateWorkItemFields } from "@src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/InlineCreateWorkItemFields";
+import { DEFAULT_ORCHESTRATOR_CONFIG } from "@src/modules/ProjectManager/WorkItems/constants";
+import {
+  CreateComposerHeader,
+  CreateComposerPinnedActions,
+} from "@src/modules/ProjectManager/shared/components/CreateComposerScaffold";
+import { primaryWorkspaceRootAtom } from "@src/store/workspace";
+import type { WorkItemDraft } from "@src/store/workstation/projectManager";
+
+import type { DefaultAiWorkItemExecutionTarget } from "./StartPageAgentComposer";
+
+interface StartPageWorkItemComposerChromeProps {
+  creatorModeControl: React.ReactNode;
+  defaultAiWorkItemExecutionTarget: DefaultAiWorkItemExecutionTarget | null;
+  headerHost: HTMLDivElement | null;
+  onDraftChange: (draft: WorkItemDraft) => void;
+  orgId?: string;
+  pinnedActionsHost: HTMLDivElement | null;
+}
+
+const ignoreUnsavedChange = () => undefined;
+
+/**
+ * Work-item-only controller loaded beside the persistent SessionCreator. Its
+ * two portals add the title and property controls without owning or replacing
+ * the composer itself.
+ */
+export default function StartPageWorkItemComposerChrome({
+  creatorModeControl,
+  defaultAiWorkItemExecutionTarget,
+  headerHost,
+  onDraftChange,
+  orgId,
+  pinnedActionsHost,
+}: StartPageWorkItemComposerChromeProps): React.ReactNode {
+  const workspaceRoot = useAtomValue(primaryWorkspaceRootAtom);
+  const inlineFields = useInlineCreateWorkItemFields({
+    aiGenerateMode: true,
+    chatPanelFooter: true,
+    dockedComposer: true,
+    onDraftChange,
+    onSetUnsaved: ignoreUnsavedChange,
+    orgId,
+    repoPath: workspaceRoot?.path ?? null,
+  });
+  const { draft, updateDraft } = inlineFields;
+  const canAutoExecuteWithTarget = Boolean(
+    draft.orchestratorConfig?.agent_definition_id ||
+    draft.orchestratorConfig?.org_id
+  );
+
+  useEffect(() => {
+    if (!defaultAiWorkItemExecutionTarget || canAutoExecuteWithTarget) return;
+
+    updateDraft({
+      orchestratorConfig: {
+        ...DEFAULT_ORCHESTRATOR_CONFIG,
+        ...(draft.orchestratorConfig ?? {}),
+        agent_definition_id: defaultAiWorkItemExecutionTarget.agentDefinitionId,
+        org_id:
+          defaultAiWorkItemExecutionTarget.type === "org"
+            ? defaultAiWorkItemExecutionTarget.id
+            : undefined,
+      },
+    });
+  }, [
+    canAutoExecuteWithTarget,
+    defaultAiWorkItemExecutionTarget,
+    draft.orchestratorConfig,
+    updateDraft,
+  ]);
+
+  return (
+    <>
+      {headerHost
+        ? createPortal(
+            <CreateComposerHeader dataTestId="create-work-item-composer-header">
+              {inlineFields.titleSection}
+            </CreateComposerHeader>,
+            headerHost,
+            "work-item-composer-header"
+          )
+        : null}
+      {pinnedActionsHost
+        ? createPortal(
+            <CreateComposerPinnedActions dataTestId="create-work-item-pinned-actions">
+              {creatorModeControl}
+              {inlineFields.workItemProjectPill}
+              {inlineFields.inlinePropertyPills}
+            </CreateComposerPinnedActions>,
+            pinnedActionsHost,
+            "work-item-composer-pinned-actions"
+          )
+        : null}
+    </>
+  );
+}


### PR DESCRIPTION
## Problem

Switching the Launchpad from Session to agent-assisted Work Item rendered the same session composer beneath different React parent trees. React therefore unmounted and recreated the entire composer, causing the visible flash and discarding in-memory editor DOM state even though only the Work Item title and property row needed to change.

## Solution

Keep one `StartPageAgentComposer` at a stable React position for Session and agent-assisted Work Item. The target switch now updates only launch semantics and injects Work Item-specific title and property controls through lazy portal hosts. The heavier Work Item controller remains split from the Session startup bundle, while manual Work Item creation retains its intentionally distinct Markdown editor path.

The resulting invariant is that switching between the two agent-assisted targets preserves the same composer/editor instance; only target-specific chrome and behavior change.

## Potential risks

The change adds portal hosts inside the persistent composer and moves the lifecycle boundary shared by the two agent targets. Focus or portal positioning could differ in the Tauri WebView, although focused tests verify component and DOM identity, prompt retention, and slot content. Manual Work Item mode intentionally still replaces the composer because it uses a different editor.

Rollback is a direct revert of this commit. There are no persistence, IPC, schema, dependency, configuration, or wire-format changes.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/StartPageWorkItemComposerChrome.test.ts src/engines/ChatPanel/StartPageAgentComposer.test.ts src/engines/ChatPanel/ChatPanelStartPage.lifecycle.test.ts src/engines/ChatPanel/ChatPanelStartPage.test.ts src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts src/modules/ProjectManager/shared/components/CreateComposerScaffold.test.ts` — passed: 6 files, 19 tests
- `pnpm run typecheck:fast` — passed
- `pnpm run lint:file -- src/engines/ChatPanel/ChatPanelEmptyContent.tsx src/engines/ChatPanel/ChatPanelStartPage.tsx src/engines/ChatPanel/ChatPanelStartPage.test.ts src/engines/ChatPanel/ChatPanelStartPage.lifecycle.test.ts src/engines/ChatPanel/StartPageAgentComposer.tsx src/engines/ChatPanel/StartPageAgentComposer.test.ts src/engines/ChatPanel/StartPageWorkItemComposerChrome.tsx src/engines/ChatPanel/StartPageWorkItemComposerChrome.test.ts` — passed
- `pnpm run check:circular` — passed; no circular dependencies across 6,434 modules
- `pnpm run check:test-placement` — passed; placement consistent across 449 directories
- `git diff --check origin/develop...HEAD` — passed
- Live Tauri/WebView visual profiling was not run because desktop computer control was not authorized. Screenshots are not included because a static image cannot demonstrate component mount identity; the lifecycle regression test asserts that the exact same editor DOM node and unfinished prompt survive the switch.

## Audit

- Frontend UI audit: 0 fix, 4 keep with reason, 0 abstract
- Architecture review: composer ownership is consolidated at one stable boundary; no domain, persistence, IPC, or wire layers change
- React performance review: the lifecycle test demonstrates the removed remount; no broader runtime-performance claim is made without profiling
