### PR TITLE
perf(chat-panel): bound terminal tab keep-alive to a grace window

### DIFF
--- a/src/engines/ChatPanel/TabContent/UnifiedChatPanelTabContent.test.ts
+++ b/src/engines/ChatPanel/TabContent/UnifiedChatPanelTabContent.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChatPanelTab } from "@src/store/chatPanel/chatPanelTabsAtom";
+
+vi.mock("../ChatPanelTerminalContent", () => ({
+  ChatPanelTerminalContent: ({
+    tabId,
+    visible,
+  }: {
+    tabId: string;
+    visible: boolean;
+  }) =>
+    createElement("div", {
+      "data-testid": "terminal",
+      "data-tab-id": tabId,
+      "data-visible": String(visible),
+    }),
+}));
+
+const { CHAT_TERMINAL_KEEP_ALIVE, UnifiedChatPanelTabContent } =
+  await import("./UnifiedChatPanelTabContent");
+
+function terminalTab(id: string): ChatPanelTab {
+  return {
+    id,
+    type: "terminal",
+    title: id,
+    terminalSessionId: `chatpanel-${id}`,
+  } as unknown as ChatPanelTab;
+}
+
+describe("UnifiedChatPanelTabContent terminal keep-alive", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const tabs = [terminalTab("t1"), terminalTab("t2"), terminalTab("t3")];
+
+  const mountedTerminalIds = () =>
+    [...container.querySelectorAll('[data-testid="terminal"]')]
+      .map((node) => node.getAttribute("data-tab-id"))
+      .sort();
+
+  const render = async (activeIndex: number) => {
+    await act(async () => {
+      root.render(
+        createElement(UnifiedChatPanelTabContent, {
+          activeTab: tabs[activeIndex],
+          chatColumn: null,
+          hasTabBar: true,
+          isTerminalTabActive: true,
+          terminalTabs: tabs,
+        })
+      );
+    });
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("mounts only the active terminal at first, then keeps the previous one warm and unmounts it after the grace window", async () => {
+    await render(0);
+    expect(mountedTerminalIds()).toEqual(["t1"]);
+
+    await render(1);
+    expect(mountedTerminalIds()).toEqual(["t1", "t2"]);
+    expect(
+      container
+        .querySelector('[data-tab-id="t1"]')
+        ?.closest("div[style]")
+        ?.getAttribute("style")
+    ).toContain("display: none");
+
+    await act(async () => {
+      vi.advanceTimersByTime(CHAT_TERMINAL_KEEP_ALIVE.graceMs);
+    });
+    expect(mountedTerminalIds()).toEqual(["t2"]);
+  });
+
+  it("never keeps more than maxWarm terminals mounted", async () => {
+    await render(0);
+    await render(1);
+    await render(2);
+    expect(mountedTerminalIds().length).toBe(CHAT_TERMINAL_KEEP_ALIVE.maxWarm);
+    expect(mountedTerminalIds()).toEqual(["t2", "t3"]);
+  });
+});

--- a/src/engines/ChatPanel/TabContent/UnifiedChatPanelTabContent.tsx
+++ b/src/engines/ChatPanel/TabContent/UnifiedChatPanelTabContent.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { useKeepAliveWindow } from "@src/hooks/ui/useKeepAliveWindow";
 import type { ChatPanelTab } from "@src/store/chatPanel/chatPanelTabsAtom";
 
 import { UnknownChatPanelTabPlaceholder } from "./UnknownChatPanelTabPlaceholder";
@@ -16,6 +17,17 @@ const ChatPanelTerminalContent = React.lazy(() =>
     default: module.ChatPanelTerminalContent,
   }))
 );
+
+/**
+ * Keep-alive window for chat-pane terminals. Two warm terminals cover the
+ * common "compare two shells" flip; 30 s is long enough to survive a glance
+ * at another tab and short enough that abandoned terminals stop holding
+ * their buffers.
+ */
+export const CHAT_TERMINAL_KEEP_ALIVE = {
+  graceMs: 30_000,
+  maxWarm: 2,
+} as const;
 
 interface UnifiedChatPanelTabContentProps {
   activeTab: ChatPanelTab | null;
@@ -38,8 +50,15 @@ interface UnifiedChatPanelTabContentProps {
  *  - Work Management mounts only while its tab is active;
  *  - dedicated surface components (Runtime / workspace / cloud-org / work-item /
  *    project / project-org / explore) render from their tab payload;
- *  - every terminal tab stays mounted (hidden unless active) so PTY output is
- *    never lost.
+ *  - terminal tabs use a bounded keep-alive window (see
+ *    `CHAT_TERMINAL_KEEP_ALIVE`): the active terminal plus the most recently
+ *    deactivated one stay mounted (hidden) for a grace period so flipping
+ *    between two tabs is instant; older ones unmount. Unmounting a terminal
+ *    only tears down the xterm instance and its 5,000-line buffer — the PTY
+ *    keeps running in Rust, the buffer is serialized into `bufferCache`, and
+ *    remounting restores it through `attach_pty_stream` (cached buffer, or the
+ *    Rust snapshot when output arrived while unmounted). This is the same path
+ *    the code editor's terminal pane already relies on.
  * A tab whose type is not in the registry renders an explicit placeholder
  * rather than silently collapsing to the Launchpad.
  */
@@ -50,6 +69,18 @@ export function UnifiedChatPanelTabContent({
   isTerminalTabActive,
   terminalTabs,
 }: UnifiedChatPanelTabContentProps): React.ReactNode {
+  const terminalTabIds = React.useMemo(
+    () => terminalTabs.map((tab) => tab.id),
+    [terminalTabs]
+  );
+  const activeTerminalTabId =
+    isTerminalTabActive && activeTab ? activeTab.id : null;
+  const mountedTerminalTabIds = useKeepAliveWindow(
+    activeTerminalTabId,
+    terminalTabIds,
+    CHAT_TERMINAL_KEEP_ALIVE
+  );
+
   const entry = activeTab
     ? resolveChatPanelTabSurfaceEntry(activeTab.type)
     : null;
@@ -84,6 +115,7 @@ export function UnifiedChatPanelTabContent({
       {terminalTabs.map((tab) => {
         const terminalSessionId = tab.terminalSessionId;
         if (!terminalSessionId) return null;
+        if (!mountedTerminalTabIds.has(tab.id)) return null;
         const isActive = isTerminalTabActive && tab.id === activeTab?.id;
         return (
           <div

--- a/src/hooks/ui/useKeepAliveWindow.test.ts
+++ b/src/hooks/ui/useKeepAliveWindow.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useKeepAliveWindow } from "./useKeepAliveWindow";
+
+interface HarnessProps {
+  activeKey: string | null;
+  presentKeys: string[];
+  graceMs: number;
+  maxWarm?: number;
+}
+
+let latest: ReadonlySet<string> = new Set();
+
+function Harness({ activeKey, presentKeys, graceMs, maxWarm }: HarnessProps) {
+  const warm = useKeepAliveWindow(activeKey, presentKeys, {
+    graceMs,
+    maxWarm,
+    now: () => Date.now(),
+  });
+  // Publish the latest result from an effect (not during render) so the
+  // harness stays a valid component under the react-hooks lint rules.
+  useEffect(() => {
+    latest = warm;
+  }, [warm]);
+  return null;
+}
+
+describe("useKeepAliveWindow", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const render = (props: HarnessProps) => {
+    act(() => {
+      root.render(createElement(Harness, props));
+    });
+    return [...latest].sort();
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-04T00:00:00Z"));
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("keeps the active key and keeps a deactivated key warm for the grace window", () => {
+    const keys = ["a", "b", "c"];
+    expect(
+      render({ activeKey: "a", presentKeys: keys, graceMs: 1000 })
+    ).toEqual(["a"]);
+    expect(
+      render({ activeKey: "b", presentKeys: keys, graceMs: 1000 })
+    ).toEqual(["a", "b"]);
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect([...latest].sort()).toEqual(["a", "b"]);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect([...latest].sort()).toEqual(["b"]);
+  });
+
+  it("re-activating a warm key cancels its expiry", () => {
+    const keys = ["a", "b"];
+    render({ activeKey: "a", presentKeys: keys, graceMs: 1000 });
+    render({ activeKey: "b", presentKeys: keys, graceMs: 1000 });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(
+      render({ activeKey: "a", presentKeys: keys, graceMs: 1000 })
+    ).toEqual(["a", "b"]);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    // "a" is active again; "b" was deactivated at t=500 and expires at t=1500.
+    expect([...latest].sort()).toEqual(["a", "b"]);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect([...latest].sort()).toEqual(["a"]);
+  });
+
+  it("bounds the warm set to maxWarm, dropping the least recently deactivated first", () => {
+    const keys = ["a", "b", "c", "d"];
+    const opts = { presentKeys: keys, graceMs: 60_000, maxWarm: 2 };
+    render({ activeKey: "a", ...opts });
+    render({ activeKey: "b", ...opts });
+    expect(render({ activeKey: "c", ...opts })).toEqual(["b", "c"]);
+    expect(render({ activeKey: "d", ...opts })).toEqual(["c", "d"]);
+  });
+
+  it("drops keys that are no longer present, and never returns an absent active key", () => {
+    render({ activeKey: "a", presentKeys: ["a", "b"], graceMs: 60_000 });
+    render({ activeKey: "b", presentKeys: ["a", "b"], graceMs: 60_000 });
+    expect(
+      render({ activeKey: "b", presentKeys: ["b"], graceMs: 60_000 })
+    ).toEqual(["b"]);
+    expect(
+      render({ activeKey: null, presentKeys: [], graceMs: 60_000 })
+    ).toEqual([]);
+  });
+});

--- a/src/hooks/ui/useKeepAliveWindow.ts
+++ b/src/hooks/ui/useKeepAliveWindow.ts
@@ -1,0 +1,117 @@
+/**
+ * useKeepAliveWindow — bounded keep-alive for tab-like content.
+ *
+ * "Hide with `display: none`" keeps every tab ever opened mounted, which is
+ * how a chat pane with ten terminal tabs ends up holding ten xterm buffers.
+ * This hook answers the question "which keys may stay mounted right now?":
+ *
+ *   - the active key, always;
+ *   - keys deactivated less than `graceMs` ago, so flipping between two tabs
+ *     stays instant and pays no rebuild;
+ *   - at most `maxWarm` keys in total (active + most recently deactivated).
+ *
+ * Everything else should be unmounted and rebuilt from state when it becomes
+ * active again. Keys that leave `presentKeys` (tab closed) drop immediately.
+ *
+ * The active-key transition uses React's "adjust state during render"
+ * pattern; only the grace expiry runs through a timer.
+ */
+import { useEffect, useMemo, useState } from "react";
+
+export interface KeepAliveWindowOptions {
+  /** How long a deactivated key stays warm, in milliseconds. */
+  graceMs: number;
+  /** Upper bound on warm keys including the active one. Default: unbounded. */
+  maxWarm?: number;
+  /** Clock override for tests. */
+  now?: () => number;
+}
+
+/** Marker for the active key: never expires on its own. */
+const ACTIVE = Number.POSITIVE_INFINITY;
+
+type WarmEntries = ReadonlyMap<string, number>;
+
+function transition(
+  entries: WarmEntries,
+  previousActive: string | null,
+  nextActive: string | null,
+  now: number,
+  maxWarm: number | undefined
+): WarmEntries {
+  const next = new Map(entries);
+  if (previousActive !== null && previousActive !== nextActive) {
+    next.set(previousActive, now);
+  }
+  if (nextActive !== null) {
+    next.set(nextActive, ACTIVE);
+  }
+  if (maxWarm !== undefined && next.size > maxWarm) {
+    // Drop the least recently deactivated keys first; the active key is
+    // +Infinity and therefore sorts last.
+    const ordered = [...next.entries()].sort((a, b) => a[1] - b[1]);
+    for (const [key] of ordered.slice(0, next.size - Math.max(1, maxWarm))) {
+      next.delete(key);
+    }
+  }
+  return next;
+}
+
+function pruneExpired(
+  entries: WarmEntries,
+  graceMs: number,
+  now: number
+): WarmEntries {
+  let changed = false;
+  const next = new Map<string, number>();
+  for (const [key, deactivatedAt] of entries) {
+    if (deactivatedAt === ACTIVE || deactivatedAt + graceMs > now) {
+      next.set(key, deactivatedAt);
+    } else {
+      changed = true;
+    }
+  }
+  return changed ? next : entries;
+}
+
+export function useKeepAliveWindow(
+  activeKey: string | null,
+  presentKeys: readonly string[],
+  options: KeepAliveWindowOptions
+): ReadonlySet<string> {
+  const { graceMs, maxWarm } = options;
+  const now = options.now ?? Date.now;
+
+  const [entries, setEntries] = useState<WarmEntries>(
+    () => new Map(activeKey === null ? [] : [[activeKey, ACTIVE]])
+  );
+  const [lastActive, setLastActive] = useState(activeKey);
+  if (activeKey !== lastActive) {
+    setLastActive(activeKey);
+    setEntries(transition(entries, lastActive, activeKey, now(), maxWarm));
+  }
+
+  // Grace expiry: wake up when the earliest warm key ages out.
+  useEffect(() => {
+    let earliest = ACTIVE;
+    for (const deactivatedAt of entries.values()) {
+      if (deactivatedAt < earliest) earliest = deactivatedAt;
+    }
+    if (earliest === ACTIVE) return undefined;
+    const delay = Math.max(0, earliest + graceMs - now());
+    const timer = setTimeout(() => {
+      setEntries((current) => pruneExpired(current, graceMs, now()));
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [entries, graceMs, now]);
+
+  return useMemo(() => {
+    const present = new Set(presentKeys);
+    const warm = new Set<string>();
+    for (const key of entries.keys()) {
+      if (present.has(key)) warm.add(key);
+    }
+    if (activeKey !== null && present.has(activeKey)) warm.add(activeKey);
+    return warm;
+  }, [entries, presentKeys, activeKey]);
+}


### PR DESCRIPTION
## Problem

`UnifiedChatPanelTabContent` renders every terminal tab in the chat pane and hides the inactive ones with `display: none`, with no upper bound. Each hidden tab keeps a live xterm instance whose 5,000-line scrollback buffer (`terminalSetup.ts`) allocates three `uint32` per cell per line, so a wide, well-used terminal holds on the order of 10 MB and ten forgotten terminal tabs hold ~100 MB for the life of the window. The WebGL context of a hidden pane is already suspended by `terminalWebglLifecycle.ts`; the buffer and DOM never were.

## Solution

- New `useKeepAliveWindow(activeKey, presentKeys, { graceMs, maxWarm })` in `src/hooks/ui/`: returns the set of keys that may stay mounted — the active key, keys deactivated less than `graceMs` ago, capped at `maxWarm` in total (least recently deactivated dropped first). Keys that leave `presentKeys` (tab closed) drop immediately. The active-key transition uses React's adjust-state-during-render pattern; only grace expiry uses a timer.
- `UnifiedChatPanelTabContent` mounts a terminal tab only while it is in that window (`CHAT_TERMINAL_KEEP_ALIVE`: 30 s grace, 2 warm). Flipping between two terminals stays instant; a terminal left behind for 30 s is unmounted.
- Unmounting is safe because the terminal component already owns its reconstruction path: on unmount the buffer is serialized into `bufferCache` and listeners detach while the PTY keeps running in Rust; on remount `attach_pty_stream` restores from the cached buffer, or from the Rust-side bounded snapshot when output arrived while unmounted (`missed_output`). The code editor's terminal pane (`EditorMainPane`, `shouldMountTerminalContent = isTerminalTabActive`) has relied on exactly this path.

## Potential risks

- A terminal that produced more output while unmounted than the Rust snapshot bound keeps only the bounded tail on remount, where it previously kept the full 5,000 lines. That bound is the same one a fresh attach already lives with.
- The first switch back to a terminal that aged out pays an xterm mount plus one `attach_pty_stream` IPC instead of a style flip. Within 30 s, or for the most recent previous terminal, nothing changes.
- The keep-alive applies only to chat-pane terminal tabs; the chat column, work-management and surface tabs keep their existing mount behaviour.

## Verification

- `pnpm exec vitest run src/hooks/ui/useKeepAliveWindow.test.ts src/engines/ChatPanel/TabContent/UnifiedChatPanelTabContent.test.ts src/engines/ChatPanel/ChatPanelShell.test.ts`: 3 files, 9 tests passed — grace expiry, re-activation cancelling expiry, `maxWarm` eviction order, absent-key pruning; dispatcher mounts only the active terminal first, keeps the previous one hidden for the grace window, unmounts it after, and never exceeds `maxWarm`.
- `pnpm exec tsgo --noEmit`: clean. oxlint + eslint (including `react-hooks` rules) on the changed files: clean. `pnpm check:test-placement`: consistent.
- Not run: a manual session in the desktop app switching between three chat-pane terminals across the 30 s boundary; the reconstruction path itself is the existing editor-terminal behaviour, not new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
