### PR TITLE
refactor(settings): consolidate account controls under General

### DIFF
--- a/docs/frontend-ui-audit-2026-09-03/SettingsNavigation.md
+++ b/docs/frontend-ui-audit-2026-09-03/SettingsNavigation.md
@@ -1,0 +1,9 @@
+# SettingsNavigation UI audit
+
+| Line                                                           | Element                      | Verdict          | Reason                                                                                                                      | Suggested change |
+| -------------------------------------------------------------- | ---------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/MainApp/Settings/sections/GeneralSection.tsx:331` | Login section above Language | keep with reason | Login uses its own shared `SectionContainer`, preserving a clear section boundary while keeping it directly above Language. | None.            |
+| `src/modules/MainApp/Settings/config.ts:65`                    | General tab pill metadata    | keep with reason | The navigation continues to use the shared `TabPill` component; Self-hosted is the only moved tab and remains last.         | None.            |
+| `src/features/Org2Cloud/Org2CloudSection.tsx:46`               | ORG2 login rows              | keep with reason | The rows retain shared `SectionRow` and `Button` primitives while General supplies the surrounding container.               | None.            |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.

--- a/src/config/mainAppPaths.test.ts
+++ b/src/config/mainAppPaths.test.ts
@@ -2,14 +2,17 @@ import { ContentWritingIcon, ContrastIcon } from "@src/icons";
 
 import {
   SETTINGS_ROUTE_ROOT,
+  SETTINGS_SECTION_TABS,
   buildCodexReauthPath,
   classifySettingsRouteRoot,
   filterDevModeIntegrationItems,
+  getDefaultSettingsSectionTab,
   getDevOnlyIntegrationRedirect,
   getPathIcon,
   getSegmentIcon,
   isIntegrationCategoryAvailable,
   parseCodexReauthIntent,
+  parseSettingsSectionTab,
 } from "./mainAppPaths";
 
 describe("My Station Code Editor icon", () => {
@@ -21,6 +24,29 @@ describe("My Station Code Editor icon", () => {
 describe("Settings sidebar icons", () => {
   it("uses the contrast glyph for Appearance", () => {
     expect(getSegmentIcon("appearance")).toBe(ContrastIcon);
+  });
+});
+
+describe("General settings tabs", () => {
+  it("keeps Self-hosted as the final General tab", () => {
+    expect(SETTINGS_SECTION_TABS.general).toEqual([
+      "general",
+      "notifications",
+      "shortcuts",
+      "self-hosted",
+    ]);
+    expect(getDefaultSettingsSectionTab("general")).toBe("general");
+  });
+
+  it("keeps Collaboration bookmarks pointed at their new General tabs", () => {
+    expect(
+      parseSettingsSectionTab("/orgii/app/settings/app/collaboration/cloud")
+    ).toEqual({ section: "general", tab: "general" });
+    expect(
+      parseSettingsSectionTab(
+        "/orgii/app/settings/app/collaboration/self-hosted"
+      )
+    ).toEqual({ section: "general", tab: "self-hosted" });
   });
 });
 

--- a/src/config/mainAppPaths/settings.ts
+++ b/src/config/mainAppPaths/settings.ts
@@ -8,7 +8,6 @@ import { SETTINGS_BASE, settingsPathParts } from "./shared";
 
 export type SettingsSectionSegment =
   | "general"
-  | "collaboration"
   | "appearance"
   | "editor"
   | "security"
@@ -19,7 +18,6 @@ export type SettingsSubpageSegment = "editor-appearance";
 
 export const SETTINGS_SECTIONS: readonly SettingsSectionSegment[] = [
   "general",
-  "collaboration",
   "appearance",
   "editor",
   "security",
@@ -32,8 +30,7 @@ export const SETTINGS_SUBPAGES: readonly SettingsSubpageSegment[] = [
 ] as const;
 
 export const SETTINGS_SECTION_TABS = {
-  general: ["general", "notifications", "shortcuts"],
-  collaboration: ["cloud", "self-hosted"],
+  general: ["general", "notifications", "shortcuts", "self-hosted"],
   appearance: ["app", "code-editor", "chat-panel"],
   editor: ["editor"],
   monitor: ["resources", "network", "storage"],
@@ -70,6 +67,13 @@ export interface SettingsPathOptions {
   subpage?: SettingsSubpageSegment;
 }
 
+/**
+ * Retired settings section kept only to resolve existing bookmarked URLs.
+ * New navigation exposes the managed login and self-hosted endpoint under
+ * General instead.
+ */
+const LEGACY_COLLABORATION_SECTION = "collaboration";
+
 export function buildSettingsPath(options: SettingsPathOptions = {}): string {
   const { section, tab, subpage } = options;
 
@@ -100,6 +104,10 @@ export function parseCoreSettingsItem(pathname: string): {
       : parts[0];
 
   if (!itemPart) return { section: null, category: null };
+
+  if (itemPart === LEGACY_COLLABORATION_SECTION) {
+    return { section: "general", category: null };
+  }
 
   let normalized = fromCategoryUrlSegment(itemPart);
   if (normalized === "notifications" || normalized === "shortcuts") {
@@ -139,6 +147,13 @@ export function parseSettingsSectionTab(pathname: string): {
 
   if (itemPart === "notifications" || itemPart === "shortcuts") {
     return { section: "general", tab: itemPart };
+  }
+
+  if (itemPart === LEGACY_COLLABORATION_SECTION) {
+    return {
+      section: "general",
+      tab: tabPart === "self-hosted" ? "self-hosted" : "general",
+    };
   }
 
   if (itemPart === "code-search-indexing" || itemPart === "workspace") {

--- a/src/config/segmentRegistry.ts
+++ b/src/config/segmentRegistry.ts
@@ -12,7 +12,6 @@ import {
   DeliveryBox01Icon as Box,
   FirstBracketIcon as Braces,
   InternetIcon as Chromium,
-  CloudIcon as Cloud,
   CodeXmlIcon as Code,
   CursorMagicSelection04Icon as ComputerUse,
   ContentWritingIcon as ContentWriting,
@@ -142,10 +141,6 @@ export const SEGMENT_REGISTRY: Record<string, SegmentRegistryEntry> = {
 
   // settings sections
   general: { labelKey: "settings:sections.general", icon: Settings2 },
-  collaboration: {
-    labelKey: "settings:sections.collaboration",
-    icon: Cloud,
-  },
   appearance: { labelKey: "settings:sections.appearance", icon: Contrast },
   editor: { labelKey: "settings:sections.editorAndWorkspace", icon: Code },
   security: { labelKey: "settings:sections.security", icon: ShieldCheck },

--- a/src/config/settingsNavigation.test.ts
+++ b/src/config/settingsNavigation.test.ts
@@ -19,7 +19,7 @@ describe("settingsNavigation", () => {
     ).toEqual([
       {
         id: "app",
-        items: ["general", "collaboration", "appearance", "editor", "monitor"],
+        items: ["general", "appearance", "editor", "monitor"],
       },
       {
         id: "core",

--- a/src/config/settingsUiManifest/sections/app.ts
+++ b/src/config/settingsUiManifest/sections/app.ts
@@ -78,15 +78,6 @@ export const APP_SETTINGS_UI_SECTIONS: SettingsSectionDefinition[] = [
     coveredKeys: GENERAL_SECTION_KEYS,
   },
   {
-    id: "collaboration",
-    tab: "app",
-    labelKey: "collaboration",
-    headingTitleKey: "sections.collaboration",
-    icon: iconForSegment("collaboration"),
-    customSectionSlotId: SETTINGS_SECTION_SLOT_IDS.APP_COLLABORATION,
-    coveredKeys: [],
-  },
-  {
     id: "appearance",
     tab: "app",
     labelKey: "appearance",

--- a/src/config/settingsUiManifest/slotIds.ts
+++ b/src/config/settingsUiManifest/slotIds.ts
@@ -1,6 +1,5 @@
 export const SETTINGS_SECTION_SLOT_IDS = {
   APP_GENERAL: "app.general",
-  APP_COLLABORATION: "app.collaboration",
   APP_APPEARANCE: "app.appearance",
   APP_EDITOR: "app.editor",
   APP_SECURITY: "app.security",

--- a/src/features/Org2Cloud/Org2CloudSection.tsx
+++ b/src/features/Org2Cloud/Org2CloudSection.tsx
@@ -1,20 +1,15 @@
 /**
- * "Session Sync" Settings section (cloud design §20.1 + §4.2).
+ * ORG2 login rows (cloud design §20.1 + §4.2).
  *
- * Two tabs:
- *  1. Cloud — ORG2 Cloud (managed) with the existing sign-in /
- *     sign-out control. Sign-in opens the managed cloud login page in the
- *     SYSTEM browser; the login page finishes through an ephemeral localhost
- *     receiver, which the OAuth plugin delivers to useDeepLinkHandler at the
- *     always-mounted app root. Installed-app custom-scheme callbacks remain
- *     supported for cold-start compatibility.
- *  2. Self-hosted — the custom ORG2 Cloud backend card (`CloudEndpointCard`,
- *     cloud-parity Phase C): self-hosting means deploying the SAME stack
- *     and pointing the app at it.
+ * Rendered as the first rows of General's first `SectionContainer`, above
+ * language. Sign-in opens the managed cloud login page in the SYSTEM browser;
+ * the login page finishes through an ephemeral localhost receiver, which the
+ * OAuth plugin delivers to useDeepLinkHandler at the always-mounted app root.
+ * Installed-app custom-scheme callbacks remain supported for cold-start
+ * compatibility.
  */
 import {
   SECTION_ACTION_GAP_CLASSES,
-  SectionContainer,
   SectionRow,
 } from "@/src/modules/shared/layouts/SectionLayout";
 import { useAtom, useStore } from "jotai";
@@ -25,7 +20,6 @@ import Button from "@src/components/Button";
 import Input from "@src/components/Input";
 import Message from "@src/components/Message";
 import { REFRESH_ICON_TOKENS } from "@src/components/RefreshIcon/tokens";
-import CloudEndpointCard from "@src/features/Org2Cloud/CloudEndpointCard";
 import { importBundledOrg2CloudAuthForDev } from "@src/features/Org2Cloud/devBundledAuthImport";
 import {
   commitRefreshedAuth,
@@ -49,18 +43,7 @@ import {
 
 const log = createLogger("Org2CloudSection");
 
-export const COLLABORATION_TAB_KEYS = {
-  CLOUD: "cloud",
-  SELF_HOSTED: "self-hosted",
-} as const;
-
-interface Org2CloudSectionProps {
-  activeTab?: string;
-}
-
-const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
-  activeTab = COLLABORATION_TAB_KEYS.CLOUD,
-}) => {
+export const Org2CloudLoginRows: React.FC = () => {
   const { t } = useTranslation(["navigation", "common"]);
   const [auth, setAuth] = useAtom(org2CloudAuthAtom);
   const [isRefreshingDevAuth, setIsRefreshingDevAuth] = useState(false);
@@ -140,10 +123,6 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
     }
   }, [auth, isRefreshingDevAuth, setAuth, store, t]);
 
-  if (activeTab === COLLABORATION_TAB_KEYS.SELF_HOSTED) {
-    return <CloudEndpointCard />;
-  }
-
   const refreshDevAuthButton = process.env.NODE_ENV === "development" && (
     <Button
       size="default"
@@ -167,120 +146,115 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
 
   return (
     <>
-      <SectionContainer>
-        <SectionRow
-          label={t("cloud.title")}
-          description={t("cloud.recommendedDesc")}
-          align="start"
-        >
-          <div className={SECTION_ACTION_GAP_CLASSES}>
-            {auth ? (
-              <>
-                {refreshDevAuthButton}
-                <Button
-                  size="default"
-                  onClick={handleSignOut}
-                  data-testid="org2-cloud-sign-out"
-                >
-                  {t("cloud.signOut")}
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button
-                  size="default"
-                  onClick={handleSignIn}
-                  data-testid="org2-cloud-sign-in"
-                >
-                  {t("cloud.signIn")}
-                </Button>
-                {refreshDevAuthButton}
-              </>
-            )}
-          </div>
+      <SectionRow
+        label={
+          auth
+            ? t("settings:general.loggedIn")
+            : t("settings:general.notLoggedIn")
+        }
+        align="start"
+      >
+        <div className={SECTION_ACTION_GAP_CLASSES}>
+          {auth ? (
+            <>
+              {refreshDevAuthButton}
+              <Button
+                size="default"
+                onClick={handleSignOut}
+                data-testid="org2-cloud-sign-out"
+              >
+                {t("cloud.signOut")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                size="default"
+                onClick={handleSignIn}
+                data-testid="org2-cloud-sign-in"
+              >
+                {t("cloud.signIn")}
+              </Button>
+              {refreshDevAuthButton}
+            </>
+          )}
+        </div>
+      </SectionRow>
+      {auth && (
+        <SectionRow label={t("cloud.userName")}>
+          {renameDraft !== null ? (
+            <div className="flex items-center gap-2">
+              <Input
+                value={renameDraft}
+                onChange={(value) => setRenameDraft(value)}
+                maxLength={64}
+                autoFocus
+                className="w-48"
+                data-testid="org2-cloud-rename-input"
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") void handleSaveRename();
+                  if (event.key === "Escape") setRenameDraft(null);
+                }}
+              />
+              <Button
+                size="default"
+                iconOnly
+                icon={
+                  <HugeiconsIcon
+                    icon={Tick01Icon}
+                    data-icon="check"
+                    size={14}
+                  />
+                }
+                loading={isSavingRename}
+                disabled={isSavingRename || !(renameDraft ?? "").trim()}
+                onClick={() => void handleSaveRename()}
+                aria-label={t("common:actions.save")}
+                title={t("common:actions.save")}
+                data-testid="org2-cloud-rename-save"
+              />
+              <Button
+                size="default"
+                iconOnly
+                icon={
+                  <HugeiconsIcon icon={Cancel01Icon} data-icon="x" size={14} />
+                }
+                disabled={isSavingRename}
+                onClick={() => setRenameDraft(null)}
+                aria-label={t("common:actions.cancel")}
+                title={t("common:actions.cancel")}
+                data-testid="org2-cloud-rename-cancel"
+              />
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span
+                className="max-w-56 truncate text-sm text-text-2"
+                data-testid="org2-cloud-signed-in-identity"
+                title={signedInIdentity}
+              >
+                {signedInIdentity}
+              </span>
+              <Button
+                size="default"
+                iconOnly
+                icon={
+                  <HugeiconsIcon
+                    icon={Pen01Icon}
+                    data-icon="pencil"
+                    size={14}
+                  />
+                }
+                aria-label={t("cloud.renameDisplayName")}
+                onClick={() => setRenameDraft(auth.profile?.displayName ?? "")}
+                data-testid="org2-cloud-rename"
+              />
+            </div>
+          )}
         </SectionRow>
-        {auth && (
-          <SectionRow label={t("cloud.userName")}>
-            {renameDraft !== null ? (
-              <div className="flex items-center gap-2">
-                <Input
-                  value={renameDraft}
-                  onChange={(value) => setRenameDraft(value)}
-                  maxLength={64}
-                  autoFocus
-                  className="w-48"
-                  data-testid="org2-cloud-rename-input"
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") void handleSaveRename();
-                    if (event.key === "Escape") setRenameDraft(null);
-                  }}
-                />
-                <Button
-                  size="default"
-                  iconOnly
-                  icon={
-                    <HugeiconsIcon
-                      icon={Tick01Icon}
-                      data-icon="check"
-                      size={14}
-                    />
-                  }
-                  loading={isSavingRename}
-                  disabled={isSavingRename || !(renameDraft ?? "").trim()}
-                  onClick={() => void handleSaveRename()}
-                  aria-label={t("common:actions.save")}
-                  title={t("common:actions.save")}
-                  data-testid="org2-cloud-rename-save"
-                />
-                <Button
-                  size="default"
-                  iconOnly
-                  icon={
-                    <HugeiconsIcon
-                      icon={Cancel01Icon}
-                      data-icon="x"
-                      size={14}
-                    />
-                  }
-                  disabled={isSavingRename}
-                  onClick={() => setRenameDraft(null)}
-                  aria-label={t("common:actions.cancel")}
-                  title={t("common:actions.cancel")}
-                  data-testid="org2-cloud-rename-cancel"
-                />
-              </div>
-            ) : (
-              <div className="flex items-center gap-2">
-                <span
-                  className="max-w-56 truncate text-sm text-text-2"
-                  data-testid="org2-cloud-signed-in-identity"
-                  title={signedInIdentity}
-                >
-                  {signedInIdentity}
-                </span>
-                <Button
-                  size="default"
-                  iconOnly
-                  icon={
-                    <HugeiconsIcon
-                      icon={Pen01Icon}
-                      data-icon="pencil"
-                      size={14}
-                    />
-                  }
-                  aria-label={t("cloud.renameDisplayName")}
-                  onClick={() =>
-                    setRenameDraft(auth.profile?.displayName ?? "")
-                  }
-                  data-testid="org2-cloud-rename"
-                />
-              </div>
-            )}
-          </SectionRow>
-        )}
-      </SectionContainer>
+      )}
     </>
   );
 };
 
-export default Org2CloudSection;
+export default Org2CloudLoginRows;

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Anmeldung",
     "tabGeneral": "Allgemein",
+    "tabSelfHosted": "Selbstgehostet",
     "loginStatus": "Anmeldestatus",
     "loggedIn": "Angemeldet",
     "notLoggedIn": "Nicht angemeldet",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Login",
     "tabGeneral": "General",
+    "tabSelfHosted": "Self-hosted",
     "loginStatus": "Login Status",
     "loggedIn": "Logged in",
     "notLoggedIn": "Not logged in",

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Inicio de sesión",
     "tabGeneral": "General",
+    "tabSelfHosted": "Autoalojado",
     "loginStatus": "Estado de inicio de sesión",
     "loggedIn": "Session iniciada",
     "notLoggedIn": "Sin Session",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Connexion",
     "tabGeneral": "Général",
+    "tabSelfHosted": "Auto-hébergé",
     "loginStatus": "État de connexion",
     "loggedIn": "Connecté",
     "notLoggedIn": "Non connecté",

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "ログイン",
     "tabGeneral": "一般",
+    "tabSelfHosted": "セルフホスト",
     "loginStatus": "ログイン状態",
     "loggedIn": "ログイン済み",
     "notLoggedIn": "未ログイン",

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "로그인",
     "tabGeneral": "일반",
+    "tabSelfHosted": "자체 호스팅",
     "loginStatus": "로그인 상태",
     "loggedIn": "로그인됨",
     "notLoggedIn": "로그인되지 않음",

--- a/src/i18n/locales/pl/settings.json
+++ b/src/i18n/locales/pl/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Logowanie",
     "tabGeneral": "Ogólne",
+    "tabSelfHosted": "Hostowane samodzielnie",
     "loginStatus": "Status logowania",
     "loggedIn": "Zalogowano",
     "notLoggedIn": "Niezalogowano",

--- a/src/i18n/locales/pt/settings.json
+++ b/src/i18n/locales/pt/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Entrar",
     "tabGeneral": "Geral",
+    "tabSelfHosted": "Auto-hospedado",
     "loginStatus": "Status do Login",
     "loggedIn": "Conectado",
     "notLoggedIn": "Não conectado",

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Вход",
     "tabGeneral": "Общие",
+    "tabSelfHosted": "Самостоятельный хостинг",
     "loginStatus": "Статус входа",
     "loggedIn": "Вход выполнен",
     "notLoggedIn": "Вход не выполнен",

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Giriş",
     "tabGeneral": "Genel",
+    "tabSelfHosted": "Kendi kendine barındırılan",
     "loginStatus": "Giriş Durumu",
     "loggedIn": "Giriş yapıldı",
     "notLoggedIn": "Giriş yapılmadı",

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "Đăng nhập",
     "tabGeneral": "Chung",
+    "tabSelfHosted": "Tự lưu trữ",
     "loginStatus": "Trạng thái đăng nhập",
     "loggedIn": "Đã đăng nhập",
     "notLoggedIn": "Chưa đăng nhập",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "登錄",
     "tabGeneral": "通用",
+    "tabSelfHosted": "自託管",
     "loginStatus": "登錄狀態",
     "loggedIn": "已登錄",
     "notLoggedIn": "未登錄",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -113,7 +113,9 @@
     }
   },
   "general": {
+    "login": "登录",
     "tabGeneral": "通用",
+    "tabSelfHosted": "自托管",
     "loginStatus": "登录状态",
     "loggedIn": "已登录",
     "notLoggedIn": "未登录",

--- a/src/modules/MainApp/Settings/config.ts
+++ b/src/modules/MainApp/Settings/config.ts
@@ -26,7 +26,6 @@ export interface SettingsSectionConfig {
 // ============================================
 export const SECTION_IDS = {
   GENERAL: "general",
-  COLLABORATION: "collaboration",
   APPEARANCE: "appearance",
   EDITOR: "editor",
   SECURITY: "security",
@@ -66,10 +65,7 @@ export const SECTION_TAB_META: Partial<
     { key: "general", labelKey: "general.tabGeneral" },
     { key: "notifications", labelKey: "sections.notifications" },
     { key: "shortcuts", labelKey: "shortcuts.title" },
-  ],
-  [SECTION_IDS.COLLABORATION]: [
-    { key: "cloud", labelKey: "collaboration.tabs.cloud" },
-    { key: "self-hosted", labelKey: "collaboration.tabs.selfHosted" },
+    { key: "self-hosted", labelKey: "general.tabSelfHosted" },
   ],
   [SECTION_IDS.APPEARANCE]: [
     { key: "app", labelKey: "appearance.tabApp" },

--- a/src/modules/MainApp/Settings/renderer/slotRegistry.app.ts
+++ b/src/modules/MainApp/Settings/renderer/slotRegistry.app.ts
@@ -3,7 +3,6 @@ import {
   type SettingsSectionSlotId,
 } from "@src/config/settingsUiManifest/slotIds";
 import type { SettingsCustomSectionSlot } from "@src/config/settingsUiManifest/types";
-import Org2CloudSection from "@src/features/Org2Cloud/Org2CloudSection";
 import AppearanceSection from "@src/modules/MainApp/Settings/sections/AppearanceSection";
 import EditorSection from "@src/modules/MainApp/Settings/sections/EditorSection";
 import GeneralSection from "@src/modules/MainApp/Settings/sections/GeneralSection";
@@ -14,7 +13,6 @@ export const appSettingsSectionSlotRegistry: Partial<
   Record<SettingsSectionSlotId, SettingsCustomSectionSlot>
 > = {
   [SETTINGS_SECTION_SLOT_IDS.APP_GENERAL]: GeneralSection,
-  [SETTINGS_SECTION_SLOT_IDS.APP_COLLABORATION]: Org2CloudSection,
   [SETTINGS_SECTION_SLOT_IDS.APP_APPEARANCE]: AppearanceSection,
   [SETTINGS_SECTION_SLOT_IDS.APP_EDITOR]: EditorSection,
   [SETTINGS_SECTION_SLOT_IDS.APP_SECURITY]: SecuritySection,

--- a/src/modules/MainApp/Settings/sections/GeneralSection.tsx
+++ b/src/modules/MainApp/Settings/sections/GeneralSection.tsx
@@ -1,10 +1,12 @@
 /**
  * General Settings Section
  *
- * Hosts three tabs:
- *   - `general` — language/date, input, app behavior, update, settings file
+ * Hosts four tabs:
+ *   - `general` — ORG2 login, language/date, input, app behavior, update,
+ *     settings file
  *   - `notifications` — master toggle + advanced blocks (lazy)
  *   - `shortcuts` — keyboard shortcuts viewer (lazy)
+ *   - `self-hosted` — custom ORG2 Cloud backend endpoint
  *
  * The General tab is rendered eagerly; the heavier Notifications and
  * Shortcuts tabs are code-split so they only load when the user clicks
@@ -42,6 +44,8 @@ import Message from "@src/components/Message";
 import { Placeholder } from "@src/components/Placeholder";
 import Select from "@src/components/Select";
 import Switch from "@src/components/Switch";
+import CloudEndpointCard from "@src/features/Org2Cloud/CloudEndpointCard";
+import { Org2CloudLoginRows } from "@src/features/Org2Cloud/Org2CloudSection";
 import { useTimezoneSelect } from "@src/hooks/geo";
 import {
   LANGUAGE_NAMES,
@@ -78,6 +82,7 @@ export const GENERAL_TAB_KEYS = {
   GENERAL: "general",
   NOTIFICATIONS: "notifications",
   SHORTCUTS: "shortcuts",
+  SELF_HOSTED: "self-hosted",
 } as const;
 
 export type GeneralTabKey =
@@ -111,6 +116,10 @@ const GeneralSection: React.FC<GeneralSectionProps> = ({
         <ShortcutsTab />
       </Suspense>
     );
+  }
+
+  if (activeTab === GENERAL_TAB_KEYS.SELF_HOSTED) {
+    return <CloudEndpointCard />;
   }
 
   return <GeneralTabBody />;
@@ -318,6 +327,9 @@ const GeneralTabBody: React.FC = () => {
 
   return (
     <>
+      <SectionContainer title={t("general.login")}>
+        <Org2CloudLoginRows />
+      </SectionContainer>
       <SectionContainer>
         <SectionRow label={t("common:common.language")}>
           <Select


### PR DESCRIPTION
## Problem

Managed login and self-hosted endpoint controls lived in a separate Collaboration settings section even though they configure the same account entry point as General. This split made the navigation longer and risked breaking existing bookmarked Collaboration URLs when consolidating the UI.

## Solution

Place the managed login rows at the top of General, keep Self-hosted as the final General tab, remove the redundant Collaboration navigation and slot, and translate legacy Collaboration URLs to their corresponding General destinations. All supported settings locales receive the new tab and section labels.

## Potential risks

Consumers that compare raw settings paths instead of using the shared parser could still assume Collaboration is a live section. The compatibility mapping covers existing cloud and self-hosted bookmarks in unit tests. No live desktop screenshot or keyboard walkthrough was captured because Computer Use was not authorized.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/config/mainAppPaths.test.ts src/config/settingsNavigation.test.ts` — passed 2 files and 14 tests
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed
- `pnpm run check:circular` — passed across 6466 modules
- `pnpm run check:test-placement` — passed across 457 directories
- `git diff --check` — passed
- Commit hooks — lint-staged and staged TypeScript checks passed
- `pnpm run check:i18n:cloud` — failed on 22 pre-existing missing `cloud.comments.unreadBadge` entries in untouched `navigation.json` locale files; this PR changes only `settings.json`
- Not run: live Tauri visual or keyboard walkthrough and screenshots

## Audit

The included frontend UI audit records 0 fix findings, 3 keep-with-reason findings, and 0 abstraction findings.