### PR TITLE
perf(session): reclaim per-session state on session delete

### DIFF
--- a/src/store/session/sessionAtom/__tests__/mutations.test.ts
+++ b/src/store/session/sessionAtom/__tests__/mutations.test.ts
@@ -17,6 +17,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import * as streamHelpers from "@src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/streamHelpers";
+import { conversationComposerModeAtomFamily } from "@src/features/Org2Cloud/SessionConversation/conversationComposerMode";
+import { pendingPlanApprovalForSessionAtomFamily } from "@src/store/session/planApprovalAtom";
+import {
+  chatFindInChatOpenAtomFamily,
+  chatSearchSyncAtomFamily,
+} from "@src/store/ui/chatPanel/miscAtoms";
 import {
   createInstrumentedStore,
   getInstrumentedStore,
@@ -318,5 +324,48 @@ describe("removeSession", () => {
     expect(streamHelpers.isSessionStreamingStopped("sess-x", "turn-1")).toBe(
       false
     );
+  });
+
+  it("releases the per-session atom families it pinned", async () => {
+    // jotai-family pins every key it is called with, so a family that is never
+    // removed keeps one atom per session for the lifetime of the app. A family
+    // hands back a *new* atom instance once its key has been released, which is
+    // what makes the release observable.
+    const { upsertSession } = await loadModule();
+    upsertSession(makeSession({ session_id: "sess-fam" }));
+
+    const before = [
+      pendingPlanApprovalForSessionAtomFamily("sess-fam"),
+      chatFindInChatOpenAtomFamily("sess-fam"),
+      chatSearchSyncAtomFamily("sess-fam"),
+      conversationComposerModeAtomFamily("sess-fam"),
+    ];
+
+    mutations.removeSession("sess-fam");
+
+    const after = [
+      pendingPlanApprovalForSessionAtomFamily("sess-fam"),
+      chatFindInChatOpenAtomFamily("sess-fam"),
+      chatSearchSyncAtomFamily("sess-fam"),
+      conversationComposerModeAtomFamily("sess-fam"),
+    ];
+
+    after.forEach((atomAfter, index) => {
+      expect(atomAfter).not.toBe(before[index]);
+    });
+  });
+
+  it("clears an abandoned image draft", async () => {
+    // Image drafts are base64 payloads and are deliberately excluded from
+    // quota recovery, so a deleted session's draft is only reclaimable here.
+    // Submitting a message already clears it; this covers the abandoned case.
+    const { upsertSession } = await loadModule();
+    const key = "orgii:chat-image-draft:sess-draft";
+    localStorage.setItem(key, JSON.stringify([{ dataUrl: "data:image/png" }]));
+    upsertSession(makeSession({ session_id: "sess-draft" }));
+
+    mutations.removeSession("sess-draft");
+
+    expect(localStorage.getItem(key)).toBeNull();
   });
 });

--- a/src/store/session/sessionAtom/mutations.ts
+++ b/src/store/session/sessionAtom/mutations.ts
@@ -32,10 +32,17 @@
  * intentional escape hatch for "the user just did something, bump
  * the row".
  */
+import { clearImageDraft } from "@src/engines/ChatPanel/InputArea/utils/imageDraftCache";
 import { disposeSessionStreamingState } from "@src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/streamHelpers";
+import { conversationComposerModeAtomFamily } from "@src/features/Org2Cloud/SessionConversation/conversationComposerMode";
 import { disposeCanvasRevisionDraftState } from "@src/store/session/canvasRevisionDraftAtom";
 import { cursorIdeTurnSummariesAtomFamily } from "@src/store/session/cursorIdeTurnSummariesAtom";
+import { pendingPlanApprovalForSessionAtomFamily } from "@src/store/session/planApprovalAtom";
 import { tuiModeAtom } from "@src/store/session/tuiModeAtom";
+import {
+  chatFindInChatOpenAtomFamily,
+  chatSearchSyncAtomFamily,
+} from "@src/store/ui/chatPanel/miscAtoms";
 import { clearTodosForSessionAtom } from "@src/store/ui/todoAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
@@ -196,9 +203,20 @@ export const removeSession = (sessionId: string) => {
   // and tuiMode additionally leaves a `orgii:tuiMode:<id>` localStorage key.
   cursorIdeTurnSummariesAtomFamily.remove(sessionId);
   tuiModeAtom.remove(sessionId);
+  // jotai-family pins every key it has ever been called with, so a family that
+  // is never removed keeps one atom per session for the lifetime of the app.
+  pendingPlanApprovalForSessionAtomFamily.remove(sessionId);
+  chatFindInChatOpenAtomFamily.remove(sessionId);
+  chatSearchSyncAtomFamily.remove(sessionId);
+  conversationComposerModeAtomFamily.remove(sessionId);
   if (typeof localStorage !== "undefined") {
     localStorage.removeItem(`orgii:tuiMode:${sessionId}`);
   }
+  // Unsent image drafts are base64 payloads and are deliberately excluded from
+  // quota recovery, so a deleted session's draft would otherwise never be
+  // reclaimed. Submitting a message already clears it; this covers the
+  // abandoned-draft path.
+  clearImageDraft(sessionId);
   store.set(clearTodosForSessionAtom, sessionId);
   removeGuestImportedSession(sessionId);
   // Rust-agent streaming-stop state (per-turn stop markers etc.). This single


### PR DESCRIPTION
## Problem

`removeSession` is the documented chokepoint that every deletion path goes
through — sidebar delete, cloud remove, fork rollback, guest-share remove. It
already frees rust-agent streaming state, todos, `tuiMode`, the cursor-IDE turn
summaries and the canvas revision draft. Five pieces of per-session state were
missing from it.

**Four atom families with no release anywhere.** `jotai-family` pins every key it
has been called with, so a family that is never removed keeps one atom per
session for the lifetime of the app. A repo-wide search for `.remove(` returns
zero call sites for `pendingPlanApprovalForSessionAtomFamily`,
`chatFindInChatOpenAtomFamily`, `chatSearchSyncAtomFamily` and
`conversationComposerModeAtomFamily`.

**Unsent image drafts.** `orgii:chat-image-draft:<sessionId>` holds base64 image
payloads in localStorage. `clearImageDraft` is called from exactly one place,
`useSubmitMessage` on send. `quotaRecovery` deliberately protects unsent drafts
— its docstring lists them alongside auth and sync cursors as intentionally
absent from every cleanup list — so an abandoned draft, or the draft of a
deleted session, was unreachable by every reclamation path in the app. A stale
profile on this machine had a single 304 KB draft key still sitting in
localStorage.

## Solution

Add all five to the existing chokepoint, next to the releases already there.

The image-draft case is deliberately handled here rather than by adding the
prefix to `quotaRecovery`'s disposable set. That set's contract is
"regenerable caches only", and a draft is neither regenerable nor disposable
while its session still exists. Keying the cleanup to session deletion respects
the protection while still reclaiming genuinely orphaned payloads.

## Potential risks

- **Releasing a family entry resets that session's state to the atom's default.**
  All four hold ephemeral UI state — plan-approval view, find-in-chat bar
  visibility, chat search query, composer mode — and the session is being
  deleted, so there is no viewer left to observe the reset. `removeSession` is
  only called on deletion, never on switch-away.
- **`clearImageDraft` on delete drops an unsent draft permanently.** That is the
  intent: the session it belonged to no longer exists, so the draft can never be
  sent. No path reads a draft for a deleted session.
- **Two new cross-layer imports** into `store/session/sessionAtom/mutations.ts`,
  from `engines/ChatPanel` and `features/Org2Cloud`. Both targets are leaf
  modules. `node scripts/quality/check-circular-dependencies.mjs` reports no
  cycles across 6,483 modules.
- No dependency, schema, config, persistence, IPC, or wire changes.

## Verification

Commit built with a temporary index because the checkout is live with another
session's unrelated uncommitted work, so no git hooks ran. The pre-commit and
`lint-staged` steps were run manually:

- `npx prettier --write` on both files
- `npx oxlint -c .oxlintrc.json --max-warnings 0` — exit 0
- `npx eslint --max-warnings 0 --report-unused-disable-directives` — exit 0
- `npx tsgo --noEmit --pretty false` (whole project) — exit 0
- `node scripts/quality/check-circular-dependencies.mjs` — no cycles, 6483 modules
- `npx vitest run src/store/session src/features/Org2Cloud` — 151 files, 1411 tests passed
- `node scripts/quality/check-test-placement.mjs` — consistent across 458 directories

Two tests were added to the existing `removeSession` suite and both were checked
against a mutant rather than only observed to pass: with the new lines removed
from `removeSession`, both fail (2 failed / 12 passed) and both pass again once
restored. The family release is observable because `jotai-family` hands back a
new atom instance for a key it has released.

Not measured: heap or localStorage size in a running app before and after. The
304 KB figure above is from a real on-disk store, but I have not quantified the
atom-family retention.

No screenshots: no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
