### PR TITLE
perf(app-bootstrap): load the E2E bridge lazily

### DIFF
--- a/src/app/root/AppBootstrap.tsx
+++ b/src/app/root/AppBootstrap.tsx
@@ -10,7 +10,7 @@
  * - Global flow tracker for agent context
  */
 import { useAtomValue, useSetAtom } from "jotai";
-import { type FC, useEffect } from "react";
+import { type FC, Suspense, lazy, useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
 
 import { DeferredGitStatusProvider } from "@src/contexts/git";
@@ -35,7 +35,6 @@ import { settingsLoadedAtom } from "@src/store/settings/settingsAtom";
 
 import { AppDeferredServices } from "./AppDeferredServices";
 import { AppGlobalRecovery } from "./AppGlobalRecovery";
-import { E2EBootstrap } from "./E2EBootstrap";
 import ErrorBoundary from "./components/ErrorBoundary";
 import GlobalShortcuts from "./components/GlobalShortcuts";
 import { RepoLoader } from "./services/RepoLoader";
@@ -43,6 +42,20 @@ import { useAppDeferredInitialization } from "./useAppDeferredInitialization";
 import { useAppShellEffects } from "./useAppShellEffects";
 import { useFirstPaintSignal } from "./useFirstPaintSignal";
 import { usePostPaintGitProbe } from "./usePostPaintGitProbe";
+
+// The E2E bridge (`window.__e2e`) is dev-only and loads as its own chunk: its
+// helpers pull ~40 modules (session sync adapters, cloud client, agent-org
+// store) that must not sit in the boot graph. In production the ternary folds
+// to `null`, so the `import()` and its chunk are eliminated with it. E2E specs
+// already poll for `window.__e2e` in `waitForApp` before invoking helpers.
+const E2EBootstrap =
+  process.env.NODE_ENV !== "production"
+    ? lazy(() =>
+        import("./E2EBootstrap").then((module) => ({
+          default: module.E2EBootstrap,
+        }))
+      )
+    : null;
 
 export const AppBootstrap: FC = () => {
   const deferredComponentsReady = useAppDeferredInitialization();
@@ -77,7 +90,11 @@ export const AppBootstrap: FC = () => {
     <DeferredGitStatusProvider>
       <GlobalShortcuts />
       <AppGlobalRecovery />
-      {process.env.NODE_ENV !== "production" && <E2EBootstrap />}
+      {E2EBootstrap && (
+        <Suspense fallback={null}>
+          <E2EBootstrap />
+        </Suspense>
+      )}
       <ErrorBoundary>
         <RouterProvider router={router} future={{ v7_startTransition: true }} />
         <RepoLoader />


### PR DESCRIPTION
## Problem

`AppBootstrap` statically imported `E2EBootstrap`, whose helper modules (session sync adapters, cloud client, agent-org store constants and atoms) are only needed when WebdriverIO specs drive the app through `window.__e2e`. The `NODE_ENV !== "production"` guard only skipped rendering; the modules were still part of the boot graph, so 22 e2e helper modules shipped in the production App chunk and evaluated at startup in every dev session.

## Solution

`E2EBootstrap` is now created with `React.lazy` inside a `NODE_ENV !== "production"` ternary and rendered under a `Suspense` with a null fallback. In production the ternary folds to `null`, so the dynamic `import()` and its chunk are eliminated; in development the bridge loads as its own chunk after the shell mounts.

## Potential risks

- `window.__e2e` now appears asynchronously, a chunk load after mount, instead of synchronously during the first render. Both e2e `waitForApp` helpers (`agentOrgUiDriver.mjs`, `accountSwitchDriver.mjs`) already poll for the required `__e2e` methods with a timeout before any spec invokes them, so no spec change is needed.
- No production behaviour change other than the removed dead code.

## Verification

- `pnpm exec tsgo --noEmit`: clean. oxlint and eslint on `AppBootstrap.tsx`: no warnings.
- Dev App chunk module diff before/after: 22 `app/root/e2e/*` modules plus `AgentOrgs/config/agentConstants` removed from the boot chunk; a separate chunk loads on mount.
- Not run: the WebdriverIO e2e suite (separate runner, not part of `pnpm test`); the readiness helpers were read to confirm they wait for the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
