### PR TITLE
fix(terminal): stop hidden panes claiming the foreground

### DIFF
--- a/src/engines/TerminalCore/index.tsx
+++ b/src/engines/TerminalCore/index.tsx
@@ -398,7 +398,16 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
                 // `display: none`, so the pane itself has to say whether it is
                 // on screen. Without it every terminal ever opened claims a
                 // foreground output schedule and a GPU context forever.
-                isForeground={session.id === activeSessionId}
+                //
+                // `visible` is as load-bearing as the active-session check.
+                // A host can mount a *single-session* TerminalCore whose
+                // `activeSessionId` is that one session (the chat pane does
+                // this, one host per terminal tab), which makes the comparison
+                // below vacuously true. Such a host is hidden with its own
+                // `display: none` and reports that through `visible`, so
+                // without this conjunct every background chat terminal would
+                // hold a GPU context and a foreground drain.
+                isForeground={visible && session.id === activeSessionId}
                 onSelectionChange={handleSelectionChange}
                 repoPath={session.cwd || repoPath}
                 workingDirectory={session.liveCwd || session.cwd}


### PR DESCRIPTION
## Problem

`TerminalCore` renders every session in its mount window and hides the inactive
ones with `display: none`, so `TerminalView` cannot infer on-screen-ness from
its own mount. That is what `isForeground` is for, and it was derived from
`session.id === activeSessionId` alone.

That comparison is only meaningful when a `TerminalCore` owns several sessions.
A host can mount a **single-session** `TerminalCore` whose `activeSessionId` is
that one session, and the chat pane does exactly this: one host per terminal
tab, built from a synthetic `terminalState` of `sessions: [session]` and
`activeSessionId: terminalSessionId` (`ChatPanelTerminalContent.tsx`). The
equality is then vacuously true.

So every background chat terminal reported itself as foreground while hidden
behind its own `display: none`. Consequences, both of which the existing comment
above the flag names as the thing it exists to prevent:

- it holds a WebGL context, out of a pool capped at 8 (`webglContextManager.ts`),
  so a few background terminals can starve the visible one onto the DOM renderer;
- it keeps a foreground output drain instead of the coalesced timer, doing
  repaint work for a pane nobody is looking at.

## Solution

`TerminalCore` already accepts a `visible` prop for its own hidden state — the
chat pane passes `visible={isActive}` — and simply was not folding it into
`isForeground`. Conjoin the two.

This is deliberately the minimal fix. It leaves the wider issue alone: because
each chat terminal tab mounts its own single-session host, the active-plus-four
warm window in `terminalMountWindow.ts` does not bound terminals *across* tabs.
Correcting that means hoisting one host for all chat terminal tabs, which is a
behavioral change to tab lifecycle and belongs in its own PR. This change makes
the hidden ones cheap in the meantime.

## Potential risks

- **A pane that should be foreground going background.** `visible` defaults to
  `true`, and the only caller that passes it explicitly (`ChatPanelTerminalContent`)
  passes the same value it uses to drive its own `display`, so a visible pane
  cannot be marked hidden by this change.
- **Reduced throughput on background panes is the intended effect**, not a
  regression: output is coalesced rather than dropped, and `attach_pty_stream`
  plus the scheduler's ACK-on-drop path already own correctness for output that
  arrives while a pane is not draining at foreground rate.
- WebGL context handback on background panes is likewise the point; the visible
  terminal is the one that should hold a slot.
- No dependency, schema, config, persistence, IPC, or wire changes.

## Verification

Commit built with a temporary index because the checkout is live with another
session's unrelated uncommitted work, so no git hooks ran. Everything
`lint-staged` and the pre-commit hook would have done was run manually:

- `npx prettier --write` on the changed file — unchanged, already formatted
- `npx oxlint -c .oxlintrc.json --max-warnings 0` — exit 0
- `npx eslint --max-warnings 0 --report-unused-disable-directives` — exit 0
- `npx tsgo --noEmit --pretty false` (whole project) — exit 0
- `npx vitest run src/engines/TerminalCore src/engines/BrowserCore src/modules/WorkStation/AppShell` — 25 files, 205 tests passed

No test is added here. The defect is a prop expression in JSX with no seam to
assert against: `TerminalCore` has no unit test harness, and the observable
consequence lives in the WebGL slot manager and the output scheduler, both of
which are already covered for their own behavior. Asserting this would require
a render test of `TerminalCore` with a mounted xterm, which the suite does not
currently support. Flagging that as a real gap rather than claiming coverage.

Not verified at runtime: I have not measured GPU context counts before and after
in a running app. The reasoning is from the code path
(`TerminalInteractive`'s `isForeground` effect -> `webglController.setForeground`),
not from a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
