### PR TITLE
perf(detail-panels): unmount hidden detail tabs after a grace window

### DIFF
--- a/src/modules/shared/layouts/blocks/PersistentDetailTabPanel.test.ts
+++ b/src/modules/shared/layouts/blocks/PersistentDetailTabPanel.test.ts
@@ -14,6 +14,7 @@ import {
 } from "vitest";
 
 import PersistentDetailTabPanel, {
+  DETAIL_TAB_PANEL_GRACE_MS,
   type PersistentDetailTabPanelProps,
 } from "./PersistentDetailTabPanel";
 
@@ -43,7 +44,7 @@ describe("PersistentDetailTabPanel", () => {
     Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
   });
 
-  it("mounts on first visit and stays mounted while hidden", () => {
+  it("mounts on first visit and stays mounted while hidden within the grace window", () => {
     const mounted = vi.fn();
     const unmounted = vi.fn();
 
@@ -100,6 +101,56 @@ describe("PersistentDetailTabPanel", () => {
       container.querySelector<HTMLElement>('[role="tabpanel"]')?.scrollTop
     ).toBe(72);
     expect(mounted).toHaveBeenCalledTimes(1);
+  });
+  it("unmounts a panel hidden for longer than the grace window and remounts it fresh", () => {
+    vi.useFakeTimers();
+    try {
+      const mounted = vi.fn();
+      const unmounted = vi.fn();
+      const StatefulContent = () => {
+        useEffect(() => {
+          mounted();
+          return () => {
+            unmounted();
+          };
+        }, []);
+        return createElement("input", { defaultValue: "preserved" });
+      };
+      const render = (active: boolean) =>
+        act(() => {
+          root.render(
+            createElement(
+              PersistentDetailTabPanel,
+              {
+                active,
+                id: "detail-tabpanel-changes",
+                ariaLabelledBy: "detail-tab-changes",
+              } as PersistentDetailTabPanelProps,
+              createElement(StatefulContent)
+            )
+          );
+        });
+      render(true);
+      container.querySelector<HTMLInputElement>("input")!.value = "edited";
+      render(false);
+      act(() => {
+        vi.advanceTimersByTime(DETAIL_TAB_PANEL_GRACE_MS - 1);
+      });
+      expect(container.querySelector("input")?.value).toBe("edited");
+      expect(unmounted).not.toHaveBeenCalled();
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(container.querySelector('[role="tabpanel"]')).toBeNull();
+      expect(unmounted).toHaveBeenCalledTimes(1);
+      render(true);
+      expect(container.querySelector<HTMLInputElement>("input")?.value).toBe(
+        "preserved"
+      );
+      expect(mounted).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/modules/shared/layouts/blocks/PersistentDetailTabPanel.tsx
+++ b/src/modules/shared/layouts/blocks/PersistentDetailTabPanel.tsx
@@ -1,6 +1,14 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useMemo } from "react";
 
-import { useStickyMount } from "@src/modules/shared/hooks/useStickyMount";
+import { useKeepAliveWindow } from "@src/hooks/ui/useKeepAliveWindow";
+
+/**
+ * How long a detail tab stays mounted-but-hidden after the user switches
+ * away. A PR's Changes tab can hold dozens of CodeMirror diff views; keeping
+ * it warm for a minute makes "glance at Checks, come back" instant while a
+ * tab abandoned for the rest of the visit stops holding its subtree.
+ */
+export const DETAIL_TAB_PANEL_GRACE_MS = 60_000;
 
 export interface PersistentDetailTabPanelProps {
   active: boolean;
@@ -13,7 +21,9 @@ export interface PersistentDetailTabPanelProps {
 
 /**
  * Lazily mounts detail-tab content on first visit, then hides it instead of
- * unmounting it so local state and native scroll positions survive tab changes.
+ * unmounting it for `DETAIL_TAB_PANEL_GRACE_MS`, so local state and native
+ * scroll positions survive quick tab changes. A panel hidden for longer than
+ * the grace window unmounts and is rebuilt on its next visit.
  */
 export default function PersistentDetailTabPanel({
   active,
@@ -23,8 +33,11 @@ export default function PersistentDetailTabPanel({
   id,
   testId,
 }: PersistentDetailTabPanelProps) {
-  const shouldRender = useStickyMount(active);
-  if (!shouldRender) return null;
+  const panelKeys = useMemo(() => [id], [id]);
+  const warmPanels = useKeepAliveWindow(active ? id : null, panelKeys, {
+    graceMs: DETAIL_TAB_PANEL_GRACE_MS,
+  });
+  if (!warmPanels.has(id)) return null;
 
   return (
     <div


### PR DESCRIPTION
## Problem

`PersistentDetailTabPanel` mounts a detail tab on first visit and then keeps it mounted forever, hidden with `display: none`. It backs the PR detail (Changes, Commits, Checks), Issue detail, Work Item detail and Project panels. A PR's Changes tab holds one CodeMirror diff view per changed file, so after one glance at Changes those editors stay resident while the user reads Checks or Commits for the rest of the visit.

## Solution

The panel keeps its "mount on first visit, hide on switch" behaviour but bounds the hidden lifetime: a panel hidden for longer than `DETAIL_TAB_PANEL_GRACE_MS` (60 s) unmounts, and is rebuilt on its next activation. Implemented with `useKeepAliveWindow` from #1260 keyed by the panel id. Quick tab flips keep local state and native scroll position exactly as before; only a tab abandoned for a minute is released. `useStickyMount` stays exported from `modules/shared/hooks` but has no remaining consumer here.

Stacked on #1260 (`dev/chat-terminal-keep-alive-window`), which adds the shared hook.

## Potential risks

- A detail tab revisited after more than 60 s remounts: scroll position and unsaved local UI state in that tab (expanded diff files, an in-progress inline comment draft if it is held in component state) are lost. Data-level state lives in atoms and survives.
- All five consumers change behaviour together; none of their tests asserted persistence beyond a synchronous hide/show.

## Verification

- `pnpm exec vitest run` on the 10 test files that reference the panel or its consumers (`PersistentDetailTabPanel`, `PrDetailPanel`, `IssueDetailPanel`, `WorkItemDetailBody`, `WorkItemPanelView`, `ProjectPanelView`): 64 tests passed, including the new case that a hidden panel keeps its edited input until the grace boundary, unmounts exactly once after it, and remounts fresh.
- `pnpm exec tsgo --noEmit`: clean. oxlint + eslint on changed files: clean. `pnpm check:test-placement`: consistent.
- Not run: a manual PR-detail session in the desktop app across the 60 s boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
