### PR TITLE
fix(cloud-sync): quiet deferred scope checks

### DIFF
--- a/src/features/Org2Cloud/org2CloudSyncEngine.retractReconcile.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.retractReconcile.ts
@@ -141,7 +141,10 @@ export async function reconcileOrgRetracts(
     const matchedScope = await resolveMatchingOrgRepoScope(scopeKeys, scopes);
     if (matchedScope !== null) continue;
     if (!deps.hasServerConfirmedScopes(orgId)) {
-      log.info(
+      // Expected steady-state until the org's scopes land — same
+      // trace-level treatment as the primary sync pass's identical wait
+      // (see org2CloudSyncEngine.ts), not console-worthy noise.
+      log.trace(
         `reconcile scope check deferred: session ${sessionId} org ${orgId}`
       );
       continue;

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -620,10 +620,9 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
         if (matchedScope === undefined) {
           // A pending or failed network-identity lookup cannot prove
           // out-of-scope. Skip until the resolver's completion event runs one
-          // coalesced follow-up pass.
-          log.rateLimited(
-            `scope-check-deferred-${session.session_id}-${org.orgId}`,
-            60_000,
+          // coalesced follow-up pass. Expected steady-state on every poll
+          // while resolution is in flight — trace-level, not console noise.
+          log.trace(
             `scope check deferred for session ${session.session_id} org ` +
               `${org.orgId}: network identity unresolved this pass`
           );
@@ -636,7 +635,9 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
           // the first passes after launch. Skip the session until this run
           // has read the org's scopes from the server.
           if (!this.repoScopeSync.hasServerConfirmedScopes(org.orgId)) {
-            log.info(
+            // Same expected steady-state as the network-identity wait above:
+            // fires on every poll until the org's scopes land — trace-level.
+            log.trace(
               `scope check deferred for session ${session.session_id} org ` +
                 `${org.orgId}: repo scopes not yet confirmed this run`
             );


### PR DESCRIPTION
## Problem

Expected steady-state cloud-sync waits are emitted at console-visible severity while network identity or repository scopes are still unresolved. Because those states can recur on every polling pass, the messages add noise even though the engine is correctly deferring work.

## Solution

Move the deferred network-identity and unconfirmed-scope messages to trace severity in both the primary sync pass and retract reconciliation. The polling cadence, retry behavior, scope decisions, session isolation, and reconciliation control flow are unchanged.

## Potential risks

These expected wait states are less visible at the default log level, so diagnosing a genuinely stuck identity or scope confirmation path requires trace logging. The messages remain available at trace level, and no persistence, protocol, cache, timer, or lifecycle behavior changes. Live long-running runtime measurement was not performed; static review and focused lifecycle tests verify that the diff is logging-only.

## Verification

- `pnpm run typecheck` — passed
- `pnpm run lint` — passed
- `pnpm exec vitest run --config config/vitest.config.ts src/features/Org2Cloud/org2CloudSyncEngine.scopeConfirmation.test.ts src/features/Org2Cloud/org2CloudSyncEngine.retractReconcile.test.ts` — 2 files passed, 9 tests passed
- `pnpm run check:circular` — no circular dependencies across 6,466 modules
- `pnpm run check:test-placement` — consistent across 457 directories
- `git diff --check` — passed
- Performance guard: keep; the diff preserves poll ownership and cadence, retry branches, identity and scope keys, reconciliation behavior, and retained state while removing one rate-limit bookkeeping path
- Not run: live Tauri soak or console-volume measurement; this change has no UI surface, and desktop control was not authorized
