### PR TITLE
perf(agent-org): reuse bounded time formatters

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/GroupChatView/AgentOrgGroupProjectionView.tsx
+++ b/src/engines/ChatPanel/ChatHistory/GroupChatView/AgentOrgGroupProjectionView.tsx
@@ -18,6 +18,7 @@ import {
   RotateLeft01Icon,
   SquareIcon,
 } from "@src/icons";
+import { formatShortLocalTime } from "@src/util/data/formatters/date";
 
 import GroupChatMessageBubble from "./GroupChatMessageBubble";
 
@@ -273,10 +274,7 @@ const AgentOrgGroupProjectionView: React.FC<
                     })}
                   </span>
                   <time className="shrink-0" dateTime={item.createdAt}>
-                    {new Date(item.createdAt).toLocaleTimeString([], {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
+                    {formatShortLocalTime(new Date(item.createdAt))}
                   </time>
                 </div>
               );

--- a/src/engines/ChatPanel/ChatHistory/GroupChatView/__tests__/AgentOrgGroupProjectionView.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/GroupChatView/__tests__/AgentOrgGroupProjectionView.test.ts
@@ -115,6 +115,7 @@ vi.mock("@src/components/MarkDown", () => ({
 }));
 
 vi.mock("@src/util/data/formatters/date", () => ({
+  formatShortLocalTime: () => "activity time",
   formatSmartDateTime: () => "visible time",
   toIntlLocaleTag: () => "en-US",
 }));
@@ -344,6 +345,7 @@ describe("AgentOrgGroupProjectionView", () => {
     expect(container.textContent).toContain(
       "groupChat.projection.activity.task_completed"
     );
+    expect(container.textContent).toContain("activity time");
     expect(
       container.querySelector(
         '[data-sender-name="groupChat.youLabel"][data-recipient-name="Coordinator"]'

--- a/src/engines/ChatPanel/ChatHistory/utils/__tests__/turnFormattingIntlCache.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/utils/__tests__/turnFormattingIntlCache.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("turn clock formatting", () => {
+  it("shares one bounded Intl formatter across page and timing labels", async () => {
+    vi.resetModules();
+    const rawLocaleTimeSpy = vi.spyOn(Date.prototype, "toLocaleTimeString");
+    const formatterConstructor = vi.spyOn(Intl, "DateTimeFormat");
+    const [{ formatTurnPageTimeLabel }, { getTurnTimingLabels }] =
+      await Promise.all([
+        import("../turnPageFormatting"),
+        import("../turnTimingFormatting"),
+      ]);
+    const startMs = Date.UTC(2026, 8, 2, 3, 0, 0);
+    const endMs = startMs + 65_000;
+    const metas = [
+      {
+        startMs,
+        endMs,
+      },
+    ] as Parameters<typeof formatTurnPageTimeLabel>[0];
+
+    const pageLabel = formatTurnPageTimeLabel(metas);
+    const timing = getTurnTimingLabels(endMs - startMs, startMs, endMs);
+    const constructorCountAfterFirstRender =
+      formatterConstructor.mock.calls.length;
+    formatTurnPageTimeLabel(metas);
+    getTurnTimingLabels(endMs - startMs, startMs, endMs);
+
+    expect(pageLabel).toBe(`${timing.startClock} ~ ${timing.endClock}`);
+    expect(rawLocaleTimeSpy).not.toHaveBeenCalled();
+    expect(constructorCountAfterFirstRender).toBeGreaterThan(0);
+    expect(formatterConstructor).toHaveBeenCalledTimes(
+      constructorCountAfterFirstRender
+    );
+  });
+});

--- a/src/engines/ChatPanel/ChatHistory/utils/turnPageFormatting.ts
+++ b/src/engines/ChatPanel/ChatHistory/utils/turnPageFormatting.ts
@@ -7,11 +7,12 @@
  */
 import type { CursorIdeTurnSummary } from "@src/api/tauri/externalHistory";
 import { PILL_TYPE_LIST } from "@src/config/pillTokens";
-import { formatClockRange } from "@src/util/time/formatClockTime";
+import { formatShortLocalTime24Hour } from "@src/util/data/formatters/date";
 
 import type { ChatGroupMeta } from "../hooks/useChatGroups";
 
 const ROUND_PREVIEW_MAX_LENGTH = 96;
+const MIN_TIME_RANGE_MS = 60_000;
 
 /**
  * Strip the bracket portion of pill serialization syntax (`[type:path]`)
@@ -64,4 +65,24 @@ export function formatTurnPageTimeLabel(metas: ChatGroupMeta[]): string {
   if (startMs === null || endMs === null) return "";
 
   return formatClockRange(startMs, endMs);
+}
+
+function formatClockRange(startMs: number, endMs: number): string {
+  const startClock = formatClockTime(startMs);
+  if (!startClock) return "";
+  if (endMs - startMs < MIN_TIME_RANGE_MS) return startClock;
+
+  const endClock = formatClockTime(endMs);
+  if (!endClock) return "";
+
+  return `${startClock} ~ ${endClock}`;
+}
+
+function formatClockTime(ms: number): string {
+  if (!Number.isFinite(ms)) return "";
+  try {
+    return formatShortLocalTime24Hour(new Date(ms));
+  } catch {
+    return "";
+  }
 }

--- a/src/engines/ChatPanel/ChatHistory/utils/turnTimingFormatting.ts
+++ b/src/engines/ChatPanel/ChatHistory/utils/turnTimingFormatting.ts
@@ -1,4 +1,4 @@
-import { formatClockTime } from "@src/util/time/formatClockTime";
+import { formatShortLocalTime24Hour } from "@src/util/data/formatters/date";
 
 export interface TurnTimingLabels {
   duration: string;
@@ -22,13 +22,23 @@ export function formatTurnDuration(durationMs: number): string {
   return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
 }
 
+/** Locale-aware 24-hour wall-clock label used by turn summaries. */
+export function formatTurnClockTime(ms: number): string {
+  if (!Number.isFinite(ms)) return "";
+  try {
+    return formatShortLocalTime24Hour(new Date(ms));
+  } catch {
+    return "";
+  }
+}
+
 export function getTurnTimingLabels(
   durationMs: number,
   startMs: number | null,
   endMs: number | null
 ): TurnTimingLabels {
-  const startClock = startMs !== null ? formatClockTime(startMs) : "";
-  const endClock = endMs !== null ? formatClockTime(endMs) : "";
+  const startClock = startMs !== null ? formatTurnClockTime(startMs) : "";
+  const endClock = endMs !== null ? formatTurnClockTime(endMs) : "";
   return {
     duration: formatTurnDuration(durationMs),
     startClock,

--- a/src/engines/ChatPanel/events/stream/session-discussion.tsx
+++ b/src/engines/ChatPanel/events/stream/session-discussion.tsx
@@ -4,14 +4,12 @@ import PersonAvatar from "@src/components/PersonAvatar";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { discussionPayloadOf } from "@src/features/Org2Cloud/SessionConversation/discussionEvents";
 import { MarkdownContent } from "@src/modules/shared/components/MarkdownContent";
+import { formatShortLocalTime } from "@src/util/data/formatters/date";
 
 function timeLabel(createdAt: string): string {
   const ms = new Date(createdAt).getTime();
   if (!Number.isFinite(ms)) return "";
-  return new Date(ms).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return formatShortLocalTime(new Date(ms));
 }
 
 export function SessionDiscussionEvent({

--- a/src/util/data/formatters/date.ts
+++ b/src/util/data/formatters/date.ts
@@ -118,7 +118,7 @@ const DATE_TIME_FORMAT_CACHE_MAX = 64;
 const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
 
 function dateTimeFormatCacheKey(
-  locale: string,
+  locale: Intl.LocalesArgument | undefined,
   options: Intl.DateTimeFormatOptions
 ): string {
   return JSON.stringify([
@@ -130,7 +130,7 @@ function dateTimeFormatCacheKey(
 }
 
 function cachedDateTimeFormatter(
-  locale: string,
+  locale: Intl.LocalesArgument | undefined,
   options: Intl.DateTimeFormatOptions
 ): Intl.DateTimeFormat {
   const key = dateTimeFormatCacheKey(locale, options);
@@ -150,6 +150,29 @@ function cachedDateTimeFormatter(
     if (oldestKey !== undefined) dateTimeFormatCache.delete(oldestKey);
   }
   return formatter;
+}
+
+const SHORT_LOCAL_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+const SHORT_LOCAL_TIME_24_HOUR_OPTIONS: Intl.DateTimeFormatOptions = {
+  ...SHORT_LOCAL_TIME_OPTIONS,
+  hour12: false,
+};
+
+/** Format a local HH:MM label without recreating Intl formatters per render. */
+export function formatShortLocalTime(date: Date): string {
+  return cachedDateTimeFormatter([], SHORT_LOCAL_TIME_OPTIONS).format(date);
+}
+
+/** Format a local 24-hour HH:MM label through the shared bounded cache. */
+export function formatShortLocalTime24Hour(date: Date): string {
+  return cachedDateTimeFormatter(
+    undefined,
+    SHORT_LOCAL_TIME_24_HOUR_OPTIONS
+  ).format(date);
 }
 
 function dateKeyInTimezone(date: Date, timeZone: string | undefined): string {

--- a/src/util/data/formatters/dateLocalDisplay.test.ts
+++ b/src/util/data/formatters/dateLocalDisplay.test.ts
@@ -6,6 +6,7 @@ import {
   formatLocalClock,
   formatLocalMonthDay,
   formatRelativeElapsedShort,
+  formatShortLocalTime,
   formatSmartDateTime,
   getLocalDateKey,
   getLocalDayDiff,
@@ -119,5 +120,28 @@ describe("local date display helpers", () => {
 
     formatterConstructor.mockRestore();
     vi.useRealTimers();
+  });
+
+  it("reuses the browser-local short-time formatter used by Group activity rows", () => {
+    const date = new Date(2026, 1, 25, 14, 25, 0);
+    const expected = date.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    const formatterConstructor = vi.spyOn(Intl, "DateTimeFormat");
+
+    const first = formatShortLocalTime(date);
+    const constructorCountAfterFirstRender =
+      formatterConstructor.mock.calls.length;
+    const second = formatShortLocalTime(date);
+
+    expect(first).toBe(expected);
+    expect(second).toBe(first);
+    expect(constructorCountAfterFirstRender).toBeGreaterThan(0);
+    expect(formatterConstructor).toHaveBeenCalledTimes(
+      constructorCountAfterFirstRender
+    );
+
+    formatterConstructor.mockRestore();
   });
 });


### PR DESCRIPTION
## Problem

Fixes #765

Repeatedly switching between the Agent Org Group projection and individual Member pages rebuilt browser-local `Intl.DateTimeFormat` / ICU formatters during rendering. The Group activity rows, Member turn-page range, Member timing labels, and discussion events bypassed the existing bounded formatter cache, creating avoidable WebKit allocation churn across remounts.

The remaining `ps` RSS increase is not retained dirty memory: macOS `footprint` classifies more than the RSS delta as reclaimable JavaScriptCore pages while physical footprint and dirty WebKit malloc both fall below baseline. This PR fixes the real formatter churn and records both metrics rather than claiming that raw RSS immediately returns pages to the OS.

## Solution

Add short local-time helpers backed by the existing 64-entry `Intl.DateTimeFormat` LRU and route every affected Group/Member hot path through them. The helpers preserve the prior locale inputs and formatting options, including the Member page's 24-hour output.

The resulting invariant is: Agent Org render paths must reuse the shared bounded date formatter instead of constructing locale formatters per render. Regression tests cover the Group projection owner and prove that repeated Member page/timing formatting does not call `Date#toLocaleTimeString` or construct additional `Intl.DateTimeFormat` instances.

## Potential risks

- Timestamp text is intended to remain unchanged; output-parity tests cover the existing locale/options combinations, but other operating-system locales were not manually enumerated.
- A formatter resolved from the operating system's default locale remains cached until eviction or process restart. This matches the repository's existing bounded formatter behavior but means an in-process OS locale change is not reflected immediately.
- Raw WebContent RSS still rises because JavaScriptCore keeps reclaimable heap pages. The physical footprint, dirty WebKit malloc, and hidden lifecycle gates pass, but this change does not promise immediate OS reclamation of RSS pages.
- Verification used the macOS BuildFast package. Windows/Linux runtime behavior and release-only signing, notarization, updater, and installer paths were not exercised because this is a frontend-only allocation fix.
- There are no persistence, schema, IPC, wire-format, dependency, or data changes. Rollback is a normal revert of this commit; no data recovery is required.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/util/data/formatters/dateLocalDisplay.test.ts src/engines/ChatPanel/ChatHistory/utils/__tests__/turnPageFormatting.test.ts src/engines/ChatPanel/ChatHistory/utils/__tests__/turnTimingFormatting.test.ts src/engines/ChatPanel/ChatHistory/utils/__tests__/turnFormattingIntlCache.test.ts src/engines/ChatPanel/ChatHistory/GroupChatView/__tests__/AgentOrgGroupProjectionView.test.ts` — 5 files, 29 tests passed.
- `pnpm test -- --reporter=dot` — 1,336 files and 10,516 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm run lint` — oxlint and ESLint passed with zero errors/warnings.
- `pnpm run check:circular` — no circular dependencies across 6,426 modules.
- `pnpm run check:test-placement` — passed across 445 directories.
- `ORGII_AGENT_ORG_REDESIGN=1 pnpm run tauri:build:fast` — passed; webpack runtime 49121; packaged `src-tauri/target/dev-build/bundle/macos/ORG2.app` in 494.9 seconds.
- Packaged binary SHA-256: `862e7dc7656bb15081e1328b01620662717c581f7c0570da0a75d614d6bbe2d6`.
- Computer Use operated the packaged app against the real Flappy Bird Agent Org run: 2 preheat cycles, 20 Group → Planner → Group cycles, 5 minutes foreground idle, and 5 minutes hidden. The final UI remained on Group view with all 18 activity timestamps visible.
- Visual screenshots are not useful for this change because the timestamp output is intentionally unchanged; the packaged-app lifecycle and memory measurements are the acceptance evidence.

## Performance evidence

| Stage | WebContent RSS | Physical footprint | Dirty WebKit malloc | Reclaimable | Dirty graphics |
| --- | ---: | ---: | ---: | ---: | ---: |
| After 20 cycles vs. post-preheat baseline | +161.1 MiB | -80.8 MiB | -86.8 MiB | +244.7 MiB | 0 MiB |
| After 5 minutes foreground idle vs. baseline | +196.1 MiB | -84.7 MiB | -86.9 MiB | +347.8 MiB | -3.7 MiB |
| Hidden minute 5 vs. hidden minute 1 | +1.7 MiB | -0.9 MiB | -1.6 MiB | +6.5 MiB | +0.8 MiB |

No polling, timer, subscription, worker, persistence, or cache-lifecycle mechanism was added. The hidden process showed no staircase growth after its transition.
