### PR TITLE
perf(workstation-pr): bound per-PR and per-branch state

### DIFF
--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/__tests__/workstationPrHelpers.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/__tests__/workstationPrHelpers.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  MAX_STORED_WORKSTATION_PRS,
   buildWorkstationPrStorageKey,
   filterPullRequestsByQuery,
   formatWorkstationPrTitle,
   getStoredWorkstationPr,
   isWorkstationPrEligible,
   normalizePullRequestStatus,
+  pruneStoredWorkstationPrs,
   setStoredWorkstationPr,
   shouldAutoCreateWorkstationPr,
 } from "../workstationPrHelpers";
@@ -187,14 +189,25 @@ describe("formatWorkstationPrTitle", () => {
 });
 
 describe("workstation PR storage", () => {
+  let store: Map<string, string>;
+
   beforeEach(() => {
-    const store = new Map<string, string>();
+    store = new Map<string, string>();
     vi.stubGlobal("localStorage", {
       getItem(key: string) {
         return store.get(key) ?? null;
       },
       setItem(key: string, value: string) {
         store.set(key, value);
+      },
+      removeItem(key: string) {
+        store.delete(key);
+      },
+      key(index: number) {
+        return [...store.keys()][index] ?? null;
+      },
+      get length() {
+        return store.size;
       },
     });
   });
@@ -210,6 +223,43 @@ describe("workstation PR storage", () => {
       url: "https://github.com/acme/app/pull/2",
       status: "open",
     });
+  });
+
+  it("holds at the cap instead of one key per branch ever pushed", () => {
+    // The regression this guards: the key space is repo x branch and nothing
+    // ever removed a key, so every feature branch left one behind forever.
+    for (let index = 0; index < MAX_STORED_WORKSTATION_PRS + 25; index += 1) {
+      setStoredWorkstationPr("/repo", `feat/branch-${index}`, {
+        url: `https://github.com/acme/app/pull/${index}`,
+      });
+    }
+    expect(store.size).toBe(MAX_STORED_WORKSTATION_PRS);
+  });
+
+  it("drops the least recently updated links first", () => {
+    setStoredWorkstationPr("/repo", "old", { url: "https://x/pull/1" });
+    setStoredWorkstationPr("/repo", "new", { url: "https://x/pull/2" });
+    // Force a deterministic order rather than relying on Date.now() resolution.
+    store.set(
+      buildWorkstationPrStorageKey("/repo", "old"),
+      JSON.stringify({ url: "https://x/pull/1", updatedAt: 1 })
+    );
+    store.set(
+      buildWorkstationPrStorageKey("/repo", "new"),
+      JSON.stringify({ url: "https://x/pull/2", updatedAt: 2 })
+    );
+
+    pruneStoredWorkstationPrs(1);
+
+    expect(getStoredWorkstationPr("/repo", "old")).toBeNull();
+    expect(getStoredWorkstationPr("/repo", "new")).not.toBeNull();
+  });
+
+  it("leaves unrelated keys alone", () => {
+    store.set("orgii:something-else", "keep me");
+    setStoredWorkstationPr("/repo", "a", { url: "https://x/pull/1" });
+    pruneStoredWorkstationPrs(0);
+    expect(store.get("orgii:something-else")).toBe("keep me");
   });
 });
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPrDetail.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPrDetail.ts
@@ -28,6 +28,7 @@ import { readRequestedReviewers } from "@src/shared/pr/prLevelActions";
 import {
   type PrIdentity,
   initialSelectedPrState,
+  retainWorkstationPrDetailScope,
   workstationPrDetailCallbackAtomFamily,
   workstationPrScopeKey,
   workstationSelectedPrAtomFamily,
@@ -59,6 +60,12 @@ export function useWorkstationPrDetail({
   const setCallbacks = useSetAtom(
     workstationPrDetailCallbackAtomFamily(scopeKey)
   );
+
+  // Mark this scope as in use so the LRU forgets older PRs' atoms instead of
+  // pinning one set per pull request ever opened.
+  useEffect(() => {
+    retainWorkstationPrDetailScope(scopeKey);
+  }, [scopeKey]);
 
   const mountedRef = useRef(true);
   useEffect(() => {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/workstationPrHelpers.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/workstationPrHelpers.ts
@@ -2,6 +2,16 @@ import { normalizePrStatus } from "@src/shared/pr/prStatus";
 
 const WORKSTATION_PR_STORAGE_PREFIX = "orgii.workstation.pr";
 
+/**
+ * How many remembered branch -> PR links survive.
+ *
+ * The key space is repo x branch, and branches are unbounded: every feature
+ * branch and worktree a user has ever pushed leaves a key behind. Nothing
+ * removed them, so the prefix grew for the life of the profile. `updatedAt`
+ * already rides along in each record, so the oldest links are the ones to drop.
+ */
+export const MAX_STORED_WORKSTATION_PRS = 64;
+
 export interface WorkstationPrRecord {
   url: string;
   status?: string;
@@ -60,6 +70,38 @@ export function getStoredWorkstationPr(
   }
 }
 
+/**
+ * Drop the least-recently-updated stored PR links beyond the cap.
+ *
+ * Exported for the regression test; callers should just use
+ * {@link setStoredWorkstationPr}, which prunes on every write. Writes happen
+ * once per branch/PR association, so the full-prefix scan is not on a hot path.
+ */
+export function pruneStoredWorkstationPrs(
+  maxEntries: number = MAX_STORED_WORKSTATION_PRS
+): void {
+  const stored: Array<{ key: string; updatedAt: number }> = [];
+  for (let index = 0; index < localStorage.length; index += 1) {
+    const key = localStorage.key(index);
+    if (!key?.startsWith(`${WORKSTATION_PR_STORAGE_PREFIX}:`)) continue;
+    let updatedAt = 0;
+    try {
+      const parsed = JSON.parse(
+        localStorage.getItem(key) ?? "{}"
+      ) as WorkstationPrRecord;
+      updatedAt = parsed?.updatedAt ?? 0;
+    } catch {
+      // Unparseable: leave updatedAt at 0 so it sorts oldest and is swept.
+    }
+    stored.push({ key, updatedAt });
+  }
+  if (stored.length <= maxEntries) return;
+  stored.sort((left, right) => left.updatedAt - right.updatedAt);
+  for (const { key } of stored.slice(0, stored.length - maxEntries)) {
+    localStorage.removeItem(key);
+  }
+}
+
 export function setStoredWorkstationPr(
   repoPath: string,
   branch: string,
@@ -75,6 +117,7 @@ export function setStoredWorkstationPr(
     buildWorkstationPrStorageKey(repoPath, branch),
     JSON.stringify(payload)
   );
+  pruneStoredWorkstationPrs();
 }
 
 export function isWorkstationPrEligible(

--- a/src/store/workstation/codeEditor/workstationSelectedPrAtom.test.ts
+++ b/src/store/workstation/codeEditor/workstationSelectedPrAtom.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_RETAINED_PR_DETAIL_SCOPES,
+  __resetRetainedPrDetailScopes,
+  retainWorkstationPrDetailScope,
+  workstationPrDetailCallbackAtomFamily,
+  workstationPrDetailTabAtomFamily,
+  workstationPrScopeKey,
+  workstationSelectedPrAtomFamily,
+} from "./workstationSelectedPrAtom";
+
+const scope = (prNumber: number) =>
+  workstationPrScopeKey("repo-1", "/repo", prNumber);
+
+beforeEach(() => {
+  __resetRetainedPrDetailScopes();
+});
+
+describe("workstationPrScopeKey", () => {
+  it("separates PRs within one repo", () => {
+    expect(scope(1)).not.toBe(scope(2));
+  });
+});
+
+describe("retainWorkstationPrDetailScope", () => {
+  it("releases the atoms of scopes pushed out of the window", () => {
+    // The regression this guards: these families are keyed per repo AND PR
+    // number, and jotai-family pins every key forever, so one set of atoms
+    // leaked per pull request the user had ever opened.
+    const first = scope(0);
+    const firstAtoms = [
+      workstationSelectedPrAtomFamily(first),
+      workstationPrDetailTabAtomFamily(first),
+      workstationPrDetailCallbackAtomFamily(first),
+    ];
+
+    for (let index = 0; index <= MAX_RETAINED_PR_DETAIL_SCOPES; index += 1) {
+      retainWorkstationPrDetailScope(scope(index));
+    }
+
+    // A family hands back a NEW atom instance for a key it has released.
+    expect(workstationSelectedPrAtomFamily(first)).not.toBe(firstAtoms[0]);
+    expect(workstationPrDetailTabAtomFamily(first)).not.toBe(firstAtoms[1]);
+    expect(workstationPrDetailCallbackAtomFamily(first)).not.toBe(
+      firstAtoms[2]
+    );
+  });
+
+  it("keeps scopes that are still inside the window", () => {
+    const kept = scope(MAX_RETAINED_PR_DETAIL_SCOPES);
+    for (let index = 0; index <= MAX_RETAINED_PR_DETAIL_SCOPES; index += 1) {
+      retainWorkstationPrDetailScope(scope(index));
+    }
+    const keptAtom = workstationSelectedPrAtomFamily(kept);
+    retainWorkstationPrDetailScope(scope(MAX_RETAINED_PR_DETAIL_SCOPES + 1));
+
+    expect(workstationSelectedPrAtomFamily(kept)).toBe(keptAtom);
+  });
+
+  it("re-retaining a scope keeps it out of the eviction slot", () => {
+    for (let index = 0; index < MAX_RETAINED_PR_DETAIL_SCOPES; index += 1) {
+      retainWorkstationPrDetailScope(scope(index));
+    }
+    const oldest = scope(0);
+    // Revisiting the oldest PR should make the *second* oldest the victim.
+    retainWorkstationPrDetailScope(oldest);
+    const oldestAtom = workstationSelectedPrAtomFamily(oldest);
+    retainWorkstationPrDetailScope(scope(999));
+
+    expect(workstationSelectedPrAtomFamily(oldest)).toBe(oldestAtom);
+  });
+});

--- a/src/store/workstation/codeEditor/workstationSelectedPrAtom.ts
+++ b/src/store/workstation/codeEditor/workstationSelectedPrAtom.ts
@@ -10,6 +10,7 @@ import type {
   PrReviewEvent,
   PullRequestMergeMethod,
 } from "@src/api/tauri/github";
+import { BoundedMap } from "@src/util/collections/BoundedMap";
 
 import { workstationRepoScopeKey } from "./workstationPrAtom";
 
@@ -195,3 +196,46 @@ export const workstationPrDetailCallbackAtomFamily = atomFamily(
     return scopedAtom;
   }
 );
+
+/**
+ * How many PR detail scopes keep their atoms.
+ *
+ * These three families are keyed per repo **and PR number**, so unlike the
+ * repo-scoped PR atoms they grow with every pull request the user has ever
+ * opened. `jotai-family` pins each key forever, so nothing was ever released.
+ *
+ * Releasing on panel unmount would be wrong: the main pane renders only the
+ * active tab, so switching tabs unmounts the panel, and dropping the scope
+ * there would reset the active detail sub-tab every time the user came back.
+ * An LRU keeps recently visited PRs intact and only forgets the ones the user
+ * has moved well past.
+ *
+ * Nothing here holds unsaved user input — the PR commit-message draft lives in
+ * `workstationPrCommitMessageAtomFamily`, which is repo-scoped and therefore
+ * already bounded, and is deliberately not touched by this eviction.
+ */
+export const MAX_RETAINED_PR_DETAIL_SCOPES = 16;
+
+const retainedPrDetailScopes = new BoundedMap<string, true>({
+  maxSize: MAX_RETAINED_PR_DETAIL_SCOPES,
+  name: "workstationPrDetailScopes",
+  onEvict: (scopeKey) => {
+    workstationSelectedPrAtomFamily.remove(scopeKey);
+    workstationPrDetailTabAtomFamily.remove(scopeKey);
+    workstationPrDetailCallbackAtomFamily.remove(scopeKey);
+  },
+});
+
+/**
+ * Mark a PR detail scope as in use, evicting the least recently used scope's
+ * atoms once the cap is exceeded. Called by `useWorkstationPrDetail` whenever
+ * it binds to a scope.
+ */
+export function retainWorkstationPrDetailScope(scopeKey: string): void {
+  retainedPrDetailScopes.set(scopeKey, true);
+}
+
+/** Test seam: forget every retained scope without firing eviction. */
+export function __resetRetainedPrDetailScopes(): void {
+  retainedPrDetailScopes.clear();
+}

--- a/src/util/core/storage/quotaRecovery.ts
+++ b/src/util/core/storage/quotaRecovery.ts
@@ -22,6 +22,13 @@ const OBSOLETE_BROWSER_CACHE_KEYS = new Set([
 
 const GITHUB_CACHE_PREFIX = "orgii.ghcache.";
 const DEV_RECORD_CACHE_PREFIX = "orgii:devRecord:cache:v1:";
+/**
+ * Remembered branch -> PR links. Regenerable: the association is re-derived
+ * from GitHub the next time the branch's PR is looked up, so losing it costs a
+ * lookup, not user data. Its own writer caps the prefix; this makes the keys
+ * reclaimable under quota pressure too.
+ */
+const WORKSTATION_PR_CACHE_PREFIX = "orgii.workstation.pr:";
 
 export type BrowserStorageCleanupMode =
   | "obsolete"
@@ -86,10 +93,15 @@ function isRegenerableDevRecordCache(key: string): boolean {
   return key.startsWith(DEV_RECORD_CACHE_PREFIX);
 }
 
+function isRegenerableWorkstationPrCache(key: string): boolean {
+  return key.startsWith(WORKSTATION_PR_CACHE_PREFIX);
+}
+
 function isDisposableBrowserCacheKey(key: string): boolean {
   return (
     isRegenerableGitHubCache(key) ||
     isRegenerableDevRecordCache(key) ||
+    isRegenerableWorkstationPrCache(key) ||
     key === BROWSER_CACHE_STORAGE_KEYS.sessionList
   );
 }


### PR DESCRIPTION
## Problem

Two workstation PR stores grew without bound.

**PR detail atom families.** `workstationSelectedPrAtomFamily`,
`workstationPrDetailTabAtomFamily` and `workstationPrDetailCallbackAtomFamily`
are keyed by `workstationPrScopeKey(repoId, repoPath, prNumber)` — per repo
**and PR number** — unlike the repo-scoped PR atoms sitting beside them in the
same modules. `jotai-family` pins every key it has been called with, and a
repo-wide search for `.remove(` finds no call site for any of the three, so one
set of atoms leaked per pull request the user had ever opened.

**Remembered branch → PR links.** `setStoredWorkstationPr` writes
`orgii.workstation.pr:<repoPath>:<branch>` to localStorage. The key space is
repo × branch and branches are unbounded — every feature branch and worktree
ever pushed leaves a key behind. Nothing removed them: the prefix appears only
in its own module, and it was not in `quotaRecovery`'s disposable set either, so
even quota pressure could not reclaim it.

## Solution

**Atoms:** retain the sixteen most recently used PR detail scopes in a
`BoundedMap` and release all three families for a scope when it is evicted.
`useWorkstationPrDetail` marks its scope as in use in an effect keyed on
`scopeKey`.

Releasing on panel unmount would have been the smaller change but is wrong here:
`EditorMainPane` renders only the active tab, so switching tabs unmounts the
detail panel, and dropping the scope there would reset the active detail
sub-tab (Conversation / Commits / Checks / Changes) every time the user came
back. An LRU keeps recently visited PRs intact and forgets only the ones the
user has moved well past.

Nothing in these three families holds unsaved input. The PR commit-message draft
lives in `workstationPrCommitMessageAtomFamily`, which is keyed by
`workstationRepoScopeKey` — repo only — so it is already bounded by repo count
and is deliberately not touched by this eviction.

**Storage:** each record already carries `updatedAt`, so `setStoredWorkstationPr`
now prunes the least recently updated links beyond a cap of 64. The prefix is
also added to `quotaRecovery`'s disposable set: the branch → PR association is
re-derived from GitHub on the next lookup, which makes it regenerable cache
rather than user data, matching that set's stated contract. Unsent drafts stay
excluded, as that docstring intends.

## Potential risks

- **Revisiting a PR outside the sixteen-scope window resets its detail sub-tab**
  to the default and re-fetches its bundle. That is the deliberate tradeoff; the
  fetch path is the same one a first open uses.
- **A dropped storage link means one extra PR lookup** for that branch the next
  time it is opened. Nothing else depends on the stored record.
- **`pruneStoredWorkstationPrs` scans the whole localStorage key space on every
  write.** Writes happen once per branch/PR association, not on a hot path, so
  the scan is not a concern — but it is O(number of localStorage keys) and worth
  knowing if the write frequency ever changes.
- **Records with unparseable JSON sort oldest** and are swept first. That is
  intentional: an unreadable record is already useless to `getStoredWorkstationPr`,
  which returns null for it.
- **Quota recovery can now delete these links.** Only under quota pressure, and
  only for regenerable data, but it does mean a branch's remembered PR can
  disappear after an eviction event.
- No dependency, schema, config, IPC, or wire changes.

## Verification

Commit built with a temporary index because the checkout is live with another
session's unrelated uncommitted work, so no git hooks ran. The pre-commit and
`lint-staged` steps were run manually on the exact file list:

- `npx prettier --write` on all six files — unchanged, already formatted
- `npx oxlint -c .oxlintrc.json --max-warnings 0` — exit 0
- `npx eslint --max-warnings 0 --report-unused-disable-directives` — exit 0
- `npx tsgo --noEmit --pretty false` (whole project) — exit 0
- `npx vitest run src/store src/modules/WorkStation src/util/core/storage` — 204 files, 1600 tests passed
- `node scripts/quality/check-test-placement.mjs` — consistent across 458 directories

Both new suites were checked against a mutant rather than only observed to pass.
With `onEvict` stripped from the scope map and the `pruneStoredWorkstationPrs()`
call removed from the writer, the two cap tests fail and pass again once
restored. The atom release is observable because `jotai-family` hands back a new
atom instance for a key it has released.

The storage tests required extending that suite's existing `localStorage` stub
with `removeItem`, `key(i)` and `length`; the previous stub had only
`getItem`/`setItem`.

Not covered: the `useWorkstationPrDetail` wiring itself — the retention call is
a one-line effect and the hook's existing suite does not exercise scope
lifecycle. I have also not measured heap before and after in a running app.

No screenshots: no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
