### PR TITLE
fix(chat-panel): disable workstation on management pages

### DIFF
--- a/src/engines/ChatPanel/ChatPanelHeader.test.ts
+++ b/src/engines/ChatPanel/ChatPanelHeader.test.ts
@@ -15,7 +15,13 @@ vi.mock("@src/scaffold/NavigationSidebar/CollapsedSidebarButton", () => ({
 vi.mock("@src/components/KeyboardShortcut/ToolbarTooltip", () => ({
   // The real tooltip portals into document.body, which the static renderer
   // rejects; the controls under test are its children.
-  ToolbarTooltip: ({ children }: { children: ReactNode }) => children,
+  ToolbarTooltip: ({
+    children,
+    label,
+  }: {
+    children: ReactNode;
+    label: string;
+  }) => createElement("span", { "data-tooltip-label": label }, children),
 }));
 vi.mock("./header/ChatPanelCollapsedTabHeading", () => ({
   ChatPanelCollapsedTabHeading: () =>
@@ -32,12 +38,14 @@ interface RenderOptions {
   tabRowCollapsed: boolean;
   sessionHeaderContent?: ReactNode;
   shouldOffsetHeaderForCollapsedSidebar?: boolean;
+  stationAvailable?: boolean;
 }
 
 function render({
   tabRowCollapsed,
   sessionHeaderContent = createElement("span", { "data-session-name": "true" }),
   shouldOffsetHeaderForCollapsedSidebar = false,
+  stationAvailable = true,
 }: RenderOptions): string {
   return renderToStaticMarkup(
     createElement(ChatPanelHeader, {
@@ -69,7 +77,7 @@ function render({
       tokenUsageVisible: false,
       turnMetadataVisible: false,
       shouldOffsetHeaderForCollapsedSidebar,
-      stationAvailable: true,
+      stationAvailable,
       showHeader: true,
       showSessionContent: true,
       showCloudShareSettings: false,
@@ -90,6 +98,19 @@ function render({
 }
 
 describe("ChatPanelHeader tab row collapse", () => {
+  it("explains why Workstation cannot be shown for an excluded page", () => {
+    const markup = render({
+      tabRowCollapsed: false,
+      stationAvailable: false,
+    });
+
+    expect(markup).toContain(
+      'data-tooltip-label="chat.workstationUnavailableForPage"'
+    );
+    expect(markup).toContain('aria-label="chat.workstationUnavailableForPage"');
+    expect(markup).toContain("disabled");
+  });
+
   it("keeps both rows while the tab strip is worth showing", () => {
     const markup = render({ tabRowCollapsed: false });
 

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -160,6 +160,7 @@ export function ChatPanelHeader({
     ? t("chat.showWorkstation")
     : t("chat.maximizeChatPanel");
   const shrinkToWorkstationLabel = t("chat.showWorkstation");
+  const workstationUnavailableLabel = t("chat.workstationUnavailableForPage");
   const tuiModeLabel = tuiMode ? t("chat.tuiModeOn") : t("chat.tuiModeOff");
 
   const sessionPublishedActions =
@@ -260,7 +261,13 @@ export function ChatPanelHeader({
   const chatFocusToggleButton = (
     <span className="inline-flex">
       <TabBarTrailingIconButton
-        title={isChatFocus ? shrinkToWorkstationLabel : chatFocusLabel}
+        title={
+          stationAvailable
+            ? isChatFocus
+              ? shrinkToWorkstationLabel
+              : chatFocusLabel
+            : workstationUnavailableLabel
+        }
         shortcutId={stationAvailable ? "maximize_chat" : undefined}
         tooltipPosition="bottom-end"
         nativeTitle={false}

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -154,8 +154,8 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     });
 
     const handleChatFocusToggle = useCallback(() => {
-      toggleChatFocus(viewportWidth);
-    }, [toggleChatFocus, viewportWidth]);
+      toggleChatFocus();
+    }, [toggleChatFocus]);
 
     const isCliAgentSession = currentSession?.category === "cli_agent";
     const [tuiMode, setTuiMode] = useAtom(tuiModeAtom(currentSessionId ?? ""));
@@ -193,14 +193,10 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     const tabCount = useAtomValue(chatPanelTabCountAtom);
     const isStandaloneToolTabActive =
       activeTab?.type === "work-management" || activeTab?.type === "runtime";
-    const stationAvailable = isChatPanelTabStationAvailable(
-      activeTab,
-      viewportWidth
-    );
+    const stationAvailable = isChatPanelTabStationAvailable(activeTab);
     const isChatFocus = resolveChatPanelMaximizedForLayout(
       userChatPanelMaximized,
-      activeTab,
-      viewportWidth
+      activeTab
     );
     const [focusedWorkstationMenuHost, setFocusedWorkstationMenuHost] =
       useState<HTMLSpanElement | null>(null);

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -998,6 +998,7 @@
     "fullScreenChat": "Chat-Panel fokussieren (Workstation ausblenden)",
     "maximizeChatPanel": "Chat-Panel maximieren",
     "showWorkstation": "Workstation anzeigen",
+    "workstationUnavailableForPage": "Workstation ist auf dieser Seite nicht verfügbar",
     "hideWorkstation": "Workstation ausblenden",
     "restoreSplitView": "Workstation anzeigen",
     "shrinkToWorkstation": "Chat-Panel verkleinern (Workstation anzeigen)",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -1055,6 +1055,7 @@
     "fullScreenChat": "Focus Chat Panel (Hide Workstation)",
     "maximizeChatPanel": "Maximize Chat Panel",
     "showWorkstation": "Show Workstation",
+    "workstationUnavailableForPage": "Workstation is not available on this page",
     "hideWorkstation": "Hide Workstation",
     "restoreSplitView": "Show Workstation",
     "shrinkToWorkstation": "Shrink Chat Panel (Show Workstation)",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -1000,6 +1000,7 @@
     "fullScreenChat": "Enfocar panel de chat (ocultar Workstation)",
     "maximizeChatPanel": "Maximizar panel de chat",
     "showWorkstation": "Mostrar Workstation",
+    "workstationUnavailableForPage": "Workstation no está disponible en esta página",
     "hideWorkstation": "Ocultar Workstation",
     "restoreSplitView": "Mostrar Workstation",
     "shrinkToWorkstation": "Reducir panel de chat (mostrar Workstation)",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -1000,6 +1000,7 @@
     "fullScreenChat": "Mettre le chat au premier plan (masquer le Workstation)",
     "maximizeChatPanel": "Agrandir le panneau de chat",
     "showWorkstation": "Afficher le Workstation",
+    "workstationUnavailableForPage": "Le Workstation n’est pas disponible sur cette page",
     "hideWorkstation": "Masquer le Workstation",
     "restoreSplitView": "Afficher le Workstation",
     "shrinkToWorkstation": "Réduire le chat (afficher le Workstation)",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -999,6 +999,7 @@
     "fullScreenChat": "Chat パネルにフォーカス（Workstation を非表示）",
     "maximizeChatPanel": "Chat パネルを最大化",
     "showWorkstation": "Workstation を表示",
+    "workstationUnavailableForPage": "このページでは Workstation を利用できません",
     "hideWorkstation": "Workstation を非表示",
     "restoreSplitView": "Workstation を表示",
     "shrinkToWorkstation": "Chat パネルを縮小（Workstation を表示）",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -999,6 +999,7 @@
     "fullScreenChat": "Chat 패널 포커스 (Workstation 숨기기)",
     "maximizeChatPanel": "Chat 패널 최대화",
     "showWorkstation": "Workstation 표시",
+    "workstationUnavailableForPage": "이 페이지에서는 Workstation을 사용할 수 없습니다",
     "hideWorkstation": "Workstation 숨기기",
     "restoreSplitView": "Workstation 표시",
     "shrinkToWorkstation": "Chat 패널 축소 (Workstation 표시)",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -1001,6 +1001,7 @@
     "fullScreenChat": "Skup panel czatu (ukryj Workstation)",
     "maximizeChatPanel": "Maksymalizuj panel czatu",
     "showWorkstation": "Pokaż Workstation",
+    "workstationUnavailableForPage": "Workstation jest niedostępny na tej stronie",
     "hideWorkstation": "Ukryj Workstation",
     "restoreSplitView": "Pokaż Workstation",
     "shrinkToWorkstation": "Zmniejsz panel czatu (pokaż Workstation)",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -999,6 +999,7 @@
     "fullScreenChat": "Focar painel de chat (ocultar Workstation)",
     "maximizeChatPanel": "Maximizar painel de chat",
     "showWorkstation": "Mostrar Workstation",
+    "workstationUnavailableForPage": "O Workstation não está disponível nesta página",
     "hideWorkstation": "Ocultar Workstation",
     "restoreSplitView": "Mostrar Workstation",
     "shrinkToWorkstation": "Reduzir painel de chat (mostrar Workstation)",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -1004,6 +1004,7 @@
     "fullScreenChat": "Фокус на панели чата (скрыть Workstation)",
     "maximizeChatPanel": "Развернуть панель чата",
     "showWorkstation": "Показать Workstation",
+    "workstationUnavailableForPage": "Workstation недоступна на этой странице",
     "hideWorkstation": "Скрыть Workstation",
     "restoreSplitView": "Показать Workstation",
     "shrinkToWorkstation": "Свернуть панель чата (показать Workstation)",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -1000,6 +1000,7 @@
     "fullScreenChat": "Chat paneline odaklan (Workstation'i gizle)",
     "maximizeChatPanel": "Chat panelini büyüt",
     "showWorkstation": "Workstation'i göster",
+    "workstationUnavailableForPage": "Workstation bu sayfada kullanılamaz",
     "hideWorkstation": "Workstation'i gizle",
     "restoreSplitView": "Workstation'i göster",
     "shrinkToWorkstation": "Chat panelini küçült (Workstation'i göster)",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -997,6 +997,7 @@
     "fullScreenChat": "Tập trung bảng chat (ẩn Workstation)",
     "maximizeChatPanel": "Phóng to bảng chat",
     "showWorkstation": "Hiện Workstation",
+    "workstationUnavailableForPage": "Workstation không khả dụng trên trang này",
     "hideWorkstation": "Ẩn Workstation",
     "restoreSplitView": "Hiện Workstation",
     "shrinkToWorkstation": "Thu nhỏ bảng chat (hiện Workstation)",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -1014,6 +1014,7 @@
     "fullScreenChat": "聚焦聊天面板（隱藏工作站）",
     "maximizeChatPanel": "最大化聊天面板",
     "showWorkstation": "顯示工作站",
+    "workstationUnavailableForPage": "此頁面不支援使用工作站",
     "hideWorkstation": "隱藏工作站",
     "restoreSplitView": "顯示工作站",
     "shrinkToWorkstation": "縮小聊天面板（顯示工作站）",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -1046,6 +1046,7 @@
     "fullScreenChat": "聚焦聊天面板（隐藏工作站）",
     "maximizeChatPanel": "最大化聊天面板",
     "showWorkstation": "显示工作站",
+    "workstationUnavailableForPage": "此页面不支持使用工作站",
     "hideWorkstation": "隐藏工作站",
     "restoreSplitView": "显示工作站",
     "shrinkToWorkstation": "缩小聊天面板（显示工作站）",

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -389,8 +389,7 @@ const AppShell = () => {
 
   const effectiveChatFocus = resolveChatPanelMaximizedForLayout(
     chatPanelMaximized,
-    activeChatPanelTab,
-    viewportWidth
+    activeChatPanelTab
   );
 
   return (

--- a/src/services/workStation/WorkStationViewService.test.ts
+++ b/src/services/workStation/WorkStationViewService.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { ROUTES } from "@src/config/routes";
 import {
-  CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
   buildInitialChatPanelTabsState,
   chatPanelTabsAtom,
   openRuntimeInChatPanelTabAtom,
@@ -59,7 +58,7 @@ describe("WorkStationViewService work-management tabs", () => {
     expect(navigationEvents).toEqual([{ path: ROUTES.workStation.base.path }]);
   });
 
-  it("rejects Station-opening actions for wide-only tabs below the threshold", async () => {
+  it("rejects Station-opening actions for Station-excluded tabs", async () => {
     const store = getInstrumentedStore();
     store.set(openRuntimeInChatPanelTabAtom, "Runtime");
 
@@ -73,18 +72,17 @@ describe("WorkStationViewService work-management tabs", () => {
     expect(store.get(stationModeAtom)).toBe("agent-station");
   });
 
-  it("allows Station-opening actions for wide-only tabs at the threshold", async () => {
+  it("keeps Station-opening actions disabled on a wide viewport", async () => {
     const store = getInstrumentedStore();
     store.set(openRuntimeInChatPanelTabAtom, "Runtime");
-    window.innerWidth = CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX;
+    window.innerWidth = 2560;
 
-    expect(await WorkStationViewService.toggleChatPanelMaximized()).toBe(true);
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
-    expect(await WorkStationViewService.showWorkStation()).toBe(true);
+    expect(await WorkStationViewService.toggleChatPanelMaximized()).toBe(false);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(await WorkStationViewService.showWorkStation()).toBe(false);
     expect(await WorkStationViewService.openStationMode("my-station")).toBe(
-      true
+      false
     );
-    expect(store.get(stationModeAtom)).toBe("my-station");
+    expect(store.get(stationModeAtom)).toBe("agent-station");
   });
 });

--- a/src/services/workStation/WorkStationViewService.ts
+++ b/src/services/workStation/WorkStationViewService.ts
@@ -119,7 +119,7 @@ export const WorkStationViewService = {
       await import("@src/store/chatPanel/chatPanelTabsAtom");
 
     const store = getStore();
-    return store.set(toggleActiveChatPanelMaximizedAtom, window.innerWidth);
+    return store.set(toggleActiveChatPanelMaximizedAtom);
   },
 
   async showWorkStation(): Promise<boolean> {
@@ -140,12 +140,7 @@ export const WorkStationViewService = {
     ]);
 
     const store = getStore();
-    if (
-      !isChatPanelTabStationAvailable(
-        store.get(activeChatPanelTabAtom),
-        window.innerWidth
-      )
-    ) {
+    if (!isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom))) {
       return false;
     }
     if (store.get(chatPanelMaximizedAtom)) {
@@ -195,10 +190,7 @@ export const WorkStationViewService = {
     const store = getStore();
     if (
       isWorkbenchRoute() &&
-      !isChatPanelTabStationAvailable(
-        store.get(activeChatPanelTabAtom),
-        window.innerWidth
-      )
+      !isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom))
     ) {
       return false;
     }

--- a/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
@@ -1,24 +1,21 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
   type ChatPanelTabType,
   isChatPanelTabStationAvailable,
   resolveChatPanelMaximizedForLayout,
 } from "../chatPanelTabsAtom";
 
 describe("Chat Panel tab Station access", () => {
-  it("uses 1920px as the wide Station breakpoint", () => {
-    expect(CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX).toBe(1920);
+  it.each<ChatPanelTabType>([
+    "session",
+    "terminal",
+    "start-page",
+    "channel",
+    "run-group",
+  ])("keeps Station access available for %s tabs", (type) => {
+    expect(isChatPanelTabStationAvailable(type)).toBe(true);
   });
-
-  it.each<ChatPanelTabType>(["session", "terminal", "start-page", "channel"])(
-    "keeps Station access available for %s tabs at every viewport width",
-    (type) => {
-      expect(isChatPanelTabStationAvailable(type, 800)).toBe(true);
-      expect(isChatPanelTabStationAvailable(type, 2000)).toBe(true);
-    }
-  );
 
   it.each<ChatPanelTabType>([
     "runtime",
@@ -31,38 +28,13 @@ describe("Chat Panel tab Station access", () => {
     "github-pr",
     "project",
     "explore",
-  ])("unlocks %s tabs only on a wide viewport", (type) => {
-    expect(
-      isChatPanelTabStationAvailable(
-        type,
-        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX - 1
-      )
-    ).toBe(false);
-    expect(
-      isChatPanelTabStationAvailable(
-        type,
-        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX
-      )
-    ).toBe(true);
+  ])("never allows Station access for %s tabs", (type) => {
+    expect(isChatPanelTabStationAvailable(type)).toBe(false);
   });
 
   it("forces the effective layout full-screen without changing the saved preference", () => {
-    expect(resolveChatPanelMaximizedForLayout(false, "work-item", 1200)).toBe(
-      true
-    );
-    expect(
-      resolveChatPanelMaximizedForLayout(
-        false,
-        "work-item",
-        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX
-      )
-    ).toBe(false);
-    expect(
-      resolveChatPanelMaximizedForLayout(
-        true,
-        "work-item",
-        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX
-      )
-    ).toBe(true);
+    expect(resolveChatPanelMaximizedForLayout(false, "work-item")).toBe(true);
+    expect(resolveChatPanelMaximizedForLayout(true, "work-item")).toBe(true);
+    expect(resolveChatPanelMaximizedForLayout(false, "session")).toBe(false);
   });
 });

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -43,7 +43,6 @@ import {
 } from "@src/util/core/state/instrumentedStore";
 
 import {
-  CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
   activateChatPanelTabAtom,
   activeChatPanelTabAtom,
   activeWorkManagementSectionAtom,
@@ -108,7 +107,6 @@ async function loadChatPanelTabAtoms() {
     activeSessionIdAtom,
     addChatPanelLaunchpadTabAtom,
     CHAT_PANEL_CREATE_TARGET,
-    CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
     CHAT_PANEL_SURFACE_KIND,
     chatPanelTabsAtom,
     isChatPanelTabStationAvailable,
@@ -498,21 +496,20 @@ describe("closeWorkItemChatPanelTabAtom", () => {
     } as never);
 
     expect(
-      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom), 1200)
+      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom))
     ).toBe(false);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
     expect(
       resolveChatPanelMaximizedForLayout(
         store.get(chatPanelMaximizedAtom),
-        store.get(activeChatPanelTabAtom),
-        1200
+        store.get(activeChatPanelTabAtom)
       )
     ).toBe(true);
 
     store.set(activateChatPanelTabAtom, sessionTabId);
 
     expect(
-      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom), 1200)
+      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom))
     ).toBe(true);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
   });
@@ -601,7 +598,7 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     vi.useRealTimers();
   });
 
-  it("opens Kanban as a singleton wide-only Station tab", async () => {
+  it("opens Kanban as a singleton Station-excluded tab", async () => {
     const {
       activeChatPanelTabAtom,
       chatPanelMaximizedAtom,
@@ -624,17 +621,16 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     ).toHaveLength(1);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
     expect(
-      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom), 1200)
+      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom))
     ).toBe(false);
     expect(store.get(activeWorkManagementSectionAtom)).toBe(
       WORK_MANAGEMENT_SECTION.KANBAN
     );
   });
 
-  it("guards the Station toggle until Kanban has a wide viewport", async () => {
+  it("keeps the Station toggle disabled for Kanban", async () => {
     const {
       activeChatPanelTabAtom,
-      CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
       chatPanelMaximizedAtom,
       isChatPanelTabStationAvailable,
       openWorkManagementChatPanelTabAtom,
@@ -648,38 +644,24 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
 
     expect(
-      isChatPanelTabStationAvailable(
-        store.get(activeChatPanelTabAtom),
-        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX - 1
-      )
+      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom))
     ).toBe(false);
-    expect(
-      store.set(
-        toggleActiveChatPanelMaximizedAtom,
-        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX - 1
-      )
-    ).toBe(false);
+    expect(store.set(toggleActiveChatPanelMaximizedAtom)).toBe(false);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
 
     // Reconciliation leaves the user's preference untouched; the effective
-    // layout remains full-screen while the viewport is below the threshold.
+    // layout remains full-screen while Kanban owns the workbench.
     store.set(syncActiveChatPanelTabStateAtom);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
     expect(
       resolveChatPanelMaximizedForLayout(
         store.get(chatPanelMaximizedAtom),
-        store.get(activeChatPanelTabAtom),
-        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX - 1
+        store.get(activeChatPanelTabAtom)
       )
     ).toBe(true);
 
-    expect(
-      store.set(
-        toggleActiveChatPanelMaximizedAtom,
-        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX
-      )
-    ).toBe(true);
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.set(toggleActiveChatPanelMaximizedAtom)).toBe(false);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
   });
 
   it("restores the session's prior full-screen state after leaving Kanban", async () => {
@@ -978,7 +960,7 @@ describe("ChatPanel navigation tabs", () => {
     ).toHaveLength(1);
   });
 
-  it("opens Runtime as its own singleton wide-only Station tab", async () => {
+  it("opens Runtime as its own singleton Station-excluded tab", async () => {
     const {
       chatPanelMaximizedAtom,
       chatPanelTabsAtom,
@@ -1004,7 +986,7 @@ describe("ChatPanel navigation tabs", () => {
     ).toHaveLength(1);
   });
 
-  it("opens Team Inbox as its own singleton wide-only Station tab", async () => {
+  it("opens Team Inbox as its own singleton Station-excluded tab", async () => {
     const {
       chatPanelMaximizedAtom,
       chatPanelTabsAtom,

--- a/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
@@ -25,22 +25,14 @@ import {
   chatPanelTabsAtom,
 } from "./chatPanelTabsState";
 
-/** User toggle guarded by the active tab and current viewport policy. */
-export const toggleActiveChatPanelMaximizedAtom = atom(
-  null,
-  (get, set, viewportWidth: number | undefined) => {
-    if (
-      !isChatPanelTabStationAvailable(
-        get(activeChatPanelTabAtom),
-        viewportWidth
-      )
-    ) {
-      return false;
-    }
-    set(toggleChatPanelMaximizedAtom);
-    return true;
+/** User toggle guarded by the active tab's Station-access policy. */
+export const toggleActiveChatPanelMaximizedAtom = atom(null, (get, set) => {
+  if (!isChatPanelTabStationAvailable(get(activeChatPanelTabAtom))) {
+    return false;
   }
-);
+  set(toggleChatPanelMaximizedAtom);
+  return true;
+});
 toggleActiveChatPanelMaximizedAtom.debugLabel =
   "toggleActiveChatPanelMaximized";
 
@@ -127,8 +119,8 @@ const syncChatPanelTabNavigationAtom = atom(
 
 /**
  * Reconcile legacy surface state after hydration or layout changes.
- * Maximize behavior is derived at the layout boundary from the active tab and
- * viewport, so reconciliation never mutates the user's persisted preference.
+ * Maximize behavior is derived at the layout boundary from the active tab, so
+ * reconciliation never mutates the user's persisted preference.
  */
 export const syncActiveChatPanelTabStateAtom = atom(null, (get, set) => {
   const state = get(chatPanelTabsAtom);

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -74,7 +74,6 @@ export {
   toggleActiveChatPanelMaximizedAtom,
 } from "./chatPanelTabPresentationAtoms";
 export {
-  CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
   isChatPanelTabStationAvailable,
   normalizePersistedChatPanelTabsState,
   resolveChatPanelMaximizedForLayout,

--- a/src/store/chatPanel/chatPanelTabsModel.ts
+++ b/src/store/chatPanel/chatPanelTabsModel.ts
@@ -128,13 +128,7 @@ export interface ChatPanelTabsState {
 /** Fixed id of the shared cloud/local organization management tab. */
 export const ORGANIZATION_TAB_ID = "chat-organization-management";
 
-type ChatPanelTabStationAccess = "always" | "wide-only";
-
-/**
- * Minimum viewport width at which standalone Chat Panel surfaces may share
- * the workbench with a Station pane.
- */
-export const CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX = 1920;
+type ChatPanelTabStationAccess = "always" | "never";
 
 /**
  * When a Chat Panel tab can share the workbench with a Station surface.
@@ -142,8 +136,7 @@ export const CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX = 1920;
  * This record is intentionally exhaustive: a new tab type must make an
  * explicit layout decision instead of silently inheriting an unsafe default.
  * Conversation-oriented tabs can always remain docked beside the Station;
- * standalone management and detail surfaces unlock the split layout only on
- * a wide desktop viewport.
+ * standalone management and detail surfaces always own the full workbench.
  */
 const CHAT_PANEL_TAB_STATION_ACCESS: Record<
   ChatPanelTabType,
@@ -154,16 +147,16 @@ const CHAT_PANEL_TAB_STATION_ACCESS: Record<
   "start-page": "always",
   channel: "always",
   "run-group": "always",
-  runtime: "wide-only",
-  "team-inbox": "wide-only",
-  "work-management": "wide-only",
-  workspace: "wide-only",
-  organization: "wide-only",
-  "work-item": "wide-only",
-  "github-issue": "wide-only",
-  "github-pr": "wide-only",
-  project: "wide-only",
-  explore: "wide-only",
+  runtime: "never",
+  "team-inbox": "never",
+  "work-management": "never",
+  workspace: "never",
+  organization: "never",
+  "work-item": "never",
+  "github-issue": "never",
+  "github-pr": "never",
+  project: "never",
+  explore: "never",
 };
 
 /**
@@ -188,29 +181,20 @@ const PERSISTED_CHAT_PANEL_TAB_TYPES = new Set<ChatPanelTabType>([
 ]);
 
 export function isChatPanelTabStationAvailable(
-  tabOrType: ChatPanelTab | ChatPanelTabType | null | undefined,
-  viewportWidth: number | undefined
+  tabOrType: ChatPanelTab | ChatPanelTabType | null | undefined
 ): boolean {
   const type =
     typeof tabOrType === "string" ? tabOrType : (tabOrType?.type ?? null);
   if (type === null) return true;
-  const access = CHAT_PANEL_TAB_STATION_ACCESS[type];
-  return (
-    access === "always" ||
-    (viewportWidth !== undefined &&
-      viewportWidth >= CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX)
-  );
+  return CHAT_PANEL_TAB_STATION_ACCESS[type] === "always";
 }
 
 /** Resolve the layout without mutating the user's persisted maximize choice. */
 export function resolveChatPanelMaximizedForLayout(
   userMaximized: boolean,
-  tabOrType: ChatPanelTab | ChatPanelTabType | null | undefined,
-  viewportWidth: number | undefined
+  tabOrType: ChatPanelTab | ChatPanelTabType | null | undefined
 ): boolean {
-  return (
-    userMaximized || !isChatPanelTabStationAvailable(tabOrType, viewportWidth)
-  );
+  return userMaximized || !isChatPanelTabStationAvailable(tabOrType);
 }
 
 export function getWorkManagementFallbackTitle(


### PR DESCRIPTION
## Problem

Management and detail tabs in the Chat Panel excluded Workstation only below a 1920px viewport breakpoint. At wider sizes, Work Items, projects, organizations, Work Management, Runtime, Team Inbox, workspace/explore, and GitHub detail pages could reveal a Station pane even though these surfaces are intended to own the full workbench. The disabled Show Workstation control also retained a generic tooltip that did not explain the restriction.

## Solution

Replace the `always | wide-only` Station-access policy with an exhaustive `always | never` policy and remove the viewport breakpoint and width-dependent call arguments. Management/detail tabs now remain full-screen and Station-opening actions are rejected at every viewport width. Session, terminal, start-page, channel, and run-group tabs retain Station access. The disabled control now says “Workstation is not available on this page,” with copy added for every supported locale and an accessible-label regression test.

## Potential risks

Wide-screen users can no longer use a split Station layout on the excluded pages; this is the intended behavior change. The persisted maximize preference is not rewritten, so returning to an eligible tab preserves its prior layout. There are no persistence-format, dependency, IPC, wire-protocol, data, concurrency, or lifecycle changes. The new localized strings were not reviewed by native speakers.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/ChatPanelHeader.test.ts src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/services/workStation/WorkStationViewService.test.ts` — passed: 4 files, 68 tests
- `pnpm run typecheck:fast` — passed
- `pnpm exec eslint src/engines/ChatPanel/ChatPanelHeader.test.ts src/engines/ChatPanel/ChatPanelHeader.tsx src/engines/ChatPanel/index.tsx src/modules/index.tsx src/services/workStation/WorkStationViewService.test.ts src/services/workStation/WorkStationViewService.ts src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/store/chatPanel/chatPanelTabPresentationAtoms.ts src/store/chatPanel/chatPanelTabsAtom.ts src/store/chatPanel/chatPanelTabsModel.ts --max-warnings 0 --report-unused-disable-directives` — passed
- `pnpm run check:test-placement` — passed across 449 directories
- Screenshot not included: the visible delta is a hover tooltip plus Station eligibility, and desktop UI control was not authorized for this run. The server-rendered header test verifies the disabled state, tooltip label, and accessible label.
- Full frontend and E2E suites were not run; the focused policy, service, and header suites cover the changed behavior at their owning boundaries.