### PR TITLE
perf(org2-cloud): bound the conversation plane and import dedup

### DIFF
--- a/src/features/Org2Cloud/SessionConversation/conversationPlaneAtom.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationPlaneAtom.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ConversationPlaneEntry,
+  MAX_TRACKED_CONVERSATIONS,
+  setPlaneEntry,
+} from "./conversationPlaneAtom";
+
+const entry = (lastSeq: number): ConversationPlaneEntry => ({
+  state: "ready",
+  events: [],
+  lastSeq,
+});
+
+function fill(count: number): Record<string, ConversationPlaneEntry> {
+  let entries: Record<string, ConversationPlaneEntry> = {};
+  for (let index = 0; index < count; index += 1) {
+    entries = setPlaneEntry(entries, `conversation-${index}`, entry(index));
+  }
+  return entries;
+}
+
+describe("setPlaneEntry", () => {
+  it("writes the entry through unchanged", () => {
+    const entries = setPlaneEntry({}, "a", entry(7));
+    expect(entries.a).toEqual(entry(7));
+  });
+
+  it("holds at the cap instead of growing per conversation opened", () => {
+    // The regression this guards: one entry per conversation ever opened,
+    // each carrying that conversation's whole event list, kept forever.
+    const entries = fill(MAX_TRACKED_CONVERSATIONS + 20);
+    expect(Object.keys(entries)).toHaveLength(MAX_TRACKED_CONVERSATIONS);
+  });
+
+  it("evicts least-recently-written conversations first", () => {
+    const entries = fill(MAX_TRACKED_CONVERSATIONS + 2);
+    expect(entries["conversation-0"]).toBeUndefined();
+    expect(entries["conversation-1"]).toBeUndefined();
+    expect(entries["conversation-2"]).toBeDefined();
+  });
+
+  it("keeps a conversation alive when it is written again", () => {
+    let entries = fill(MAX_TRACKED_CONVERSATIONS);
+    // Re-writing conversation-0 moves it to the most-recent position, so the
+    // next overflow takes conversation-1 instead.
+    entries = setPlaneEntry(entries, "conversation-0", entry(99));
+    entries = setPlaneEntry(entries, "fresh", entry(0));
+
+    expect(entries["conversation-0"]).toEqual(entry(99));
+    expect(entries["conversation-1"]).toBeUndefined();
+  });
+
+  it("never evicts the key currently being written", () => {
+    const entries = setPlaneEntry(fill(MAX_TRACKED_CONVERSATIONS), "new", {
+      state: "loading",
+      events: [],
+      lastSeq: 0,
+    });
+    expect(entries.new).toBeDefined();
+    expect(Object.keys(entries)).toHaveLength(MAX_TRACKED_CONVERSATIONS);
+  });
+
+  it("does not mutate the record it is given", () => {
+    const before = fill(3);
+    const snapshot = { ...before };
+    setPlaneEntry(before, "another", entry(1));
+    expect(before).toEqual(snapshot);
+  });
+});

--- a/src/features/Org2Cloud/SessionConversation/conversationPlaneAtom.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationPlaneAtom.ts
@@ -51,6 +51,46 @@ export const conversationPlaneAtom = atom<
   Record<string, ConversationPlaneEntry>
 >({});
 
+/**
+ * How many conversations keep a fetched plane entry.
+ *
+ * The store used to hold one entry per conversation ever opened, forever, and
+ * each entry carries that conversation's full event list — so it grew without
+ * bound across a long session. Eviction is safe and self-healing: a dropped
+ * entry falls back to `EMPTY_ENTRY`, whose `lastSeq` of 0 makes the next open
+ * refetch the conversation from the start.
+ */
+export const MAX_TRACKED_CONVERSATIONS = 24;
+
+/**
+ * Rewrite `key` to the most-recently-used position and drop the least recently
+ * used entries beyond the cap.
+ *
+ * Recency rides on object key order, which is insertion order for string keys:
+ * deleting `key` before re-adding it moves it to the end, so the oldest
+ * entries sit at the front and are pruned first. `key` itself is never a
+ * victim — the caller is writing it right now.
+ */
+export function setPlaneEntry(
+  entries: Record<string, ConversationPlaneEntry>,
+  key: string,
+  entry: ConversationPlaneEntry,
+  maxEntries: number = MAX_TRACKED_CONVERSATIONS
+): Record<string, ConversationPlaneEntry> {
+  const { [key]: _replaced, ...rest } = entries;
+  const next: Record<string, ConversationPlaneEntry> = {
+    ...rest,
+    [key]: entry,
+  };
+  const keys = Object.keys(next);
+  if (keys.length <= maxEntries) return next;
+  for (const victim of keys.slice(0, keys.length - maxEntries)) {
+    if (victim === key) continue;
+    delete next[victim];
+  }
+  return next;
+}
+
 /** orgId → monotonically increasing signal counter (realtime bump). */
 export const conversationPlaneSignalAtom = atom<Record<string, number>>({});
 
@@ -114,10 +154,12 @@ export function useConversationPlaneEvents(
         const probe = await getCloudCapabilitiesConfirmed(fresh.accessToken);
         if (!probe.capabilities.conversationEvents) {
           if (probe.confirmed) {
-            setEntries((current) => ({
-              ...current,
-              [key]: { ...EMPTY_ENTRY, state: "unsupported" },
-            }));
+            setEntries((current) =>
+              setPlaneEntry(current, key, {
+                ...EMPTY_ENTRY,
+                state: "unsupported",
+              })
+            );
           }
           return;
         }
@@ -128,13 +170,13 @@ export function useConversationPlaneEvents(
             rootSessionId: targetSessionId,
             afterSeq,
           });
-          setEntries((current) => {
-            const previous = current[key] ?? EMPTY_ENTRY;
-            return {
-              ...current,
-              [key]: mergePlaneEvents(previous, page.events),
-            };
-          });
+          setEntries((current) =>
+            setPlaneEntry(
+              current,
+              key,
+              mergePlaneEvents(current[key] ?? EMPTY_ENTRY, page.events)
+            )
+          );
           if (!page.hasMore || page.events.length === 0) break;
           afterSeq = page.events[page.events.length - 1].seq;
         }
@@ -143,7 +185,7 @@ export function useConversationPlaneEvents(
         setEntries((current) => {
           const previous = current[key] ?? EMPTY_ENTRY;
           if (previous.state === "ready") return current;
-          return { ...current, [key]: { ...previous, state: "error" } };
+          return setPlaneEntry(current, key, { ...previous, state: "error" });
         });
       } finally {
         inFlightByKey.delete(key);

--- a/src/features/Org2Cloud/SessionConversation/useEnsureFamilyLoaded.ts
+++ b/src/features/Org2Cloud/SessionConversation/useEnsureFamilyLoaded.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { buildCloudSessionFetchClient } from "@src/features/Org2Cloud/org2CloudBackendAdapter";
 import { importRemoteSession } from "@src/features/TeamCollaboration/engine/collabSessionImport";
 import { createLogger } from "@src/hooks/logger";
+import { BoundedMap } from "@src/util/collections/BoundedMap";
 
 import { commitRefreshedAuth, org2CloudAuthAtom } from "../org2CloudAuthAtom";
 import { ensureFreshSession } from "../org2CloudClient";
@@ -12,11 +13,25 @@ import type { ConversationFamilyMember } from "./continuationEvents";
 const log = createLogger("ConversationFamilyLoader");
 
 /**
- * Keyed by org, session AND replay position — a member whose owner pushes
- * more events gets a fresh (incremental) import, so open conversations keep
- * following the family without re-downloading unchanged transcripts.
+ * Last import position attempted per family member, keyed by org + session.
+ *
+ * The value is the member's replay position (`epoch:count`): a member whose
+ * owner pushes more events no longer matches, so it gets a fresh (incremental)
+ * import and open conversations keep following the family without
+ * re-downloading unchanged transcripts.
+ *
+ * This used to be a `Set` keyed by org + session + position, which meant every
+ * push by every member added a permanent entry — the set grew for the lifetime
+ * of the process, in step with how active the org was. Keying by member and
+ * holding the position as the value makes it one entry per member instead of
+ * one per push, and the cap bounds the number of distinct members.
  */
-const attemptedImports = new Set<string>();
+const MAX_TRACKED_FAMILY_MEMBERS = 256;
+
+const attemptedImportPositions = new BoundedMap<string, string>({
+  maxSize: MAX_TRACKED_FAMILY_MEMBERS,
+  name: "ConversationFamilyLoader.attemptedImports",
+});
 
 /**
  * Silently import family members the viewer has no local copy of, so their
@@ -50,9 +65,12 @@ export function useEnsureFamilyLoaded(
         continue;
       }
       if (row.id === `local-${bareSessionId}`) continue;
-      const key = `${row.orgId}:${bareSessionId}:${row.eventsEpoch}:${row.eventsCount}`;
-      if (attemptedImports.has(key)) continue;
-      attemptedImports.add(key);
+      const memberKey = `${row.orgId}:${bareSessionId}`;
+      const position = `${row.eventsEpoch}:${row.eventsCount}`;
+      // `get` rather than `peek`: re-checking a member is what keeps it warm,
+      // so an actively followed conversation should not be the eviction victim.
+      if (attemptedImportPositions.get(memberKey) === position) continue;
+      attemptedImportPositions.set(memberKey, position);
       void (async () => {
         try {
           const fresh = await ensureFreshSession(auth);
@@ -65,8 +83,9 @@ export function useEnsureFamilyLoaded(
             sourceEndpointUrl: auth.supabaseUrl,
           });
         } catch (error) {
-          // Leave the attempt marker: a broken member should not retry in a
-          // loop on every render. The next push (new epoch/count) re-keys.
+          // Leave the recorded position: a broken member should not retry in
+          // a loop on every render. The next push (new epoch/count) no longer
+          // matches the stored value, so it is retried then.
           log.warn(
             `background family import failed for ${bareSessionId}`,
             error


### PR DESCRIPTION
## Problem

Two client stores in the cloud conversation path grew for the lifetime of the
process.

**Family import dedup.** `useEnsureFamilyLoaded` guarded against re-importing a
family member with a `Set` keyed by `orgId:sessionId:eventsEpoch:eventsCount`.
The replay position belongs in the identity — a member whose owner pushes more
events *should* get a fresh incremental import — but as a set key it meant every
push by every member added a permanent entry. The set grew in step with how
active the org was, and nothing ever deleted from it: the file contained only
`has` and `add`.

**Conversation plane.** `conversationPlaneAtom` held one entry per conversation
ever opened, forever. Each entry carries that conversation's full event list,
and `mergePlaneEvents` only ever appends. Individual events are capped at 64 KB
on the wire, so the store is unbounded on both the entry axis and the per-entry
axis. The file's only `delete` is on `inFlightByKey`, which is the concurrency
guard, not the data.

## Solution

**Import dedup:** key by member (`orgId:sessionId`) and hold the replay position
as the *value*. Re-import becomes a value comparison rather than a new key, so
the store holds one entry per member instead of one per push. A `BoundedMap`
then caps the number of distinct members. The lookup uses `get` rather than
`peek` so that re-checking an actively followed member keeps it warm and it is
not the eviction victim.

**Conversation plane:** route every write through `setPlaneEntry`, which moves
the written key to the most-recently-used position and evicts the least recently
used beyond the cap. Recency rides on object key order, which is insertion order
for string keys, so deleting before re-adding is the whole LRU mechanism. The
key being written is never a victim.

Eviction here is self-healing rather than lossy: a dropped entry falls back to
`EMPTY_ENTRY`, whose `lastSeq` of 0 makes the next open refetch the conversation
from the start.

This also gives `BoundedMap` its first production caller. It was written
explicitly to replace ad-hoc "Map plus manual eviction" patterns and had none.

## Potential risks

- **Reopening an evicted conversation costs a full refetch**, not an incremental
  one, because `lastSeq` resets to 0. With a cap of 24 conversations this should
  be rare, and the request is the same one a first open makes.
- **The per-entry event array is still unbounded** and this PR deliberately does
  not cap it. Truncating within an entry would be lossy in a way eviction is
  not: `lastSeq` would still point past the dropped range, so the incremental
  fetch would never re-request those events and they would be missing until the
  whole entry was evicted. A correct fix needs a backfill path or a
  drop-the-whole-entry rule, and belongs in its own change. The entry-count axis
  fixed here is the one that grows with time rather than with a single
  conversation's length.
- **The import cap can force a re-import.** If more than 256 distinct family
  members are seen, the oldest is evicted and a later sighting re-imports it.
  `importRemoteSession` is incremental and dedupes concurrent calls, so the
  worst case is one redundant fetch, not duplicate data.
- The plane's error path now routes through `setPlaneEntry` too, so an error
  write also refreshes recency. That is intentional: a conversation being
  actively retried should not be evicted underneath the retry.
- No dependency, schema, config, persistence, IPC, or wire changes.

## Verification

Commit built with a temporary index because the checkout is live with another
session's unrelated uncommitted work, so no git hooks ran. The pre-commit and
`lint-staged` steps were run manually on the exact file list:

- `npx prettier --write` on all three files
- `npx oxlint -c .oxlintrc.json --max-warnings 0` — exit 0
- `npx eslint --max-warnings 0 --report-unused-disable-directives` — exit 0
- `npx tsgo --noEmit --pretty false` (whole project) — exit 0
- `npx vitest run src/features/Org2Cloud src/store/session` — 151 files, 1411 tests passed
- `node scripts/quality/check-test-placement.mjs` — consistent across 458 directories

`conversationPlaneAtom.test.ts` covers the cap holding, least-recently-written
eviction order, a re-written conversation surviving the next overflow, the
written key never being its own victim, and the helper not mutating its input.

Not covered: `useEnsureFamilyLoaded`'s change has no direct test — it is a hook
whose effect body needs auth, a live family and the import engine, and there is
no harness for it. The bound comes from `BoundedMap`, which is itself fully
tested. I have also not measured heap before and after in a running app; the
growth claim is read off the key construction and the absence of any delete.

No screenshots: no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
