### PR TITLE
perf(project-manager): bound trio tab keep-alive to a grace window

### DIFF
--- a/src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerContentRouter.test.ts
+++ b/src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerContentRouter.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@src/modules/WorkStation/TabContent/UnifiedTabContent", () => ({
+  UnifiedTabContent: ({
+    tab,
+    isActive,
+  }: {
+    tab: { id: string };
+    isActive: boolean;
+  }) =>
+    createElement("div", {
+      "data-testid": "trio-pane",
+      "data-tab-id": tab.id,
+      "data-active": String(isActive),
+    }),
+}));
+vi.mock("@src/modules/WorkStation/shared", () => ({
+  NoTabsPlaceholder: () => createElement("div", { "data-testid": "no-tabs" }),
+}));
+vi.mock("@src/components/Placeholder", () => ({
+  Placeholder: () => null,
+}));
+
+const { PROJECT_TRIO_KEEP_ALIVE, ProjectManagerContentRouter } =
+  await import("./ProjectManagerContentRouter");
+
+type RouterProps = Parameters<typeof ProjectManagerContentRouter>[0];
+type Tab = RouterProps["tabs"][number];
+
+function trioTab(id: string, type: Tab["type"]): Tab {
+  return { id, type, title: id, data: {} } as unknown as Tab;
+}
+
+describe("ProjectManagerContentRouter trio keep-alive", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const tabs = [
+    trioTab("wi", "project-workitems"),
+    trioTab("lp", "project-linear-projects"),
+    trioTab("lw", "project-linear-work-items"),
+  ];
+
+  const mountedIds = () =>
+    [...container.querySelectorAll('[data-testid="trio-pane"]')]
+      .map((node) => node.getAttribute("data-tab-id"))
+      .sort();
+
+  const render = (activeIndex: number) =>
+    act(() => {
+      root.render(
+        createElement(ProjectManagerContentRouter, {
+          repoPath: "/repo",
+          tabs,
+          activeTab: tabs[activeIndex],
+          projectQuickActions: [],
+        } as unknown as RouterProps)
+      );
+    });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("mounts only the active trio tab first, keeps the previous one hidden for the grace window, then unmounts it", () => {
+    render(0);
+    expect(mountedIds()).toEqual(["wi"]);
+
+    render(1);
+    expect(mountedIds()).toEqual(["lp", "wi"]);
+    const hidden = container.querySelector('[data-tab-id="wi"]');
+    expect(hidden?.getAttribute("data-active")).toBe("false");
+    expect(hidden?.closest("div[style]")?.getAttribute("style")).toContain(
+      "display: none"
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(PROJECT_TRIO_KEEP_ALIVE.graceMs);
+    });
+    expect(mountedIds()).toEqual(["lp"]);
+  });
+
+  it("never keeps more than maxWarm trio tabs mounted", () => {
+    render(0);
+    render(1);
+    render(2);
+    expect(mountedIds()).toEqual(["lp", "lw"]);
+    expect(mountedIds().length).toBe(PROJECT_TRIO_KEEP_ALIVE.maxWarm);
+  });
+});

--- a/src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerContentRouter.tsx
+++ b/src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerContentRouter.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, useMemo } from "react";
 
 import { Placeholder } from "@src/components/Placeholder";
+import { useKeepAliveWindow } from "@src/hooks/ui/useKeepAliveWindow";
 import { UnifiedTabContent } from "@src/modules/WorkStation/TabContent/UnifiedTabContent";
 import { NoTabsPlaceholder } from "@src/modules/WorkStation/shared";
 
@@ -27,16 +28,31 @@ export const STORY_MANAGER_SUSPENSE_LOADING_FALLBACK = (
  *
  * Two concerns stay in this host and are deliberately NOT routed through the
  * dispatcher:
- *   - The persistent "keep-alive trio" (project-workitems /
- *     project-linear-projects / project-linear-work-items) is still mounted for
- *     every open trio tab and hidden with `display:none` when inactive, so those
- *     surfaces retain their in-tab state across tab switches. Each pane still
- *     renders through `UnifiedTabContent`.
+ *   - The "keep-alive trio" (project-workitems / project-linear-projects /
+ *     project-linear-work-items) is mounted for the active trio tab plus a
+ *     bounded window of recently active ones (`PROJECT_TRIO_KEEP_ALIVE`),
+ *     hidden with `display:none` when inactive, so flipping between two lists
+ *     keeps their in-tab state and scroll position. Older trio tabs unmount:
+ *     each one is a full non-virtualized table, and every open one used to stay
+ *     resident for the life of the host. Each pane still renders through
+ *     `UnifiedTabContent`; the list data itself lives in atoms and survives.
  *   - `chat-session` and `git-commit-detail` keep bespoke inline branches: the
  *     project host needs `<ChatView secondary />` (the unified chat renderer
  *     uses `readOnly`, which is wrong here), and git-commit-detail is mounted
  *     directly from tab data.
  */
+/**
+ * Two warm trio tabs cover the "compare two lists" flip; a tab left for 60 s
+ * is rebuilt from its atoms on the next visit.
+ */
+export const PROJECT_TRIO_KEEP_ALIVE = { graceMs: 60_000, maxWarm: 2 } as const;
+
+const TRIO_TAB_TYPES = new Set([
+  "project-workitems",
+  "project-linear-projects",
+  "project-linear-work-items",
+]);
+
 export function ProjectManagerContentRouter({
   repoPath,
   tabs,
@@ -45,14 +61,19 @@ export function ProjectManagerContentRouter({
 }: ProjectManagerContentRouterProps) {
   const hasNoTabs = tabs.length === 0;
   const persistentWorkItemTabs = useMemo(
-    () =>
-      tabs.filter(
-        (tab) =>
-          tab.type === "project-workitems" ||
-          tab.type === "project-linear-projects" ||
-          tab.type === "project-linear-work-items"
-      ),
+    () => tabs.filter((tab) => TRIO_TAB_TYPES.has(tab.type)),
     [tabs]
+  );
+  const trioTabIds = useMemo(
+    () => persistentWorkItemTabs.map((tab) => tab.id),
+    [persistentWorkItemTabs]
+  );
+  const activeTrioTabId =
+    activeTab && TRIO_TAB_TYPES.has(activeTab.type) ? activeTab.id : null;
+  const mountedTrioTabIds = useKeepAliveWindow(
+    activeTrioTabId,
+    trioTabIds,
+    PROJECT_TRIO_KEEP_ALIVE
   );
 
   const activeContent = renderActiveContent({
@@ -76,6 +97,7 @@ export function ProjectManagerContentRouter({
       )}
 
       {persistentWorkItemTabs.map((tab) => {
+        if (!mountedTrioTabIds.has(tab.id)) return null;
         const isActiveTab = activeTab?.id === tab.id;
         return (
           <div


### PR DESCRIPTION
## Problem

`ProjectManagerContentRouter` mounts every open work-items / Linear-projects / Linear-work-items tab and hides the inactive ones with `display: none`. Those panes render through `components/Table`, which maps `table.getRowModel().rows` with no virtualization, so each hidden tab keeps a full table subtree resident for the life of the project host. Nested inside the host keep-alive (#1261), that meant a hidden project host could hold several hidden tables at once.

## Solution

The router keeps the active trio tab plus a bounded window of recently active ones (`PROJECT_TRIO_KEEP_ALIVE`: 60 s grace, 2 warm) through `useKeepAliveWindow`, and unmounts the rest. Flipping between two lists keeps their in-tab state and scroll position as before; a list left for a minute is rebuilt on the next visit. The list data itself lives in atoms (`WorkItemsTabContent` holds no local state; `LinearProjects` holds only a collapse-all counter), so a remount is a render, not a refetch.

Stacked on #1260 (`dev/chat-terminal-keep-alive-window`), which adds the shared hook.

## Potential risks

- A trio tab revisited after more than 60 s loses its scroll position and any transient local UI state (the Linear projects collapse-all signal); filters and selection live in atoms and survive.
- With three or more trio tabs open, only the two most recent stay mounted; the third and older ones remount on activation.
- Non-trio content (`chat-session`, `git-commit-detail`, dispatcher-routed tabs) is unchanged.

## Verification

- `pnpm exec vitest run src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerContentRouter.test.ts` (new, jsdom, mocks `UnifiedTabContent`): 2 tests — only the active tab mounts first, the previous one stays hidden for the grace window and unmounts after; the warm set never exceeds `maxWarm`.
- `pnpm exec tsgo --noEmit`: clean. oxlint + eslint on changed files: clean. `pnpm check:test-placement`: consistent.
- Not run: a manual session flipping between three Linear lists in the desktop app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
