### PR TITLE
perf(agent-station): mount the simulator only while displayed

### DIFF
--- a/src/modules/WorkStation/AppShell/AppShellContent.tsx
+++ b/src/modules/WorkStation/AppShell/AppShellContent.tsx
@@ -48,9 +48,6 @@ interface AppShellContentProps {
   isActive: boolean;
   chatPanelFocused: boolean;
   isAgentStation: boolean;
-  hasVisitedAgentStation: boolean;
-  /** Whether Agent Station has a live session attached (keep-alive gate). */
-  hasAgentStationSession: boolean;
   hasVisitedCode: boolean;
   hasVisitedBrowser: boolean;
   hasVisitedProject: boolean;
@@ -82,8 +79,6 @@ export function AppShellContent({
   isActive,
   chatPanelFocused,
   isAgentStation,
-  hasVisitedAgentStation,
-  hasAgentStationSession,
   hasVisitedCode,
   hasVisitedBrowser,
   hasVisitedProject,
@@ -122,10 +117,11 @@ export function AppShellContent({
   // Optional: AppShellContent always sits under BrowserProvider in the app,
   // but isolated mounts (tests) shouldn't crash — no provider ⇒ no sessions.
   const browserContextValue = useBrowserContextOptional();
+  // Mounted iff displayed — the render below uses the same condition, so the
+  // simulator's twelve-cell worst case cannot survive being hidden.
   const mountAgentStationHost = shouldMountAgentStationHost({
     isAgentStation,
-    hasVisited: hasVisitedAgentStation,
-    hasActiveSession: hasAgentStationSession,
+    isChatPanelMaximized: chatPanelFocused,
   });
   const mountCodeHost = shouldMountWorkstationHost({
     hasRealTabs,

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellStationMode.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellStationMode.ts
@@ -1,5 +1,4 @@
 import { useAtomValue } from "jotai";
-import { useEffect, useState } from "react";
 
 import { replayModeAtom } from "@src/engines/SessionCore";
 import {
@@ -11,7 +10,6 @@ import {
 interface AppShellStationModeState {
   stationMode: StationMode;
   isAgentStation: boolean;
-  hasVisitedAgentStation: boolean;
   illuminateAgentStationChrome: boolean;
 }
 
@@ -27,18 +25,6 @@ export function useAppShellStationMode({
     simulatorSessionPlaybackPlayingAtom
   );
 
-  const [hasVisitedAgentStation, setHasVisitedAgentStation] = useState(
-    () => isAgentStation
-  );
-  useEffect(() => {
-    if (isAgentStation && !hasVisitedAgentStation) {
-      const handle = requestAnimationFrame(() => {
-        setHasVisitedAgentStation(true);
-      });
-      return () => cancelAnimationFrame(handle);
-    }
-  }, [isAgentStation, hasVisitedAgentStation]);
-
   const showAgentStationChrome = followAgentHighlightEnabled && isAgentStation;
   const illuminateAgentStationChrome =
     showAgentStationChrome &&
@@ -48,7 +34,6 @@ export function useAppShellStationMode({
   return {
     stationMode,
     isAgentStation,
-    hasVisitedAgentStation,
     illuminateAgentStationChrome,
   };
 }

--- a/src/modules/WorkStation/AppShell/hostMountPolicy.test.ts
+++ b/src/modules/WorkStation/AppShell/hostMountPolicy.test.ts
@@ -96,39 +96,35 @@ describe("shouldMountBrowserHost", () => {
 });
 
 describe("shouldMountAgentStationHost", () => {
-  it("always mounts while Agent Station is the visible surface", () => {
+  it("mounts while Agent Station is the visible surface", () => {
     expect(
       shouldMountAgentStationHost({
         isAgentStation: true,
-        hasVisited: false,
-        hasActiveSession: false,
+        isChatPanelMaximized: false,
       })
     ).toBe(true);
   });
 
-  it("keeps the hidden simulator warm only while a session is attached", () => {
+  it("releases the simulator as soon as another surface is shown", () => {
+    // The regression this guards: the host used to stay mounted (hidden)
+    // for as long as a session was attached, so the grid's per-cell
+    // ChatHistory instances survived the whole time the user was in the
+    // code editor.
     expect(
       shouldMountAgentStationHost({
         isAgentStation: false,
-        hasVisited: true,
-        hasActiveSession: true,
-      })
-    ).toBe(true);
-    expect(
-      shouldMountAgentStationHost({
-        isAgentStation: false,
-        hasVisited: true,
-        hasActiveSession: false,
+        isChatPanelMaximized: false,
       })
     ).toBe(false);
   });
 
-  it("never mounts an unvisited, hidden simulator", () => {
+  it("releases the simulator behind a maximized chat panel", () => {
+    // A maximized chat panel hides the simulator as completely as leaving
+    // the surface does, so "mounted" must not diverge from "displayed".
     expect(
       shouldMountAgentStationHost({
-        isAgentStation: false,
-        hasVisited: false,
-        hasActiveSession: true,
+        isAgentStation: true,
+        isChatPanelMaximized: true,
       })
     ).toBe(false);
   });

--- a/src/modules/WorkStation/AppShell/hostMountPolicy.ts
+++ b/src/modules/WorkStation/AppShell/hostMountPolicy.ts
@@ -63,16 +63,32 @@ export function shouldMountBrowserHost(options: {
 }
 
 /**
- * Agent Station simulator: always mounted while Agent Station is the visible
- * surface; kept warm while hidden only for as long as a session is attached,
- * so my-station ↔ agent-station toggles stay instant mid-session but an idle
- * simulator releases its subtree.
+ * Agent Station simulator: mounted exactly when it is displayed.
+ *
+ * This host is the most expensive keep-alive in the app, so it gets no warm
+ * window at all. The simulator grid mounts one full `ChatHistory` per cell —
+ * its own virtualizer, projection pipeline, replay interval, and
+ * `runtimeMemoryStats` entry — and the layout enum goes up to `3x4`, so a
+ * hidden simulator can hold twelve of them. It previously stayed mounted
+ * whenever a session was attached, which kept all of that alive for the entire
+ * time the user was in the code editor or behind a maximized chat panel.
+ *
+ * Unmounting is safe because the simulator is a pure view: every event it
+ * renders lives in the EventStore (kept warm by the snapshot cache's own LRU),
+ * and it owns no subscription or interval that has to outlive its subtree. The
+ * keep-alive was buying back a React tree rebuild from already-warm data, not
+ * avoiding a refetch.
+ *
+ * `isChatPanelMaximized` is part of the condition rather than only
+ * `isAgentStation` so that "mounted" and "displayed" cannot drift apart: a
+ * maximized chat panel hides the simulator just as completely as leaving the
+ * surface does. It is a deliberate layout mode, not focus/blur, so this does
+ * not thrash.
  */
 export function shouldMountAgentStationHost(options: {
   isAgentStation: boolean;
-  hasVisited: boolean;
-  hasActiveSession: boolean;
+  isChatPanelMaximized: boolean;
 }): boolean {
-  const { isAgentStation, hasVisited, hasActiveSession } = options;
-  return isAgentStation || (hasVisited && hasActiveSession);
+  const { isAgentStation, isChatPanelMaximized } = options;
+  return isAgentStation && !isChatPanelMaximized;
 }

--- a/src/modules/WorkStation/AppShell/index.tsx
+++ b/src/modules/WorkStation/AppShell/index.tsx
@@ -63,11 +63,8 @@ const AppShell = React.memo(
     // chat visibility / chat width); the content host follows the active tab.
     useAppShellRouteSync();
 
-    const {
-      isAgentStation,
-      hasVisitedAgentStation,
-      illuminateAgentStationChrome,
-    } = useAppShellStationMode({ followAgentHighlightEnabled });
+    const { isAgentStation, illuminateAgentStationChrome } =
+      useAppShellStationMode({ followAgentHighlightEnabled });
 
     const agentStationCaptionVisible =
       isAgentStation &&
@@ -158,8 +155,6 @@ const AppShell = React.memo(
                 isActive={isActive}
                 chatPanelFocused={chatPanelFocused}
                 isAgentStation={isAgentStation}
-                hasVisitedAgentStation={hasVisitedAgentStation}
-                hasAgentStationSession={!!workstationActiveSessionId}
                 hasVisitedCode={hasVisitedCode}
                 hasVisitedBrowser={hasVisitedBrowser}
                 hasVisitedProject={hasVisitedProject}


### PR DESCRIPTION
## Problem

The Agent Station host stayed mounted, hidden behind `display: none`, for as
long as a session was attached — `shouldMountAgentStationHost` returned
`isAgentStation || (hasVisited && hasActiveSession)`.

It is the most expensive keep-alive in the app. `ActivitySimulatorGrid` maps
over every grid cell, and in multi-task mode each `IndependentGridCell` mounts a
full `ChatHistory` through `SubagentChatPane` — its own `@tanstack/react-virtual`
virtualizer, projection pipeline, `useCellPlayback` interval, and a registered
`runtimeMemoryStats` entry. The layout enum reaches `3x4`, and
`calculateAutoLayout` escalates to it automatically at ten or more threads, so
up to twelve of those survived the entire time the user was in the code editor.

A second, separate case had the same shape: the host's own render condition is
`isAgentStation && !chatPanelFocused`, so a maximized chat panel hid the
simulator while `mountAgentStationHost` stayed true.

## Solution

Mount the host exactly when it is displayed. `shouldMountAgentStationHost` now
takes `isAgentStation` and `isChatPanelMaximized` and returns the same
expression the render uses, so "mounted" and "displayed" cannot drift apart
again.

Gating on the maximized chat panel is safe because it is a deliberate layout
mode (`chatPanelMaximizedAtom`, resolved through
`resolveChatPanelMaximizedForLayout`), not focus/blur, so it does not toggle
rapidly.

Unmounting is safe because the simulator is a pure view over the EventStore.
Every event it renders lives in that store, kept warm by the snapshot cache's
own LRU with its three-minute release grace, and the simulator owns no
subscription or interval that must outlive its subtree — its only backend call
is `es_get_child_sessions`, a read that re-runs on mount. The keep-alive was
buying back a React tree rebuild from already-warm data, not avoiding a refetch.

This also drops the now-dead plumbing that fed the old warm mount:
`hasVisitedAgentStation` / `hasAgentStationSession` through `AppShellContent`,
and the visited-tracking `useState` plus `requestAnimationFrame` effect in
`useAppShellStationMode`.

## Potential risks

- **Switching back to Agent Station now rebuilds the React tree** instead of
  unhiding it. This is the deliberate tradeoff. Event data is served from the
  snapshot cache rather than refetched, so the cost is render work, not IPC —
  but on a twelve-cell grid over a long transcript that render is not free, and
  the toggle will be perceptibly slower than an unhide. Reverting means
  restoring a warm window, ideally a time-bounded one rather than the old
  session-lifetime one.
- **Per-cell replay cursors and scroll positions reset on remount.** Cursor
  state is persisted in `simulatorAtom`'s `CellReplayPersistState`; scroll
  position is not, so a scrolled-back cell returns to its default position.
- **Toggling the maximized chat panel now unmounts and remounts the simulator.**
  Same cost as above, on a control the user may hit repeatedly.
- Removing `hasVisitedAgentStation` narrows `useAppShellStationMode`'s return
  type. It had no other consumer; `grep` for both removed props across `src/`
  returns nothing.
- No dependency, schema, config, persistence, IPC, or wire changes.

## Verification

Commit built with a temporary index because the checkout is live with another
session's unrelated uncommitted work, so no git hooks ran. The pre-commit and
`lint-staged` steps were run manually:

- `npx prettier --write` on all five files — unchanged, already formatted
- `npx oxlint -c .oxlintrc.json --max-warnings 0` — exit 0
- `npx eslint --max-warnings 0 --report-unused-disable-directives` — exit 0
- `npx tsgo --noEmit --pretty false` (whole project) — exit 0
- `npx vitest run src/modules/WorkStation/AppShell src/engines/BrowserCore src/engines/TerminalCore` — 25 files, 205 tests passed

`hostMountPolicy.test.ts` is updated to the new invariant, including an explicit
case for each half of the regression: the host releasing when another surface is
shown, and releasing behind a maximized chat panel. The superseded
"keeps the hidden simulator warm while a session is attached" case is removed
because that behavior is precisely what this change deletes.

Not covered: `AppShellContent`'s wiring has no render test, so the assertion
that the mount condition and the render condition are now the same expression
rests on reading them side by side. I have also not measured resident memory in
a running app before and after; the twelve-instance figure is read off the
layout enum and the grid's render path, not observed.

No screenshots: there is no visual change while Agent Station is displayed. The
change only affects what remains mounted once it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
