### PR TITLE
feat(composer): make pasted image attachments undoable

### DIFF
--- a/src/components/ComposerInput/__tests__/ComposerInput.undoImagePaste.test.ts
+++ b/src/components/ComposerInput/__tests__/ComposerInput.undoImagePaste.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import ComposerInput, {
+  type ComposerExternalEdit,
+  type ComposerInputRef,
+} from "../index";
+import { placeCaretAtEnd } from "../selection";
+
+vi.mock("@src/util/ui/theme/themeUtils", () => ({
+  useCurrentTheme: () => ({ isDark: false }),
+}));
+
+vi.mock("@src/store/skills/installedSkillsAtom", async () => {
+  const { atom } = await import("jotai");
+  return { installedSkillsAtom: atom([]) };
+});
+
+describe("ComposerInput undo for pasted image attachments", () => {
+  let root: SmokeRoot;
+  let ref: ReturnType<typeof createRef<ComposerInputRef>>;
+  let host: HTMLDivElement;
+
+  beforeEach(() => {
+    root = createSmokeRoot();
+    ref = createRef<ComposerInputRef>();
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+    window.getSelection()?.removeAllRanges();
+  });
+
+  async function mount(
+    onImagePaste: (files: File[]) => void | ComposerExternalEdit
+  ): Promise<void> {
+    await root.render(
+      createElement(ComposerInput, {
+        ref,
+        requireCmdEnter: true,
+        onContentChange: vi.fn(),
+        onSubmit: vi.fn(),
+        onImagePaste,
+      })
+    );
+    host = root.container.querySelector('[contenteditable="true"]')!;
+    placeCaretAtEnd(host);
+  }
+
+  function pasteImage(): Event {
+    const file = new File(["png"], "shot.png", { type: "image/png" });
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: {
+          length: 1,
+          0: { type: "image/png", getAsFile: () => file },
+        },
+        getData: () => "",
+        types: ["Files"],
+      },
+    });
+    act(() => host.dispatchEvent(event));
+    return event;
+  }
+
+  function pasteText(text: string): void {
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: {
+        items: { length: 0 },
+        getData: (type: string) => (type === "text/plain" ? text : ""),
+        types: ["text/plain"],
+      },
+    });
+    act(() => host.dispatchEvent(event));
+  }
+
+  function key(shift = false): KeyboardEvent {
+    const event = new KeyboardEvent("keydown", {
+      key: "z",
+      metaKey: true,
+      shiftKey: shift,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => host.dispatchEvent(event));
+    return event;
+  }
+
+  it("records a returned handle as an undo step and drives undo/redo", async () => {
+    const edit = { undo: vi.fn(), redo: vi.fn() };
+    const onImagePaste = vi.fn(() => edit);
+    await mount(onImagePaste);
+
+    expect(pasteImage().defaultPrevented).toBe(true);
+    expect(onImagePaste).toHaveBeenCalledTimes(1);
+
+    const undo = key();
+    expect(undo.defaultPrevented).toBe(true);
+    expect(edit.undo).toHaveBeenCalledTimes(1);
+    expect(edit.redo).not.toHaveBeenCalled();
+
+    const redo = key(true);
+    expect(redo.defaultPrevented).toBe(true);
+    expect(edit.redo).toHaveBeenCalledTimes(1);
+
+    key();
+    expect(edit.undo).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the image step separate from surrounding text edits", async () => {
+    const edit = { undo: vi.fn(), redo: vi.fn() };
+    await mount(() => edit);
+    pasteText("before ");
+    pasteImage();
+    pasteText("after");
+    expect(ref.current?.getText()).toBe("before after");
+
+    key();
+    expect(ref.current?.getText()).toBe("before ");
+    expect(edit.undo).not.toHaveBeenCalled();
+
+    key();
+    expect(ref.current?.getText()).toBe("before ");
+    expect(edit.undo).toHaveBeenCalledTimes(1);
+
+    key();
+    expect(ref.current?.getText()).toBe("");
+  });
+
+  it("leaves a void-returning handler outside the history", async () => {
+    const onImagePaste = vi.fn();
+    await mount(onImagePaste);
+    pasteImage();
+    expect(onImagePaste).toHaveBeenCalledTimes(1);
+    expect(key().defaultPrevented).toBe(false);
+  });
+});

--- a/src/components/ComposerInput/index.tsx
+++ b/src/components/ComposerInput/index.tsx
@@ -46,7 +46,13 @@ import type { ComposerInputProps, ComposerInputRef } from "./types";
 import { useEditorOperations } from "./useEditorOperations";
 import { PILL_DATA_ATTR, extractPlainText } from "./utils";
 
-export type { ComposerInputRef, ComposerSnapshot, PillIconType } from "./types";
+export type {
+  ComposerExternalEdit,
+  ComposerInputProps,
+  ComposerInputRef,
+  ComposerSnapshot,
+  PillIconType,
+} from "./types";
 /** Attribute marking a pill host span — read-only surfaces route clicks on it. */
 export { PILL_DATA_ATTR, serializePillNode } from "./utils";
 
@@ -233,6 +239,7 @@ const ComposerInput = forwardRef<ComposerInputRef, ComposerInputProps>(
             ops.insertPill(attrs);
           },
           insertTextAtCaret: ops.insertTextAtCaret,
+          recordExternalEdit: ops.recordExternalEdit,
           getOnImagePaste: () => onImagePasteRef.current,
           getInstalledSkills: () => installedSkillsRef.current,
         }),

--- a/src/components/ComposerInput/pasteHandlers.ts
+++ b/src/components/ComposerInput/pasteHandlers.ts
@@ -26,7 +26,7 @@ import { extractSkillNameFromPath } from "@src/util/skills/skillPath";
 import type { ComposerFragmentPart } from "./cutHandler";
 import { parseGitHubPillUrl } from "./githubUrl";
 import { parseHttpUrlPill } from "./httpUrl";
-import type { ComposerPillAttrs } from "./types";
+import type { ComposerExternalEdit, ComposerPillAttrs } from "./types";
 import { TERMINAL_COPY_MAX_AGE, sanitizeText } from "./utils";
 
 const logger = createLogger("ComposerInput");
@@ -34,7 +34,11 @@ const logger = createLogger("ComposerInput");
 export interface PasteHandlerContext {
   insertPill: (attrs: ComposerPillAttrs) => void;
   insertTextAtCaret: (text: string) => void;
-  getOnImagePaste: () => ((files: File[]) => void) | undefined;
+  /** Fold an attachment-side edit into the composer's undo history. */
+  recordExternalEdit: (edit: ComposerExternalEdit) => void;
+  getOnImagePaste: () =>
+    | ((files: File[]) => void | ComposerExternalEdit)
+    | undefined;
   /** Returns the current installed-skills list for paste-time matching. */
   getInstalledSkills: () => InstalledSkill[];
 }
@@ -213,7 +217,10 @@ export function createPasteHandler(ctx: PasteHandlerContext) {
     const onImagePaste = ctx.getOnImagePaste();
     if (imageFiles.length > 0 && onImagePaste) {
       event.preventDefault();
-      onImagePaste(imageFiles);
+      // Attachments live outside the document, so without this the paste
+      // left no undo step and Cmd+Z skipped straight past it.
+      const externalEdit = onImagePaste(imageFiles);
+      if (externalEdit) ctx.recordExternalEdit(externalEdit);
       return true;
     }
 

--- a/src/components/ComposerInput/types.ts
+++ b/src/components/ComposerInput/types.ts
@@ -45,6 +45,18 @@ export interface ComposerPillAttrs {
   lineEnd: number | null;
 }
 
+/**
+ * Undo/redo pair for an edit that lives outside the composer's document but
+ * was triggered from it (an image attachment created by a clipboard paste).
+ * Returned from `onImagePaste` so the composer can fold the paste into its
+ * undo history; both callbacks may run before or after any async work the
+ * owner does, and must tolerate the attachment already being gone.
+ */
+export interface ComposerExternalEdit {
+  undo: () => void;
+  redo: () => void;
+}
+
 export interface ComposerInputProps {
   /** Placeholder text shown while the editor is empty */
   placeholder?: string;
@@ -96,8 +108,12 @@ export interface ComposerInputProps {
    * Slash behavior for command vs context surfaces.
    */
   slashTriggerMode?: "command" | "context";
-  /** Called for clipboard image attachments */
-  onImagePaste?: (files: File[]) => void;
+  /**
+   * Called for clipboard image attachments. Return a `ComposerExternalEdit`
+   * to make the paste undoable with Cmd+Z / Edit → Undo; return nothing to
+   * keep it outside the composer's history.
+   */
+  onImagePaste?: (files: File[]) => void | ComposerExternalEdit;
 }
 
 /**

--- a/src/components/ComposerInput/useEditorOperations.ts
+++ b/src/components/ComposerInput/useEditorOperations.ts
@@ -21,7 +21,11 @@ import {
   placeCaretAtEnd,
   rangeInsideHost,
 } from "./selection";
-import type { ComposerPillAttrs, ComposerSnapshot } from "./types";
+import type {
+  ComposerExternalEdit,
+  ComposerPillAttrs,
+  ComposerSnapshot,
+} from "./types";
 import { PILL_DATA_ATTR, extractPlainText, pillDataAttributes } from "./utils";
 
 const PILL_ID_ATTR = "data-pill-id";
@@ -47,13 +51,28 @@ function snapshotsEqual(
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
-function pushHistoryEntry(
-  stack: ComposerSnapshot[],
-  snapshot: ComposerSnapshot
-): void {
+/**
+ * One undo step: the document to restore, plus an optional edit outside the
+ * document (an image attachment) that is undone/redone alongside it.
+ */
+interface HistoryEntry {
+  snapshot: ComposerSnapshot;
+  external?: ComposerExternalEdit;
+}
+
+function pushHistoryEntry(stack: HistoryEntry[], entry: HistoryEntry): void {
   const previous = stack[stack.length - 1];
-  if (previous && snapshotsEqual(previous, snapshot)) return;
-  stack.push(snapshot);
+  // Two plain snapshots of the same document are one step; an external edit
+  // is always its own step even when the document did not change.
+  if (
+    previous &&
+    !previous.external &&
+    !entry.external &&
+    snapshotsEqual(previous.snapshot, entry.snapshot)
+  ) {
+    return;
+  }
+  stack.push(entry);
   if (stack.length > MAX_HISTORY_ENTRIES) stack.shift();
 }
 
@@ -106,6 +125,12 @@ export interface UseEditorOperationsResult {
   markHistoryBoundary: () => void;
   /** Store the current programmatic edit as one undoable transaction. */
   commitHistoryBoundary: (options?: CommitHistoryOptions) => void;
+  /**
+   * Record an edit that happened outside the document (image attachment)
+   * as its own undo step. Undoing it restores the current document and runs
+   * `edit.undo()`; redo runs `edit.redo()`.
+   */
+  recordExternalEdit: (edit: ComposerExternalEdit) => void;
   /** Undo the latest programmatic editor transaction. */
   undo: () => boolean;
   /** Redo the latest undone programmatic editor transaction. */
@@ -142,8 +167,8 @@ export function useEditorOperations(): UseEditorOperationsResult {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const pillHostsRef = useRef<Map<string, HTMLSpanElement>>(new Map());
   const pillAttrsRef = useRef<Map<string, ComposerPillAttrs>>(new Map());
-  const undoStackRef = useRef<ComposerSnapshot[]>([]);
-  const redoStackRef = useRef<ComposerSnapshot[]>([]);
+  const undoStackRef = useRef<HistoryEntry[]>([]);
+  const redoStackRef = useRef<HistoryEntry[]>([]);
   const historyBoundaryRef = useRef<ComposerSnapshot | null>(null);
   const lastCommitKeyRef = useRef<string | null>(null);
   const lastCommitAtRef = useRef(0);
@@ -408,7 +433,19 @@ export function useEditorOperations(): UseEditorOperationsResult {
       // Extending a group keeps the entry pushed when the group opened; its
       // "before" already predates every keystroke in the burst.
       if (extendsOpenGroup) return;
-      pushHistoryEntry(undoStackRef.current, before);
+      pushHistoryEntry(undoStackRef.current, { snapshot: before });
+    },
+    [captureSnapshot]
+  );
+
+  const recordExternalEdit = useCallback(
+    (edit: ComposerExternalEdit) => {
+      pushHistoryEntry(undoStackRef.current, {
+        snapshot: captureSnapshot(),
+        external: edit,
+      });
+      redoStackRef.current = [];
+      lastCommitKeyRef.current = null;
     },
     [captureSnapshot]
   );
@@ -416,24 +453,32 @@ export function useEditorOperations(): UseEditorOperationsResult {
   const undo = useCallback(() => {
     const previous = undoStackRef.current.pop();
     if (!previous) return false;
-    pushHistoryEntry(redoStackRef.current, captureSnapshot());
-    const restored = restoreSnapshotContent(previous);
+    pushHistoryEntry(redoStackRef.current, {
+      snapshot: captureSnapshot(),
+      external: previous.external,
+    });
+    const restored = restoreSnapshotContent(previous.snapshot);
     const host = hostRef.current;
     if (restored && host) placeCaretAtEnd(host);
     historyBoundaryRef.current = null;
     lastCommitKeyRef.current = null;
+    previous.external?.undo();
     return restored;
   }, [captureSnapshot, restoreSnapshotContent]);
 
   const redo = useCallback(() => {
     const next = redoStackRef.current.pop();
     if (!next) return false;
-    pushHistoryEntry(undoStackRef.current, captureSnapshot());
-    const restored = restoreSnapshotContent(next);
+    pushHistoryEntry(undoStackRef.current, {
+      snapshot: captureSnapshot(),
+      external: next.external,
+    });
+    const restored = restoreSnapshotContent(next.snapshot);
     const host = hostRef.current;
     if (restored && host) placeCaretAtEnd(host);
     historyBoundaryRef.current = null;
     lastCommitKeyRef.current = null;
+    next.external?.redo();
     return restored;
   }, [captureSnapshot, restoreSnapshotContent]);
 
@@ -533,6 +578,7 @@ export function useEditorOperations(): UseEditorOperationsResult {
       insertTextAtCaret,
       markHistoryBoundary,
       commitHistoryBoundary,
+      recordExternalEdit,
       undo,
       redo,
       resetHistory,
@@ -553,6 +599,7 @@ export function useEditorOperations(): UseEditorOperationsResult {
       insertTextAtCaret,
       markHistoryBoundary,
       commitHistoryBoundary,
+      recordExternalEdit,
       undo,
       redo,
       resetHistory,

--- a/src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx
@@ -3,7 +3,10 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import ComposerBar from "@src/components/ComposerBar";
-import type { ComposerInputRef } from "@src/components/ComposerInput";
+import type {
+  ComposerInputProps,
+  ComposerInputRef,
+} from "@src/components/ComposerInput";
 import { VoiceInputButton, VoiceRecordingBar } from "@src/components/Voice";
 import { INPUT_AREA_CONTROL_GROUP_CLASS } from "@src/config/inputAreaTokens";
 import type { PromptPolishControl } from "@src/engines/ChatPanel/hooks/useInputArea/types";
@@ -35,7 +38,7 @@ interface SharedComposerBarProps {
   onDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
   onDragLeave: (event: React.DragEvent<HTMLDivElement>) => void;
   onDrop: (event: React.DragEvent<HTMLDivElement>) => void;
-  onImagePaste?: (files: File[]) => void;
+  onImagePaste?: ComposerInputProps["onImagePaste"];
   onAddContent: () => void;
   isCiteCode: boolean;
   selectedCiteRange: { start: number; end: number } | null;

--- a/src/engines/ChatPanel/InputArea/components/InputEditor.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputEditor.tsx
@@ -8,7 +8,10 @@ import { clsx } from "clsx";
 import { useAtomValue } from "jotai";
 import React, { memo, useCallback, useRef } from "react";
 
-import ComposerInput, { ComposerInputRef } from "@src/components/ComposerInput";
+import ComposerInput, {
+  type ComposerInputProps,
+  ComposerInputRef,
+} from "@src/components/ComposerInput";
 import {
   INPUT_AREA_EDITOR_CLASS,
   INPUT_AREA_EDITOR_HEIGHT,
@@ -51,7 +54,7 @@ export interface InputEditorProps {
   /** Inline ghost hint after the last content node (see ComposerInput) */
   trailingHint?: string | null;
   /** Callback when images are pasted from clipboard */
-  onImagePaste?: (files: File[]) => void;
+  onImagePaste?: ComposerInputProps["onImagePaste"];
   /** Whether inline "/" slash command menu is visible */
   showSlashMenu?: boolean;
   /** Keyboard handler ref for the inline "/" slash command menu */

--- a/src/engines/ChatPanel/InputArea/index.tsx
+++ b/src/engines/ChatPanel/InputArea/index.tsx
@@ -250,7 +250,7 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
       currentRepoPath,
       skillWorkspacePaths,
       attachedImages,
-      handleImagePaste,
+      handleComposerImagePaste,
       hasImages,
       clearAttachedImages,
       promptPolish,
@@ -498,7 +498,7 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
                 onImagePaste={
-                  allowFileAttachments ? handleImagePaste : undefined
+                  allowFileAttachments ? handleComposerImagePaste : undefined
                 }
                 onAddContent={handleOpenContextMenu}
                 isCiteCode={isCiteCode}
@@ -540,7 +540,7 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
                 onImagePaste={
-                  allowFileAttachments ? handleImagePaste : undefined
+                  allowFileAttachments ? handleComposerImagePaste : undefined
                 }
                 onAddContent={handleOpenContextMenu}
                 isCiteCode={isCiteCode}

--- a/src/engines/ChatPanel/hooks/useInputArea/__tests__/useImageAttachment.undo.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/__tests__/useImageAttachment.undo.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, forwardRef, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { chatImageAttachmentsAtom } from "@src/store/ui/chatImageAtom";
+import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import { useImageAttachment } from "../useImageAttachment";
+
+vi.mock("@tauri-apps/plugin-fs", () => ({ readFile: vi.fn() }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/components/Message", () => ({
+  default: { warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }),
+}));
+vi.mock("@src/util/optimization/imageOptimizer", () => ({
+  optimizeImage: vi.fn(async (file: File) => ({
+    dataUrl: `data:${file.type};base64,QUJD`,
+    optimizedSize: 3,
+    finalDimensions: { width: 1, height: 1 },
+  })),
+}));
+
+type HookApi = ReturnType<typeof useImageAttachment>;
+
+const Harness = forwardRef<HookApi, { ownerId?: string }>(function Harness(
+  { ownerId },
+  ref
+) {
+  const api = useImageAttachment(ownerId);
+  useImperativeHandle(ref, () => api, [api]);
+  return null;
+});
+
+describe("useImageAttachment.handleImagePasteUndoable", () => {
+  let root: SmokeRoot;
+  let store: ReturnType<typeof createStore>;
+  let api: HookApi | null;
+
+  beforeEach(async () => {
+    root = createSmokeRoot();
+    store = createStore();
+    api = null;
+    await root.render(
+      createElement(
+        Provider,
+        { store },
+        createElement(Harness, {
+          ownerId: "composer-a",
+          ref: (value: HookApi | null) => {
+            api = value;
+          },
+        })
+      )
+    );
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+  });
+
+  const images = () => store.get(chatImageAttachmentsAtom);
+  const flush = () => act(async () => {});
+
+  it("undo removes exactly the attachments the paste added, redo restores them", async () => {
+    store.set(chatImageAttachmentsAtom, [
+      {
+        id: "pre-existing",
+        dataUrl: "data:image/png;base64,QUJD",
+        fileName: "kept.png",
+        size: 3,
+        width: 1,
+        height: 1,
+        ownerId: "composer-a",
+      },
+    ]);
+    const file = new File(["png"], "shot.png", { type: "image/png" });
+    const handle = api!.handleImagePasteUndoable([file]);
+    await flush();
+    expect(images().map((image) => image.fileName)).toEqual([
+      "kept.png",
+      "shot.png",
+    ]);
+    const addedId = images()[1].id;
+
+    act(() => handle.undo());
+    await flush();
+    expect(images().map((image) => image.id)).toEqual(["pre-existing"]);
+
+    act(() => handle.redo());
+    await flush();
+    expect(images().map((image) => image.id)).toEqual([
+      "pre-existing",
+      addedId,
+    ]);
+    expect(images()[1].ownerId).toBe("composer-a");
+  });
+
+  it("undo issued before optimization finishes still removes the attachment", async () => {
+    const file = new File(["png"], "late.png", { type: "image/png" });
+    const handle = api!.handleImagePasteUndoable([file]);
+    act(() => handle.undo());
+    await flush();
+    expect(images()).toEqual([]);
+  });
+
+  it("undo is a no-op for an attachment the user already removed", async () => {
+    const file = new File(["png"], "gone.png", { type: "image/png" });
+    const handle = api!.handleImagePasteUndoable([file]);
+    await flush();
+    const id = images()[0].id;
+    act(() => api!.removeImage(id));
+    expect(images()).toEqual([]);
+
+    act(() => handle.undo());
+    await flush();
+    expect(images()).toEqual([]);
+
+    act(() => handle.redo());
+    await flush();
+    expect(images().map((image) => image.id)).toEqual([id]);
+  });
+
+  it("ignores non-image files and returns an inert handle", async () => {
+    const file = new File(["x"], "notes.txt", { type: "text/plain" });
+    const handle = api!.handleImagePasteUndoable([file]);
+    await flush();
+    expect(images()).toEqual([]);
+    act(() => handle.undo());
+    act(() => handle.redo());
+    await flush();
+    expect(images()).toEqual([]);
+  });
+});

--- a/src/engines/ChatPanel/hooks/useInputArea/index.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/index.ts
@@ -753,6 +753,7 @@ export function useInputArea(
     // Image attachments
     attachedImages: imageAttachment.images,
     handleImagePaste: imageAttachment.handleImagePaste,
+    handleComposerImagePaste: imageAttachment.handleImagePasteUndoable,
     hasImages: imageAttachment.hasImages,
     clearAttachedImages: imageAttachment.clearImages,
   };

--- a/src/engines/ChatPanel/hooks/useInputArea/types.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/types.ts
@@ -9,7 +9,10 @@ import type {
   RefObject,
 } from "react";
 
-import type { ComposerInputRef } from "@src/components/ComposerInput";
+import type {
+  ComposerExternalEdit,
+  ComposerInputRef,
+} from "@src/components/ComposerInput";
 import type { ComposerModeEntry } from "@src/config/sessionCreatorConfig";
 import type { MenuItemId } from "@src/scaffold/ContextMenu/config";
 import type { ChatImageAttachment } from "@src/store/ui/chatImageAtom";
@@ -264,6 +267,8 @@ export interface UseInputAreaReturn {
   // Image attachments
   attachedImages: ChatImageAttachment[];
   handleImagePaste: (files: File[]) => void;
+  /** Composer `onImagePaste` handler; returns the undo/redo pair for Cmd+Z. */
+  handleComposerImagePaste: (files: File[]) => ComposerExternalEdit;
   hasImages: boolean;
   clearAttachedImages: () => void;
 }

--- a/src/engines/ChatPanel/hooks/useInputArea/useImageAttachment.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useImageAttachment.ts
@@ -7,6 +7,8 @@
  * strip (`ImageAttachmentPreview`) renders uniformly.
  *
  *  - `handleImagePaste(files)`    — browser `File[]` (paste event, input element)
+ *  - `handleImagePasteUndoable(files)` — same, returning the undo/redo pair
+ *    the composer folds into its Cmd+Z history
  *  - `handleImagePath(path, name?)` — absolute filesystem path (Tauri drag-drop)
  */
 import { readFile } from "@tauri-apps/plugin-fs";
@@ -14,6 +16,7 @@ import { useAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { ComposerExternalEdit } from "@src/components/ComposerInput";
 import Message from "@src/components/Message";
 import { createLogger } from "@src/hooks/logger";
 import {
@@ -62,16 +65,17 @@ export function useImageAttachment(ownerId?: string) {
   /**
    * Shared tail: run each File through `optimizeImage` and push the results
    * into `chatImageAttachmentsAtom`.  Enforces the per-chat image cap (and
-   * warns the user if the incoming batch would exceed it).
+   * warns the user if the incoming batch would exceed it). Resolves with the
+   * attachments that were actually added so callers can undo them.
    */
   const ingestFiles = useCallback(
-    async (files: File[]) => {
-      if (files.length === 0) return;
+    async (files: File[]): Promise<ChatImageAttachment[]> => {
+      if (files.length === 0) return [];
 
       const remaining = MAX_CHAT_IMAGES - imagesLengthRef.current;
       if (remaining <= 0) {
         Message.warning(t("chatImage.maxReached", { max: MAX_CHAT_IMAGES }));
-        return;
+        return [];
       }
 
       const filesToProcess = files.slice(0, remaining);
@@ -116,6 +120,7 @@ export function useImageAttachment(ownerId?: string) {
       if (newAttachments.length > 0) {
         setImages((prev) => [...prev, ...newAttachments]);
       }
+      return newAttachments;
     },
     [setImages, ownerId, t]
   );
@@ -126,6 +131,44 @@ export function useImageAttachment(ownerId?: string) {
       await ingestFiles(validFiles);
     },
     [ingestFiles]
+  );
+
+  /**
+   * Paste entry point for the composer: same ingest as `handleImagePaste`,
+   * but returns the undo/redo pair synchronously so the composer can record
+   * the paste as an undo step before optimization finishes. Undo removes
+   * exactly the attachments this paste added (a no-op for ones the user
+   * already removed); redo re-adds them without re-optimizing.
+   */
+  const handleImagePasteUndoable = useCallback(
+    (files: File[]): ComposerExternalEdit => {
+      const ingested = ingestFiles(files.filter(isChatImageFile)).catch(
+        (error: unknown) => {
+          log.error("Failed to ingest pasted images", error);
+          return [] as ChatImageAttachment[];
+        }
+      );
+      return {
+        undo: () => {
+          void ingested.then((added) => {
+            if (added.length === 0) return;
+            const ids = new Set(added.map((image) => image.id));
+            setImages((prev) => prev.filter((image) => !ids.has(image.id)));
+          });
+        },
+        redo: () => {
+          void ingested.then((added) => {
+            if (added.length === 0) return;
+            setImages((prev) => {
+              const present = new Set(prev.map((image) => image.id));
+              const missing = added.filter((image) => !present.has(image.id));
+              return missing.length > 0 ? [...prev, ...missing] : prev;
+            });
+          });
+        },
+      };
+    },
+    [ingestFiles, setImages]
   );
 
   useEffect(() => {
@@ -265,6 +308,7 @@ export function useImageAttachment(ownerId?: string) {
   return {
     images: ownerImages,
     handleImagePaste,
+    handleImagePasteUndoable,
     handleImagePath,
     clearImages,
     removeImage,

--- a/src/engines/SessionCore/hooks/session/useSessionCreator/types.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionCreator/types.ts
@@ -4,7 +4,10 @@
 import type { ChangeEvent, MutableRefObject, RefObject } from "react";
 
 import type { AgentInfo, ProviderInfo } from "@src/api/http/config";
-import type { ComposerInputRef } from "@src/components/ComposerInput";
+import type {
+  ComposerExternalEdit,
+  ComposerInputRef,
+} from "@src/components/ComposerInput";
 import type { ComposerModeEntry } from "@src/config/sessionCreatorConfig";
 import type {
   AdvancedConfig,
@@ -101,6 +104,8 @@ export interface UseSessionCreatorReturn {
   // Image attachments
   attachedImages: ChatImageAttachment[];
   handleImagePaste: (files: File[]) => void;
+  /** Composer `onImagePaste` handler; returns the undo/redo pair for Cmd+Z. */
+  handleComposerImagePaste: (files: File[]) => ComposerExternalEdit;
   removeImage: (id: string) => void;
   clearImages: () => void;
   hasImages: boolean;

--- a/src/engines/SessionCore/hooks/session/useSessionCreator/useSessionCreator.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionCreator/useSessionCreator.ts
@@ -325,6 +325,7 @@ export function useSessionCreator(
   const {
     images: attachedImages,
     handleImagePaste,
+    handleImagePasteUndoable: handleComposerImagePaste,
     clearImages,
     removeImage,
     hasImages,
@@ -523,6 +524,7 @@ export function useSessionCreator(
     // Image attachments
     attachedImages,
     handleImagePaste,
+    handleComposerImagePaste,
     removeImage,
     clearImages,
     hasImages,

--- a/src/features/SessionCreator/components/EditorArea.tsx
+++ b/src/features/SessionCreator/components/EditorArea.tsx
@@ -12,7 +12,10 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import ComposerBar from "@src/components/ComposerBar";
-import ComposerInput, { ComposerInputRef } from "@src/components/ComposerInput";
+import ComposerInput, {
+  type ComposerInputProps,
+  ComposerInputRef,
+} from "@src/components/ComposerInput";
 import ComposerShell from "@src/components/ComposerShell";
 import Message from "@src/components/Message";
 import { VoiceInputButton, VoiceRecordingBar } from "@src/components/Voice";
@@ -119,7 +122,7 @@ export interface EditorAreaProps {
   /** Whether to hide the session info line (when rendered externally) */
   hideInfoLine?: boolean;
   /** Callback when images are pasted from clipboard */
-  onImagePaste?: (files: File[]) => void;
+  onImagePaste?: ComposerInputProps["onImagePaste"];
   /** Currently attached images */
   attachedImages?: ChatImageAttachment[];
   /** Remove an attached image by ID */

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -218,7 +218,7 @@ const SessionCreatorChatPanelContent: React.FC<
     handleLaunch: originalHandleLaunch,
     handleBranchChange,
     attachedImages,
-    handleImagePaste,
+    handleComposerImagePaste,
     removeImage,
     clearImages,
     editorContent,
@@ -527,7 +527,7 @@ const SessionCreatorChatPanelContent: React.FC<
         branchName:
           isOSMode && !sessionRepoId ? undefined : effectiveBranchName,
         onBranchChange: handleBranchChange,
-        onImagePaste: isHumanMode ? undefined : handleImagePaste,
+        onImagePaste: isHumanMode ? undefined : handleComposerImagePaste,
         attachedImages: isHumanMode ? [] : attachedImages,
         onRemoveImage: isHumanMode ? undefined : removeImage,
         launchDisabled: isHumanMode ? !humanNoteHasContent : !composerCanLaunch,


### PR DESCRIPTION
## Problem

Pasting an image into `ComposerInput` could not be undone. Image attachments live in `chatImageAttachmentsAtom`, outside the composer's document, and the paste handler simply forwarded the files to `onImagePaste`, so the composer's undo history never learned that anything happened. Cmd+Z after an image paste skipped straight to the previous text edit while the image stayed attached; the only way to remove it was the preview strip's delete button.

Root cause: the composer's history could only describe document snapshots, and the attachment side had no way to hand back an undo action.

## Solution

- `ComposerInputProps.onImagePaste` may now return a `ComposerExternalEdit` (`{ undo, redo }`). Returning nothing keeps the old behaviour, so every existing caller is unaffected until it opts in.
- History entries in `useEditorOperations` gain an optional `external` edit. `recordExternalEdit()` pushes a step whose snapshot is the current document; undo restores that snapshot and runs `external.undo()`, redo runs `external.redo()`. Such a step is never deduplicated against a neighbouring identical snapshot and always closes any open typing group.
- The paste handler records the handle when one is returned.
- `useImageAttachment` gains `handleImagePasteUndoable(files)`: it starts the same ingest as `handleImagePaste` and returns the handle synchronously. Undo removes exactly the attachments that paste produced (waiting for optimisation if it is still running; a no-op for ones the user already removed), redo re-adds them without re-optimising. `ingestFiles` now resolves with the attachments it added.
- The chat input (`useInputArea` → `InputArea`) and the session creator (`useSessionCreator` → its ChatPanel variant) pass the undoable variant as `handleComposerImagePaste`; the intermediate `onImagePaste` prop types on `InputComposerBars`, `InputEditor` and `EditorArea` become `ComposerInputProps["onImagePaste"]`. `handleImagePaste` keeps its `Promise<void>` shape for the drop consumer, the file upload hook, the webview screenshot path, and the cancel-restore path.

Resulting behaviour: an image paste is one undo step in the composer, ordered with the text edits around it, and Cmd+Z / Edit → Undo remove the attachment while Cmd+Shift+Z brings it back.

## Potential risks

- Undo and redo of an attachment are asynchronous relative to the optimisation pipeline. An undo issued before optimisation finishes still removes the attachment once it lands (covered by a test), but the preview strip may show the image for a frame before it disappears.
- Redo re-adds the original attachment objects without re-checking the image cap; the cap was already applied when the paste was accepted.
- The Kanban and Install session-creator variants still pass the plain `handleImagePaste`, so image pastes there stay outside the history as before.
- `ingestFiles` now returns the added attachments; every existing caller ignores the value, so no behaviour change there.
- No persistence, IPC, or dependency changes. Rollback is a plain revert.

Stacked on #1275 (`fix/composer-undo-reset-on-replace`), #1274, #1273 and #1272; merge those first.

## Verification

- `npx vitest run --config config/vitest.config.ts src/components/ComposerInput/__tests__ src/engines/ChatPanel/hooks/useInputArea/__tests__/useImageAttachment.undo.test.ts` in a clean worktree at `origin/develop` plus the stacked branches: 18 files, 115 tests passed, including the new `ComposerInput.undoImagePaste.test.ts` (3 cases: handle recorded and driven by undo/redo, image step ordered between text edits, void handler stays outside history) and `useImageAttachment.undo.test.ts` (4 cases: undo/redo against the store, undo before optimisation finishes, already-removed attachment, non-image files).
- `npx vitest run ... src/engines/ChatPanel/hooks/useInputArea src/engines/SessionCore/hooks/session/useSessionCreator src/engines/ChatPanel/InputArea src/features/SessionCreator`: 75 files, 426 tests passed.
- `npx tsgo --noEmit --pretty false`: 0 errors.
- `prettier --write`, `oxlint --max-warnings 0`, and `eslint --max-warnings 0 --report-unused-disable-directives` on all sixteen changed files: clean.
- Not run: full vitest suite, on-device paste-then-undo check.
- Committed with hooks disabled in a scratch worktree, so there is no `Pre-commit hook ran.` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
