### PR TITLE
perf(browser): bound live webviews to a recent window

### DIFF
--- a/src/engines/BrowserCore/index.tsx
+++ b/src/engines/BrowserCore/index.tsx
@@ -13,7 +13,13 @@
  * - Native webview rendering
  */
 import { useAtomValue } from "jotai";
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
@@ -38,6 +44,10 @@ import BrowserSessionWebview from "./BrowserSessionWebview";
 import "./index.scss";
 import { BROWSER_WEBVIEW_FRAME_ANCHOR_ATTRIBUTE } from "./nativeFrameAnchor";
 import type { BrowserState } from "./types";
+import {
+  pushRecentWebviewId,
+  selectMountedBrowserSessions,
+} from "./webviewMountWindow";
 
 const log = createLogger("BrowserCore");
 
@@ -117,6 +127,24 @@ export const BrowserCore: React.FC<BrowserCoreProps> = ({
 }) => {
   const { t } = useTranslation();
   const { sessions, activeSessionId, updateSession, addSession } = browserState;
+
+  // Most-recently-active browser session ids (newest first) — see
+  // ./webviewMountWindow.ts for the mount policy this drives.
+  const [recentWebviewIds, setRecentWebviewIds] = useState<readonly string[]>(
+    []
+  );
+  // Derived-from-previous-render state (React's "storing information from
+  // previous renders" pattern), matching TerminalCore: update synchronously
+  // during render so an evicted session never renders once with stale data.
+  if (activeSessionId) {
+    const nextRecent = pushRecentWebviewId(recentWebviewIds, activeSessionId);
+    if (nextRecent !== recentWebviewIds) setRecentWebviewIds(nextRecent);
+  }
+  const mountedWebviewSessions = selectMountedBrowserSessions(
+    sessions,
+    activeSessionId,
+    recentWebviewIds
+  );
 
   // Check if webviews should be blocked by overlays or station ownership.
   const isWebviewBlocked = useAtomValue(webviewBlockedAtom);
@@ -315,7 +343,7 @@ export const BrowserCore: React.FC<BrowserCoreProps> = ({
 
           {/* Only the owning instance renders BrowserSessionWebview. */}
           {manageWebviews &&
-            sessions.map((session) => (
+            mountedWebviewSessions.map((session) => (
               <BrowserSessionWebview
                 key={session.id}
                 session={session}

--- a/src/engines/BrowserCore/webviewMountWindow.test.ts
+++ b/src/engines/BrowserCore/webviewMountWindow.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_WARM_INACTIVE_WEBVIEWS,
+  pushRecentWebviewId,
+  selectMountedBrowserSessions,
+} from "./webviewMountWindow";
+
+const session = (id: string) => ({ id });
+
+describe("pushRecentWebviewId", () => {
+  it("bounds the list to the active slot plus the warm slots", () => {
+    let recent: readonly string[] = [];
+    for (const id of ["a", "b", "c", "d", "e", "f"]) {
+      recent = pushRecentWebviewId(recent, id);
+    }
+    expect(recent).toHaveLength(MAX_WARM_INACTIVE_WEBVIEWS + 1);
+    expect(recent[0]).toBe("f");
+    // Oldest ids fall out of the window entirely.
+    expect(recent).not.toContain("a");
+  });
+
+  it("returns the same reference when the active id is already newest", () => {
+    // Keeps the render-phase setState in BrowserCore a no-op.
+    const recent = pushRecentWebviewId([], "a");
+    expect(pushRecentWebviewId(recent, "a")).toBe(recent);
+  });
+
+  it("moves a revisited id back to the front without duplicating it", () => {
+    let recent = pushRecentWebviewId([], "a");
+    recent = pushRecentWebviewId(recent, "b");
+    recent = pushRecentWebviewId(recent, "a");
+    expect(recent).toEqual(["a", "b"]);
+  });
+});
+
+describe("selectMountedBrowserSessions", () => {
+  it("drops sessions that have fallen out of the recent window", () => {
+    // The regression this guards: every session ever visited kept a live
+    // native webview, because deactivation only parks it offscreen and
+    // destroy() runs on unmount alone.
+    const sessions = ["a", "b", "c", "d", "e", "f"].map(session);
+    let recent: readonly string[] = [];
+    for (const s of sessions) recent = pushRecentWebviewId(recent, s.id);
+
+    const mounted = selectMountedBrowserSessions(sessions, "f", recent);
+
+    expect(mounted.map((s) => s.id)).toEqual(["c", "d", "e", "f"]);
+    expect(mounted).toHaveLength(MAX_WARM_INACTIVE_WEBVIEWS + 1);
+  });
+
+  it("always mounts the active session even when it is not in the window", () => {
+    const sessions = [session("a"), session("b")];
+    expect(
+      selectMountedBrowserSessions(sessions, "b", []).map((s) => s.id)
+    ).toEqual(["b"]);
+  });
+
+  it("mounts nothing for never-activated sessions", () => {
+    // Restored-from-storage tabs stay free until first visit; they have no
+    // native webview to hold, so leaving them unmounted costs nothing.
+    const sessions = [session("a"), session("b")];
+    expect(selectMountedBrowserSessions(sessions, "", [])).toEqual([]);
+  });
+});

--- a/src/engines/BrowserCore/webviewMountWindow.ts
+++ b/src/engines/BrowserCore/webviewMountWindow.ts
@@ -1,0 +1,67 @@
+/**
+ * Browser webview mount window policy.
+ *
+ * Only the active browser session plus the `MAX_WARM_INACTIVE_WEBVIEWS` most
+ * recently active ones keep their `BrowserSessionWebview` mounted. Everything
+ * else unmounts, which is what actually destroys the native webview:
+ * `useInlineWebview` calls `destroy()` from its unmount cleanup only, so a
+ * session that merely goes inactive is not released — it is parked offscreen
+ * at `(-10000, -10000)` sized `1x1` and keeps running (see
+ * `useInlineWebviewNativeVisibility`). A parked webview is a full live page:
+ * its own WebContent process on macOS, holding page JS, timers, and media.
+ *
+ * `recentIdWindow.ts` already named browser-tab webviews as an intended
+ * consumer; until this module, the terminal pane window was its only caller.
+ *
+ * A window rather than a blanket unmount-on-deactivate, because the tradeoff
+ * differs from terminals. A terminal remounts losslessly from Rust
+ * (`attach_pty_stream` snapshot plus the serialized client buffer). A webview
+ * has no such restore: unmounting drops in-page state — scroll position, form
+ * input, media playback — and the tab reloads from `session.url` on return.
+ * Keeping a few recent tabs warm preserves that for the ones a user actually
+ * flips between, which is the same tradeoff a browser makes when it discards
+ * background tabs.
+ *
+ * The warm count is smaller than the terminal window's because a WKWebView is
+ * far more expensive than an xterm instance.
+ */
+import { pushRecentId } from "@src/util/core/recentIdWindow";
+
+/**
+ * How many *inactive* browser sessions keep a live webview in addition to the
+ * active one.
+ */
+export const MAX_WARM_INACTIVE_WEBVIEWS = 3;
+
+/**
+ * Push `activeId` to the front of the most-recently-active list, bounded to
+ * the active slot plus `maxWarm` inactive slots. Returns the same array
+ * reference when nothing changes so React state updates stay no-ops.
+ */
+export function pushRecentWebviewId(
+  prev: readonly string[],
+  activeId: string,
+  maxWarm: number = MAX_WARM_INACTIVE_WEBVIEWS
+): readonly string[] {
+  return pushRecentId(prev, activeId, maxWarm + 1);
+}
+
+/**
+ * Select which sessions keep their webview mounted: the active one always,
+ * plus any still inside the recent window.
+ *
+ * A session that has never been activated is not in the recent window and so
+ * is not mounted — which costs nothing, because `BrowserSessionWebview` defers
+ * native creation until a session is actually shown. Restored-from-storage
+ * tabs therefore stay free until first visit, exactly as before.
+ */
+export function selectMountedBrowserSessions<T extends { id: string }>(
+  sessions: readonly T[],
+  activeSessionId: string,
+  recentWebviewIds: readonly string[]
+): T[] {
+  const warm = new Set(recentWebviewIds);
+  return sessions.filter(
+    (session) => session.id === activeSessionId || warm.has(session.id)
+  );
+}


### PR DESCRIPTION
## Problem

Deactivating a browser session does not release its native webview.

`useInlineWebviewNativeVisibility` handles `isVisible: false` by parking the
webview offscreen at `(-10000, -10000)` sized `1x1` — its own log line says
"Staging WebView offscreen (isVisible=false, but still mounted)". The actual
`destroy()` is called from `useInlineWebview`'s unmount cleanup only.

A parked webview is a full live page: on macOS its own WebContent process,
holding page JS, timers, and media. Because `BrowserCore` rendered a
`BrowserSessionWebview` for **every** session, every session a user had ever
visited kept one alive until that session was closed. `shouldMountBrowserHost`
keeps the host mounted whenever any session exists, so those webviews outlived
leaving the browser surface entirely.

`recentIdWindow.ts` already names browser-tab webviews as an intended consumer
of the shared most-recently-used helper, but `terminalMountWindow.ts` was its
only caller — this half was never wired up.

## Solution

Add `webviewMountWindow.ts`, mirroring `terminalMountWindow.ts`, and mount
`BrowserSessionWebview` only for the active session plus the three most recently
active ones. Unmounting is what actually destroys the native webview, so the
live set is now bounded by the window instead of by session count.

A window rather than unmount-on-deactivate, because the tradeoff differs from
terminals. A terminal remounts losslessly from Rust (`attach_pty_stream`
snapshot plus serialized client buffer). A webview has no restore path:
unmounting drops in-page state — scroll position, form input, media playback —
and the tab reloads from `session.url` on return. Keeping a few recent tabs warm
preserves that for the ones a user actually flips between, which is the tradeoff
a browser makes when it discards background tabs.

The warm count is 3 rather than the terminal window's 4 because a WKWebView is
substantially more expensive than an xterm instance.

The recent-id list is updated during render via React's
"storing information from previous renders" pattern, matching `TerminalCore`, so
an evicted session never renders once with stale data.

## Potential risks

- **Returning to an evicted tab reloads the page.** This is the deliberate
  tradeoff above and is user-visible: scroll position, form input, and media
  playback are lost for tabs outside the window. A tab that is mid-form or
  playing media and then left for four other tabs will lose that state where it
  previously would not. If 3 proves too tight in practice the constant is the
  single place to change.
- **Re-navigation on remount.** A remounted session navigates to `session.url`.
  Sessions persist `url`/`history`/`historyEntries` in `BrowserContext`, so
  history survives, but any in-page SPA route state not reflected in the URL
  does not.
- **Side effects that stop with the unmount.** `BrowserSessionWebview` renders
  `null`; besides owning the webview it holds one
  `internal-browser:url-changed` listener and reports load state via
  `onSessionUpdate`. Both are meaningful only for a session with a live webview,
  so stopping them for an evicted session drops nothing.
- **Unvisited tabs are unaffected.** `BrowserSessionWebview` already defers
  native creation until first activation, so restored-from-storage tabs held no
  webview before this change and hold none now.
- No dependency, schema, config, persistence, IPC, or wire changes.

## Verification

Commit built with a temporary index because the checkout is live with another
session's unrelated uncommitted work, so no git hooks ran. The pre-commit and
`lint-staged` steps were run manually:

- `npx prettier --write` on all three files — unchanged, already formatted
- `npx oxlint -c .oxlintrc.json --max-warnings 0` — exit 0
- `npx eslint --max-warnings 0 --report-unused-disable-directives` — exit 0
- `npx tsgo --noEmit --pretty false` (whole project) — exit 0
- `npx vitest run src/engines/BrowserCore src/engines/TerminalCore src/modules/WorkStation/AppShell` — 25 files, 205 tests passed
- `node scripts/quality/check-test-placement.mjs` — consistent across 460 directories

`webviewMountWindow.test.ts` covers the policy directly: the window bound,
reference stability for the render-phase setState, revisit reordering, the
active session always mounting, and never-activated sessions mounting nothing.

Not covered: the wiring inside `BrowserCore` is not under test — there is no
render harness for it — so the assertion that unmounting actually reaches
`destroy()` rests on reading `useInlineWebview`'s cleanup, not on an executed
test. I have also not measured WebContent process counts in a running app
before and after; the claim is from the code path, not a measurement.

No screenshots: there is no visual change. The affected component renders
`null` and the native webview is composited outside the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
