### PR TITLE
build(dev): make DEV_SOURCEMAPS a three-way switch defaulting to off

### DIFF
--- a/config/rspack.config.js
+++ b/config/rspack.config.js
@@ -41,6 +41,34 @@ module.exports = () => {
     (process.env.ORGII_DEV_EAGER_APP !== "false" &&
       process.platform === "linux");
 
+  // DEV_SOURCEMAPS controls how much source text the webview has to hold.
+  // Every evaluated module's source stays resident in JSC for the life of
+  // the page, and the eval-* devtools keep it twice (outer chunk script plus
+  // the eval'd string). Measured 2026-09-03 on the two boot chunks
+  // (main + src_App_tsx, 3,685 modules): 57 MB of source text, of which
+  // 30 MB (53%) was inline base64 source maps.
+  //
+  //   unset / "false"  (default) — `eval`: per-module eval for fast HMR,
+  //                    no maps. Stack traces name the module file
+  //                    (`//# sourceURL`) but line numbers are the SWC output.
+  //   "true" / "inline" — `eval-cheap-module-source-map`: original
+  //                    lines, at the cost above.
+  //   "external"      — `cheap-module-source-map`: separate .map files the
+  //                    webview only fetches when DevTools opens; source is
+  //                    held once instead of twice, original lines kept.
+  //                    Measured 2026-09-04: cold build 4.1 s vs 4.2 s, HMR
+  //                    rebuild 660-800 ms vs 555 ms for `eval`.
+  //
+  // eagerDevApp (Linux) never inlines maps: App is bundled into main.js and
+  // eval-* would push it past the ~80 MB WebKitGTK can load.
+  const devSourceMapMode =
+    process.env.DEV_SOURCEMAPS === "true" ||
+    process.env.DEV_SOURCEMAPS === "inline"
+      ? "inline"
+      : process.env.DEV_SOURCEMAPS === "external"
+        ? "external"
+        : "none";
+
   // Mirror dotenv-webpack(systemvars) for the env keys src actually reads.
   const envKeys = [
     "TZ",
@@ -380,9 +408,16 @@ module.exports = () => {
       timings: true,
       colors: true,
     },
-    // eagerDevApp inlines App into main.js; eval-* would additionally inline
-    // every module's source there, pushing it past the ~80 MB WebKitGTK can
-    // load. Linux therefore writes separate .map files (webpack.config.js:694).
-    devtool: eagerDevApp ? "cheap-source-map" : "eval-cheap-module-source-map",
+    // See the DEV_SOURCEMAPS comment above for the mode table.
+    devtool:
+      devSourceMapMode === "none"
+        ? eagerDevApp
+          ? false
+          : "eval"
+        : eagerDevApp
+          ? "cheap-source-map"
+          : devSourceMapMode === "external"
+            ? "cheap-module-source-map"
+            : "eval-cheap-module-source-map",
   };
 };

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -30,8 +30,21 @@ module.exports = (env, argv) => {
   // React Fast Refresh. esbuild is faster but can't support Fast Refresh.
   const useFastDev =
     !isProduction && (isLightDev || process.env.FAST_DEV === "true");
-  const useDevSourceMaps =
-    !isProduction && !isLightDev && process.env.DEV_SOURCEMAPS !== "false";
+  // DEV_SOURCEMAPS: unset/"false" (default) → no maps; "true"/"inline" →
+  // eval-cheap-module-source-map; "external" → cheap-module-source-map
+  // (.map files fetched only when DevTools opens). Default flipped to off on
+  // 2026-09-03: inline maps were 53% of the source text the webview retains
+  // (see config/rspack.config.js for the measurement and the mode table).
+  const devSourceMapMode =
+    isProduction || isLightDev
+      ? "none"
+      : process.env.DEV_SOURCEMAPS === "true" ||
+          process.env.DEV_SOURCEMAPS === "inline"
+        ? "inline"
+        : process.env.DEV_SOURCEMAPS === "external"
+          ? "external"
+          : "none";
+  const useDevSourceMaps = devSourceMapMode !== "none";
   const retryMainScriptLoad =
     !isProduction &&
     (process.env.ORGII_RETRY_MAIN_SCRIPT_LOAD === "true" ||
@@ -108,7 +121,9 @@ module.exports = (env, argv) => {
       // toggling the flag would wipe the warm non-compiler dev cache other
       // sessions rely on. A separate name keeps both caches alive side by side.
       ...(useReactCompiler
-        ? { name: `react-compiler-${isProduction ? "production" : "development"}` }
+        ? {
+            name: `react-compiler-${isProduction ? "production" : "development"}`,
+          }
         : {}),
       version: `${
         isProduction ? (useFastProd ? "prod-fast" : "prod") : "dev"
@@ -739,15 +754,18 @@ module.exports = (env, argv) => {
     // held in the dev server's memory FS, and rebuilds only re-eval the
     // changed modules instead of re-mapping whole chunks.
     //
-    // DEV_SOURCEMAPS=false (and light dev) trade original-line mapping for
+    // No maps (default, and light dev) trade original-line mapping for
     // memory: plain `eval` keeps per-module eval (fast HMR) but emits no maps
     // at all. Measured warm-start dev server: peak 3.6 GB -> 2.5 GB, idle
     // 2.4 GB -> 1.7 GB, emitted JS 171 MB -> 92 MB, and the webview parses
     // proportionally less. Linux keeps `false` there (WebKitGTK path).
+    // DEV_SOURCEMAPS=external writes separate .map files instead.
     devtool: useDevSourceMaps
       ? eagerDevApp
         ? "cheap-source-map"
-        : "eval-cheap-module-source-map"
+        : devSourceMapMode === "external"
+          ? "cheap-module-source-map"
+          : "eval-cheap-module-source-map"
       : isProduction || eagerDevApp
         ? false
         : "eval",


### PR DESCRIPTION
## Problem

Dev builds retain far more source text in the webview than the code itself: with the default `eval-cheap-module-source-map` devtool every module carries an inline base64 source map, and the two boot chunks alone (`main` + `src_App_tsx`, 3,685 modules) measured 57 MB of source text of which 30 MB (53%) was inline maps. JSC keeps that text resident for the life of the page, and eval-style devtools hold it twice (outer chunk script plus the eval'd string). The webpack config already had a `DEV_SOURCEMAPS=false` escape hatch; the rspack config, which `pnpm tauri:dev` uses, had none and hard-coded inline maps.

## Solution

Both bundler configs read the same three-way `DEV_SOURCEMAPS` switch, documented in `config/rspack.config.js`:

| value | devtool | effect |
|---|---|---|
| unset / `false` (new default) | `eval` | no maps; stack traces name the module file via `sourceURL`, line numbers are SWC output |
| `true` / `inline` | `eval-cheap-module-source-map` | previous behaviour |
| `external` | `cheap-module-source-map` | separate .map files fetched only when DevTools opens; source held once |

The Linux eager-App path keeps its existing `cheap-source-map` / `false` behaviour in every mode.

## Potential risks

- Developer-facing only; production output is unchanged (`devtool: false`).
- With the new default, dev stack traces point at compiled lines rather than TSX lines. Set `DEV_SOURCEMAPS=external` (original lines, single retention) or `inline` (previous behaviour) when line-precise debugging is needed.
- Measured on this machine with rspack on a scratch port: cold build 4.1 s (`external`) vs 4.2 s (`eval`); HMR rebuild 660–800 ms vs 555 ms. `external` is a candidate for a later default flip once more developers have tried it.

## Verification

- Resolved devtool per mode, both bundlers, via `node -e 'require("./config/rspack.config.js")().devtool'` and the webpack equivalent: unset→`eval`, `true`/`inline`→`eval-cheap-module-source-map`, `external`→`cheap-module-source-map`, `false`→`eval`; with `ORGII_DEV_EAGER_APP=true`: none→`false`, inline/external→`cheap-source-map`.
- Two full rspack dev-server runs on port 1999 for the timing table above (initial compile + two HMR rebuilds each), servers stopped afterwards.
- prettier clean. Not run: a full `tauri:dev` session under each mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
