### PR TITLE
fix(github-work-items): clarify filter button state

### DIFF
--- a/src/modules/MainApp/WorkManagement/GitHubWorkItemControls.test.ts
+++ b/src/modules/MainApp/WorkManagement/GitHubWorkItemControls.test.ts
@@ -268,8 +268,26 @@ describe("GitHub work-item header controls", () => {
 
     expect(markup).toContain('data-icon="funnel"');
     expect(markup).toContain('aria-label="Filter (1)"');
+    expect(markup).toContain('aria-pressed="true"');
+    expect(markup).toContain("bg-fill-1! text-primary-6!");
     expect(markup).not.toContain('data-tooltip-label="Filter (1)"');
     expect(markup).not.toContain(">Filter<");
     expect(markup).toContain("height:28px");
+  });
+
+  it("keeps Filter unhighlighted when no filters are selected", () => {
+    const markup = renderToStaticMarkup(
+      createElement(IssuePersonalFilterDropdown, {
+        options: [{ value: "byMe", label: "Created by me" }],
+        selectedFilters: [],
+        filterLabel: "Filter",
+        onSelect: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('aria-label="Filter"');
+    expect(markup).toContain('aria-pressed="false"');
+    expect(markup).not.toContain("bg-fill-1! text-primary-6!");
+    expect(markup).not.toContain("data-tooltip-label");
   });
 });

--- a/src/modules/MainApp/WorkManagement/GitHubWorkItemControls.test.ts
+++ b/src/modules/MainApp/WorkManagement/GitHubWorkItemControls.test.ts
@@ -256,7 +256,7 @@ describe("GitHub work-item row actions", () => {
 });
 
 describe("GitHub work-item header controls", () => {
-  it("renders Filter as a tertiary icon-only header button", () => {
+  it("renders Filter as a tertiary icon-only header button without a tooltip", () => {
     const markup = renderToStaticMarkup(
       createElement(IssuePersonalFilterDropdown, {
         options: [{ value: "byMe", label: "Created by me" }],
@@ -268,7 +268,7 @@ describe("GitHub work-item header controls", () => {
 
     expect(markup).toContain('data-icon="funnel"');
     expect(markup).toContain('aria-label="Filter (1)"');
-    expect(markup).toContain('data-tooltip-label="Filter (1)"');
+    expect(markup).not.toContain('data-tooltip-label="Filter (1)"');
     expect(markup).not.toContain(">Filter<");
     expect(markup).toContain("height:28px");
   });

--- a/src/modules/MainApp/WorkManagement/GitHubWorkItemControls.tsx
+++ b/src/modules/MainApp/WorkManagement/GitHubWorkItemControls.tsx
@@ -7,7 +7,6 @@ import {
   DROPDOWN_CLASSES,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
-import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip";
 import type { SelectOption } from "@src/components/Select";
 import {
   BubbleChatIcon,
@@ -44,32 +43,30 @@ export function IssuePersonalFilterDropdown({
       : filterLabel;
 
   return (
-    <ToolbarTooltip label={accessibleLabel}>
-      <Dropdown
-        options={options}
-        value={selectedFilters}
-        mode="multiple"
-        position="bottom-end"
-        className={`${DROPDOWN_CLASSES.panelAnimated} ${DROPDOWN_WIDTHS.menuClass}`}
-        onSelect={(value) => onSelect(Array.isArray(value) ? value : [value])}
-      >
-        <Button
-          htmlType="button"
-          variant="tertiary"
-          size="small"
-          icon={
-            <HugeiconsIcon
-              icon={FunnelIcon}
-              data-icon="funnel"
-              size={14}
-              strokeWidth={1.8}
-            />
-          }
-          iconOnly
-          aria-label={accessibleLabel}
-        />
-      </Dropdown>
-    </ToolbarTooltip>
+    <Dropdown
+      options={options}
+      value={selectedFilters}
+      mode="multiple"
+      position="bottom-end"
+      className={`${DROPDOWN_CLASSES.panelAnimated} ${DROPDOWN_WIDTHS.menuClass}`}
+      onSelect={(value) => onSelect(Array.isArray(value) ? value : [value])}
+    >
+      <Button
+        htmlType="button"
+        variant="tertiary"
+        size="small"
+        icon={
+          <HugeiconsIcon
+            icon={FunnelIcon}
+            data-icon="funnel"
+            size={14}
+            strokeWidth={1.8}
+          />
+        }
+        iconOnly
+        aria-label={accessibleLabel}
+      />
+    </Dropdown>
   );
 }
 

--- a/src/modules/MainApp/WorkManagement/GitHubWorkItemControls.tsx
+++ b/src/modules/MainApp/WorkManagement/GitHubWorkItemControls.tsx
@@ -37,10 +37,10 @@ export function IssuePersonalFilterDropdown({
   filterLabel: string;
   onSelect: (values: (string | number)[]) => void;
 }): React.ReactNode {
-  const accessibleLabel =
-    selectedFilters.length > 0
-      ? `${filterLabel} (${selectedFilters.length})`
-      : filterLabel;
+  const hasSelectedFilters = selectedFilters.length > 0;
+  const accessibleLabel = hasSelectedFilters
+    ? `${filterLabel} (${selectedFilters.length})`
+    : filterLabel;
 
   return (
     <Dropdown
@@ -55,6 +55,7 @@ export function IssuePersonalFilterDropdown({
         htmlType="button"
         variant="tertiary"
         size="small"
+        className={hasSelectedFilters ? "bg-fill-1! text-primary-6!" : ""}
         icon={
           <HugeiconsIcon
             icon={FunnelIcon}
@@ -65,6 +66,7 @@ export function IssuePersonalFilterDropdown({
         }
         iconOnly
         aria-label={accessibleLabel}
+        aria-pressed={hasSelectedFilters}
       />
     </Dropdown>
   );


### PR DESCRIPTION
## Problem

The GitHub issues and pull requests filter button shows a hover tooltip that obscures nearby content, and the trigger has no persistent visual indication when personal filters are active. The tooltip wrapper and missing selected-state styling make the filter control less clear in both hover and active states.

## Solution

Remove the tooltip wrapper while preserving the dynamic accessible label. When one or more personal filters are selected, render the trigger with the existing selected-control treatment (`bg-fill-1` and `text-primary-6`) and expose `aria-pressed=true`; keep the default presentation and `aria-pressed=false` when no filters are selected. Component tests cover both active and inactive states and require tooltip markup to remain absent.

## Potential risks

Risk is limited to the filter trigger presentation and pressed-state semantics. The dropdown structure, filter selection behavior, and accessible name remain unchanged. A runtime screenshot was not captured because the desktop UI was not launched; server-rendered component tests verify the state-dependent classes and accessibility attributes.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/modules/MainApp/WorkManagement/GitHubWorkItemControls.test.ts src/modules/MainApp/WorkManagement/GitHubWorkItemsHeaderControls.test.ts` — passed, 12 tests across 2 files.
- `pnpm lint:file src/modules/MainApp/WorkManagement/GitHubWorkItemControls.tsx src/modules/MainApp/WorkManagement/GitHubWorkItemControls.test.ts` — passed.
- `pnpm typecheck:fast` — passed.
- `git diff --check` — passed.
- Pre-commit lint-staged and staged-file TypeScript checks — passed for both commits.
- Manual runtime visual verification was not run because the desktop UI was not launched.

## Submit checklist

- [x] I read and followed `.github/PR_RULES.md`.
- [x] The PR is focused and has a scoped Conventional Commit title.
- [x] I ran the relevant checks and documented the unrun runtime visual check.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] No docs or locale changes are needed for this narrow behavior change.