### PR TITLE
perf(session): release a run group's derived atom on removal

### DIFF
--- a/src/store/session/__tests__/runGroupsAtom.test.ts
+++ b/src/store/session/__tests__/runGroupsAtom.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createInstrumentedStore,
+  getInstrumentedStore,
+  resetInstrumentedStore,
+} from "@src/util/core/state/instrumentedStore";
+
+import {
+  removeRunGroupAtom,
+  runGroupByIdAtom,
+  runGroupsAtom,
+} from "../runGroupsAtom";
+
+beforeEach(() => {
+  resetInstrumentedStore();
+  createInstrumentedStore();
+});
+
+describe("removeRunGroupAtom", () => {
+  it("drops the group's data", () => {
+    const store = getInstrumentedStore();
+    store.set(runGroupsAtom, {
+      "group-1": { groupId: "group-1", entries: [] },
+    } as never);
+
+    store.set(removeRunGroupAtom, "group-1");
+
+    expect(store.get(runGroupsAtom)["group-1"]).toBeUndefined();
+  });
+
+  it("releases the group's derived atom", () => {
+    // The regression this guards: removing a group dropped its data but left
+    // the per-id derived atom in the module cache, so the map grew with every
+    // run group ever created.
+    const store = getInstrumentedStore();
+    const before = runGroupByIdAtom("group-1");
+
+    store.set(removeRunGroupAtom, "group-1");
+
+    expect(runGroupByIdAtom("group-1")).not.toBe(before);
+  });
+
+  it("keeps other groups' derived atoms", () => {
+    const store = getInstrumentedStore();
+    const other = runGroupByIdAtom("group-2");
+
+    store.set(removeRunGroupAtom, "group-1");
+
+    expect(runGroupByIdAtom("group-2")).toBe(other);
+  });
+});

--- a/src/store/session/runGroupsAtom.ts
+++ b/src/store/session/runGroupsAtom.ts
@@ -134,13 +134,17 @@ export const replaceRunGroupEntryAtom = atom(
 );
 replaceRunGroupEntryAtom.debugLabel = "replaceRunGroupEntryAtom";
 
+const _runGroupByIdCache = new Map<string, Atom<RunGroup | undefined>>();
+
 export const removeRunGroupAtom = atom(null, (get, set, groupId: string) => {
   const { [groupId]: _removed, ...rest } = get(runGroupsAtom);
   set(runGroupsAtom, rest);
+  // Drop the derived atom too. Removing only the data left the per-id atom in
+  // the cache forever, so the map grew with every group ever created — the
+  // hand-rolled equivalent of an atomFamily that is never `remove`d.
+  _runGroupByIdCache.delete(groupId);
 });
 removeRunGroupAtom.debugLabel = "removeRunGroupAtom";
-
-const _runGroupByIdCache = new Map<string, Atom<RunGroup | undefined>>();
 
 /** Per-id atom so a group panel re-renders only for its own group. */
 export function runGroupByIdAtom(groupId: string): Atom<RunGroup | undefined> {


### PR DESCRIPTION
## Problem

`runGroupByIdAtom` memoizes one derived atom per group id in a module-level
`Map`, so a group panel re-renders only for its own group. `removeRunGroupAtom`
dropped the group's data from `runGroupsAtom` but left that derived atom in the
cache.

The map therefore grew with every run group ever created, and nothing could
reach the stale entries — it is the hand-rolled equivalent of an `atomFamily`
that is never `remove`d, with the same consequence: the entry and its jotai
store subscription outlive the data they read.

## Solution

Delete the cache entry alongside the data in `removeRunGroupAtom`, so the
removal path frees both halves of a group's state.

The cache declaration moves above `removeRunGroupAtom` so it is initialised
before the atom that references it; the declaration itself is unchanged.

## Potential risks

- **A removed-then-recreated group gets a fresh derived atom.** Any component
  still subscribed to the old instance would keep reading `undefined` rather
  than the recreated group's data. In practice removal is terminal — the group
  panel closes with it — and the previous behavior of handing back a stale atom
  bound to deleted data was not better.
- Removal is the only path touched. `runGroupByIdAtom` still memoizes normally
  for live groups, so repeated reads keep returning the same instance and the
  re-render narrowing it exists for is unaffected.
- No dependency, schema, config, persistence, IPC, or wire changes.

## Verification

Commit built with a temporary index because the checkout is live with another
session's unrelated uncommitted work, so no git hooks ran. The pre-commit and
`lint-staged` steps were run manually:

- `npx prettier --write` on both files — unchanged, already formatted
- `npx oxlint -c .oxlintrc.json --max-warnings 0` — exit 0
- `npx eslint --max-warnings 0 --report-unused-disable-directives` — exit 0
- `npx tsgo --noEmit --pretty false` (whole project) — exit 0
- `npx vitest run src/store src/modules/WorkStation src/util/core/storage` — 204 files, 1600 tests passed
- `node scripts/quality/check-test-placement.mjs` — consistent across 458 directories

`runGroupsAtom.test.ts` is new and covers the data drop, the derived-atom
release, and that an unrelated group's atom survives. It was checked against a
mutant: with the `delete` removed, the release test fails and passes again once
restored.

Not measured: heap in a running app. The growth claim is read off the cache
having no delete path, not observed.

No screenshots: no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
