### PR TITLE
feat(sessions): add open-in-new-window menu action

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.test.ts
@@ -5,6 +5,7 @@ import { buildCloudSessionNativeMenuItems } from "./cloudSessionNativeMenuItems"
 describe("buildCloudSessionNativeMenuItems", () => {
   it("keeps secondary-click and ellipsis destination actions in the canonical team menu", () => {
     const onOpenInNewTab = vi.fn();
+    const onOpenInNewWindow = vi.fn();
     const onOpenInMyStation = vi.fn();
     const onCopyUrl = vi.fn();
     const onTogglePin = vi.fn();
@@ -13,12 +14,14 @@ describe("buildCloudSessionNativeMenuItems", () => {
     const items = buildCloudSessionNativeMenuItems({
       labels: {
         openInNewTab: "Open in New Tab",
+        openInNewWindow: "Open in New Window",
         openInMyStation: "Open in My Station",
         copyUrl: "Copy URL",
         togglePin: "Pin",
         remove: "Remove",
       },
       onOpenInNewTab,
+      onOpenInNewWindow,
       onOpenInMyStation,
       onCopyUrl,
       onTogglePin,
@@ -29,6 +32,7 @@ describe("buildCloudSessionNativeMenuItems", () => {
       items.map((item) => ("item" in item ? item.item : item.text))
     ).toEqual([
       "Open in New Tab",
+      "Open in New Window",
       "Open in My Station",
       "Copy URL",
       "Pin",
@@ -40,6 +44,7 @@ describe("buildCloudSessionNativeMenuItems", () => {
       if ("action" in item) item.action?.("test-menu-item");
     }
     expect(onOpenInNewTab).toHaveBeenCalledOnce();
+    expect(onOpenInNewWindow).toHaveBeenCalledOnce();
     expect(onOpenInMyStation).toHaveBeenCalledOnce();
     expect(onCopyUrl).toHaveBeenCalledOnce();
     expect(onTogglePin).toHaveBeenCalledOnce();

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.ts
@@ -3,12 +3,14 @@ import type { NativeMenuItemOptions } from "@src/util/platform/tauri/nativeMenuP
 interface BuildCloudSessionNativeMenuItemsParams {
   labels: {
     openInNewTab: string;
+    openInNewWindow: string;
     openInMyStation: string;
     copyUrl: string;
     togglePin: string;
     remove: string;
   };
   onOpenInNewTab: () => void;
+  onOpenInNewWindow: () => void;
   onOpenInMyStation: () => void;
   onCopyUrl: () => void;
   onTogglePin: () => void;
@@ -22,6 +24,7 @@ interface BuildCloudSessionNativeMenuItemsParams {
 export function buildCloudSessionNativeMenuItems({
   labels,
   onOpenInNewTab,
+  onOpenInNewWindow,
   onOpenInMyStation,
   onCopyUrl,
   onTogglePin,
@@ -29,6 +32,7 @@ export function buildCloudSessionNativeMenuItems({
 }: BuildCloudSessionNativeMenuItemsParams): NativeMenuItemOptions[] {
   return [
     { text: labels.openInNewTab, action: onOpenInNewTab },
+    { text: labels.openInNewWindow, action: onOpenInNewWindow },
     { text: labels.openInMyStation, action: onOpenInMyStation },
     { text: labels.copyUrl, action: onCopyUrl },
     { text: labels.togglePin, action: onTogglePin },

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
@@ -363,7 +363,7 @@ export function useCloudSessionsSection({
   const openTeamSessionAtDestination = useCallback(
     (
       row: RemoteTeammateSessionMetadata,
-      destination: SidebarTabDisposition | "my-station"
+      destination: SidebarTabDisposition | "my-station" | "new-window"
     ) => {
       const openLocalSession = (sessionId: string) => {
         openSessionAtDestination(destination, {
@@ -592,6 +592,10 @@ export function useCloudSessionsSection({
       return buildCloudSessionNativeMenuItems({
         labels: {
           openInNewTab: tCommon("actions.openInNewTab", "Open in New Tab"),
+          openInNewWindow: tCommon(
+            "actions.openInNewWindow",
+            "Open in New Window"
+          ),
           openInMyStation: tSessions(
             "controlTower.sidebar.openInMyStation",
             "Open in My Station"
@@ -603,6 +607,8 @@ export function useCloudSessionsSection({
           remove: tCommon("actions.remove", "Remove"),
         },
         onOpenInNewTab: () => openTeamSessionAtDestination(row, "new-tab"),
+        onOpenInNewWindow: () =>
+          openTeamSessionAtDestination(row, "new-window"),
         onOpenInMyStation: () =>
           openTeamSessionAtDestination(row, "my-station"),
         onCopyUrl: () => {

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.types.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.types.ts
@@ -14,7 +14,10 @@ import type { NativeMenuItemOptions } from "@src/util/platform/tauri/nativeMenuP
 
 import type { SidebarTabDisposition } from "../sidebarTabNavigation";
 
-type CloudSessionOpenDestination = SidebarTabDisposition | "my-station";
+type CloudSessionOpenDestination =
+  | SidebarTabDisposition
+  | "my-station"
+  | "new-window";
 
 interface CloudSessionDestinationOptions {
   sessionId: string;

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import Message from "@src/components/Message";
 import { ROUTES } from "@src/config/routes";
 import { useAppNavigation } from "@src/hooks/navigation/useAppNavigation";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
@@ -115,6 +116,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     openOrganizationTab,
     openSessionInNewChatTab,
     openSessionInWorkstation,
+    openSessionInNewWindow,
     openOrReplaceSessionInChatPanelTab,
     activateChatPanelTab,
     openStartPageTab,
@@ -254,9 +256,16 @@ export const WorkstationSidebarConnector: React.FC = () => {
 
   const openCloudSessionAtDestination = useCallback(
     (
-      destination: "replace-all" | "new-tab" | "my-station",
+      destination: "replace-all" | "new-tab" | "my-station" | "new-window",
       options: { sessionId: string; title: string }
     ) => {
+      if (destination === "new-window") {
+        void openSessionInNewWindow(options).catch((error) => {
+          Message.error(error instanceof Error ? error.message : String(error));
+        });
+        return;
+      }
+
       setStationMode("my-station");
       setStationChatVisible("my-station", true);
       if (location.pathname !== ROUTES.workStation.code.path) {
@@ -292,6 +301,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
       navigate,
       navigateChatPanel,
       openSessionInNewChatTab,
+      openSessionInNewWindow,
       openSessionInWorkstation,
       openOrReplaceSessionInChatPanelTab,
       closeOtherThanActiveChatPanelTabs,
@@ -407,6 +417,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     handleTogglePin,
     handleOpenInNewTab,
     handleOpenInMyStation,
+    handleOpenInNewWindow,
     handleOpenLinkedWorkItemSession,
     handleToggleSubagentExpansion,
   } = useWorkstationSidebarSessionInteractionHandlers({
@@ -435,6 +446,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     navigateChatPanel,
     openSessionInNewChatTab,
     openSessionInWorkstation,
+    openSessionInNewWindow,
     setExpandedSubagentParentIds,
   });
 
@@ -453,6 +465,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
       handleMenuItemClick(item.key, item, "new-tab"),
     handleExportMarkdown,
     handleOpenInNewTab,
+    handleOpenInNewWindow,
     handleOpenInMyStation,
     handleTogglePin,
     handleToggleSubagentExpansion,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.chatPanelAtoms.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.chatPanelAtoms.ts
@@ -21,7 +21,10 @@ import {
   openTeamInboxInChatPanelTabAtom,
   openWorkManagementChatPanelTabAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
-import { openSessionInWorkstationAtom } from "@src/store/session/sessionTabPlacementAtom";
+import {
+  openSessionInNewWindowAtom,
+  openSessionInWorkstationAtom,
+} from "@src/store/session/sessionTabPlacementAtom";
 import {
   activeStationChatVisibleAtom,
   chatPanelContentModeAtom,
@@ -52,6 +55,7 @@ export function useWorkstationSidebarChatPanelAtoms() {
   const openOrganizationTab = useSetAtom(openOrganizationInChatPanelTabAtom);
   const openSessionInNewChatTab = useSetAtom(openSessionInNewChatTabAtom);
   const openSessionInWorkstation = useSetAtom(openSessionInWorkstationAtom);
+  const openSessionInNewWindow = useSetAtom(openSessionInNewWindowAtom);
   const openOrReplaceSessionInChatPanelTab = useSetAtom(
     openOrReplaceSessionInChatPanelTabAtom
   );
@@ -82,6 +86,7 @@ export function useWorkstationSidebarChatPanelAtoms() {
     openOrganizationTab,
     openSessionInNewChatTab,
     openSessionInWorkstation,
+    openSessionInNewWindow,
     openOrReplaceSessionInChatPanelTab,
     activateChatPanelTab,
     openStartPageTab,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.sessionInteractionHandlers.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.sessionInteractionHandlers.ts
@@ -7,6 +7,7 @@
  */
 import { useCallback } from "react";
 
+import Message from "@src/components/Message";
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import { loadMoreCategory } from "@src/store/session";
 import {
@@ -71,6 +72,10 @@ interface UseWorkstationSidebarSessionInteractionHandlersParams {
     sessionId: string;
     title?: string;
   }) => void;
+  openSessionInNewWindow: (options: {
+    sessionId: string;
+    title?: string;
+  }) => Promise<boolean>;
   setExpandedSubagentParentIds: (
     updater: (previousIds: Set<string>) => Set<string>
   ) => void;
@@ -102,6 +107,7 @@ export function useWorkstationSidebarSessionInteractionHandlers({
   navigateChatPanel,
   openSessionInNewChatTab,
   openSessionInWorkstation,
+  openSessionInNewWindow,
   setExpandedSubagentParentIds,
 }: UseWorkstationSidebarSessionInteractionHandlersParams) {
   const handleCloudSidebarItemClick = useCallback(
@@ -196,6 +202,18 @@ export function useWorkstationSidebarSessionInteractionHandlers({
       sessionMap,
     ]
   );
+  const handleOpenInNewWindow = useCallback(
+    (sessionId: string) => {
+      const session = sessionMap.get(sessionId);
+      void openSessionInNewWindow({
+        sessionId,
+        title: session?.name,
+      }).catch((error) => {
+        Message.error(error instanceof Error ? error.message : String(error));
+      });
+    },
+    [openSessionInNewWindow, sessionMap]
+  );
 
   const handleOpenLinkedWorkItemSession = useCallback(
     (item: NavigationMenuItem) => {
@@ -239,6 +257,7 @@ export function useWorkstationSidebarSessionInteractionHandlers({
     handleTogglePin,
     handleOpenInNewTab,
     handleOpenInMyStation,
+    handleOpenInNewWindow,
     handleOpenLinkedWorkItemSession,
     handleToggleSubagentExpansion,
   };

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarRowActions.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarRowActions.ts
@@ -23,6 +23,7 @@ interface UseSessionSidebarRowActionsParams {
   handleOpenDraftInNewTab: ContextMenuParams["handleOpenDraftInNewTab"];
   handleExportMarkdown: ContextMenuParams["handleExportMarkdown"];
   handleOpenInNewTab: ContextMenuParams["handleOpenInNewTab"];
+  handleOpenInNewWindow: ContextMenuParams["handleOpenInNewWindow"];
   handleOpenInMyStation: ContextMenuParams["handleOpenInMyStation"];
   handleTogglePin: ContextMenuParams["handleTogglePin"];
   handleToggleSubagentExpansion: DecorateRowActionsParams["handleToggleSubagentExpansion"];
@@ -46,6 +47,7 @@ export function useSessionSidebarRowActions({
   handleOpenDraftInNewTab,
   handleExportMarkdown,
   handleOpenInNewTab,
+  handleOpenInNewWindow,
   handleOpenInMyStation,
   handleTogglePin,
   handleToggleSubagentExpansion,
@@ -73,6 +75,7 @@ export function useSessionSidebarRowActions({
     handleOpenDraftInNewTab,
     handleExportMarkdown,
     handleOpenInNewTab,
+    handleOpenInNewWindow,
     handleOpenInMyStation,
     handleTogglePin,
     isMoveEligible: moveToOrg.isMoveEligible,

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/useWorkstationSidebarContextMenu.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/useWorkstationSidebarContextMenu.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
+import type { Session } from "@src/store/session";
+import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
+
+import { useWorkstationSidebarContextMenu } from "../useWorkstationSidebarContextMenu";
+
+vi.mock("@src/util/platform/tauri/nativeMenuPopup", () => ({
+  popupNativeMenu: vi.fn().mockResolvedValue({ status: "closed" }),
+}));
+
+const mockedPopupNativeMenu = vi.mocked(popupNativeMenu);
+const translate = (key: string, defaultValue?: string) => defaultValue ?? key;
+
+function session(sessionId: string): Session {
+  return {
+    session_id: sessionId,
+    name: `Session ${sessionId}`,
+    status: "completed",
+    created_at: "2026-09-03T00:00:00Z",
+    updated_at: "2026-09-03T00:00:00Z",
+  };
+}
+
+describe("useWorkstationSidebarContextMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockedPopupNativeMenu.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("offers the detached-window action for every supported local session menu", async () => {
+    const sessions = [
+      session("sdeagent-local"),
+      session("cursoride-imported"),
+      session("chatpaneltui-terminal"),
+    ];
+    const sessionMap = new Map(
+      sessions.map((row) => [row.session_id, row] as const)
+    );
+    const handleOpenInNewWindow = vi.fn();
+    let openMenu:
+      | ReturnType<typeof useWorkstationSidebarContextMenu>
+      | undefined;
+
+    function Probe(): null {
+      const value = useWorkstationSidebarContextMenu({
+        sessionMap,
+        rename: {
+          visible: false,
+          currentName: "",
+          loading: false,
+          open: vi.fn(),
+          onConfirm: vi.fn(async () => undefined),
+          onCancel: vi.fn(),
+          renameSessionId: null,
+        },
+        handleDeleteSession: vi.fn(async () => undefined),
+        handleDeleteDraft: vi.fn(),
+        handleOpenDraftInNewTab: vi.fn(),
+        handleExportMarkdown: vi.fn(async () => undefined),
+        handleOpenInNewTab: vi.fn(),
+        handleOpenInNewWindow,
+        handleOpenInMyStation: vi.fn(),
+        handleTogglePin: vi.fn(async () => undefined),
+        isMoveEligible: () => false,
+        handleOpenMoveToOrg: vi.fn(),
+        moveToOrgLabel: "Move to organization",
+        isCloudSyncLevelEligible: () => false,
+        handleOpenCloudSyncLevel: vi.fn(),
+        cloudSyncLevelLabel: "Cloud sync",
+        isCloudShareEligible: () => false,
+        handleOpenCloudShare: vi.fn(),
+        cloudShareLabel: "Share",
+        isCopyReferenceEligible: () => false,
+        handleCopyReference: vi.fn(),
+        copyReferenceLabel: "Copy URL",
+        tCommon: translate,
+      });
+      useEffect(() => {
+        openMenu = value;
+      }, [value]);
+      return null;
+    }
+
+    await act(async () => root.render(createElement(Probe)));
+    if (!openMenu) throw new Error("context menu hook did not render");
+
+    for (const row of sessions) {
+      const item: NavigationMenuItem = {
+        id: row.session_id,
+        key: row.session_id,
+        label: row.name ?? row.session_id,
+      };
+      const event = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as never;
+
+      await openMenu(event, item.key, item);
+      const popupOptions = mockedPopupNativeMenu.mock.lastCall?.[0];
+      const items = await popupOptions?.buildItems();
+      const detachedWindowItem = items?.find(
+        (menuItem) =>
+          "text" in menuItem && menuItem.text === "Open in New Window"
+      );
+
+      expect(detachedWindowItem).toBeDefined();
+      if (detachedWindowItem && "action" in detachedWindowItem) {
+        detachedWindowItem.action?.("open-in-new-window");
+      }
+      expect(handleOpenInNewWindow).toHaveBeenLastCalledWith(row.session_id);
+    }
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarContextMenu.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarContextMenu.ts
@@ -30,6 +30,7 @@ interface UseWorkstationSidebarContextMenuParams {
   handleOpenDraftInNewTab: (item: NavigationMenuItem) => void;
   handleExportMarkdown: (sessionId: string) => Promise<void>;
   handleOpenInNewTab: (sessionId: string) => void;
+  handleOpenInNewWindow: (sessionId: string) => void;
   handleOpenInMyStation: (sessionId: string) => void;
   handleTogglePin: (sessionId: string) => Promise<void>;
   /** Owner-side share dialog gate + opener (design §6.3, M4b). */
@@ -68,6 +69,7 @@ export function useWorkstationSidebarContextMenu({
   handleOpenDraftInNewTab,
   handleExportMarkdown,
   handleOpenInNewTab,
+  handleOpenInNewWindow,
   handleOpenInMyStation,
   handleTogglePin,
   isMoveEligible,
@@ -120,6 +122,10 @@ export function useWorkstationSidebarContextMenu({
         text: tCommon("actions.openInNewTab", "Open in New Tab"),
         action: () => handleOpenInNewTab(item.id),
       };
+      const openInNewWindowItem: NativeMenuItemOptions = {
+        text: tCommon("actions.openInNewWindow", "Open in New Window"),
+        action: () => handleOpenInNewWindow(item.id),
+      };
       const openInMyStationItem: NativeMenuItemOptions = {
         text: tCommon(
           "sessions:controlTower.sidebar.openInMyStation",
@@ -135,7 +141,12 @@ export function useWorkstationSidebarContextMenu({
       };
 
       if (isCursorIde) {
-        return [openInNewTabItem, openInMyStationItem, pinItem];
+        return [
+          openInNewTabItem,
+          openInNewWindowItem,
+          openInMyStationItem,
+          pinItem,
+        ];
       }
 
       const deleteItem: NativeMenuItemOptions = {
@@ -143,11 +154,12 @@ export function useWorkstationSidebarContextMenu({
         action: () => handleDeleteSession(item.id),
       };
       if (isChatPanelTuiSessionId(item.id)) {
-        return [openInNewTabItem, pinItem, deleteItem];
+        return [openInNewTabItem, openInNewWindowItem, pinItem, deleteItem];
       }
 
       const primaryItems: NativeMenuItemOptions[] = [
         openInNewTabItem,
+        openInNewWindowItem,
         openInMyStationItem,
         {
           text: tCommon("actions.rename"),
@@ -204,6 +216,7 @@ export function useWorkstationSidebarContextMenu({
       handleOpenDraftInNewTab,
       handleExportMarkdown,
       handleOpenInNewTab,
+      handleOpenInNewWindow,
       handleOpenInMyStation,
       handleTogglePin,
       handleOpenMoveToOrg,


### PR DESCRIPTION
## Problem

Session sidebar context menus expose destinations such as a new tab and My Station, but they do not expose the detached window behavior that already exists in session headers. This affects supported local session rows and Team Conversation rows. The root cause is that both native menu builders stop at their tab and station handlers and never dispatch to openSessionInNewWindowAtom.

## Solution

Add Open in New Window immediately after Open in New Tab in the local and Team Conversation native menus. Local rows dispatch through the existing detached-window atom so successful opens retain its tab-ownership behavior and failed opens preserve the current tabs. Team Conversation rows reuse the existing replay/import destination resolver and pass the resolved local session id to the same detached-window path. Focused regression tests cover the menu entry and callback for regular local, Cursor import, terminal, and team-session menu variants.

## Potential risks

Remote Team Conversations still depend on the existing replay/import lifecycle before the detached surface can load the local replay, and native window creation remains platform-dependent. Failures use the existing visible error path and do not close current tabs. No dependency, persistence, data migration, configuration, public API, IPC, or wire-format changes are included, so rollback is limited to reverting this commit. The native desktop menu was not manually exercised or captured because local computer control was not authorized; menu ordering is verified at the native-menu option boundary.

## Verification

- pnpm test -- --run src/scaffold/NavigationSidebar/connectors/__tests__/useWorkstationSidebarContextMenu.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.test.ts — passed, 2 files and 2 tests
- pnpm typecheck — passed
- pnpm exec eslint on all 10 changed TypeScript files with --max-warnings 0 --report-unused-disable-directives — passed
- pnpm lint:fast — passed
- pnpm check:circular — passed, no circular dependencies across 6452 modules
- pnpm check:test-placement — passed, consistent across 456 directories
- git diff --check origin/develop...HEAD — passed
- Commit hooks — lint-staged, Oxlint, ESLint fix, Prettier, and staged TypeScript checks passed
- Not run: native desktop screenshot or recording; computer-control permission was not provided