### PR TITLE
perf(composer): coalesce typed bursts into word-level undo steps

### DIFF
--- a/src/components/ComposerInput/__tests__/ComposerInput.undoTyping.test.ts
+++ b/src/components/ComposerInput/__tests__/ComposerInput.undoTyping.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import ComposerInput, { type ComposerInputRef } from "../index";
+import { placeCaretAtEnd } from "../selection";
+import { historyCoalesceKey } from "../useEditorOperations";
+
+vi.mock("@src/util/ui/theme/themeUtils", () => ({
+  useCurrentTheme: () => ({ isDark: false }),
+}));
+
+vi.mock("@src/store/skills/installedSkillsAtom", async () => {
+  const { atom } = await import("jotai");
+  return { installedSkillsAtom: atom([]) };
+});
+
+describe("historyCoalesceKey", () => {
+  it("groups word characters, whitespace, and deletions separately", () => {
+    expect(historyCoalesceKey("insertText", "a")).toBe("typing");
+    expect(historyCoalesceKey("insertText", " ")).toBe("typing:whitespace");
+    expect(historyCoalesceKey("insertText", "\n")).toBe("typing:whitespace");
+    expect(historyCoalesceKey("deleteContentBackward", null)).toBe(
+      "deleteContentBackward"
+    );
+    expect(historyCoalesceKey("deleteWordForward", null)).toBe(
+      "deleteWordForward"
+    );
+  });
+
+  it("leaves structural edits as their own undo steps", () => {
+    expect(historyCoalesceKey("insertFromPaste", "x")).toBeUndefined();
+    expect(historyCoalesceKey("insertParagraph", null)).toBeUndefined();
+    expect(historyCoalesceKey(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("ComposerInput undo granularity for typed text", () => {
+  let root: SmokeRoot;
+  let ref: ReturnType<typeof createRef<ComposerInputRef>>;
+  let host: HTMLDivElement;
+  let now = 0;
+
+  beforeEach(() => {
+    root = createSmokeRoot();
+    ref = createRef<ComposerInputRef>();
+    now = 10_000;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+    window.getSelection()?.removeAllRanges();
+    vi.restoreAllMocks();
+  });
+
+  async function mount(): Promise<void> {
+    await root.render(
+      createElement(ComposerInput, {
+        ref,
+        requireCmdEnter: true,
+        onContentChange: vi.fn(),
+        onSubmit: vi.fn(),
+      })
+    );
+    host = root.container.querySelector('[contenteditable="true"]')!;
+    placeCaretAtEnd(host);
+  }
+
+  function fire(type: string, init: Record<string, unknown> = {}): Event {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    for (const [key, value] of Object.entries(init)) {
+      Object.defineProperty(event, key, { value });
+    }
+    act(() => host.dispatchEvent(event));
+    return event;
+  }
+
+  /** Type one character the way a browser does, `gapMs` after the last. */
+  function typeChar(char: string, gapMs = 50): void {
+    now += gapMs;
+    fire("beforeinput", { inputType: "insertText", data: char });
+    const range = window.getSelection()!.getRangeAt(0);
+    range.insertNode(document.createTextNode(char));
+    placeCaretAtEnd(host);
+    fire("input", { inputType: "insertText", data: char });
+  }
+
+  function backspace(gapMs = 50): void {
+    now += gapMs;
+    fire("beforeinput", { inputType: "deleteContentBackward", data: null });
+    const last = host.lastChild;
+    if (last?.nodeType === Node.TEXT_NODE) {
+      const text = last.textContent ?? "";
+      if (text.length > 1) last.textContent = text.slice(0, -1);
+      else last.remove();
+    }
+    placeCaretAtEnd(host);
+    fire("input", { inputType: "deleteContentBackward", data: null });
+  }
+
+  function typeText(text: string): void {
+    for (const char of text) typeChar(char);
+  }
+
+  function undo(): KeyboardEvent {
+    const event = new KeyboardEvent("keydown", {
+      key: "z",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => host.dispatchEvent(event));
+    return event;
+  }
+
+  function redo(): void {
+    act(() =>
+      host.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "z",
+          metaKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        })
+      )
+    );
+  }
+
+  it("undoes a typed burst word by word instead of character by character", async () => {
+    await mount();
+    typeText("hello world");
+    expect(ref.current?.getText()).toBe("hello world");
+
+    undo();
+    expect(ref.current?.getText()).toBe("hello ");
+    undo();
+    expect(ref.current?.getText()).toBe("hello");
+    undo();
+    expect(ref.current?.getText()).toBe("");
+    expect(undo().defaultPrevented).toBe(false);
+  });
+
+  it("redo restores a whole coalesced group", async () => {
+    await mount();
+    typeText("abc");
+    undo();
+    expect(ref.current?.getText()).toBe("");
+    redo();
+    expect(ref.current?.getText()).toBe("abc");
+  });
+
+  it("starts a new group after a pause", async () => {
+    await mount();
+    typeText("ab");
+    typeChar("c", 1_500);
+    typeText("d");
+
+    undo();
+    expect(ref.current?.getText()).toBe("ab");
+    undo();
+    expect(ref.current?.getText()).toBe("");
+  });
+
+  it("keeps a backspace run separate from the typing before it", async () => {
+    await mount();
+    typeText("abcd");
+    backspace();
+    backspace();
+    expect(ref.current?.getText()).toBe("ab");
+
+    undo();
+    expect(ref.current?.getText()).toBe("abcd");
+    undo();
+    expect(ref.current?.getText()).toBe("");
+  });
+
+  it("does not fold typing into a paste, or a paste into typing", async () => {
+    await mount();
+    typeText("hi");
+    now += 50;
+    const paste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, "clipboardData", {
+      value: {
+        items: { length: 0 },
+        getData: (type: string) => (type === "text/plain" ? " there" : ""),
+        types: ["text/plain"],
+      },
+    });
+    act(() => host.dispatchEvent(paste));
+    typeText("!");
+    expect(ref.current?.getText()).toBe("hi there!");
+
+    undo();
+    expect(ref.current?.getText()).toBe("hi there");
+    undo();
+    expect(ref.current?.getText()).toBe("hi");
+    undo();
+    expect(ref.current?.getText()).toBe("");
+  });
+
+  it("typing after an undo opens a fresh group", async () => {
+    await mount();
+    typeText("abc");
+    undo();
+    typeText("xy");
+    expect(ref.current?.getText()).toBe("xy");
+    undo();
+    expect(ref.current?.getText()).toBe("");
+    expect(undo().defaultPrevented).toBe(false);
+  });
+});

--- a/src/components/ComposerInput/composerInput.inputHandler.ts
+++ b/src/components/ComposerInput/composerInput.inputHandler.ts
@@ -15,6 +15,10 @@
 import { type MentionState, canStartSlashCommand } from "./keyboard";
 import { getInlineMentionQuery } from "./mentionQuery";
 import { caretTextOffset, rangeInsideHost } from "./selection";
+import {
+  type CommitHistoryOptions,
+  historyCoalesceKey,
+} from "./useEditorOperations";
 import { PILL_DATA_ATTR, extractPlainText } from "./utils";
 
 const TRIGGER_CLOSE_GRACE_MS = 120;
@@ -50,7 +54,7 @@ export interface InputHandlerContext {
   /** True while an IME composition is in progress (see native events). */
   isComposing: () => boolean;
   reconcilePillsFromDom: () => void;
-  commitHistoryBoundary: () => void;
+  commitHistoryBoundary: (options?: CommitHistoryOptions) => void;
   clearHost: () => void;
   updateEmptyState: () => void;
   getOnContentChange: () => ((text: string) => void) | undefined;
@@ -78,17 +82,25 @@ export function createInputHandler(ctx: InputHandlerContext) {
     const host = ctx.host();
     if (!host) return;
     ctx.reconcilePillsFromDom();
-    // A composition is one undo transaction: the boundary was marked at
-    // compositionstart and is committed at compositionend, so the
-    // intermediate `input` events must not close it early.
-    if (!ctx.isComposing()) ctx.commitHistoryBoundary();
-
-    const text = extractPlainText(host);
-    const hasPills = host.querySelector(`[${PILL_DATA_ATTR}]`) != null;
     const inputType =
       nativeEvent && "inputType" in nativeEvent
         ? String(nativeEvent.inputType)
         : undefined;
+    const inputData =
+      nativeEvent && "data" in nativeEvent
+        ? (nativeEvent.data as string | null)
+        : undefined;
+    // A composition is one undo transaction: the boundary was marked at
+    // compositionstart and is committed at compositionend, so the
+    // intermediate `input` events must not close it early.
+    if (!ctx.isComposing()) {
+      ctx.commitHistoryBoundary({
+        coalesce: historyCoalesceKey(inputType, inputData),
+      });
+    }
+
+    const text = extractPlainText(host);
+    const hasPills = host.querySelector(`[${PILL_DATA_ATTR}]`) != null;
     const isDeletion = inputType?.startsWith("delete") ?? false;
 
     if (isDeletion && !hasPills && text.trim().length === 0) {

--- a/src/components/ComposerInput/useEditorOperations.ts
+++ b/src/components/ComposerInput/useEditorOperations.ts
@@ -26,6 +26,13 @@ import { PILL_DATA_ATTR, extractPlainText, pillDataAttributes } from "./utils";
 
 const PILL_ID_ATTR = "data-pill-id";
 const MAX_HISTORY_ENTRIES = 100;
+/**
+ * Consecutive commits that share a coalesce key and land within this window
+ * extend one undo entry instead of creating a new one, so a typed burst is
+ * undone as a unit (word-level, see `historyCoalesceKey`) rather than one
+ * character per Cmd+Z.
+ */
+const HISTORY_COALESCE_WINDOW_MS = 1000;
 
 let pillIdCounter = 0;
 function nextPillId(): string {
@@ -55,6 +62,39 @@ export interface PillEntry {
   attrs: ComposerPillAttrs;
 }
 
+export interface CommitHistoryOptions {
+  /**
+   * Group this commit with the previous one when both carry the same key and
+   * arrive within `HISTORY_COALESCE_WINDOW_MS`. Omit for edits that must
+   * always be their own undo step (paste, pill insert, newline).
+   */
+  coalesce?: string;
+}
+
+/**
+ * Coalesce key for a native `input` event, mirroring how native editors
+ * group undo: a run of non-whitespace characters is one step, the whitespace
+ * between words is its own step, and backspace/delete runs group separately.
+ * Returns `undefined` for everything else so those commits stand alone.
+ */
+export function historyCoalesceKey(
+  inputType: string | undefined,
+  data: string | null | undefined
+): string | undefined {
+  if (inputType === "insertText") {
+    return data && /\s/.test(data) ? "typing:whitespace" : "typing";
+  }
+  if (
+    inputType === "deleteContentBackward" ||
+    inputType === "deleteContentForward" ||
+    inputType === "deleteWordBackward" ||
+    inputType === "deleteWordForward"
+  ) {
+    return inputType;
+  }
+  return undefined;
+}
+
 export interface UseEditorOperationsResult {
   hostRef: React.MutableRefObject<HTMLDivElement | null>;
   pillEntries: PillEntry[];
@@ -65,7 +105,7 @@ export interface UseEditorOperationsResult {
   /** Capture the current document before a programmatic edit. */
   markHistoryBoundary: () => void;
   /** Store the current programmatic edit as one undoable transaction. */
-  commitHistoryBoundary: () => void;
+  commitHistoryBoundary: (options?: CommitHistoryOptions) => void;
   /** Undo the latest programmatic editor transaction. */
   undo: () => boolean;
   /** Redo the latest undone programmatic editor transaction. */
@@ -99,6 +139,8 @@ export function useEditorOperations(): UseEditorOperationsResult {
   const undoStackRef = useRef<ComposerSnapshot[]>([]);
   const redoStackRef = useRef<ComposerSnapshot[]>([]);
   const historyBoundaryRef = useRef<ComposerSnapshot | null>(null);
+  const lastCommitKeyRef = useRef<string | null>(null);
+  const lastCommitAtRef = useRef(0);
   const [pillEntries, setPillEntries] = useState<PillEntry[]>([]);
 
   const syncPillEntries = useCallback(() => {
@@ -340,15 +382,30 @@ export function useEditorOperations(): UseEditorOperationsResult {
     historyBoundaryRef.current = captureSnapshot();
   }, [captureSnapshot]);
 
-  const commitHistoryBoundary = useCallback(() => {
-    const before = historyBoundaryRef.current;
-    historyBoundaryRef.current = null;
-    if (!before) return;
-    const after = captureSnapshot();
-    if (snapshotsEqual(before, after)) return;
-    pushHistoryEntry(undoStackRef.current, before);
-    redoStackRef.current = [];
-  }, [captureSnapshot]);
+  const commitHistoryBoundary = useCallback(
+    (options?: CommitHistoryOptions) => {
+      const before = historyBoundaryRef.current;
+      historyBoundaryRef.current = null;
+      if (!before) return;
+      const after = captureSnapshot();
+      if (snapshotsEqual(before, after)) return;
+      const now = performance.now();
+      const key = options?.coalesce ?? null;
+      const extendsOpenGroup =
+        key !== null &&
+        key === lastCommitKeyRef.current &&
+        now - lastCommitAtRef.current < HISTORY_COALESCE_WINDOW_MS &&
+        undoStackRef.current.length > 0;
+      lastCommitKeyRef.current = key;
+      lastCommitAtRef.current = now;
+      redoStackRef.current = [];
+      // Extending a group keeps the entry pushed when the group opened; its
+      // "before" already predates every keystroke in the burst.
+      if (extendsOpenGroup) return;
+      pushHistoryEntry(undoStackRef.current, before);
+    },
+    [captureSnapshot]
+  );
 
   const undo = useCallback(() => {
     const previous = undoStackRef.current.pop();
@@ -358,6 +415,7 @@ export function useEditorOperations(): UseEditorOperationsResult {
     const host = hostRef.current;
     if (restored && host) placeCaretAtEnd(host);
     historyBoundaryRef.current = null;
+    lastCommitKeyRef.current = null;
     return restored;
   }, [captureSnapshot, restoreSnapshotContent]);
 
@@ -369,6 +427,7 @@ export function useEditorOperations(): UseEditorOperationsResult {
     const host = hostRef.current;
     if (restored && host) placeCaretAtEnd(host);
     historyBoundaryRef.current = null;
+    lastCommitKeyRef.current = null;
     return restored;
   }, [captureSnapshot, restoreSnapshotContent]);
 
@@ -379,6 +438,7 @@ export function useEditorOperations(): UseEditorOperationsResult {
     pillAttrsRef.current.clear();
     host.textContent = "";
     historyBoundaryRef.current = null;
+    lastCommitKeyRef.current = null;
     syncPillEntries();
   }, [syncPillEntries]);
 


### PR DESCRIPTION
## Problem

Every keystroke in `ComposerInput` was its own undo entry. The structured history marks a boundary in `beforeinput` and commits it in `input`, with no grouping, so undoing a typed sentence took one Cmd+Z per character, and the 100-entry history cap meant only the last 100 characters were reachable at all. Native editors (NSTextView, Chromium's contenteditable) group a typed burst into word-sized steps, which is what users expect from Cmd+Z.

Root cause: `commitHistoryBoundary` had no notion of an open group; each commit pushed a new snapshot.

## Solution

- `commitHistoryBoundary` accepts an optional `coalesce` key. When the key matches the previous commit's key and the commit lands within 1 s of it, the commit extends the open group instead of pushing a new entry. The entry pushed when the group opened already holds the pre-burst snapshot, so undo restores to before the whole burst.
- New `historyCoalesceKey(inputType, data)` derives the key from the native `input` event: runs of non-whitespace characters share `typing`, whitespace is `typing:whitespace`, and each backspace/delete variant groups with itself. Everything else (paste, pill insert, newline, composition) returns no key and stays a standalone step.
- The `input` handler passes that key. Undo, redo and `clearHost` close any open group, so typing after an undo starts fresh, and the redo stack is cleared on every commit as before.

Resulting behaviour: `hello world` is three undo steps (`world`, the space, `hello`), a pause longer than 1 s starts a new step, and structural edits never merge with typing on either side.

## Potential risks

- Group boundaries are heuristic. A very slow typist (more than 1 s per character) still gets per-character steps, and a fast typist who wants to undo a single character inside a word now undoes the word. Both match native behaviour.
- The time window uses `performance.now()`; tests pin it with a spy, and nothing else in the composer depends on the clock.
- Coalescing only applies to `input` events with a recognised `inputType`. Engines that report `insertText` for other operations would group them with typing, but WebKit and Chromium both use the dedicated types for paste, drop, composition and paragraph insertion.
- No persistence, IPC, or dependency changes. Rollback is a plain revert.

Stacked on #1273 (`fix/composer-ime-undo`) and #1272; merge those first.

## Verification

- `npx vitest run --config config/vitest.config.ts src/components/ComposerInput/__tests__` in a clean worktree at `origin/develop` plus the stacked branches: 15 files, 103 tests passed, including the new `ComposerInput.undoTyping.test.ts` (8 cases: key derivation, word-by-word undo, whole-group redo, new group after a pause, backspace run kept separate, no merging across a paste, fresh group after undo).
- `npx tsgo --noEmit --pretty false`: 0 errors.
- `prettier --write`, `oxlint --max-warnings 0`, and `eslint --max-warnings 0 --report-unused-disable-directives` on the three changed files: clean.
- Not run: full vitest suite, on-device typing check.
- Committed with hooks disabled in a scratch worktree, so there is no `Pre-commit hook ran.` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
