### PR TITLE
fix(app-window): mirror macos root tint natively for live resize

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -482,6 +482,18 @@
       html[data-host-desktop="macos"][data-orgii-secondary-window] #root {
         background: transparent;
       }
+      /*
+       * The bundle mirrors the macOS root tint (the translucent html/body/#root
+       * surfaces in src/index.scss) into a native layer under the webview
+       * (src/util/platform/macosRootTint.ts) and then sets this attribute so
+       * the CSS tint stops stacking on top of it. Kept here as well as in
+       * src/index.scss because this stylesheet stays attached after boot.
+       */
+      html[data-host-desktop="macos"][data-native-root-tint],
+      html[data-host-desktop="macos"][data-native-root-tint] body,
+      html[data-host-desktop="macos"][data-native-root-tint] #root {
+        background: transparent;
+      }
       /* Remove border radius in fullscreen mode */
       html.fullscreen,
       html.fullscreen body,

--- a/src-tauri/crates/app-window/src/commands.rs
+++ b/src-tauri/crates/app-window/src/commands.rs
@@ -246,6 +246,38 @@ pub async fn remove_window_background(window: tauri::WebviewWindow) -> Result<()
     Ok(())
 }
 
+/// Paint the CALLING window's root tint as a native layer under the webview.
+///
+/// macOS only; a no-op elsewhere. The frontend passes the composite of its
+/// translucent root surfaces (`html`, `body`, `#root`) as sRGB `[r, g, b, a]`
+/// in `0.0..=1.0` after first paint and again on every theme or skin change,
+/// then flips `<html data-native-root-tint>` so its own CSS tint goes
+/// transparent. During a live resize the strip of window the page has not yet
+/// painted then shows this tint over the vibrancy material — the same surface
+/// the page itself settles on — instead of raw material. `None` removes the
+/// layer and the frontend restores its CSS tint.
+#[tauri::command]
+pub async fn set_window_root_tint(
+    window: tauri::WebviewWindow,
+    color: Option<[f64; 4]>,
+) -> Result<(), String> {
+    let color = match color {
+        Some(color) => Some(
+            super::root_tint::normalize_root_tint(color)
+                .ok_or_else(|| format!("Root tint has a non-finite component: {color:?}"))?,
+        ),
+        None => None,
+    };
+
+    #[cfg(target_os = "macos")]
+    super::set_macos_window_root_tint(&window, color);
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = (window, color);
+
+    Ok(())
+}
+
 // ============================================
 // Detached session windows
 // ============================================

--- a/src-tauri/crates/app-window/src/lib.rs
+++ b/src-tauri/crates/app-window/src/lib.rs
@@ -21,6 +21,7 @@ mod macos_material;
 #[cfg(windows)]
 mod windows_corner;
 
+pub mod root_tint;
 pub mod startup_backdrop;
 
 // ============================================
@@ -300,6 +301,15 @@ pub fn apply_host_desktop_decorated_window_corners(
 pub fn apply_macos_window_material(window: &tauri::WebviewWindow) {
     if let Err(error) = macos_material::set_enabled(window, true) {
         tracing::warn!(%error, "Failed to apply macOS menu vibrancy");
+    }
+}
+
+/// Paint the app's root tint natively under the webview (see
+/// `macos_material::set_root_tint`). `None` removes it.
+#[cfg(target_os = "macos")]
+pub fn set_macos_window_root_tint(window: &tauri::WebviewWindow, color: Option<[f64; 4]>) {
+    if let Err(error) = macos_material::set_root_tint(window, color) {
+        tracing::warn!(%error, "Failed to apply macOS root tint");
     }
 }
 

--- a/src-tauri/crates/app-window/src/macos_material.rs
+++ b/src-tauri/crates/app-window/src/macos_material.rs
@@ -5,17 +5,34 @@
 //! Do not use NSGlassEffectView or the undocumented NSVisualEffectView
 //! `setCornerRadius:` selector: AppKit clips the decorated window itself.
 
+use objc2::msg_send;
+use objc2::runtime::{AnyClass, AnyObject};
 use objc2_app_kit::{
     NSAutoresizingMaskOptions, NSUserInterfaceItemIdentification, NSView,
     NSVisualEffectBlendingMode, NSVisualEffectMaterial, NSVisualEffectState, NSVisualEffectView,
     NSWindow, NSWindowOrderingMode,
 };
-use objc2_foundation::{ns_string, MainThreadMarker};
+use objc2_foundation::{MainThreadMarker, NSString};
+
+const MATERIAL_IDENTIFIER: &str = "org2.window.menu-vibrancy";
+const ROOT_TINT_IDENTIFIER: &str = "org2.window.root-tint";
 
 /// Complete the native mutation before returning, including when called by an
 /// async Tauri command. Looking up the NSWindow inside the main-thread closure
 /// avoids carrying an unretained native pointer across a dispatch boundary.
 pub(super) fn set_enabled(window: &tauri::WebviewWindow, enabled: bool) -> Result<(), String> {
+    with_content_view(window, move |content_view, mtm| {
+        set_on_content_view(content_view, enabled, mtm)
+    })
+}
+
+/// Run `mutate` against the window's content view on the AppKit main thread,
+/// synchronously, whether or not the caller is already there.
+fn with_content_view(
+    window: &tauri::WebviewWindow,
+    mutate: impl FnOnce(&NSView, MainThreadMarker) + Send,
+) -> Result<(), String> {
+    let mut mutate = Some(mutate);
     let mut result = Ok(());
     let mut run = || {
         result = (|| {
@@ -30,7 +47,9 @@ pub(super) fn set_enabled(window: &tauri::WebviewWindow, enabled: bool) -> Resul
             let content_view = native_window
                 .contentView()
                 .ok_or("Native window has no content view")?;
-            set_on_content_view(&content_view, enabled, mtm);
+            if let Some(mutate) = mutate.take() {
+                mutate(&content_view, mtm);
+            }
             Ok(())
         })();
     };
@@ -43,11 +62,115 @@ pub(super) fn set_enabled(window: &tauri::WebviewWindow, enabled: bool) -> Resul
     result
 }
 
+fn find_subview(
+    content_view: &NSView,
+    identifier: &NSString,
+) -> Option<objc2::rc::Retained<NSView>> {
+    content_view
+        .subviews()
+        .iter()
+        .find(|view| view.identifier().as_deref() == Some(identifier))
+}
+
+/// Paint (or remove) the app's root tint as a native layer directly under the
+/// webview and above the vibrancy material.
+///
+/// The page's root surfaces on macOS are translucent tints over the material
+/// (`html[data-host-desktop="macos"]` in `src/index.scss`). When the window
+/// grows, AppKit resizes the window and the WKWebView's view synchronously,
+/// but the page pixels arrive from the WebContent process one or more frames
+/// later; the newly exposed strip shows whatever sits behind the webview.
+/// With the tint living in CSS that strip was raw material, visibly lighter
+/// than the page. Hosting the same composite tint natively makes the strip
+/// match the page, and the frontend then drops its CSS tint
+/// (`data-native-root-tint`) so the two never stack.
+///
+/// `color` is sRGB `[r, g, b, a]` in `0.0..=1.0`. `None` removes the layer.
+pub(super) fn set_root_tint(
+    window: &tauri::WebviewWindow,
+    color: Option<[f64; 4]>,
+) -> Result<(), String> {
+    with_content_view(window, move |content_view, mtm| {
+        set_root_tint_on_content_view(content_view, color, mtm)
+    })
+}
+
+fn set_root_tint_on_content_view(
+    content_view: &NSView,
+    color: Option<[f64; 4]>,
+    mtm: MainThreadMarker,
+) {
+    let identifier = NSString::from_str(ROOT_TINT_IDENTIFIER);
+    let existing = find_subview(content_view, &identifier);
+    let Some([r, g, b, a]) = color else {
+        if let Some(view) = existing {
+            view.removeFromSuperview();
+        }
+        return;
+    };
+
+    let tint = match existing {
+        Some(view) => view,
+        None => {
+            let view = NSView::initWithFrame(mtm.alloc(), content_view.bounds());
+            view.setIdentifier(Some(&identifier));
+            view.setAutoresizingMask(
+                NSAutoresizingMaskOptions::ViewWidthSizable
+                    | NSAutoresizingMaskOptions::ViewHeightSizable,
+            );
+            // Own an explicit layer rather than relying on `wantsLayer` to
+            // create one lazily: the colour below is set immediately, and a
+            // nil layer would leave an invisible view and no fix.
+            // SAFETY: plain class-method sends on the main thread.
+            unsafe {
+                let layer_class = AnyClass::get(c"CALayer").expect("CALayer");
+                let layer: *mut AnyObject = msg_send![layer_class, layer];
+                let _: () = msg_send![&*view, setLayer: layer];
+            }
+            view.setWantsLayer(true);
+            // Above the material when it is mounted, otherwise at the very
+            // bottom: `set_on_content_view` always inserts the material at the
+            // bottom, so the tint stays above it across vibrancy toggles.
+            match find_subview(content_view, &NSString::from_str(MATERIAL_IDENTIFIER)) {
+                Some(material) => content_view.addSubview_positioned_relativeTo(
+                    &view,
+                    NSWindowOrderingMode::Above,
+                    Some(&material),
+                ),
+                None => content_view.addSubview_positioned_relativeTo(
+                    &view,
+                    NSWindowOrderingMode::Below,
+                    None,
+                ),
+            }
+            view
+        }
+    };
+
+    // SAFETY: plain AppKit / CoreAnimation message sends on the main thread
+    // against objects this function owns or just created.
+    unsafe {
+        let ns_color_class = AnyClass::get(c"NSColor").expect("NSColor");
+        let ns_color: *mut AnyObject = msg_send![
+            ns_color_class,
+            colorWithSRGBRed: r,
+            green: g,
+            blue: b,
+            alpha: a,
+        ];
+        let cg_color: *mut AnyObject = msg_send![ns_color, CGColor];
+        let layer: *mut AnyObject = msg_send![&*tint, layer];
+        if !layer.is_null() {
+            let _: () = msg_send![layer, setBackgroundColor: cg_color];
+        }
+    }
+}
+
 fn set_on_content_view(content_view: &NSView, enabled: bool, mtm: MainThreadMarker) {
-    let identifier = ns_string!("org2.window.menu-vibrancy");
+    let identifier = NSString::from_str(MATERIAL_IDENTIFIER);
     let subviews = content_view.subviews();
     for view in subviews.iter() {
-        if view.identifier().as_deref() == Some(identifier) {
+        if view.identifier().as_deref() == Some(&*identifier) {
             if !enabled {
                 view.removeFromSuperview();
             }
@@ -59,7 +182,7 @@ fn set_on_content_view(content_view: &NSView, enabled: bool, mtm: MainThreadMark
     }
 
     let material = NSVisualEffectView::initWithFrame(mtm.alloc(), content_view.bounds());
-    material.setIdentifier(Some(identifier));
+    material.setIdentifier(Some(&identifier));
     material.setMaterial(NSVisualEffectMaterial::Menu);
     material.setBlendingMode(NSVisualEffectBlendingMode::BehindWindow);
     material.setState(NSVisualEffectState::FollowsWindowActiveState);

--- a/src-tauri/crates/app-window/src/root_tint.rs
+++ b/src-tauri/crates/app-window/src/root_tint.rs
@@ -1,0 +1,43 @@
+//! Validation for the native root tint the frontend pushes on macOS.
+//!
+//! Platform-neutral so the contract is unit-tested everywhere, even though
+//! only `macos_material::set_root_tint` consumes the result.
+
+/// Normalise an sRGB `[r, g, b, a]` tint from the wire.
+///
+/// Components are expected in `0.0..=1.0`; anything finite is clamped there,
+/// while a non-finite component rejects the whole colour so a NaN from a
+/// failed CSS parse can never reach CoreAnimation.
+pub fn normalize_root_tint(color: [f64; 4]) -> Option<[f64; 4]> {
+    if color.iter().any(|component| !component.is_finite()) {
+        return None;
+    }
+    Some(color.map(|component| component.clamp(0.0, 1.0)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_root_tint;
+
+    #[test]
+    fn keeps_in_range_components() {
+        assert_eq!(
+            normalize_root_tint([0.05, 0.5, 1.0, 0.386]),
+            Some([0.05, 0.5, 1.0, 0.386])
+        );
+    }
+
+    #[test]
+    fn clamps_out_of_range_components() {
+        assert_eq!(
+            normalize_root_tint([-0.2, 1.7, 0.3, 2.0]),
+            Some([0.0, 1.0, 0.3, 1.0])
+        );
+    }
+
+    #[test]
+    fn rejects_non_finite_components() {
+        assert_eq!(normalize_root_tint([f64::NAN, 0.0, 0.0, 1.0]), None);
+        assert_eq!(normalize_root_tint([0.0, f64::INFINITY, 0.0, 1.0]), None);
+    }
+}

--- a/src-tauri/src/commands/handler_list.inc
+++ b/src-tauri/src/commands/handler_list.inc
@@ -16,6 +16,7 @@ app_window::commands::set_window_vibrancy,
 app_window::commands::set_main_webview_zoom,
 app_window::commands::set_webview_zoom,
 app_window::commands::remove_window_background,
+app_window::commands::set_window_root_tint,
 app_window::commands::main_window_chrome_is_acrylic,
 app_window::commands::open_session_window,
 // Optional sidecar commands - lazy install after first paint

--- a/src/index.scss
+++ b/src/index.scss
@@ -603,6 +603,19 @@ html[data-host-desktop="macos"] #root {
   background: color-mix(in srgb, var(--color-bg-2) 15%, transparent);
 }
 
+// Once the frontend has mirrored the composite of the three tints above into
+// a native layer under the webview (`set_window_root_tint`, see
+// src/util/platform/macosRootTint.ts), the CSS tints go transparent so the
+// two never stack. The page — sidebar included — composites onto exactly the
+// surface it did before; the strip a live resize exposes now shows that same
+// surface instead of raw material. Must outrank the identical rules in
+// public/index.html, hence the doubled attribute selector.
+html[data-host-desktop="macos"][data-native-root-tint],
+html[data-host-desktop="macos"][data-native-root-tint] body,
+html[data-host-desktop="macos"][data-native-root-tint] #root {
+  background: transparent;
+}
+
 html[data-host-desktop="macos"] .sidebar-base {
   background: transparent;
 }

--- a/src/util/core/init/deferredInit.ts
+++ b/src/util/core/init/deferredInit.ts
@@ -10,6 +10,7 @@
  * - Use `deferAfterPaint()` for one-time deferred operations
  */
 import { createLogger } from "@src/hooks/logger";
+import { syncMacosRootTint } from "@src/util/platform/macosRootTint";
 
 const log = createLogger("DeferredInit");
 
@@ -43,7 +44,10 @@ export function signalFirstPaintComplete(): void {
     .then(({ invoke }) => invoke("remove_window_background"))
     .catch(() => {
       // Non-Tauri env or unimportant failure — ignore.
-    });
+    })
+    // macOS: move the CSS root tint into a native layer under the webview so
+    // the strip exposed by a live resize matches the page.
+    .then(() => syncMacosRootTint());
 
   // Resolve the promise
   if (firstPaintResolver) {

--- a/src/util/platform/macosRootTint.test.ts
+++ b/src/util/platform/macosRootTint.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+/**
+ * The macOS root tint mirrored into a native layer must equal what the CSS
+ * stack painted, or the sidebar and every other transparent surface would
+ * visibly change when the attribute flips. These tests pin the colour math
+ * and the attribute contract; the native layer itself is exercised by hand.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  NATIVE_ROOT_TINT_ATTRIBUTE,
+  compositeSrcOver,
+  measureCssRootTint,
+  parseCssColor,
+  syncMacosRootTint,
+} from "./macosRootTint";
+
+const { invoke, isMacOS } = vi.hoisted(() => ({
+  invoke: vi.fn<(command: string, args?: unknown) => Promise<unknown>>(),
+  isMacOS: vi.fn(() => true),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("@src/util/platform/tauri", () => ({ isMacOS }));
+
+describe("parseCssColor", () => {
+  it("reads the legacy comma serialisation", () => {
+    expect(parseCssColor("rgba(13, 13, 13, 0.15)")).toEqual({
+      r: 13 / 255,
+      g: 13 / 255,
+      b: 13 / 255,
+      a: 0.15,
+    });
+    expect(parseCssColor("rgb(255, 0, 128)")).toEqual({
+      r: 1,
+      g: 0,
+      b: 128 / 255,
+      a: 1,
+    });
+  });
+
+  it("reads the modern space serialisations WebKit emits for color-mix", () => {
+    expect(parseCssColor("rgb(13 13 13 / 0.15)")).toEqual({
+      r: 13 / 255,
+      g: 13 / 255,
+      b: 13 / 255,
+      a: 0.15,
+    });
+    expect(parseCssColor("color(srgb 0.05 0.05 0.05 / 0.15)")).toEqual({
+      r: 0.05,
+      g: 0.05,
+      b: 0.05,
+      a: 0.15,
+    });
+    expect(parseCssColor("color(srgb 1 0 0)")).toEqual({
+      r: 1,
+      g: 0,
+      b: 0,
+      a: 1,
+    });
+  });
+
+  it("treats transparent as a zero-alpha layer", () => {
+    expect(parseCssColor("transparent")).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    expect(parseCssColor("rgba(0, 0, 0, 0)")?.a).toBe(0);
+  });
+
+  it("rejects colour spaces it cannot composite in", () => {
+    expect(parseCssColor("color(display-p3 1 0 0)")).toBeNull();
+    expect(parseCssColor("lab(50% 0 0)")).toBeNull();
+    expect(parseCssColor("url(x.png)")).toBeNull();
+  });
+});
+
+describe("compositeSrcOver", () => {
+  it("collapses three equal 15% tints into one 38.6% tint of the same colour", () => {
+    const tint = { r: 13 / 255, g: 13 / 255, b: 13 / 255, a: 0.15 };
+    const result = compositeSrcOver([tint, tint, tint]);
+    expect(result.a).toBeCloseTo(1 - 0.85 ** 3, 10);
+    expect(result.r).toBeCloseTo(tint.r, 10);
+    expect(result.g).toBeCloseTo(tint.g, 10);
+    expect(result.b).toBeCloseTo(tint.b, 10);
+  });
+
+  it("weights an upper layer by its own alpha over the lower composite", () => {
+    const below = { r: 0, g: 0, b: 0, a: 0.5 };
+    const above = { r: 1, g: 1, b: 1, a: 0.5 };
+    const result = compositeSrcOver([below, above]);
+    expect(result.a).toBeCloseTo(0.75, 10);
+    // 0.5 of white over 0.25 of black, normalised by 0.75.
+    expect(result.r).toBeCloseTo(0.5 / 0.75, 10);
+  });
+
+  it("is transparent when every layer is", () => {
+    expect(compositeSrcOver([{ r: 1, g: 1, b: 1, a: 0 }])).toEqual({
+      r: 0,
+      g: 0,
+      b: 0,
+      a: 0,
+    });
+  });
+});
+
+describe("syncMacosRootTint", () => {
+  const html = document.documentElement;
+
+  beforeEach(() => {
+    invoke.mockReset();
+    invoke.mockResolvedValue(undefined);
+    isMacOS.mockReturnValue(true);
+    delete html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE];
+    html.style.backgroundColor = "rgba(13, 13, 13, 0.15)";
+    document.body.style.backgroundColor = "rgba(13, 13, 13, 0.15)";
+    document.body.innerHTML = '<div id="root"></div>';
+    document.getElementById("root")!.style.backgroundColor =
+      "rgba(13, 13, 13, 0.15)";
+  });
+
+  afterEach(() => {
+    delete html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE];
+    html.style.backgroundColor = "";
+    document.body.style.backgroundColor = "";
+    document.body.innerHTML = "";
+  });
+
+  it("pushes the composite of html, body and #root, then flips the attribute", async () => {
+    await syncMacosRootTint();
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    const [command, args] = invoke.mock.calls[0];
+    expect(command).toBe("set_window_root_tint");
+    const color = (args as { color: number[] }).color;
+    expect(color[0]).toBeCloseTo(13 / 255, 10);
+    expect(color[3]).toBeCloseTo(1 - 0.85 ** 3, 10);
+    expect(html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE]).toBe("1");
+  });
+
+  it("measures the stylesheet, not the transparent override, on a re-sync", () => {
+    html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE] = "1";
+    // jsdom does not apply the attribute rule from index.scss, so stand in
+    // for it: the read must lift the attribute while measuring and restore it.
+    const observed: Array<string | undefined> = [];
+    const original = window.getComputedStyle;
+    vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+      observed.push(html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE]);
+      return original(element);
+    });
+
+    const tint = measureCssRootTint();
+
+    expect(observed).toEqual([undefined, undefined, undefined]);
+    expect(html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE]).toBe("1");
+    expect(tint?.a).toBeCloseTo(1 - 0.85 ** 3, 10);
+    vi.restoreAllMocks();
+  });
+
+  it("removes the native layer and restores the CSS tint when the root is not a plain colour", async () => {
+    html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE] = "1";
+    document.body.style.backgroundImage = "url(wallpaper.png)";
+
+    await syncMacosRootTint();
+
+    expect(invoke).toHaveBeenCalledWith("set_window_root_tint", {
+      color: null,
+    });
+    expect(html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE]).toBeUndefined();
+    document.body.style.backgroundImage = "";
+  });
+
+  it("keeps the CSS tint when the native call fails", async () => {
+    invoke.mockRejectedValue(new Error("window closed"));
+
+    await expect(syncMacosRootTint()).resolves.toBeUndefined();
+
+    expect(html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE]).toBeUndefined();
+  });
+
+  it("coalesces a call made while a push is in flight into one follow-up", async () => {
+    let release: () => void = () => {};
+    invoke.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+
+    const first = syncMacosRootTint();
+    const second = syncMacosRootTint();
+    const third = syncMacosRootTint();
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    // The first invoke only happens after the dynamic import resolves.
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
+    release();
+    await first;
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("is a no-op off macOS", async () => {
+    isMacOS.mockReturnValue(false);
+
+    await syncMacosRootTint();
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE]).toBeUndefined();
+  });
+});

--- a/src/util/platform/macosRootTint.ts
+++ b/src/util/platform/macosRootTint.ts
@@ -1,0 +1,215 @@
+/**
+ * Mirror the app's translucent root surface into a native layer on macOS.
+ *
+ * On macOS the window is transparent and Rust mounts vibrancy material behind
+ * the webview; `html[data-host-desktop="macos"]` in `src/index.scss` then
+ * paints `html`, `body` and `#root` as translucent tints of `--color-bg-2`
+ * over that material. Those three tints stack, and every "transparent"
+ * surface in the app (the navigation sidebar, empty panes) actually sits on
+ * their composite.
+ *
+ * When the window grows, AppKit resizes the window and the webview's view in
+ * the same frame, but the page's pixels are produced by WebKit's WebContent
+ * process and land one or more frames later. The strip the page has not yet
+ * painted shows whatever is behind the webview: with the tint in CSS, raw
+ * material — a visibly lighter band at the trailing edge of the drag.
+ *
+ * `syncMacosRootTint` composites the three CSS tints, hands the result to
+ * `set_window_root_tint` (a native layer between the material and the
+ * webview), and then flips `<html data-native-root-tint>` so the CSS tints
+ * go transparent. The page composites onto exactly the surface it painted
+ * before, the sidebar included, and the resize strip now shows that same
+ * surface instead of bare material.
+ *
+ * Only the sRGB colour math lives here; nothing about it is Tauri-specific.
+ */
+import { isMacOS } from "@src/util/platform/tauri";
+
+export const NATIVE_ROOT_TINT_ATTRIBUTE = "nativeRootTint";
+
+/** Straight-alpha sRGB colour with components in `0..=1`. */
+export interface Rgba {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+const TRANSPARENT: Rgba = { r: 0, g: 0, b: 0, a: 0 };
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function parseChannel(token: string, scale: number): number | null {
+  const trimmed = token.trim();
+  if (trimmed === "none") return 0;
+  if (trimmed.endsWith("%")) {
+    const percent = Number.parseFloat(trimmed.slice(0, -1));
+    return Number.isFinite(percent) ? clamp01(percent / 100) : null;
+  }
+  const value = Number.parseFloat(trimmed);
+  return Number.isFinite(value) ? clamp01(value / scale) : null;
+}
+
+function parseAlpha(token: string | undefined): number | null {
+  if (token === undefined) return 1;
+  return parseChannel(token, 1);
+}
+
+/**
+ * Parse the serialisations WebKit uses for a computed `background-color`:
+ * `rgb()` / `rgba()` with commas or spaces, `color(srgb r g b / a)`, and the
+ * `transparent` keyword. Anything else (an image, `currentcolor`, a colour
+ * space we cannot composite in) returns `null`.
+ */
+export function parseCssColor(value: string): Rgba | null {
+  const text = value.trim().toLowerCase();
+  if (text === "transparent") return TRANSPARENT;
+
+  const match = /^(rgba?|color)\((.*)\)$/.exec(text);
+  if (!match) return null;
+  const [, fn, body] = match;
+
+  let channels: string[];
+  let alphaToken: string | undefined;
+  if (fn === "color") {
+    const [space, ...rest] = body.trim().split(/\s+/);
+    if (space !== "srgb") return null;
+    const slash = rest.indexOf("/");
+    if (slash >= 0) {
+      channels = rest.slice(0, slash);
+      alphaToken = rest[slash + 1];
+    } else {
+      channels = rest;
+    }
+    if (channels.length !== 3) return null;
+    const [r, g, b] = channels.map((token) => parseChannel(token, 1));
+    const a = parseAlpha(alphaToken);
+    if (r === null || g === null || b === null || a === null) return null;
+    return { r, g, b, a };
+  }
+
+  if (body.includes(",")) {
+    const parts = body.split(",").map((part) => part.trim());
+    if (parts.length !== 3 && parts.length !== 4) return null;
+    channels = parts.slice(0, 3);
+    alphaToken = parts[3];
+  } else {
+    const [lhs, rhs] = body.split("/");
+    channels = lhs.trim().split(/\s+/);
+    alphaToken = rhs?.trim();
+    if (channels.length !== 3) return null;
+  }
+  const [r, g, b] = channels.map((token) => parseChannel(token, 255));
+  const a = parseAlpha(alphaToken);
+  if (r === null || g === null || b === null || a === null) return null;
+  return { r, g, b, a };
+}
+
+/**
+ * Source-over composite of `layers`, bottom first. The result is the single
+ * straight-alpha colour that paints the same as the stack.
+ */
+export function compositeSrcOver(layers: readonly Rgba[]): Rgba {
+  return layers.reduce<Rgba>((below, above) => {
+    const a = above.a + below.a * (1 - above.a);
+    if (a === 0) return TRANSPARENT;
+    const blend = (top: number, bottom: number): number =>
+      (top * above.a + bottom * below.a * (1 - above.a)) / a;
+    return {
+      r: blend(above.r, below.r),
+      g: blend(above.g, below.g),
+      b: blend(above.b, below.b),
+      a,
+    };
+  }, TRANSPARENT);
+}
+
+/**
+ * The root surfaces the page paints on macOS, bottom first. `#root` is
+ * optional so the pre-mount splash can still be measured.
+ */
+function rootSurfaces(): HTMLElement[] {
+  const surfaces: HTMLElement[] = [document.documentElement];
+  if (document.body) surfaces.push(document.body);
+  const root = document.getElementById("root");
+  if (root) surfaces.push(root);
+  return surfaces;
+}
+
+/**
+ * Read the composite of the CSS root tints as they would paint *without* the
+ * native layer. The attribute that zeroes the CSS tints is lifted for the
+ * duration of the read so a second sync (theme swap, skin change) measures
+ * the stylesheet, not the transparent override.
+ */
+export function measureCssRootTint(): Rgba | null {
+  const html = document.documentElement;
+  const previous = html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE];
+  if (previous !== undefined) delete html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE];
+  try {
+    const layers: Rgba[] = [];
+    for (const surface of rootSurfaces()) {
+      const style = getComputedStyle(surface);
+      if (style.backgroundImage && style.backgroundImage !== "none") {
+        return null;
+      }
+      const color = parseCssColor(style.backgroundColor);
+      if (!color) return null;
+      layers.push(color);
+    }
+    return compositeSrcOver(layers);
+  } finally {
+    if (previous !== undefined)
+      html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE] = previous;
+  }
+}
+
+let pending: Promise<void> | null = null;
+let rerunRequested = false;
+
+async function pushRootTint(): Promise<void> {
+  const html = document.documentElement;
+  const tint = measureCssRootTint();
+  const { invoke } = await import("@tauri-apps/api/core");
+  await invoke("set_window_root_tint", {
+    color: tint ? [tint.r, tint.g, tint.b, tint.a] : null,
+  });
+  if (tint) {
+    html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE] = "1";
+  } else {
+    delete html.dataset[NATIVE_ROOT_TINT_ATTRIBUTE];
+  }
+}
+
+/**
+ * Push the current CSS root tint to the native layer for this window.
+ *
+ * Idempotent and coalescing: a call that arrives while a push is in flight
+ * schedules exactly one follow-up so the native layer always ends on the
+ * latest stylesheet. Never throws — a browser preview or a window mid-close
+ * simply keeps its CSS tint.
+ */
+export function syncMacosRootTint(): Promise<void> {
+  if (typeof document === "undefined" || !isMacOS()) {
+    return Promise.resolve();
+  }
+  if (pending) {
+    rerunRequested = true;
+    return pending;
+  }
+  pending = (async () => {
+    try {
+      do {
+        rerunRequested = false;
+        await pushRootTint();
+      } while (rerunRequested);
+    } catch {
+      // Non-Tauri environment or the window is gone; the CSS tint stays.
+    } finally {
+      pending = null;
+    }
+  })();
+  return pending;
+}

--- a/src/util/ui/theme/applySkinTokens.ts
+++ b/src/util/ui/theme/applySkinTokens.ts
@@ -22,6 +22,7 @@ import { resolveAppliedSkinTokens } from "@src/config/appearance/skins/appliedTo
 import { SKIN_TOKEN_KEYS } from "@src/config/appearance/skins/deriveSkinTokens";
 import { resolveSkinId } from "@src/config/appearance/skins/registry";
 import type { SkinVariant } from "@src/config/appearance/skins/types";
+import { syncMacosRootTint } from "@src/util/platform/macosRootTint";
 
 /**
  * Mirror of the user's skin and accent selection, kept in `localStorage` so
@@ -74,6 +75,9 @@ export function writeSkinTokens(tokens: Record<string, string>): void {
     if (value === undefined) body.style.removeProperty(key);
     else body.style.setProperty(key, value);
   }
+  // `--color-bg-2` on <body> feeds the macOS root tint; keep the native
+  // mirror current (no-op off macOS).
+  void syncMacosRootTint();
 }
 
 export function clearSkinTokens(): void {
@@ -82,6 +86,7 @@ export function clearSkinTokens(): void {
   for (const key of OWNED_SKIN_TOKEN_KEYS) {
     body.style.removeProperty(key);
   }
+  void syncMacosRootTint();
 }
 
 /**

--- a/src/util/ui/theme/swapThemeCss.ts
+++ b/src/util/ui/theme/swapThemeCss.ts
@@ -7,6 +7,7 @@
  * loading, creating a mixed light/dark state. This utility avoids that
  * by keeping the old CSS active until the new one is fully loaded.
  */
+import { syncMacosRootTint } from "@src/util/platform/macosRootTint";
 import { isWindows } from "@src/util/platform/tauri";
 
 import { applySkinTokensForVariant } from "./applySkinTokens";
@@ -52,6 +53,9 @@ export function syncThemeAppearance(cssPath: string): void {
   root.dataset.themeId = colorScheme;
   root.style.colorScheme = colorScheme;
   applySkinTokensForVariant(colorScheme);
+  // The base stylesheet changed `--color-bg-2`; re-measure the root tint the
+  // native macOS layer mirrors (no-op off macOS).
+  void syncMacosRootTint();
 
   if (!isWindows()) return;
 


### PR DESCRIPTION
## Problem

On macOS the window is transparent: Rust mounts an `NSVisualEffectView` behind the webview and `html[data-host-desktop="macos"]` in `src/index.scss` paints `html`, `body` and `#root` as 15% tints of `--color-bg-2` over that material. The three tints stack (about 38.6% effective), and every "transparent" surface in the app, the navigation sidebar included, actually sits on their composite.

When the window is enlarged, AppKit resizes the `NSWindow` and the `WKWebView`'s view synchronously on every live-resize tick, but the page pixels come from WebKit's WebContent process one or more frames later. The strip the page has not yet painted shows whatever is behind the webview, which is raw vibrancy material, visibly lighter than the page. It shows up most on right-edge drags and lasts longer whenever the page main thread is busy with layout.

The strip cannot be coloured through WebKit: `WebViewImpl::updateLayer` pins the `WKWebView` layer background to clear whenever `drawsBackground` is off, and `underPageBackgroundColor` does not participate. Anything painted under the whole page also stacks with the CSS tint, so simply adding a native colour would darken every transparent surface.

## Solution

- `macos_material::set_root_tint` mounts an autoresizing `NSView` with an explicit `CALayer` between the vibrancy material and the webview, keyed by identifier so repeated calls update in place, and removes it on `None`. It stays above the material across vibrancy toggles because the material is always inserted at the bottom.
- New `set_window_root_tint` command acts on the calling window, so the main window and detached session windows each own their layer. Components pass through `root_tint::normalize_root_tint`, which clamps to `0..=1` and rejects non-finite values.
- `src/util/platform/macosRootTint.ts` reads the computed `background-color` of `html`, `body` and `#root`, composites them source-over into one colour, pushes it to Rust, and then sets `<html data-native-root-tint>`. A re-sync lifts the attribute while measuring so it reads the stylesheet rather than the transparent override. Concurrent calls coalesce into one follow-up push, and any failure leaves the CSS tint in place.
- It runs after first paint (`signalFirstPaintComplete`), on every stylesheet swap (`syncThemeAppearance`), and whenever skin tokens are written or cleared, since `--color-bg-2` on `<body>` feeds the tint.
- With the attribute set, `src/index.scss` and `public/index.html` make the three root surfaces transparent. The page composites onto exactly the surface it painted before, sidebar included, and the resize strip now shows that same surface instead of bare material.

Invariant: on macOS the composite of the three CSS root tints and the native layer are never both painted at once; the frontend only flips the attribute after the native push resolves.

## Potential risks

- The exposed strip matches transparent regions (root tint over material). Next to an opaque pane it is still a lighter band, just no longer raw material. Fully hiding it would require freezing the page during resize or dropping vibrancy, which this PR deliberately does not do.
- The native layer and the attribute flip land in different frames, so a theme or skin change can paint one frame with both tints or neither. Theme swaps run under the transition cover; first paint happens once at boot.
- If WebKit ever serialises the computed root colour in a colour space other than sRGB, `parseCssColor` returns `null`, the layer is removed and the CSS tint is restored. Behaviour then degrades to today's, never to a wrong colour.
- Off macOS the command is a no-op and `syncMacosRootTint` returns early; Windows and Linux are untouched.
- New Tauri command (IPC surface): additive, guarded by `app-window-*` capability like the neighbouring `remove_window_background`. Rollback is removing the command and the three call sites; no persisted state.
- The branch was committed via plumbing from a shared checkout, so no pre-commit hook ran and there is no `Pre-commit hook ran.` trailer. Every check below was run manually on a detached worktree of this exact commit.

## Verification

Run on a detached worktree at `6158ab6` (origin/develop + this diff only):

- `cargo check -p app_window --tests`: clean.
- `cargo test -p app_window`: 9 passed (3 new `root_tint` tests).
- `vitest run src/util/platform/macosRootTint.test.ts src/util/ui/theme/__tests__/swapThemeCss.test.ts src/util/ui/theme/__tests__/applySkinTokens.test.ts`: 3 files, 24 tests passed (13 new).
- `pnpm typecheck:fast` (tsgo): 0 errors.
- `oxlint` + `eslint --max-warnings 0 --report-unused-disable-directives` on the five touched TS files: clean. `rustfmt --check` on the Rust files: clean.
- `npm run check:test-placement`: consistent.
- `cargo check --bin org2` (command registration in `handler_list.inc`): run on the live checkout, which carried this diff on top of unrelated local work, not on the worktree; the worktree only re-checked the `app_window` crate.
- Manual: ran the dev app on macOS, dragged the right edge outward; the exposed strip now shows the tinted surface and the sidebar looks unchanged before and after the attribute flips. No screenshots captured of a mid-drag frame.
- Not run: full vitest suite, clippy, Windows/Linux builds (the change is `cfg(target_os = "macos")` on the Rust side and early-returns on the frontend elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
