### PR TITLE
perf(codemirror): reuse one theme instance across renders

### DIFF
--- a/src/features/CodeMirror/config/themeConfig.test.ts
+++ b/src/features/CodeMirror/config/themeConfig.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The theme factories must hand back the *same* extension instance on every
+ * call.
+ *
+ * Two separate costs ride on this. `createGithubTheme()` allocates an
+ * `EditorView.theme` plus a `HighlightStyle`, i.e. two style-mod
+ * `StyleModule`s, and style-mod never unmounts a module once its rules are in
+ * the document. And `@uiw/react-codemirror` reconfigures the view whenever the
+ * `theme` extension's identity changes — `Editor/index.tsx` calls
+ * `getCodeMirrorTheme()` straight from its render body, so a fresh instance per
+ * call meant a fresh set of permanent CSS rules per keystroke.
+ *
+ * Reference equality is the whole invariant, so that is what these assert.
+ */
+import { describe, expect, it } from "vitest";
+
+import { createCodeMirrorTheme, getCodeMirrorTheme } from "./themeConfig";
+
+describe("getCodeMirrorTheme", () => {
+  it("returns the same instance across calls", () => {
+    expect(getCodeMirrorTheme()).toBe(getCodeMirrorTheme());
+  });
+
+  it("returns a non-empty extension", () => {
+    // Guards against the cache latching onto an empty/undefined value and the
+    // identity assertion above passing vacuously.
+    expect(getCodeMirrorTheme()).toEqual(expect.any(Array));
+    expect(getCodeMirrorTheme() as unknown[]).toHaveLength(2);
+  });
+});
+
+describe("createCodeMirrorTheme", () => {
+  it("returns the same instance across calls", () => {
+    expect(createCodeMirrorTheme()).toBe(createCodeMirrorTheme());
+  });
+
+  it("is a distinct extension from the syntax theme", () => {
+    // The two factories are separate extensions with different roles; caching
+    // must not collapse them onto one another.
+    expect(createCodeMirrorTheme()).not.toBe(getCodeMirrorTheme());
+  });
+});

--- a/src/features/CodeMirror/config/themeConfig.ts
+++ b/src/features/CodeMirror/config/themeConfig.ts
@@ -24,10 +24,37 @@ export const CODE_LINE_HEIGHT = "var(--cm-line-height)";
 // ============================================
 
 /**
+ * Both theme factories below return a cached singleton rather than a fresh
+ * extension per call.
+ *
+ * `createGithubTheme()` builds an `EditorView.theme` plus a `HighlightStyle`,
+ * i.e. two style-mod `StyleModule`s. style-mod mounts a module's rules into
+ * the document and never removes them again — its own docs say to "treat them
+ * as one-time allocations". `@uiw/react-codemirror` reconfigures whenever the
+ * `theme` extension's identity changes, and `Editor/index.tsx` calls this from
+ * its render body, so before this cache every render mounted a fresh set of
+ * CSS rules that outlived the editor.
+ *
+ * A single instance stays correct across app-theme swaps: every color in these
+ * themes is a `var(--…)` reference resolved at paint time (see
+ * `themes/github.ts`), so the JS objects hold no palette of their own.
+ *
+ * Cached lazily so the module stays free of declaration-order constraints —
+ * the theme constants these read are declared further down this file.
+ */
+let cachedCodeMirrorTheme: Extension | null = null;
+
+/**
  * Get the app-theme-backed CodeMirror theme.
  */
 export function getCodeMirrorTheme(): Extension {
-  return [createGithubTheme(), CODEMIRROR_VISUAL_OVERRIDE_THEME];
+  if (!cachedCodeMirrorTheme) {
+    cachedCodeMirrorTheme = [
+      createGithubTheme(),
+      CODEMIRROR_VISUAL_OVERRIDE_THEME,
+    ];
+  }
+  return cachedCodeMirrorTheme;
 }
 
 // ============================================
@@ -124,6 +151,14 @@ export const CODEMIRROR_BASE_LAYOUT_THEME = EditorView.theme({
   },
 });
 
+let cachedCodeMirrorLayoutTheme: Extension | null = null;
+
 export function createCodeMirrorTheme(): Extension {
-  return [CODEMIRROR_BASE_LAYOUT_THEME, CODEMIRROR_VISUAL_OVERRIDE_THEME];
+  if (!cachedCodeMirrorLayoutTheme) {
+    cachedCodeMirrorLayoutTheme = [
+      CODEMIRROR_BASE_LAYOUT_THEME,
+      CODEMIRROR_VISUAL_OVERRIDE_THEME,
+    ];
+  }
+  return cachedCodeMirrorLayoutTheme;
 }


### PR DESCRIPTION
## Problem

`getCodeMirrorTheme()` returned a freshly built extension on every call, and
`src/features/CodeMirror/Editor/index.tsx:295` calls it directly from its render
body (`SqlEditor` and `SearchEditorDocument` do the same).

Each call runs `createGithubTheme()`, which allocates an `EditorView.theme` plus
a `HighlightStyle` — two style-mod `StyleModule`s. style-mod mounts a module's
rules into the document and never removes them again; its own source comment
says to "treat them as one-time allocations". `@uiw/react-codemirror`
reconfigures the view whenever the `theme` extension's identity changes
(`useCodeMirror.js` lists `theme` first in its effect deps), so every render of
an editor mounted a fresh set of CSS rules that outlived the editor itself.

The rules accumulate in the CSSOM for the lifetime of the webview and survive
editor unmount, so the cost is not reclaimed by closing the file.

`createCodeMirrorTheme()` had a milder version of the same problem: both of its
members were already module constants so it leaked no `StyleModule`, but it
returned a fresh array per call, which still churned extension identity and
triggered reconfiguration for no reason.

## Solution

Cache both factories at their definition in
`src/features/CodeMirror/config/themeConfig.ts`, so the invariant is "one
instance per process" rather than "every caller must remember to memoize".

`createGithubTheme()` has exactly one caller, so fixing it here covers all five
consumers — `Editor`, `SqlEditor`, `SearchEditorDocument`, `Diff`, and
`ConflictEditor` — instead of adding five `useMemo` call sites that a sixth
consumer could forget.

A single shared instance stays correct across app-theme swaps: every color in
these themes is a `var(--…)` reference string built by `cssVar()` and resolved
at paint time, so the JS objects carry no palette of their own. `themes/github.ts`
already documents this ("referenced directly so theme swaps update the editor
without JS copies"); light/dark switching is pure CSS.

Caching is lazy rather than a top-level `const` because the constants these
factories read (`CODEMIRROR_VISUAL_OVERRIDE_THEME`,
`CODEMIRROR_BASE_LAYOUT_THEME`) are declared further down the same file, and a
top-level constant would put them in the temporal dead zone. Lazy caching keeps
the file free of declaration-order constraints.

Public signatures are unchanged, so existing test mocks and all call sites are
untouched.

## Potential risks

- **Runtime theme switching.** The main behavioral question is whether a shared
  instance can go stale on light/dark switch. It cannot: the extensions embed
  CSS variable references, not resolved colors. If a future theme is added that
  reads a resolved value in JS rather than through `cssVar()`, this cache would
  need to be keyed on that input — worth knowing before extending
  `createGithubTheme()`.
- **Cross-view sharing.** The same extension instance is now shared by every
  live `EditorView`. CodeMirror extension values are designed to be shared this
  way (that is the premise of the style-mod guidance above), and
  `Editor/hooks/useEditorExtensions.ts:110` already memoized
  `createCodeMirrorTheme()` per mount without issue.
- **Not covered.** This does not address `ConflictEditor` rebuilding its whole
  `EditorView` on every `content` change, which is a separate finding and is
  left for its own change.
- No dependency, schema, config, persistence, IPC, or wire changes.

## Verification

Commit was built with a temporary index because the checkout is live with
another session's unrelated uncommitted work, so no git hooks ran. Everything
`lint-staged` and the pre-commit hook would have done was run manually on the
exact file list:

- `npx prettier --check <both files>` — "All matched files use Prettier code style!"
- `npx oxlint -c .oxlintrc.json --max-warnings 0 src/features/CodeMirror/config` — clean
- `npx eslint <both files> --max-warnings 0 --report-unused-disable-directives` — clean, exit 0
- `npx tsgo --noEmit --pretty false` (whole project) — exit 0, no errors
- `npx vitest run --config config/vitest.config.ts src/features/CodeMirror` — 2 files, 5 tests passed
- `node scripts/quality/check-test-placement.mjs` — consistent across 460 directories

The new `themeConfig.test.ts` was checked against a mutant rather than only
observed to pass: with the cache temporarily removed, the identity assertion
fails (1 failed, 3 passed) and passes again once restored. The two
non-identity assertions exist so the identity check cannot pass vacuously on an
empty or undefined cached value.

Not run: the full `pnpm test` suite and any Rust checks. This change touches no
Rust and no non-CodeMirror TypeScript, and the project typecheck passed over the
whole tree, so CI carries the rest.

No visual evidence attached: the rendered output is unchanged by construction —
the same extension values are handed to CodeMirror, just once instead of per
render.

Because this commit was made with git plumbing, the `Pre-commit hook ran.`
trailer is absent. In this repo that trailer is documented as tamper-evidence
for `--no-verify`, so its absence is disclosed here rather than left to imply
the hook was skipped silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
