### PR TITLE
fix(session-window): stop the startup flash in detached windows

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -463,6 +463,25 @@
         border-radius: var(--border-radius-window);
         overflow: hidden;
       }
+      /*
+       * macOS detached windows settle on native vibrancy, not on a solid
+       * plate (see the `html[data-host-desktop="macos"]` rule in
+       * src/index.scss). Painting --splash-bg here would cover the material
+       * the window already has behind the webview for the whole bundle boot
+       * — an opaque white rectangle on a light theme, with the splash mark
+       * suppressed, on a window that ends up transparent. Compositing onto
+       * the material from the first frame is the honest pre-paint surface.
+       *
+       * Scoped to macOS on purpose: Windows and Linux secondary windows are
+       * opaque (`transparent(true)` in open_session_window is macOS-only),
+       * so there is nothing behind their webview but the builder's
+       * background colour, and they still need the splash plate.
+       */
+      html[data-host-desktop="macos"][data-orgii-secondary-window],
+      html[data-host-desktop="macos"][data-orgii-secondary-window] body,
+      html[data-host-desktop="macos"][data-orgii-secondary-window] #root {
+        background: transparent;
+      }
       /* Remove border radius in fullscreen mode */
       html.fullscreen,
       html.fullscreen body,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "perf_utils",
+ "settings",
  "tauri",
  "tracing",
  "window-vibrancy",

--- a/src-tauri/crates/app-window/Cargo.toml
+++ b/src-tauri/crates/app-window/Cargo.toml
@@ -22,6 +22,10 @@ name = "app_window"
 
 [dependencies]
 perf_utils = { path = "../perf-utils" }
+# The startup backdrop follows the user's `general.theme`, which lives in
+# `~/.orgii/settings.jsonc`. `settings` is itself a leaf crate (app_paths +
+# tauri), so this stays acyclic and does not pull in `app`.
+settings = { path = "../settings" }
 
 tauri = { workspace = true }
 tracing = "0.1"

--- a/src-tauri/crates/app-window/src/commands.rs
+++ b/src-tauri/crates/app-window/src/commands.rs
@@ -274,8 +274,11 @@ fn session_window_label(session_id: &str) -> String {
 ///
 /// The window loads the standalone `/orgii/app/session/<id>` route — the same
 /// bundle as the main window, rendering only the session surface. There is no
-/// prewarmed window pool: the window is built on demand and visible from the
-/// first frame (the splash), which is the fastest honest feedback we can give.
+/// prewarmed window pool: the window is built on demand and shown as soon as
+/// its chrome is in place, which is the fastest honest feedback we can give.
+/// It is built hidden (not `visible(true)`) only so the frames between
+/// `build()` and the chrome below never reach the screen — the `show()` is
+/// synchronous with creation, NOT deferred to the frontend's first paint.
 ///
 /// Chrome follows the decorated-secondary-window recipe used by
 /// `browser::open_browser_window`: native decorations everywhere, macOS
@@ -315,16 +318,26 @@ pub async fn open_session_window(
     }
 
     let route = format!("orgii/app/session/{session_id}");
+    let backdrop = super::startup_backdrop::startup_backdrop(&app);
     let builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(route.into()))
         .title(&window_title)
         .inner_size(1100.0, 800.0)
         .min_inner_size(450.0, 300.0)
         .resizable(true)
-        .visible(true)
+        // Shown explicitly after the chrome below is applied, so the window
+        // never appears in its pre-chrome state.
+        .visible(false)
         .decorations(true)
-        // Match the main window's startup backdrop so the pre-paint frame is
-        // never a white flash. The page paints its own background on top.
-        .background_color(tauri::window::Color(0x0d, 0x0d, 0x0d, 0xff));
+        // Opaque startup backdrop for the hosts whose secondary windows are
+        // opaque (Windows, Linux): it covers the gap before the webview
+        // paints. It follows the app's own theme and matches --splash-bg
+        // exactly, so the native backdrop and the first thing the page paints
+        // are the same colour — a fixed dark value opened a light-theme
+        // window dark, then white, then the app. macOS clears it again below:
+        // a transparent window wants its vibrancy there, not a plate.
+        .background_color(tauri::window::Color(
+            backdrop.0, backdrop.1, backdrop.2, 0xff,
+        ));
 
     // Same chrome contract as the main window's config: a TRANSPARENT
     // NSWindow under the overlay title bar. Without transparency, macOS
@@ -347,22 +360,39 @@ pub async fn open_session_window(
         .map_err(|e| format!("Failed to create session window: {e}"))?;
     ownership_observation.commit();
 
-    // Same post-build sequence as `recreate_main_window`: reposition the
-    // traffic lights (the builder option alone is unreliable for dynamically
-    // created windows), paint the startup background so the transparent
-    // window never shows the desktop through, and mount the same vibrancy
-    // material the main window uses. The frontend clears the startup
-    // background via `remove_window_background` once React paints — that
-    // command operates on the calling window, so this window gets the same
-    // post-paint traffic-light re-apply main does.
+    // Reposition the traffic lights (the builder option alone is unreliable
+    // for dynamically created windows), mount the same vibrancy material the
+    // main window uses, and then clear the builder's opaque backdrop so the
+    // webview composites onto that material from its very first frame.
+    //
+    // Deliberately NOT `apply_window_background_color` (what
+    // `recreate_main_window` does). That helper enables WKWebView background
+    // drawing, and the webview then paints its own base colour — plus the
+    // opaque `--splash-bg` plate from index.html — over the material for the
+    // whole bundle boot. On a light theme that is a full-window white
+    // rectangle, with the splash mark suppressed in secondary windows, on a
+    // window whose settled appearance is transparent: the white flash. A
+    // detached window ends on vibrancy, so vibrancy is also its honest
+    // pre-paint surface. index.html keeps the splash plate off this window to
+    // match (`html[data-host-desktop="macos"][data-orgii-secondary-window]`).
+    //
+    // The frontend still invokes `remove_window_background` once React paints;
+    // on this window the background clear is a no-op and the call's remaining
+    // job is the post-paint traffic-light re-apply that main also gets.
     #[cfg(target_os = "macos")]
     {
         super::set_traffic_light_position(&window, super::TRAFFIC_LIGHT_X, super::TRAFFIC_LIGHT_Y);
-        super::apply_window_background_color(&window);
         super::apply_macos_window_material(&window);
+        super::remove_window_background_color(&window);
     }
 
     super::apply_host_desktop_decorated_window_corners(&window);
+
+    // Chrome is in place: reveal the window. Not deferred to the frontend's
+    // first paint — the click that opened it must get immediate feedback.
+    window
+        .show()
+        .map_err(|e| format!("Failed to show session window: {e}"))?;
 
     let _ = window.set_focus();
 

--- a/src-tauri/crates/app-window/src/lib.rs
+++ b/src-tauri/crates/app-window/src/lib.rs
@@ -21,6 +21,8 @@ mod macos_material;
 #[cfg(windows)]
 mod windows_corner;
 
+pub mod startup_backdrop;
+
 // ============================================
 // macOS window background color
 // ============================================
@@ -55,8 +57,12 @@ pub fn apply_window_background_color(window: &tauri::WebviewWindow) {
             let _: () = msg_send![ns_win, setBackgroundColor: bg];
 
             let content_view: *mut AnyObject = msg_send![ns_win, contentView];
-            if !content_view.is_null() {
-                set_draws_background_recursive(content_view, true);
+            if !content_view.is_null() && !set_webview_background_recursive(content_view, true, bg)
+            {
+                tracing::warn!(
+                    "No WKWebView under the window's contentView; startup backdrop not applied \
+                     to the webview and it will paint its own base colour"
+                );
             }
         }
     };
@@ -91,8 +97,13 @@ pub fn remove_window_background_color(window: &tauri::WebviewWindow) {
             let _: () = msg_send![ns_win, setBackgroundColor: clear];
 
             let content_view: *mut AnyObject = msg_send![ns_win, contentView];
-            if !content_view.is_null() {
-                set_draws_background_recursive(content_view, false);
+            if !content_view.is_null()
+                && !set_webview_background_recursive(content_view, false, clear)
+            {
+                tracing::warn!(
+                    "No WKWebView under the window's contentView; the webview keeps whatever \
+                     background it had and the window will not be transparent"
+                );
             }
         }
     };
@@ -104,10 +115,37 @@ pub fn remove_window_background_color(window: &tauri::WebviewWindow) {
     }
 }
 
-/// Recursively search for WKWebView subviews and set _drawsBackground.
+/// Recursively search for WKWebView subviews and pin their background.
+///
+/// Two levers, because `_setDrawsBackground:` alone is not enough:
+///
+/// - `_setDrawsBackground:` decides WHETHER the webview paints a base layer
+///   under the document.
+/// - `underPageBackgroundColor` decides WHAT that base layer is. Left unset,
+///   WebKit derives it from the document — and before the first document has
+///   painted there is nothing to derive from, so it falls back to WHITE. That
+///   fallback is visible for the entire load of a freshly created window,
+///   underneath a page whose own background is transparent, and it is the
+///   white flash this function exists to prevent. Pinning it is also what
+///   makes the setting survive a navigation, which re-derives the default.
+///
+/// `underPageBackgroundColor` is public API from macOS 12; the bundle targets
+/// 10.15, so it is probed with `respondsToSelector:` rather than assumed.
+///
+/// Returns whether a WKWebView was actually found. Callers apply this right
+/// after `build()`, where a silent miss looks exactly like a working fix.
 #[cfg(target_os = "macos")]
-unsafe fn set_draws_background_recursive(view: *mut AnyObject, draws: bool) {
+unsafe fn set_webview_background_recursive(
+    view: *mut AnyObject,
+    draws: bool,
+    color: *mut AnyObject,
+) -> bool {
     use objc2::runtime::Bool;
+    use objc2::sel;
+
+    if view.is_null() {
+        return false;
+    }
 
     let class_name: *mut AnyObject = msg_send![view, className];
     let class_str: *const std::os::raw::c_char = msg_send![class_name, UTF8String];
@@ -116,16 +154,24 @@ unsafe fn set_draws_background_recursive(view: *mut AnyObject, draws: bool) {
         if name.contains("WKWebView") {
             let val: Bool = Bool::new(draws);
             let _: () = msg_send![view, _setDrawsBackground: val];
-            return;
+
+            let responds: Bool =
+                msg_send![view, respondsToSelector: sel!(setUnderPageBackgroundColor:)];
+            if responds.as_bool() {
+                let _: () = msg_send![view, setUnderPageBackgroundColor: color];
+            }
+            return true;
         }
     }
 
     let subviews: *mut AnyObject = msg_send![view, subviews];
     let count: usize = msg_send![subviews, count];
+    let mut found = false;
     for idx in 0..count {
         let subview: *mut AnyObject = msg_send![subviews, objectAtIndex: idx];
-        set_draws_background_recursive(subview, draws);
+        found |= set_webview_background_recursive(subview, draws, color);
     }
+    found
 }
 
 // ============================================

--- a/src-tauri/crates/app-window/src/startup_backdrop.rs
+++ b/src-tauri/crates/app-window/src/startup_backdrop.rs
@@ -1,0 +1,136 @@
+//! The opaque colour a window paints before its webview has painted anything.
+//!
+//! Hosts whose secondary windows are opaque (Windows, Linux) show this colour
+//! for the whole gap between the window appearing and the page's first frame.
+//! A fixed dark value is wrong half the time: on a light theme the window
+//! opens dark, then the splash plate repaints it white, then the app paints.
+//! Two flashes, neither of them the app's colour.
+//!
+//! The values below mirror `--splash-bg` in `public/index.html` exactly, so
+//! the native backdrop and the first thing the page paints are the same
+//! colour and the seam is invisible.
+//!
+//! Skin caveat: a non-baseline skin overrides `--splash-bg` from
+//! `localStorage["orgii_skin_surface"]`, which `useAppSkin` mirrors for the
+//! splash. Nothing derives those tokens outside the bundle — the derivation
+//! lives in TS (`deriveSkinTokens`) — so a skinned app gets ORGII's base
+//! surface here rather than the skin's. That keeps the light/dark polarity
+//! right, which is what removes the flash; matching the exact skin surface
+//! would mean duplicating the skin registry in Rust.
+
+use tauri::{AppHandle, Manager};
+
+/// sRGB triples mirroring `--splash-bg` in `public/index.html`.
+pub const LIGHT_BACKDROP: (u8, u8, u8) = (0xff, 0xff, 0xff);
+pub const DARK_BACKDROP: (u8, u8, u8) = (0x14, 0x14, 0x14);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Appearance {
+    Light,
+    Dark,
+}
+
+/// Resolve a stored `general.theme` value to an appearance.
+///
+/// Mirrors `normalizeGlobalThemePreference` + `LEGACY_THEME_ALIASES` in
+/// `src/config/appearance/globalThemes.ts`. `None` means "follow the OS":
+/// the explicit `system` preference, an absent setting, and any unrecognised
+/// value all land there, matching the TS default of
+/// `DEFAULT_GLOBAL_THEME_PREFERENCE = system`.
+pub fn appearance_for_preference(preference: Option<&str>) -> Option<Appearance> {
+    match preference?.trim() {
+        "light" | "github-light" | "/orgii_main.css" => Some(Appearance::Light),
+        "dark"
+        | "github-dark"
+        | "orgii-high-contrast"
+        | "/orgii_dark.css"
+        | "/orgii_high_contrast.css" => Some(Appearance::Dark),
+        // "system", "", and anything unrecognised follow the OS.
+        _ => None,
+    }
+}
+
+/// The user's stored global theme preference, if the settings file has one.
+fn stored_theme_preference() -> Option<String> {
+    settings::file_io::read_settings()
+        .ok()?
+        .get("general.theme")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// The OS appearance, read off the main window (Tauri reports the system
+/// theme for a window that has not overridden it). Falls back to light, which
+/// matches `getSystemColorScheme()`'s own fallback in the frontend.
+fn os_appearance(app: &AppHandle) -> Appearance {
+    match app
+        .get_webview_window("main")
+        .and_then(|window| window.theme().ok())
+    {
+        Some(tauri::Theme::Dark) => Appearance::Dark,
+        _ => Appearance::Light,
+    }
+}
+
+/// The colour a freshly built window should paint until its page does.
+pub fn startup_backdrop(app: &AppHandle) -> (u8, u8, u8) {
+    let appearance = appearance_for_preference(stored_theme_preference().as_deref())
+        .unwrap_or_else(|| os_appearance(app));
+
+    match appearance {
+        Appearance::Light => LIGHT_BACKDROP,
+        Appearance::Dark => DARK_BACKDROP,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{appearance_for_preference, Appearance};
+
+    #[test]
+    fn resolves_the_current_theme_ids() {
+        assert_eq!(
+            appearance_for_preference(Some("light")),
+            Some(Appearance::Light)
+        );
+        assert_eq!(
+            appearance_for_preference(Some("dark")),
+            Some(Appearance::Dark)
+        );
+    }
+
+    #[test]
+    fn resolves_the_legacy_aliases_the_frontend_still_accepts() {
+        // Kept in step with LEGACY_THEME_ALIASES in globalThemes.ts: a
+        // settings.jsonc written before skins landed still holds these.
+        for light in ["github-light", "/orgii_main.css"] {
+            assert_eq!(
+                appearance_for_preference(Some(light)),
+                Some(Appearance::Light),
+                "{light} should resolve light"
+            );
+        }
+        for dark in [
+            "github-dark",
+            "orgii-high-contrast",
+            "/orgii_dark.css",
+            "/orgii_high_contrast.css",
+        ] {
+            assert_eq!(
+                appearance_for_preference(Some(dark)),
+                Some(Appearance::Dark),
+                "{dark} should resolve dark"
+            );
+        }
+    }
+
+    #[test]
+    fn defers_to_the_os_when_there_is_no_usable_preference() {
+        // The TS default preference is "system", and an unrecognised value
+        // normalizes to it rather than to a hardcoded light/dark.
+        assert_eq!(appearance_for_preference(Some("system")), None);
+        assert_eq!(appearance_for_preference(None), None);
+        assert_eq!(appearance_for_preference(Some("")), None);
+        assert_eq!(appearance_for_preference(Some("solarized")), None);
+    }
+}

--- a/src/app/root/__tests__/secondaryWindowStartupSurface.test.ts
+++ b/src/app/root/__tests__/secondaryWindowStartupSurface.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import postcss from "postcss";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Startup-surface guard for macOS detached (session) windows.
+ *
+ * A detached window is built transparent with an NSVisualEffectView mounted
+ * behind its webview, and it settles on that vibrancy — `html[data-host-
+ * desktop="macos"]` in src/index.scss paints only a 15% tint. So its
+ * pre-paint surface must already BE the vibrancy. Anything opaque painted in
+ * the meantime is visible as a flash, and the window is on screen for the
+ * whole cold boot of its own webview (each Tauri window re-parses and
+ * re-executes the bundle), so "in the meantime" is hundreds of milliseconds.
+ *
+ * Two independent sources used to paint over it, and each is pinned below:
+ *
+ * 1. index.html's splash plate, `html, body, #root { background:
+ *    var(--splash-bg) }`. On a light theme --splash-bg is #ffffff, and
+ *    secondary windows suppress the splash mark, so this was a bare white
+ *    rectangle.
+ * 2. `apply_window_background_color` in the Rust open path, which enables
+ *    WKWebView background drawing — the webview then paints its own opaque
+ *    base beneath the page instead of compositing onto the material.
+ *
+ * Both halves are asserted here because neither alone removes the flash.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+
+const MACOS_SECONDARY_PREFIX =
+  'html[data-host-desktop="macos"][data-orgii-secondary-window]';
+
+/** Subjects the splash plate paints, and that the override must neutralize. */
+const PLATE_SUBJECTS = ["html", "body", "#root"] as const;
+
+/**
+ * Drop `//` comments so the Rust assertions below read calls, not prose —
+ * the function documents at length which helper it must NOT call. Naive on
+ * purpose: `open_session_window` contains no string literal holding `//`.
+ */
+function stripLineComments(rust: string): string {
+  return rust
+    .split("\n")
+    .map((line) => line.replace(/\/\/.*$/, ""))
+    .join("\n");
+}
+
+function readIndexHtmlStyles(): postcss.Root {
+  const html = readFileSync(path.join(REPO_ROOT, "public/index.html"), "utf8");
+  const opening = html.indexOf("<style");
+  const contentStart = html.indexOf(">", opening) + 1;
+  const contentEnd = html.indexOf("</style>", contentStart);
+  expect(opening).toBeGreaterThan(-1);
+  expect(contentEnd).toBeGreaterThan(contentStart);
+
+  return postcss.parse(html.slice(contentStart, contentEnd));
+}
+
+/**
+ * Rules in document order, flattened out of `@layer base`. Order matters:
+ * the override and the plate sit in the same layer, so the later rule wins
+ * any tie — though it does not need the tie-break, see below.
+ */
+function backgroundRules(root: postcss.Root): {
+  selectors: string[];
+  background: string;
+}[] {
+  const rules: { selectors: string[]; background: string }[] = [];
+
+  root.walkRules((rule) => {
+    let background: string | undefined;
+    rule.walkDecls("background", (decl) => {
+      background = decl.value;
+    });
+    if (background === undefined) return;
+    rules.push({
+      selectors: rule.selectors.map((selector) => selector.trim()),
+      background,
+    });
+  });
+
+  return rules;
+}
+
+describe("macOS detached-window startup surface", () => {
+  describe("index.html splash plate", () => {
+    const rules = backgroundRules(readIndexHtmlStyles());
+
+    const plateIndex = rules.findIndex(
+      (rule) =>
+        rule.background === "var(--splash-bg)" &&
+        PLATE_SUBJECTS.every((subject) => rule.selectors.includes(subject))
+    );
+    const overrideIndex = rules.findIndex(
+      (rule) =>
+        rule.background === "transparent" &&
+        rule.selectors.every((selector) =>
+          selector.startsWith(MACOS_SECONDARY_PREFIX)
+        ) &&
+        rule.selectors.length === PLATE_SUBJECTS.length
+    );
+
+    it("still paints the opaque plate on the default startup surface", () => {
+      // Not a leftover: a main window (and every non-macOS window) is opaque
+      // before first paint and would otherwise flash black on a light theme.
+      expect(plateIndex).toBeGreaterThan(-1);
+    });
+
+    it("neutralizes the plate for macOS secondary windows", () => {
+      expect(overrideIndex).toBeGreaterThan(-1);
+    });
+
+    it("neutralizes every subject the plate paints", () => {
+      // A subject left behind is a full-window opaque rectangle of its own:
+      // #root alone covers the viewport.
+      const overrideSubjects = rules[overrideIndex].selectors.map((selector) =>
+        selector.slice(MACOS_SECONDARY_PREFIX.length).trim()
+      );
+
+      // `html[...][...]` itself is the html subject, written without a
+      // descendant part; body and #root are descendants of it.
+      expect(new Set(overrideSubjects)).toEqual(new Set(["", "body", "#root"]));
+    });
+
+    it("wins the cascade over the plate", () => {
+      // Same layer, so this is decided on specificity and then order. Each
+      // override selector is the plate's own selector qualified with two
+      // attribute selectors on <html>, which is strictly more specific; the
+      // source order below only guards against a future equal-specificity
+      // rewrite.
+      expect(overrideIndex).toBeGreaterThan(plateIndex);
+    });
+
+    it("does not leak the transparent surface to other hosts or to main", () => {
+      // Windows/Linux secondary windows are opaque (transparent(true) in
+      // open_session_window is macOS-only) and a macOS MAIN window keeps the
+      // plate, so both attribute qualifiers must stay on the selector.
+      for (const selector of rules[overrideIndex].selectors) {
+        expect(selector).toContain('[data-host-desktop="macos"]');
+        expect(selector).toContain("[data-orgii-secondary-window]");
+      }
+    });
+  });
+
+  describe("open_session_window native chrome", () => {
+    const source = readFileSync(
+      path.join(REPO_ROOT, "src-tauri/crates/app-window/src/commands.rs"),
+      "utf8"
+    );
+    const start = source.indexOf("pub async fn open_session_window");
+    const end = source.indexOf("mod session_window_tests", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const openFn = stripLineComments(source.slice(start, end));
+
+    it("does not enable WKWebView background drawing", () => {
+      // `apply_window_background_color` is correct for the main window, whose
+      // settled surface is opaque. Here it repaints the vibrancy away.
+      expect(openFn).not.toContain("apply_window_background_color");
+    });
+
+    it("mounts the vibrancy material and clears the builder backdrop", () => {
+      expect(openFn).toContain("apply_macos_window_material");
+      expect(openFn).toContain("remove_window_background_color");
+    });
+
+    it("shows the window only after its chrome is applied", () => {
+      // Built hidden so the pre-chrome frames never reach the screen. The
+      // show() is part of creation, not deferred to first paint — deferring
+      // it would make the click that opened the window feel dead.
+      expect(openFn).toContain(".visible(false)");
+      expect(openFn).toMatch(/window\s*\n?\s*\.show\(\)/);
+      expect(openFn.indexOf("apply_macos_window_material")).toBeLessThan(
+        openFn.search(/window\s*\n?\s*\.show\(\)/)
+      );
+    });
+  });
+});

--- a/src/modules/MainApp/TeamInbox/__tests__/AssignedWorkItemDetail.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/AssignedWorkItemDetail.test.ts
@@ -86,7 +86,8 @@ const mocks = vi.hoisted(() => ({
   } as WorkItem,
 }));
 
-vi.mock("@src/api/http/git/remotes", () => ({
+vi.mock("@src/api/http/git/remotes", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@src/api/http/git/remotes")>()),
   getGitRemotes: mocks.getGitRemotes,
 }));
 


### PR DESCRIPTION
## Problem

Opening a detached session window showed three states in a row: the window
appeared transparent, flashed an opaque plate, then settled back to its
vibrancy. Two independent layers painted that plate and neither of them was
the app's own surface.

On macOS the window is built transparent with an `NSVisualEffectView` behind
its webview and settles on that material (`html[data-host-desktop="macos"]` in
`src/index.scss` paints only a 15% tint). Two things covered it during boot:

1. `apply_window_background_color` toggled `_setDrawsBackground:` on the
   WKWebView but never pinned `underPageBackgroundColor`. WebKit derives that
   colour from the document, and before the first document has painted there
   is nothing to derive from, so it falls back to **white** — for the entire
   cold boot of that window's webview, since each Tauri window re-parses and
   re-executes the bundle.
2. `public/index.html`'s splash plate, `html, body, #root { background:
   var(--splash-bg) }`. On a light theme that resolves to `#ffffff`, and
   secondary windows suppress the splash mark, so it was a bare white
   rectangle over the vibrancy.

On Windows and Linux the secondary window is opaque (`transparent(true)` in
`open_session_window` is macOS-only), and its startup backdrop was a hardcoded
`#0d0d0d`. On a light theme that opened the window dark, then the splash plate
repainted it white, then the app painted — two flashes, neither the app's
colour.

Separately, the window was built `visible(true)`, so the frames between
`build()` and the post-build chrome reached the screen as the leading
transparent state.

## Solution

The pre-paint surface should be whatever the window settles on, so there is no
seam to see.

- `set_webview_background_recursive` (was `set_draws_background_recursive`) now
  pins `underPageBackgroundColor` alongside `_setDrawsBackground:`, so the
  webview paints the intended colour instead of its white default, and the
  setting survives the navigation that re-derives it. Public API from macOS 12
  and the bundle targets 10.15, so it is probed with `respondsToSelector:`.
  It also returns whether a WKWebView was actually found, and both callers warn
  when it was not — the previous version failed silently, which is exactly the
  case that is indistinguishable from a working fix.
- `open_session_window` no longer calls `apply_window_background_color` (right
  for the main window, which settles opaque; wrong here). It mounts the
  vibrancy material and clears the builder backdrop, so the webview composites
  onto the material from its first frame. `public/index.html` skips the splash
  plate for macOS secondary windows to match, scoped to
  `[data-host-desktop="macos"][data-orgii-secondary-window]` so opaque hosts
  and the main window keep it.
- New `startup_backdrop.rs` resolves the opaque backdrop from `general.theme`
  and matches `--splash-bg` exactly (`#ffffff` / `#141414`), mirroring
  `normalizeGlobalThemePreference` + `LEGACY_THEME_ALIASES` from
  `globalThemes.ts` and falling back to the OS theme for `system`, absent, and
  unrecognised values.
- The window is built hidden and shown once its chrome is applied. The `show()`
  stays synchronous with creation, **not** deferred to the frontend's first
  paint — deferring it would make the click that opens the window feel dead.

- Updated the Team Inbox test harness to preserve the real Git-remotes module exports while overriding only `getGitRemotes`; this prevents the PR import graph from exposing a stale full-module mock during full-suite collection.

## Potential risks

- **The macOS half is diagnosed by elimination, not yet observed working.** An
  earlier iteration of this change (the CSS plate plus dropping
  `apply_window_background_color`) shipped to a local dev build and the flash
  persisted, which is what identified `underPageBackgroundColor` as the
  remaining white source: the NSWindow was `clearColor`, the vibrancy is dark
  on a dark system appearance, and the page was proven transparent. The
  `underPageBackgroundColor` fix itself has not been run — see Verification.
- `underPageBackgroundColor` is macOS 12+. On 10.15/11 the `respondsToSelector:`
  probe skips it and those hosts keep the old behaviour, including the white
  base. No crash, no regression, but no fix there either.
- If `apply_macos_window_material` ever fails, the boot window is now
  see-through to the desktop where it previously showed a plate. The same
  failure already shows through after first paint, since the macOS rule paints
  only a 15% tint, so this widens an existing failure mode rather than adding
  one.
- `app_window` now depends on the `settings` crate: one JSONC read per detached
  window open (a user gesture, not a hot path). `read_settings()` creates the
  settings file with `{}` when absent, so a window open can now create it. The
  dependency is acyclic — `settings` pulls only `app_paths` + `tauri`.
- A non-baseline skin overrides `--splash-bg` from
  `localStorage["orgii_skin_surface"]`, derived by `deriveSkinTokens` in TS.
  Nothing derives those tokens outside the bundle, so a skinned app gets
  ORGII's base surface as its backdrop. Light/dark polarity is still correct,
  which is what removes the flash; matching the exact skin surface would mean
  duplicating the skin registry in Rust.
- The Windows/Linux backdrop change is reasoned from the shared code path and
  covered by unit tests, but has not been run on either platform.
- The main window is untouched. `apply_window_background_color` still uses a
  fixed `#0d0d0d` for `recreate_main_window`, and `tauri.conf.json`'s
  `backgroundColor` is static, so a light-theme macOS cold start still opens on
  a dark frame. Same defect class, different window, left for its own change.

- The CI repair changes only a Vitest mock boundary; production code and runtime behavior are unaffected.

## Verification

- GitHub Actions [CI run 33753170543](https://github.com/org2AI/ORG2/actions/runs/33753170543) → frontend, Rust clippy/workspace tests, and cargo audit passed

- `../../../node_modules/.bin/vitest run --config config/vitest.config.ts src/modules/MainApp/TeamInbox/__tests__/AssignedWorkItemDetail.test.ts --reporter=verbose` → **9/9 passed**, 0 failed
- `../../../node_modules/.bin/eslint src/modules/MainApp/TeamInbox/__tests__/AssignedWorkItemDetail.test.ts --max-warnings 0 --report-unused-disable-directives` → clean
- `../../../node_modules/.bin/tsgo --noEmit --pretty false` → clean
- `node scripts/quality/check-test-placement.mjs` → consistent across 457 directories

Ran:

- `cargo test -p app_window` — 6 passed (3 pre-existing + 3 new theme-resolution
  tests covering current ids, every legacy alias, and the follow-the-OS
  fallbacks).
- `cargo check -p app_window` — clean.
- `cargo fmt -p app_window -- --check` — clean.
- `npx vitest run src/app/root/__tests__/secondaryWindowStartupSurface.test.ts`
  — 8 passed. Mutation-checked: removing the CSS override fails 4 of the 8, so
  the guard is not vacuous.
- `pnpm typecheck:fast` (tsgo) — clean.
- `pnpm run check:test-placement` — clean across 458 directories.
- `prettier --check`, `oxlint`, `eslint --max-warnings 0` on the changed TS —
  clean.
- Cascade reproduced in a real engine, not asserted from source: fetched the
  served `index.html`, dropped the bundle scripts, set
  `data-host-desktop="macos"` + `data-orgii-secondary-window`, and read computed
  styles. `--splash-bg` resolves to `#ffffff` while `html`, `body`, `#root` and
  `#splash` are all `rgba(0, 0, 0, 0)` — the override wins and the page paints
  nothing.

Did **not** run:

- **The app.** The local `tauri dev` stack was stopped before the
  `underPageBackgroundColor` change was built, so the macOS fix has never been
  exercised at runtime. The prior iteration was confirmed live (dev binary
  rebuilt before the retest) and did not fix the flash; this one is untested.
  Needs a run on macOS with a light app theme, opening a detached session
  window, before it can be called fixed.
- Any Windows or Linux run.
- The e2e suite.
- The pre-commit hook. This branch was built with `git commit-tree` from a
  temp index because the checkout holds a concurrent session's unrelated work,
  so no hook ran and there is no `Pre-commit hook ran.` trailer. The checks it
  would have run (typecheck, oxlint, eslint, prettier) were run manually and
  are listed above.

No screenshots: the change is a sub-second pre-paint transient, and since the
fix is not yet confirmed working there is no correct-state frame to capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
