### PR TITLE
perf(workstation): release hidden content hosts after a grace window

### DIFF
--- a/src/modules/WorkStation/AppShell/hooks/useAppShellDock.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellDock.ts
@@ -1,12 +1,25 @@
 import { useAtomValue } from "jotai";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import { useKeepAliveWindow } from "@src/hooks/ui/useKeepAliveWindow";
 import { activeHostAtom } from "@src/store/workstation";
 import { mainPaneHasRealTabsAtom } from "@src/store/workstation/tabHost";
 
 export interface AppShellDockState {
   visitedModes: Set<string>;
 }
+
+/**
+ * How long a host that the user left stays mounted-but-hidden. Long enough
+ * to make "peek at the browser, come back to the editor" a style flip, short
+ * enough that a host abandoned for the rest of the session — the file tree,
+ * the browser layout with its DevTools, the project tables — stops holding
+ * its subtree. The active host is never subject to this window.
+ */
+export const HOST_KEEP_ALIVE_GRACE_MS = 60_000;
+
+/** Content hosts the window applies to; `agent-station` mounts iff displayed. */
+const KEEP_ALIVE_HOSTS = ["code", "browser", "project"] as const;
 
 interface AppShellDockSnapshot extends AppShellDockState {
   activeHost: string;
@@ -48,12 +61,17 @@ export function advanceAppShellDockSnapshot(
  * real work, so `AppShellContent` can keep them mounted-but-hidden for
  * instant tab switches.
  *
- * The keep-alive is bounded: when the pool empties down to the Launchpad the
- * visited set is cleared and every host unmounts, releasing its subtree (and
- * idle background work like the file-tree autoload). This is safe because the
- * ACTIVE host never depends on this set — `AppShellContent` mounts it through
- * the synchronous `is*Mode` branch the moment a tab activates — and because
- * cross-surface requests travel through atoms that survive host remounts.
+ * The keep-alive is bounded twice. When the pool empties down to the
+ * Launchpad the visited set is cleared and every host unmounts, releasing its
+ * subtree (and idle background work like the file-tree autoload). And a
+ * visited host only stays warm for `HOST_KEEP_ALIVE_GRACE_MS` after the user
+ * leaves it: a hidden host holds an entire surface (file tree and sidebars,
+ * browser layout with DevTools, project tables), so one that is not returned
+ * to within a minute is released and rebuilt from atom state on the next
+ * visit. This is safe because the ACTIVE host never depends on this set —
+ * `AppShellContent` mounts it through the synchronous `is*Mode` branch the
+ * moment a tab activates — and because cross-surface requests travel through
+ * atoms that survive host remounts.
  *
  * The old unconditional Browser pre-mount (so a "New Browser" click had a
  * mounted consumer) is gone: `AppShellContent` now mounts the Browser host
@@ -80,6 +98,20 @@ export function useAppShellDock(): AppShellDockState {
   if (nextSnapshot !== snapshot) {
     setSnapshot(nextSnapshot);
   }
-
-  return { visitedModes: nextSnapshot.visitedModes };
+  // Grace window: a host the user left stays warm for a bounded time only.
+  // With no real tabs the window is empty immediately, matching the
+  // synchronous clear above.
+  const warmHosts = useKeepAliveWindow(
+    hasRealTabs ? activeHost : null,
+    KEEP_ALIVE_HOSTS,
+    { graceMs: HOST_KEEP_ALIVE_GRACE_MS }
+  );
+  const visitedModes = useMemo(() => {
+    const result = new Set<string>();
+    for (const host of nextSnapshot.visitedModes) {
+      if (warmHosts.has(host)) result.add(host);
+    }
+    return result;
+  }, [nextSnapshot.visitedModes, warmHosts]);
+  return { visitedModes };
 }

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellDock.window.test.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellDock.window.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const atomValues = { activeHost: "code", hasRealTabs: true };
+
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("jotai")>()),
+  useAtomValue: (atom: unknown) => {
+    const { activeHostAtom } = atomsModule;
+    return atom === activeHostAtom
+      ? atomValues.activeHost
+      : atomValues.hasRealTabs;
+  },
+}));
+
+const atomsModule = await import("@src/store/workstation");
+const { HOST_KEEP_ALIVE_GRACE_MS, useAppShellDock } =
+  await import("./useAppShellDock");
+
+let latest: string[] = [];
+
+function Harness() {
+  const { visitedModes } = useAppShellDock();
+  useEffect(() => {
+    latest = [...visitedModes].sort();
+  }, [visitedModes]);
+  return null;
+}
+
+describe("useAppShellDock keep-alive window", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const render = (activeHost: string, hasRealTabs = true) => {
+    atomValues.activeHost = activeHost;
+    atomValues.hasRealTabs = hasRealTabs;
+    act(() => {
+      root.render(createElement(Harness));
+    });
+    return latest;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("keeps a left host warm for the grace window, then releases it", () => {
+    expect(render("code")).toEqual(["code"]);
+    expect(render("browser")).toEqual(["browser", "code"]);
+
+    act(() => {
+      vi.advanceTimersByTime(HOST_KEEP_ALIVE_GRACE_MS - 1);
+    });
+    expect(latest).toEqual(["browser", "code"]);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(latest).toEqual(["browser"]);
+  });
+
+  it("returning to a warm host cancels its release", () => {
+    render("code");
+    render("browser");
+    act(() => {
+      vi.advanceTimersByTime(HOST_KEEP_ALIVE_GRACE_MS / 2);
+    });
+    expect(render("code")).toEqual(["browser", "code"]);
+    act(() => {
+      vi.advanceTimersByTime(HOST_KEEP_ALIVE_GRACE_MS);
+    });
+    expect(latest).toEqual(["code"]);
+  });
+
+  it("releases everything at once when the real-tab pool empties", () => {
+    render("code");
+    render("project");
+    expect(render("project", false)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`AppShellContent` keeps every WorkStation content host the user has visited mounted-but-hidden (`display: none`) until the tab pool empties to the Launchpad. In practice the pool rarely empties, so after one visit each the code host (file tree, primary sidebar, editor pane), the browser host (browser layout with DevTools) and the project host (project manager with its tables) all stay resident for the rest of the session. The Agent Station simulator host was already changed to mount only while displayed; the other three had no bound beyond "pool emptied".

## Solution

`useAppShellDock` now intersects the visited-host set with a keep-alive window from `useKeepAliveWindow` (introduced on the base branch): a host the user leaves stays warm for `HOST_KEEP_ALIVE_GRACE_MS` (60 s) and is then dropped from `visitedModes`, so `shouldMountWorkstationHost` / `shouldMountBrowserHost` unmount it. Returning within the window is still a style flip; returning later rebuilds the host from atom state. The existing rules are unchanged: the active host is always mounted through the synchronous `is*Mode` branch, the pool emptying still releases everything at once, and the browser host's extra mount triggers (pending new-session request, live engine sessions, background browser tabs) still apply.

Stacked on #1260 (`dev/chat-terminal-keep-alive-window`), which adds the shared hook; GitHub will retarget this PR to `develop` when that merges.

## Potential risks

- A host revisited after more than a minute pays a full remount (file tree reload, sidebar data, browser layout) instead of an instant switch. The host mount policy already handled this path for the Launchpad case, and every cross-surface request travels through atoms that survive remounts.
- Browser host: `shouldMountBrowserHost` keeps it mounted while engine sessions or a pending new-session request exist regardless of the window, so live browser sessions are unaffected. If the user has no browser sessions and does not return within 60 s, the layout unmounts and remounts on the next visit.
- The window is time-based; a test or automation that switches hosts and waits more than 60 s before switching back now observes a remount.

## Verification

- `pnpm exec vitest run` on `useAppShellDock.window.test.ts` (new: warm-then-release across the grace boundary, return cancels release, pool-empty releases immediately), `useAppShellDock.test.ts` and `hostMountPolicy.test.ts`: 3 files, 17 tests passed.
- `pnpm exec tsgo --noEmit`: clean. oxlint + eslint on changed files: clean. `pnpm check:test-placement`: consistent.
- Not run: a manual host-switching session in the desktop app across the 60 s boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
