### PR TITLE
refactor(sidebar): preserve tabs during navigation

### DIFF
--- a/src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelCreationContent.test.ts
@@ -64,7 +64,7 @@ vi.mock("@src/store/chatPanel/chatPanelTabsAtom", async () => {
   return {
     openProjectInChatPanelTabAtom: atom(null, vi.fn()),
     openWorkItemInChatPanelTabAtom: atom(null, vi.fn()),
-    openSessionInNewChatTabAtom: atom(null, (_get, _set, value) =>
+    openOrReplaceSessionInChatPanelTabAtom: atom(null, (_get, _set, value) =>
       mocks.openSession(value)
     ),
   };
@@ -176,5 +176,15 @@ describe("chat creation ownership", () => {
         value: CHAT_PANEL_CREATE_TARGET.PARALLEL_RUN,
       }),
     ]);
+  });
+
+  it("routes a Launchpad-created session through placeholder replacement", () => {
+    render(true);
+
+    act(() => {
+      mocks.content!.handleStartPageSessionStart({ sessionId: "session-a" });
+    });
+
+    expect(mocks.openSession).toHaveBeenCalledWith({ sessionId: "session-a" });
   });
 });

--- a/src/engines/ChatPanel/hooks/useChatPanelCreationContent.tsx
+++ b/src/engines/ChatPanel/hooks/useChatPanelCreationContent.tsx
@@ -10,7 +10,7 @@ import {
 } from "@src/config/mainAppPaths";
 import { allAgentDefsAtom } from "@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom";
 import { installAvailableAppUpdate } from "@src/scaffold/AppUpdater";
-import { openSessionInNewChatTabAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
+import { openOrReplaceSessionInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { projectListRefreshAtom } from "@src/store/project/projectAtom";
 import { sessionCreatorStateAtom } from "@src/store/session";
 import {
@@ -83,7 +83,9 @@ export function useChatPanelCreationContent({
     setCreateTarget(CHAT_PANEL_CREATE_TARGET.AGENT_SESSION);
     resetActiveSession();
   }, [handleOpenLaunchpadTab, resetActiveSession, setCreateTarget]);
-  const openLaunchedSessionTab = useSetAtom(openSessionInNewChatTabAtom);
+  const openLaunchedSessionTab = useSetAtom(
+    openOrReplaceSessionInChatPanelTabAtom
+  );
   const handleStartPageSessionStart = useCallback(
     (info: { sessionId: string }) => {
       openLaunchedSessionTab({ sessionId: info.sessionId });

--- a/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
@@ -160,7 +160,10 @@ const SidebarOrgSelector: React.FC<SidebarOrgSelectorProps> = React.memo(
               popupVisible={menuOpen}
               dropdownRender={renderDropdown}
               showTriggerIcon={false}
-              appearance="ghost"
+              // This selector owns its sidebar-specific hover/open surface.
+              // `ghost` also applies the generic (and opaque on translucent
+              // sidebars) surface-hover color before that override settles.
+              appearance="bare"
               size="small"
               radius="lg"
               dropdownWidth={250}

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/channelsSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/channelsSection.tsx
@@ -331,7 +331,7 @@ export function useCloudChannelsSection({
   const handleChannelsItemClick = useCallback(
     (
       item: NavigationMenuItem,
-      disposition: SidebarTabDisposition = "replace-all"
+      disposition: SidebarTabDisposition = "default"
     ): boolean => {
       if (!isCloudChannelsMenuItemId(item.id)) return false;
       if (item.id === CLOUD_CHANNELS_EMPTY_ID) {

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -33,6 +33,7 @@ import SidebarSettingsMenuButton from "../../blocks/SidebarSettingsMenuButton";
 import NavigationSidebar from "../../variants/NavigationSidebar";
 import SidebarAccountButton from "../SidebarAccountButton";
 import SidebarGuideButton from "../SidebarGuideButton";
+import type { SidebarTabDisposition } from "../sidebarTabNavigation";
 import { useSessionMenuItems } from "../useSessionMenuItems";
 import { DEFAULT_COLLAPSED_SECTION_IDS } from "../workstationSidebarData";
 import { SidebarDialogs } from "./SidebarDialogs";
@@ -256,7 +257,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
 
   const openCloudSessionAtDestination = useCallback(
     (
-      destination: "replace-all" | "new-tab" | "my-station" | "new-window",
+      destination: SidebarTabDisposition | "my-station" | "new-window",
       options: { sessionId: string; title: string }
     ) => {
       if (destination === "new-window") {
@@ -281,13 +282,15 @@ export const WorkstationSidebarConnector: React.FC = () => {
         return;
       }
 
-      if (destination === "replace-all") {
+      if (destination === "default" || destination === "replace-all") {
         navigateChatPanel({ kind: CHAT_PANEL_SURFACE_KIND.SESSION });
         openOrReplaceSessionInChatPanelTab({
           sessionId: options.sessionId,
           sessionName: options.title,
         });
-        void closeOtherThanActiveChatPanelTabs();
+        if (destination === "replace-all") {
+          void closeOtherThanActiveChatPanelTabs();
+        }
         return;
       }
 
@@ -395,7 +398,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
 
   const {
     resetWorkManagementStateForProjectsContent,
-    activateMyStationRouteForProjectsContent,
     activateMyStationRouteForProjectTabContent,
     handleGoToNewSession,
   } = useSidebarStationNavigation({
@@ -485,7 +487,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
     enabled: activeSidebarKey === "projects" || workItemsContentVisible,
     activeProjectOrgId,
     activateMyStationRouteForProjectTabContent,
-    activateMyStationRouteForProjectsContent,
     resetWorkManagementStateForProjectsContent,
     handleOpenLinkedWorkItemSession,
   });
@@ -556,7 +557,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     activeSidebarKey,
     workItemsContentVisible,
     handleMenuItemContextMenu,
-    resetWorkManagementStateForProjectsContent,
+    activateMyStationRouteForProjectTabContent,
     t,
     setSelectedOrgId,
     activeCloudOrgId,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/localChannelsSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/localChannelsSection.tsx
@@ -249,7 +249,7 @@ export function useLocalChannelsSection({
   const handleLocalChannelsItemClick = useCallback(
     (
       item: NavigationMenuItem,
-      disposition: SidebarTabDisposition = "replace-all"
+      disposition: SidebarTabDisposition = "default"
     ): boolean => {
       if (!isLocalChannelsMenuItemId(item.id)) return false;
       if (item.id === LOCAL_CHANNELS_EMPTY_ID) {

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.chrome.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.chrome.tsx
@@ -40,7 +40,7 @@ interface UseWorkstationSidebarChromeParams {
     item: NavigationMenuItem
   ) => Promise<void>;
   // Forwarded to useWorkstationSidebarOrgSelectorActions:
-  resetWorkManagementStateForProjectsContent: OrgSelectorActionsParams["resetWorkManagementStateForProjectsContent"];
+  activateMyStationRouteForProjectTabContent: OrgSelectorActionsParams["activateMyStationRouteForProjectTabContent"];
   t: OrgSelectorActionsParams["t"];
   setSelectedOrgId: OrgSelectorActionsParams["setSelectedOrgId"];
   activeCloudOrgId: OrgSelectorActionsParams["activeCloudOrgId"];
@@ -78,7 +78,7 @@ export function useWorkstationSidebarChrome({
   activeSidebarKey,
   workItemsContentVisible,
   handleMenuItemContextMenu,
-  resetWorkManagementStateForProjectsContent,
+  activateMyStationRouteForProjectTabContent,
   t,
   setSelectedOrgId,
   activeCloudOrgId,
@@ -109,7 +109,7 @@ export function useWorkstationSidebarChrome({
     handleOrgSelectorChange,
     handleManageOrg,
   } = useWorkstationSidebarOrgSelectorActions({
-    resetWorkManagementStateForProjectsContent,
+    activateMyStationRouteForProjectTabContent,
     t,
     setSelectedOrgId,
     activeCloudOrgId,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuItemRouting.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuItemRouting.test.ts
@@ -89,10 +89,10 @@ describe("sidebar cross-surface routing precedence", () => {
     click(newConversation);
     click(draft);
     expect(sessionClick.mock.calls).toEqual([
-      [newConversation.key, newConversation, "replace-all"],
-      [draft.key, draft, "replace-all"],
+      [newConversation.key, newConversation, "default"],
+      [draft.key, draft, "default"],
     ]);
-    expect(closeOtherTabs).toHaveBeenCalledTimes(2);
+    expect(closeOtherTabs).not.toHaveBeenCalled();
     expect(projectsClick).not.toHaveBeenCalled();
     const workItem = row("projects-work-item:work-a");
     click(workItem, mouseEvent(true));
@@ -115,18 +115,18 @@ describe("sidebar cross-surface routing precedence", () => {
     expect(openInNewTab).toHaveBeenCalledTimes(2);
   });
 
-  it("replaces the tab strip on plain sidebar navigation and preserves it for modifiers", () => {
+  it("preserves the tab strip for plain and modifier sidebar navigation", () => {
     render(false);
     const inbox = row(TEAM_INBOX_MENU_ITEM_ID);
     click(inbox);
     click(inbox, mouseEvent(true));
     expect(openTeamInbox).toHaveBeenCalledTimes(2);
-    expect(closeOtherTabs).toHaveBeenCalledOnce();
+    expect(closeOtherTabs).not.toHaveBeenCalled();
 
     const sessionItem = row(session.session_id);
     click(sessionItem);
     click(sessionItem, mouseEvent(false, true));
-    expect(closeOtherTabs).toHaveBeenCalledTimes(2);
+    expect(closeOtherTabs).not.toHaveBeenCalled();
     expect(openInNewTab).toHaveBeenCalledWith(session.session_id);
   });
 
@@ -144,6 +144,19 @@ describe("sidebar cross-surface routing precedence", () => {
     routing.handleProjectsScopeMenuItemClick(item.key, item, mouseEvent());
     expect(openTeamInbox).toHaveBeenCalledWith(item.label);
     expect(projectsClick).not.toHaveBeenCalled();
-    expect(closeOtherTabs).toHaveBeenCalledOnce();
+    expect(closeOtherTabs).not.toHaveBeenCalled();
+  });
+
+  it("opens Work Item destinations without closing existing tabs", () => {
+    render(true);
+    const item: NavigationMenuItem = {
+      ...row("projects-work-item:work-a"),
+      opensChatPanelTab: true,
+    };
+
+    click(item);
+
+    expect(projectsClick).toHaveBeenCalledWith(item.key, item);
+    expect(closeOtherTabs).not.toHaveBeenCalled();
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.orgSelectorActions.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.orgSelectorActions.ts
@@ -24,7 +24,7 @@ type OpenOrganizationTab = ReturnType<
   typeof useSetAtom<typeof openOrganizationInChatPanelTabAtom>
 >;
 interface UseWorkstationSidebarOrgSelectorActionsParams {
-  resetWorkManagementStateForProjectsContent: () => void;
+  activateMyStationRouteForProjectTabContent: () => void;
   t: TFunction<"navigation">;
   setSelectedOrgId: OrgScopeResult["setSelectedOrgId"];
   activeCloudOrgId: OrgScopeResult["activeCloudOrgId"];
@@ -34,7 +34,7 @@ interface UseWorkstationSidebarOrgSelectorActionsParams {
 }
 
 export function useWorkstationSidebarOrgSelectorActions({
-  resetWorkManagementStateForProjectsContent,
+  activateMyStationRouteForProjectTabContent,
   t,
   setSelectedOrgId,
   activeCloudOrgId,
@@ -64,7 +64,7 @@ export function useWorkstationSidebarOrgSelectorActions({
     [setSelectedOrgId]
   );
   const handleManageOrg = useCallback(() => {
-    resetWorkManagementStateForProjectsContent();
+    activateMyStationRouteForProjectTabContent();
     if (activeCloudOrgId && manageableCloudOrg) {
       openOrganizationTab({
         organization: {
@@ -105,12 +105,12 @@ export function useWorkstationSidebarOrgSelectorActions({
     }
     handleAddOrgFromSelector();
   }, [
+    activateMyStationRouteForProjectTabContent,
     activeCloudOrgId,
     handleAddOrgFromSelector,
     manageableCloudOrg,
     manageableLocalOrg,
     openOrganizationTab,
-    resetWorkManagementStateForProjectsContent,
     t,
   ]);
 

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useChannelsSidebarSurface.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useChannelsSidebarSurface.test.ts
@@ -123,15 +123,12 @@ describe("channel sidebar surface ownership", () => {
     const item: NavigationMenuItem = localRows[0];
     mocks.localClick.mockReturnValue(true);
     expect(surface.handleItemClick(item)).toBe(true);
-    expect(mocks.localClick).toHaveBeenLastCalledWith(item, "replace-all");
+    expect(mocks.localClick).toHaveBeenLastCalledWith(item, "default");
     expect(mocks.cloudClick).not.toHaveBeenCalled();
     mocks.localClick.mockReturnValue(false);
     mocks.cloudClick.mockReturnValue(true);
     expect(surface.handleItemClick(cloudRows[0])).toBe(true);
-    expect(mocks.cloudClick).toHaveBeenLastCalledWith(
-      cloudRows[0],
-      "replace-all"
-    );
+    expect(mocks.cloudClick).toHaveBeenLastCalledWith(cloudRows[0], "default");
     mocks.cloudClick.mockReturnValue(false);
     expect(
       surface.handleItemClick({

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useChannelsSidebarSurface.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useChannelsSidebarSurface.ts
@@ -15,7 +15,7 @@ export function useChannelsSidebarSurface(activeCloudOrgId: string | null) {
   const handleItemClick = useCallback(
     (
       item: NavigationMenuItem,
-      disposition: SidebarTabDisposition = "replace-all"
+      disposition: SidebarTabDisposition = "default"
     ): boolean =>
       handleLocalChannelsItemClick(item, disposition) ||
       handleChannelsItemClick(item, disposition),

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useProjectsMenuItemClick.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useProjectsMenuItemClick.ts
@@ -44,7 +44,6 @@ interface UseProjectsMenuItemClickParams<
   LinearWorkItem,
 > {
   activateMyStationRouteForProjectTabContent: () => void;
-  activateMyStationRouteForProjectsContent: () => void;
   getProjectsLoadMoreGroupId: (id: string) => string | null;
   loadProjectsLinearOrgWorkItems: (orgId: string) => void;
   openProjectsLinearOrg: (org: LinearOrg) => void;
@@ -108,7 +107,6 @@ export function useProjectsMenuItemClick<
   LinearWorkItem,
 >({
   activateMyStationRouteForProjectTabContent,
-  activateMyStationRouteForProjectsContent,
   getProjectsLoadMoreGroupId,
   loadProjectsLinearOrgWorkItems,
   openProjectsLinearOrg,
@@ -187,7 +185,7 @@ export function useProjectsMenuItemClick<
       if (localOrgId) {
         const localOrg = projectsLocalOrgMap.get(localOrgId);
         if (!localOrg) return;
-        activateMyStationRouteForProjectsContent();
+        activateMyStationRouteForProjectTabContent();
         setProjectsSelectedMenuItemId(item.id);
         openOrganizationTab({
           organization: {
@@ -250,7 +248,7 @@ export function useProjectsMenuItemClick<
       if (projectOverviewSlug) {
         const project = projectsProjectMap.get(projectOverviewSlug);
         if (!project) return;
-        activateMyStationRouteForProjectsContent();
+        activateMyStationRouteForProjectTabContent();
         setProjectsSelectedMenuItemId(item.id);
         openProjectTab(toChatPanelProject(project));
         return;
@@ -271,13 +269,12 @@ export function useProjectsMenuItemClick<
       const workItem = projectsWorkItemMap.get(workItemId);
       if (!workItem) return;
       const chatPanelWorkItem = toChatPanelWorkItem(workItem);
-      activateMyStationRouteForProjectsContent();
+      activateMyStationRouteForProjectTabContent();
       setProjectsSelectedMenuItemId(item.id);
       openWorkItemTab(chatPanelWorkItem);
     },
     [
       activateMyStationRouteForProjectTabContent,
-      activateMyStationRouteForProjectsContent,
       getProjectsLoadMoreGroupId,
       loadProjectsLinearOrgWorkItems,
       linkedSessionIds,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSidebarStationNavigation.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSidebarStationNavigation.ts
@@ -39,12 +39,6 @@ export function useSidebarStationNavigation({
     openStartPageTab({ title: t("routes.launchpad") });
   }, [openStartPageTab, setStationChatVisible, setStationMode, t]);
 
-  const activateMyStationRouteForProjectsContent = useCallback(() => {
-    const targetRoute = ROUTES.workStation.code.path;
-    resetWorkManagementStateForProjectsContent();
-    if (location.pathname !== targetRoute) navigate(targetRoute);
-  }, [location.pathname, navigate, resetWorkManagementStateForProjectsContent]);
-
   const activateMyStationRouteForProjectTabContent = useCallback(() => {
     const stationMode: StationMode = "my-station";
     const targetRoute = ROUTES.workStation.code.path;
@@ -66,7 +60,6 @@ export function useSidebarStationNavigation({
 
   return {
     resetWorkManagementStateForProjectsContent,
-    activateMyStationRouteForProjectsContent,
     activateMyStationRouteForProjectTabContent,
     handleGoToNewSession,
   };

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.test.ts
@@ -81,7 +81,6 @@ describe("persistent work-item sidebar surface", () => {
   let container: HTMLDivElement;
   let surface: ReturnType<typeof useWorkItemsSidebarSurface>;
   const activateDetail = vi.fn();
-  const activateProjects = vi.fn();
   const reset = vi.fn();
   const openLinkedSession = vi.fn();
   const loadLinear = vi.fn();
@@ -93,7 +92,6 @@ describe("persistent work-item sidebar surface", () => {
       enabled,
       activeProjectOrgId: orgId,
       activateMyStationRouteForProjectTabContent: activateDetail,
-      activateMyStationRouteForProjectsContent: activateProjects,
       resetWorkManagementStateForProjectsContent: reset,
       handleOpenLinkedWorkItemSession: openLinkedSession,
     });
@@ -200,8 +198,8 @@ describe("persistent work-item sidebar surface", () => {
     expect(openLinearWorkItem).toHaveBeenCalledWith(linearWorkItem);
     click(row("projects-linear-load:linear-a"));
     expect(loadLinear).toHaveBeenCalledWith("linear-a");
-    expect(activateProjects).toHaveBeenCalledTimes(3);
-    expect(activateDetail).toHaveBeenCalledTimes(2);
+    expect(activateDetail).toHaveBeenCalledTimes(5);
+    expect(reset).not.toHaveBeenCalled();
   });
 
   it("keeps linked-session row keys and creator organization context", () => {
@@ -213,7 +211,7 @@ describe("persistent work-item sidebar surface", () => {
     click(linked);
     expect(openLinkedSession).toHaveBeenCalledWith(linked);
     expect(surface.selectedMenuItemId).toBe(linked.key);
-    expect(activateProjects).not.toHaveBeenCalled();
+    expect(activateDetail).not.toHaveBeenCalled();
     click(row(`${PROJECTS_NEW_WORK_ITEM_MENU_ITEM_ID}:org-a`));
     expect(mocks.openCreator).toHaveBeenCalledWith({
       target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.ts
@@ -18,17 +18,15 @@ interface WorkItemsSidebarSurfaceParams {
     typeof useProjectsWorkItemMenuItems
   >[0]["selectedOrgId"];
   activateMyStationRouteForProjectTabContent: StationNavigation["activateMyStationRouteForProjectTabContent"];
-  activateMyStationRouteForProjectsContent: StationNavigation["activateMyStationRouteForProjectsContent"];
   resetWorkManagementStateForProjectsContent: StationNavigation["resetWorkManagementStateForProjectsContent"];
   handleOpenLinkedWorkItemSession: (item: NavigationMenuItem) => void;
 }
 
-/** Always mounted: visibility only gates the existing work-item data source. */
+/** Always mounted: visibility only gates the existing project data source. */
 export function useWorkItemsSidebarSurface({
   enabled,
   activeProjectOrgId,
   activateMyStationRouteForProjectTabContent,
-  activateMyStationRouteForProjectsContent,
   resetWorkManagementStateForProjectsContent,
   handleOpenLinkedWorkItemSession,
 }: WorkItemsSidebarSurfaceParams) {
@@ -62,7 +60,6 @@ export function useWorkItemsSidebarSurface({
   });
   const handleProjectsMenuItemClick = useProjectsMenuItemClick({
     activateMyStationRouteForProjectTabContent,
-    activateMyStationRouteForProjectsContent,
     getProjectsLoadMoreGroupId,
     loadProjectsLinearOrgWorkItems,
     openProjectsLinearOrg,

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts
@@ -54,6 +54,21 @@ describe("SidebarOrgSelector", () => {
     expect(markup).not.toContain("placeholders.pleaseSelect");
   });
 
+  it("uses the sidebar-owned hover surface without the generic ghost treatment", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(SidebarOrgSelector, {
+        ...baseProps,
+        value: "personal",
+        options: [{ value: "personal", label: "Local profile" }],
+        loading: false,
+      })
+    );
+
+    expect(markup).toContain("select-bare");
+    expect(markup).not.toContain("select-ghost");
+    expect(markup).toContain("hover:bg-sidebar-selected!");
+  });
+
   it("does not repeat the signed-in identity in the organization menu", () => {
     const markup = renderToStaticMarkup(
       React.createElement(SidebarOrgSelector, {

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/sidebarTabNavigation.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/sidebarTabNavigation.test.ts
@@ -6,10 +6,10 @@ import {
 } from "../sidebarTabNavigation";
 
 describe("sidebar tab navigation", () => {
-  it("uses replace-all for a plain click and new-tab for platform modifiers", () => {
+  it("uses destination defaults for a plain click and new-tab for platform modifiers", () => {
     expect(
       resolveSidebarTabDisposition({ metaKey: false, ctrlKey: false })
-    ).toBe("replace-all");
+    ).toBe("default");
     expect(
       resolveSidebarTabDisposition({ metaKey: true, ctrlKey: false })
     ).toBe("new-tab");
@@ -18,9 +18,10 @@ describe("sidebar tab navigation", () => {
     ).toBe("new-tab");
   });
 
-  it("closes sibling tabs only for replace-all navigation", () => {
+  it("closes sibling tabs only for explicit replace-all navigation", () => {
     const closeOtherTabs = vi.fn();
 
+    completeSidebarTabNavigation("default", closeOtherTabs);
     completeSidebarTabNavigation("new-tab", closeOtherTabs);
     expect(closeOtherTabs).not.toHaveBeenCalled();
 

--- a/src/scaffold/NavigationSidebar/connectors/sidebarTabNavigation.ts
+++ b/src/scaffold/NavigationSidebar/connectors/sidebarTabNavigation.ts
@@ -1,16 +1,19 @@
-export type SidebarTabDisposition = "replace-all" | "new-tab";
+export type SidebarTabDisposition = "default" | "replace-all" | "new-tab";
 
 export function resolveSidebarTabDisposition(event: {
   metaKey: boolean;
   ctrlKey: boolean;
 }): SidebarTabDisposition {
-  return event.metaKey || event.ctrlKey ? "new-tab" : "replace-all";
+  return event.metaKey || event.ctrlKey ? "new-tab" : "default";
 }
 
 export function completeSidebarTabNavigation(
   disposition: SidebarTabDisposition,
   closeOtherThanActiveTabs: () => void | Promise<void>
 ): void {
+  // Normal navigation lets each destination apply its own placement policy:
+  // Launchpad may be consumed by sessions, while substantive tabs survive.
+  // Only an explicit replace-all action is allowed to collapse the strip.
   if (disposition === "replace-all") {
     void closeOtherThanActiveTabs();
   }

--- a/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
@@ -315,7 +315,7 @@ export function useWorkstationSidebarHandlers({
     (
       _key: string,
       item: NavigationMenuItem,
-      disposition: SidebarTabDisposition = "replace-all"
+      disposition: SidebarTabDisposition = "default"
     ) => {
       if (item.id === NEW_SESSION_MENU_ITEM_ID) {
         goToNewSession();

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -330,10 +330,14 @@ describe("closeOtherChatPanelTabsAtom", () => {
       chatPanelTabsAtom,
       closeOtherChatPanelTabsAtom,
       createChatPanelTerminalAtom,
+      openSessionInNewChatTabAtom,
       store,
       terminalSessionsAtom,
     } = await loadChatPanelTabAtoms();
-    const retainedTabId = store.get(chatPanelTabsAtom).activeTabId;
+    const retainedTabId = store.set(openSessionInNewChatTabAtom, {
+      sessionId: "session-retained",
+      sessionName: "Retained session",
+    });
     const terminalSessionId = store.set(
       createChatPanelTerminalAtom,
       "Terminal"
@@ -358,9 +362,14 @@ describe("closeOtherChatPanelTabsAtom", () => {
       chatPanelTabsAtom,
       closeOtherThanActiveChatPanelTabsAtom,
       openTeamInboxInChatPanelTabAtom,
+      openSessionInNewChatTabAtom,
       store,
     } = await loadChatPanelTabAtoms();
 
+    store.set(openSessionInNewChatTabAtom, {
+      sessionId: "session-existing",
+      sessionName: "Existing session",
+    });
     const inboxTabId = store.set(openTeamInboxInChatPanelTabAtom, "Inbox");
     expect(store.get(chatPanelTabsAtom).tabs).toHaveLength(2);
 
@@ -997,9 +1006,6 @@ describe("ChatPanel navigation tabs", () => {
       store,
     } = await loadChatPanelTabAtoms();
 
-    const existingTabIds = store
-      .get(chatPanelTabsAtom)
-      .tabs.map((tab) => tab.id);
     const runtimeTabId = store.set(openRuntimeInChatPanelTabAtom, "Runtime");
     const focusedTabId = store.set(openRuntimeInChatPanelTabAtom, "Runtime");
 
@@ -1007,7 +1013,6 @@ describe("ChatPanel navigation tabs", () => {
     expect(store.get(chatPanelTabsAtom).activeTabId).toBe(runtimeTabId);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
     expect(store.get(chatPanelTabsAtom).tabs.map((tab) => tab.id)).toEqual([
-      ...existingTabIds,
       runtimeTabId,
     ]);
     expect(
@@ -1039,6 +1044,10 @@ describe("ChatPanel navigation tabs", () => {
     expect(focusedTabId).toBe(teamInboxTabId);
     expect(store.get(chatPanelTabsAtom).activeTabId).toBe(teamInboxTabId);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(store.get(chatPanelTabsAtom).tabs).toHaveLength(1);
+    expect(
+      store.get(chatPanelTabsAtom).tabs.some((tab) => tab.type === "start-page")
+    ).toBe(false);
     expect(
       store
         .get(chatPanelTabsAtom)
@@ -1055,6 +1064,31 @@ describe("ChatPanel navigation tabs", () => {
     ).toBe(false);
   });
 
+  it("replaces the active new-session placeholder when Inbox opens", async () => {
+    const {
+      chatPanelTabsAtom,
+      openTeamInboxInChatPanelTabAtom,
+      store,
+      WORK_MANAGEMENT_SECTION,
+    } = await loadChatPanelTabAtoms();
+    const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
+
+    const inboxTabId = store.set(openTeamInboxInChatPanelTabAtom, "Inbox");
+
+    expect(store.get(chatPanelTabsAtom)).toMatchObject({
+      activeTabId: inboxTabId,
+      tabs: [
+        {
+          id: inboxTabId,
+          type: "work-management",
+          title: "Inbox",
+          managementSection: WORK_MANAGEMENT_SECTION.INBOX,
+        },
+      ],
+    });
+    expect(inboxTabId).not.toBe(launchpadTabId);
+  });
+
   it("opens org management in its own singleton tab and restores the selected org", async () => {
     const {
       activateChatPanelTabAtom,
@@ -1064,7 +1098,7 @@ describe("ChatPanel navigation tabs", () => {
       openOrganizationInChatPanelTabAtom,
       store,
     } = await loadChatPanelTabAtoms();
-    const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
+    const consumedLaunchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
 
     const managementTabId = store.set(openOrganizationInChatPanelTabAtom, {
       organization: {
@@ -1151,7 +1185,11 @@ describe("ChatPanel navigation tabs", () => {
       }),
     ]);
 
-    store.set(activateChatPanelTabAtom, launchpadTabId);
+    expect(
+      store
+        .get(chatPanelTabsAtom)
+        .tabs.some((tab) => tab.id === consumedLaunchpadTabId)
+    ).toBe(false);
     store.set(activateChatPanelTabAtom, managementTabId);
     expect(store.get(activeChatPanelSurfaceAtom)).toEqual({
       kind: CHAT_PANEL_SURFACE_KIND.PROJECT_ORG,
@@ -1166,10 +1204,10 @@ describe("ChatPanel navigation tabs", () => {
       openSessionInNewChatTabAtom,
       store,
     } = await loadChatPanelTabAtoms();
-    const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
+    const consumedLaunchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
 
-    // Move focus onto a session tab, then invoke the new-session entry point
-    // repeatedly. Each call must focus the original start page, never add one.
+    // Consuming the initial placeholder means the next new-session action
+    // creates a fresh singleton; repeated actions must keep focusing that one.
     store.set(openSessionInNewChatTabAtom, {
       sessionId: "session-a",
       sessionName: "Session A",
@@ -1182,9 +1220,9 @@ describe("ChatPanel navigation tabs", () => {
       title: "Launchpad",
     });
 
-    expect(firstId).toBe(launchpadTabId);
-    expect(secondId).toBe(launchpadTabId);
-    expect(store.get(chatPanelTabsAtom).activeTabId).toBe(launchpadTabId);
+    expect(firstId).not.toBe(consumedLaunchpadTabId);
+    expect(secondId).toBe(firstId);
+    expect(store.get(chatPanelTabsAtom).activeTabId).toBe(firstId);
     expect(
       store
         .get(chatPanelTabsAtom)
@@ -1203,7 +1241,7 @@ describe("ChatPanel navigation tabs", () => {
       openSessionInNewChatTabAtom,
       store,
     } = await loadChatPanelTabAtoms();
-    const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
+    const consumedLaunchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
 
     store.set(openSessionInNewChatTabAtom, {
       sessionId: "session-a",
@@ -1218,8 +1256,8 @@ describe("ChatPanel navigation tabs", () => {
       },
     });
 
-    expect(openedTabId).toBe(launchpadTabId);
-    expect(store.get(chatPanelTabsAtom).activeTabId).toBe(launchpadTabId);
+    expect(openedTabId).not.toBe(consumedLaunchpadTabId);
+    expect(store.get(chatPanelTabsAtom).activeTabId).toBe(openedTabId);
     expect(store.get(chatPanelCreateTargetAtom)).toBe(
       CHAT_PANEL_CREATE_TARGET.PROJECT
     );
@@ -1246,7 +1284,7 @@ describe("ChatPanel navigation tabs", () => {
       store,
       syncActiveChatPanelTabStateAtom,
     } = await loadChatPanelTabAtoms();
-    const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
+    const consumedLaunchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
 
     store.set(openSessionInNewChatTabAtom, {
       sessionId: "session-a",
@@ -1260,7 +1298,9 @@ describe("ChatPanel navigation tabs", () => {
     // session back to Launchpad.
     store.set(syncActiveChatPanelTabStateAtom);
 
-    expect(store.get(chatPanelTabsAtom).activeTabId).toBe(launchpadTabId);
+    expect(store.get(chatPanelTabsAtom).activeTabId).not.toBe(
+      consumedLaunchpadTabId
+    );
     expect(store.get(chatPanelStartPageOpenAtom)).toBe(true);
     expect(store.get(chatPanelCreateTargetAtom)).toBe(
       CHAT_PANEL_CREATE_TARGET.WORK_ITEM
@@ -1621,7 +1661,7 @@ describe("openOrReplaceSessionInChatPanelTabAtom", () => {
     vi.useRealTimers();
   });
 
-  it("reuses the active session tab for normal sidebar navigation", async () => {
+  it("opens another tab instead of repointing the active session", async () => {
     const {
       activeSessionIdAtom,
       chatPanelTabsAtom,
@@ -1642,19 +1682,27 @@ describe("openOrReplaceSessionInChatPanelTabAtom", () => {
       repoPath: "/repos/b",
     });
 
-    expect(replacementTabId).toBe(originalTabId);
+    expect(replacementTabId).not.toBe(originalTabId);
     expect(store.get(chatPanelTabsAtom)).toMatchObject({
-      activeTabId: originalTabId,
+      activeTabId: replacementTabId,
       tabs: expect.arrayContaining([
         expect.objectContaining({
           id: originalTabId,
+          type: "session",
+          title: "Session A",
+          sessionId: "session-a",
+        }),
+        expect.objectContaining({
+          id: replacementTabId,
           type: "session",
           title: "Session B",
           sessionId: "session-b",
         }),
       ]),
     });
-    expect(store.get(chatPanelTabsAtom).tabs).toHaveLength(originalTabCount);
+    expect(store.get(chatPanelTabsAtom).tabs).toHaveLength(
+      originalTabCount + 1
+    );
     expect(store.get(activeSessionIdAtom)).toBe("session-b");
   });
 
@@ -1699,12 +1747,11 @@ describe("openOrReplaceSessionInChatPanelTabAtom", () => {
       store,
     } = await loadChatPanelTabAtoms();
 
-    const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
-    const trailingTabId = store.set(openSessionInNewChatTabAtom, {
+    const leadingTabId = store.set(openSessionInNewChatTabAtom, {
       sessionId: "session-a",
       sessionName: "Session A",
     });
-    store.set(openOrFocusChatPanelStartPageTabAtom, {});
+    const launchpadTabId = store.set(openOrFocusChatPanelStartPageTabAtom, {});
     expect(store.get(chatPanelTabsAtom).activeTabId).toBe(launchpadTabId);
 
     const sessionTabId = store.set(openOrReplaceSessionInChatPanelTabAtom, {
@@ -1713,8 +1760,8 @@ describe("openOrReplaceSessionInChatPanelTabAtom", () => {
     });
 
     expect(store.get(chatPanelTabsAtom).tabs).toMatchObject([
+      { id: leadingTabId, type: "session", sessionId: "session-a" },
       { id: sessionTabId, type: "session", sessionId: "session-b" },
-      { id: trailingTabId, type: "session", sessionId: "session-a" },
     ]);
   });
 

--- a/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
@@ -478,9 +478,9 @@ closeOtherChatPanelTabsAtom.debugLabel = "closeOtherChatPanelTabs";
 /**
  * Keep whichever chat-panel tab is active and close every sibling.
  *
- * Sidebar navigation uses this after opening or focusing its destination so a
- * plain row click behaves like full-page navigation. Explicit new-tab actions
- * skip this mutation and preserve the existing strip.
+ * Reserved for explicit replace-all navigation. Plain sidebar clicks preserve
+ * the tab strip and let the destination opener decide whether the active
+ * Launchpad placeholder should be consumed.
  */
 export const closeOtherThanActiveChatPanelTabsAtom = atom(
   null,

--- a/src/store/chatPanel/chatPanelTabOpen/session.ts
+++ b/src/store/chatPanel/chatPanelTabOpen/session.ts
@@ -15,7 +15,6 @@ import {
   activateChatPanelTabAtom,
   appendAndActivateChatPanelTabAtom,
 } from "../chatPanelTabPresentationAtoms";
-import type { ChatPanelTab } from "../chatPanelTabsModel";
 import { chatPanelTabsAtom } from "../chatPanelTabsState";
 
 /** Open or focus the singleton Runtime tab. */
@@ -89,11 +88,10 @@ openOrFocusSessionInChatPanelTabAtom.debugLabel =
   "openOrFocusSessionInChatPanelTab";
 
 /**
- * Open a session from the sidebar without stacking tabs during normal
- * navigation. An already-open target is focused; otherwise the active tab is
- * consumed when it is a session pill (repointed at the target) or the
- * Launchpad start page (swapped for a session pill in place). Every other tab
- * type owns a surface the user asked for, so it is never replaced.
+ * Open a session from normal navigation. An already-open target is focused;
+ * otherwise only the active Launchpad placeholder is consumed. Session and
+ * every other substantive tab own user state, so they are never repointed or
+ * replaced by a later session click.
  */
 export const openOrReplaceSessionInChatPanelTabAtom = atom(
   null,
@@ -112,25 +110,18 @@ export const openOrReplaceSessionInChatPanelTabAtom = atom(
     }
 
     const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
-    if (activeTab?.type !== "session" && activeTab?.type !== "start-page") {
+    if (activeTab?.type !== "start-page") {
       return set(openSessionInNewChatTabAtom, options);
     }
 
     const session = get(sessionByIdAtom(options.sessionId));
     const title = options.sessionName ?? session?.name ?? "Chat";
-    // The Launchpad is the pane's "new session" placeholder, so opening a
-    // session from it consumes the placeholder rather than leaving an empty
-    // start page parked behind the conversation. A session pill keeps its own
-    // id (and any state keyed to it) and is repointed at the new session.
-    const replacementTab: ChatPanelTab =
-      activeTab.type === "start-page"
-        ? createSessionTab({ sessionId: options.sessionId, title })
-        : {
-            ...activeTab,
-            title,
-            sessionId: options.sessionId,
-            updatedAt: new Date().toISOString(),
-          };
+    // Launchpad is the pane's replaceable "new session" placeholder. Mint a
+    // real session tab in its position so no state-bearing tab is repurposed.
+    const replacementTab = createSessionTab({
+      sessionId: options.sessionId,
+      title,
+    });
     set(chatPanelTabsAtom, {
       tabs: state.tabs.map((tab) =>
         tab.id === activeTab.id ? replacementTab : tab

--- a/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
@@ -218,7 +218,13 @@ interface AppendAndActivateChatPanelTabOptions {
   repoPath?: string;
 }
 
-/** Append a tab and run the same navigation activation chain. */
+/**
+ * Open a tab and run the shared navigation activation chain.
+ *
+ * The active Launchpad is a disposable "create new session" placeholder, so
+ * any substantive destination consumes it in place. Real session and content
+ * tabs are always preserved and the new destination is appended beside them.
+ */
 export const appendAndActivateChatPanelTabAtom = atom(
   null,
   (
@@ -227,8 +233,17 @@ export const appendAndActivateChatPanelTabAtom = atom(
     { tab, sessionName, repoPath }: AppendAndActivateChatPanelTabOptions
   ) => {
     const state = get(chatPanelTabsAtom);
+    const activeTab = state.tabs.find(
+      (candidate) => candidate.id === state.activeTabId
+    );
+    const tabs =
+      tab.type !== "start-page" && activeTab?.type === "start-page"
+        ? state.tabs.map((candidate) =>
+            candidate.id === activeTab.id ? tab : candidate
+          )
+        : [...state.tabs, tab];
     set(chatPanelTabsAtom, {
-      tabs: [...state.tabs, tab],
+      tabs,
       activeTabId: tab.id,
     });
     set(activateChatPanelTabAtom, {


### PR DESCRIPTION
## Problem

Plain sidebar clicks were globally interpreted as replace-all navigation. Opening a session, channel, project, Work Item, Inbox, or organization could therefore close unrelated Chat Panel tabs or repoint state-bearing tabs. The organization selector also inherited a generic hover layer instead of using the sidebar surface that owns it.

## Solution

Make plain clicks use destination defaults, reserve replace-all for explicit callers, consume only the disposable Launchpad placeholder, and always append substantive destinations beside existing session/content tabs. Route project and organization actions through the same station activation path, and keep the organization selector on the sidebar-owned bare surface.

## Potential risks

Callers that implicitly depended on a plain sidebar click closing sibling tabs will now retain them unless they request replace-all explicitly. The tab-state tests cover all changed destination families, but no live keyboard/modifier walkthrough or desktop screenshot was captured because Computer Use was not authorized.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts ...` — passed 7 focused files and 68 tests covering Chat Panel creation, tab lifecycle, channel/project/work-item routing, modifiers, and the organization selector
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed
- `pnpm run check:circular` — passed across 6466 modules
- `pnpm run check:test-placement` — passed across 457 directories
- `git diff --check` — passed
- Commit hooks — lint-staged and staged TypeScript checks passed
- Not run: live Tauri sidebar and modifier-key walkthrough or screenshots

## Audit

The control-flow review distinguishes disposable Launchpad tabs from persistent session/content tabs and reduces the dispatch decision to one explicit disposition. No wire, initialization, persistence-format, or backend change is included.