### PR TITLE
ci(nightly): gate the production boot bundle on a budget

### DIFF
--- a/.github/workflows/nightly-full-checks.yml
+++ b/.github/workflows/nightly-full-checks.yml
@@ -81,6 +81,45 @@ jobs:
         if: always()
         run: pnpm run test
 
+  # ── Production bundle budget ────────────────────────────────────────────────
+  # ci.yml never builds the production bundle, so nothing stopped the boot
+  # graph from growing: by 2026-09 the shell statically pulled 2,790 src JS
+  # modules (6.3 MB of JS) before first paint. This job builds once a night
+  # and fails when the boot chunks exceed config/bundle-budget.json.
+  bundle-budget:
+    name: Frontend (production bundle budget)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Production build with stats
+        run: pnpm build:stats
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
+
+      - name: Check boot bundle budget
+        run: pnpm check:bundle-budget
+
   # ── Dependency audit ────────────────────────────────────────────────────────
   cargo-audit:
     name: Rust (cargo audit)

--- a/config/bundle-budget.json
+++ b/config/bundle-budget.json
@@ -1,0 +1,8 @@
+{
+  "$comment": "Boot-bundle ceiling for the production build, checked by scripts/quality/check-bundle-budget.mjs (nightly). Boot = the `main` entrypoint chunks plus the chunk group loaded by src/index.tsx's import(\"@src/App\"). Ratchet: lower these numbers in the PR that shrinks the boot graph; raising them needs a stated reason in the PR.",
+  "statsPath": "build/stats.json",
+  "boot": {
+    "maxJsBytes": 6700000,
+    "maxSrcModules": 2850
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "clean:worktrees": "node scripts/dev/clean-cache-if-large.js --worktrees",
     "clean:full": "node scripts/dev/clean-cache-if-large.js --full",
     "scripts:test": "node --test scripts/dev/*.test.cjs",
+    "build:stats": "webpack --config config/webpack.config.js --mode production --json build/stats.json",
+    "check:bundle-budget": "node scripts/quality/check-bundle-budget.mjs",
     "analyze": "webpack --config config/webpack.config.js --mode production --profile --json > build/stats.json && webpack-bundle-analyzer build/stats.json",
     "typecheck": "tsc --noEmit --pretty false",
     "typecheck:fast": "tsgo --noEmit --pretty false",

--- a/scripts/quality/check-bundle-budget.mjs
+++ b/scripts/quality/check-bundle-budget.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * Fails when the production boot bundle grows past config/bundle-budget.json.
+ *
+ * "Boot" is what the webview evaluates before first paint: the `main`
+ * entrypoint chunks (runtime, vendors, main) plus the chunk group that
+ * src/index.tsx loads with `import("@src/App")` — App and every async-vendor
+ * chunk split out of it. Measured 2026-09-04: 37 chunks, 6.3 MB of JS, 2,790
+ * src JS modules (47% of the tree), because the persistent shell statically
+ * imports the chat engine, cloud sync, spotlight and sidebar connectors. Every
+ * evaluated module's source text stays resident in JSC for the life of the
+ * page, so this number is the frontend's memory floor.
+ *
+ * Usage:
+ *   pnpm build:stats            # webpack production build + build/stats.json
+ *   pnpm check:bundle-budget    # this script
+ *   node scripts/quality/check-bundle-budget.mjs path/to/stats.json
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SCRIPT_DIR, "..", "..");
+
+const budget = JSON.parse(
+  readFileSync(join(ROOT, "config", "bundle-budget.json"), "utf8")
+);
+const statsPath = resolve(ROOT, process.argv[2] ?? budget.statsPath);
+
+let stats;
+try {
+  stats = JSON.parse(readFileSync(statsPath, "utf8"));
+} catch (error) {
+  console.error(
+    `check-bundle-budget: cannot read ${statsPath} (${error.message}). Run \`pnpm build:stats\` first.`
+  );
+  process.exit(2);
+}
+
+const entry = stats.entrypoints?.main;
+if (!entry) {
+  console.error("check-bundle-budget: stats has no `main` entrypoint.");
+  process.exit(2);
+}
+
+/** Leaf modules, flattening webpack's concatenated-module groups. */
+function* leafModules(modules) {
+  for (const module of modules ?? []) {
+    if (module.modules?.length) yield* leafModules(module.modules);
+    else yield module;
+  }
+}
+
+const bootIds = new Set(entry.chunks.map(String));
+for (const chunk of stats.chunks) {
+  const loadedByAppImport = (chunk.origins ?? []).some(
+    (origin) =>
+      origin.request === "@src/App" &&
+      (origin.moduleName ?? "").includes("src/index.tsx")
+  );
+  if (loadedByAppImport) bootIds.add(String(chunk.id));
+}
+
+const assetSize = new Map(
+  stats.assets.map((asset) => [asset.name, asset.size])
+);
+const bootChunks = stats.chunks.filter((chunk) =>
+  bootIds.has(String(chunk.id))
+);
+
+let jsBytes = 0;
+let cssBytes = 0;
+for (const chunk of bootChunks) {
+  for (const file of chunk.files ?? []) {
+    const size = assetSize.get(file) ?? 0;
+    if (file.endsWith(".js")) jsBytes += size;
+    else if (file.endsWith(".css")) cssBytes += size;
+  }
+}
+
+// Only JavaScript modules count toward the module budget: JSON and asset
+// modules (`?url` icons resolve to a one-line URL stub) are not code the
+// engine has to parse, so they must not be able to trip the gate.
+const isJsModule = (module) =>
+  (module.moduleType ?? "javascript/auto").startsWith("javascript");
+
+const GROUPED_ROOTS = new Set([
+  "modules",
+  "features",
+  "engines",
+  "scaffold",
+  "store",
+  "components",
+  "hooks",
+  "api",
+  "app",
+]);
+const srcModules = new Set();
+const areaSizes = new Map();
+for (const chunk of bootChunks) {
+  for (const module of leafModules(chunk.modules)) {
+    const name = module.name ?? "";
+    if (!name.startsWith("./src/") || srcModules.has(name)) continue;
+    if (!isJsModule(module)) continue;
+    srcModules.add(name);
+    const segments = name.split("/");
+    const area = GROUPED_ROOTS.has(segments[2])
+      ? segments.slice(2, 4).join("/")
+      : segments[2];
+    const current = areaSizes.get(area) ?? { modules: 0, bytes: 0 };
+    current.modules += 1;
+    current.bytes += module.size ?? 0;
+    areaSizes.set(area, current);
+  }
+}
+
+const mb = (bytes) => `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+const { maxJsBytes, maxSrcModules } = budget.boot;
+
+console.log(`Boot bundle (${bootChunks.length} chunks)`);
+console.log(
+  `  JS          ${mb(jsBytes).padStart(9)}   budget ${mb(maxJsBytes)}`
+);
+console.log(`  CSS         ${mb(cssBytes).padStart(9)}`);
+console.log(
+  `  src JS mods ${String(srcModules.size).padStart(9)}   budget ${maxSrcModules}`
+);
+console.log("  Largest areas (src JS modules / unminified bytes):");
+for (const [area, { modules, bytes }] of [...areaSizes.entries()]
+  .sort((a, b) => b[1].modules - a[1].modules)
+  .slice(0, 12)) {
+  console.log(
+    `    ${String(modules).padStart(5)}  ${mb(bytes).padStart(9)}  ${area}`
+  );
+}
+
+const failures = [];
+if (jsBytes > maxJsBytes) {
+  failures.push(`boot JS ${mb(jsBytes)} exceeds budget ${mb(maxJsBytes)}`);
+}
+if (srcModules.size > maxSrcModules) {
+  failures.push(
+    `boot src JS modules ${srcModules.size} exceed budget ${maxSrcModules}`
+  );
+}
+
+if (failures.length > 0) {
+  console.error(
+    `\ncheck-bundle-budget: FAILED\n  - ${failures.join("\n  - ")}`
+  );
+  console.error(
+    "\nSomething new is statically reachable from the shell. Move it behind a\n" +
+      "React.lazy island or a dynamic import(); if the growth is intended,\n" +
+      "raise config/bundle-budget.json in this PR and say why."
+  );
+  process.exit(1);
+}
+console.log("\ncheck-bundle-budget: OK");


### PR DESCRIPTION
## Problem

`ci.yml` never builds the production bundle, so nothing stops the boot graph from growing. As of today the shell statically reaches 2,790 src JS modules (47% of the tree) and 6.27 MB of JS across 37 chunks before first paint, because the persistent layout imports the chat engine, cloud sync, spotlight and sidebar connectors. Every evaluated module's source text stays resident in JSC for the life of the page, so this is the frontend's memory floor, and today it is invisible to review.

## Solution

- `scripts/quality/check-bundle-budget.mjs` reads a webpack stats file, defines "boot" as the `main` entrypoint chunks plus the chunk group loaded by `src/index.tsx`'s `import("@src/App")`, and reports boot JS bytes, CSS bytes and the number of src JavaScript modules (JSON and asset stubs excluded) with a per-area breakdown. It exits 1 when either number exceeds `config/bundle-budget.json`.
- `config/bundle-budget.json` starts at the measured baseline plus ~2% headroom: 6.7 MB JS, 2,850 modules. The comment states the ratchet: lower it in the PR that shrinks the boot graph, raise it only with a stated reason.
- `package.json`: `build:stats` (production build with `--json build/stats.json`) and `check:bundle-budget`.
- `nightly-full-checks.yml`: new `bundle-budget` job mirroring the frontend setup steps, running the build and the check.

## Potential risks

- Adds a production build (several minutes) to the nightly workflow; PR CI is unchanged.
- The boot definition relies on webpack recording the `@src/App` origin request on each chunk in that group; if the entry import is renamed the script reports only the entrypoint chunks and the budget would look too generous rather than fail spuriously.
- The webpack build in CI was not executed from this branch; the script was validated against a stats file from a local production build of yesterday's develop.

## Verification

- `node scripts/quality/check-bundle-budget.mjs <local stats.json>`: 37 boot chunks, 6.27 MB JS, 0.34 MB CSS, 2,790 src JS modules, budget OK, top areas listed (ChatPanel 421, SessionCore 183, Org2Cloud 160, NavigationSidebar 141, GlobalSpotlight 127, …).
- Workflow YAML parses; jobs: `full-frontend`, `bundle-budget`, `cargo-audit`. prettier clean.
- Not run: `pnpm build:stats` end to end (a full production build on this machine while a dev server is running); `webpack --json <path>` is the documented webpack-cli flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
