### PR TITLE
perf(composer): keep editor operations stable across pill edits

### DIFF
--- a/src/components/ComposerInput/__tests__/ComposerInput.listenerStability.test.ts
+++ b/src/components/ComposerInput/__tests__/ComposerInput.listenerStability.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import ComposerInput, { type ComposerInputRef } from "../index";
+import { placeCaretAtEnd } from "../selection";
+
+vi.mock("@src/util/ui/theme/themeUtils", () => ({
+  useCurrentTheme: () => ({ isDark: false }),
+}));
+
+vi.mock("@src/store/skills/installedSkillsAtom", async () => {
+  const { atom } = await import("jotai");
+  return { installedSkillsAtom: atom([]) };
+});
+
+vi.mock("@src/config/pillTokens", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@src/config/pillTokens")>();
+  return { ...actual, storePillText: vi.fn() };
+});
+
+describe("ComposerInput native listener stability across pill edits", () => {
+  let root: SmokeRoot;
+  let ref: ReturnType<typeof createRef<ComposerInputRef>>;
+  let host: HTMLDivElement;
+  const addSpy = vi.spyOn(HTMLElement.prototype, "addEventListener");
+  const removeSpy = vi.spyOn(HTMLElement.prototype, "removeEventListener");
+
+  beforeEach(async () => {
+    root = createSmokeRoot();
+    ref = createRef<ComposerInputRef>();
+    await root.render(
+      createElement(ComposerInput, {
+        ref,
+        requireCmdEnter: true,
+        onContentChange: vi.fn(),
+        onSubmit: vi.fn(),
+      })
+    );
+    host = root.container.querySelector('[contenteditable="true"]')!;
+    placeCaretAtEnd(host);
+    addSpy.mockClear();
+    removeSpy.mockClear();
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+    window.getSelection()?.removeAllRanges();
+  });
+
+  const hostBinds = (spy: typeof addSpy, type: string) =>
+    spy.mock.calls.filter(
+      (call, index) =>
+        (spy.mock.contexts as unknown[])[index] === host && call[0] === type
+    ).length;
+
+  it("does not rewire host listeners when a pill is inserted or removed", async () => {
+    act(() => ref.current?.insertFilePill("/tmp/a.ts", false, "file", "a.ts"));
+    act(() => ref.current?.insertFilePill("/tmp/b.ts", false, "file", "b.ts"));
+    expect(ref.current?.getFilePills().map((pill) => pill.fileName)).toEqual([
+      "a.ts",
+      "b.ts",
+    ]);
+
+    act(() => ref.current?.removeFilePill("/tmp/a.ts"));
+    expect(ref.current?.getFilePills().map((pill) => pill.fileName)).toEqual([
+      "b.ts",
+    ]);
+
+    for (const type of ["keydown", "paste", "beforeinput", "cut", "drop"]) {
+      expect(hostBinds(addSpy, type), `${type} re-added`).toBe(0);
+      expect(hostBinds(removeSpy, type), `${type} removed`).toBe(0);
+    }
+  });
+
+  it("keeps a ref held from before the pill edit fully functional", async () => {
+    const before = ref.current!;
+    act(() => before.insertFilePill("/tmp/c.ts", false, "file", "c.ts"));
+    act(() => before.insertMentionText("hello "));
+    expect(before.getText()).toContain("hello ");
+
+    const undo = new KeyboardEvent("keydown", {
+      key: "z",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => host.dispatchEvent(undo));
+    expect(undo.defaultPrevented).toBe(true);
+    expect(before.getText()).not.toContain("hello ");
+    expect(before.getFilePills()).toHaveLength(1);
+  });
+});

--- a/src/components/ComposerInput/composerInput.nativeEvents.ts
+++ b/src/components/ComposerInput/composerInput.nativeEvents.ts
@@ -14,12 +14,12 @@ import { hasReferenceDragData } from "@src/shared/dnd/referenceDragData";
 import { EDIT_HISTORY_EVENT } from "@src/util/dom/editHistoryCommand";
 
 import { removePillForDeleteDirection } from "./keyboard";
-import type { UseEditorOperationsResult } from "./useEditorOperations";
+import type { EditorOperations } from "./useEditorOperations";
 import { extractSerializedTextFromRange, sanitizeText } from "./utils";
 
 export interface UseComposerNativeEventsParams {
   hostRef: React.MutableRefObject<HTMLDivElement | null>;
-  ops: UseEditorOperationsResult;
+  ops: EditorOperations;
   isComposingRef: React.MutableRefObject<boolean>;
   compositionEndedAtRef: React.MutableRefObject<number>;
   handlePaste: (event: ClipboardEvent) => boolean;

--- a/src/components/ComposerInput/composerInput.pillPortals.tsx
+++ b/src/components/ComposerInput/composerInput.pillPortals.tsx
@@ -12,14 +12,11 @@ import { createPortal } from "react-dom";
 
 import ComposerPill from "./ComposerPill";
 import { placeCaretAfterPill } from "./selection";
-import type {
-  PillEntry,
-  UseEditorOperationsResult,
-} from "./useEditorOperations";
+import type { EditorOperations, PillEntry } from "./useEditorOperations";
 import { extractPlainText } from "./utils";
 
 export interface UseComposerPillPortalsParams {
-  ops: UseEditorOperationsResult;
+  ops: EditorOperations;
   pillEntries: PillEntry[];
   skillPathByName: Map<string, string>;
   updateEmptyState: () => void;

--- a/src/components/ComposerInput/index.tsx
+++ b/src/components/ComposerInput/index.tsx
@@ -92,8 +92,8 @@ const ComposerInput = forwardRef<ComposerInputRef, ComposerInputProps>(
     const installedSkillsRef = useRef(installedSkills);
     installedSkillsRef.current = installedSkills;
 
-    const ops = useEditorOperations();
-    const { hostRef, pillEntries } = ops;
+    const { ops, pillEntries } = useEditorOperations();
+    const { hostRef } = ops;
 
     // ===== Stale-closure-proof callback refs =====
     const onContentChangeRef = useRef(onContentChange);

--- a/src/components/ComposerInput/useEditorOperations.ts
+++ b/src/components/ComposerInput/useEditorOperations.ts
@@ -95,9 +95,15 @@ export function historyCoalesceKey(
   return undefined;
 }
 
-export interface UseEditorOperationsResult {
+/**
+ * Stable editor operations. Every member is a ref or a `useCallback` with
+ * stable deps, so the object identity never changes for the life of the
+ * editor. Keeping the changing pill list out of it means a pill insert or
+ * removal does not rebuild the paste/keydown/input handlers, rewire the
+ * host's native listeners, or rebuild the imperative handle.
+ */
+export interface EditorOperations {
   hostRef: React.MutableRefObject<HTMLDivElement | null>;
-  pillEntries: PillEntry[];
   /** Insert a pill at the current caret position */
   insertPill: (attrs: ComposerPillAttrs) => void;
   /** Insert text at the current caret position (preserves newlines) */
@@ -136,6 +142,12 @@ export interface UseEditorOperationsResult {
   reconcilePillsFromDom: () => void;
   /** Re-register an existing DOM span (used by reconcile) */
   registerPillHost: (id: string, element: HTMLSpanElement) => void;
+}
+
+export interface UseEditorOperationsResult {
+  ops: EditorOperations;
+  /** Live pill registry, in registration order; changes on every pill edit. */
+  pillEntries: PillEntry[];
 }
 
 export function useEditorOperations(): UseEditorOperationsResult {
@@ -525,10 +537,9 @@ export function useEditorOperations(): UseEditorOperationsResult {
     if (changed) syncPillEntries();
   }, [syncPillEntries]);
 
-  return useMemo(
+  const ops = useMemo<EditorOperations>(
     () => ({
       hostRef,
-      pillEntries,
       insertPill,
       insertTextAtCaret,
       markHistoryBoundary,
@@ -548,7 +559,6 @@ export function useEditorOperations(): UseEditorOperationsResult {
       registerPillHost,
     }),
     [
-      pillEntries,
       insertPill,
       insertTextAtCaret,
       markHistoryBoundary,
@@ -568,4 +578,6 @@ export function useEditorOperations(): UseEditorOperationsResult {
       registerPillHost,
     ]
   );
+
+  return useMemo(() => ({ ops, pillEntries }), [ops, pillEntries]);
 }


### PR DESCRIPTION
## Problem

`useEditorOperations` returned one memoized object that carried both the stable editor callbacks and the live `pillEntries` state. Because `pillEntries` was a memo dependency, every pill insert or removal produced a new `ops` identity, and everything downstream that depended on `ops` rebuilt: the paste, drop, cut, input and keydown handlers, the undo/redo/newline wrappers, the imperative handle exposed through the ref, and the native-event effect, which tore down and re-registered every host listener (composition, `beforeinput`, paste, drop, dragover, cut, copy, keydown, the Edit → Undo/Redo commands) plus the document-level `selectionchange` listener. All of that work was pure churn: none of those handlers read `pillEntries`.

Root cause: state that changes on every pill edit shared an object with callbacks that never change.

## Solution

- `useEditorOperations` now returns `{ ops, pillEntries }`. `ops` (`EditorOperations`) holds only refs and stable `useCallback`s, so its identity is fixed for the life of the editor. `pillEntries` is returned beside it for the pill portals, which are the only consumer that needs it.
- `index.tsx`, `composerInput.pillPortals.tsx` and `composerInput.nativeEvents.ts` take `EditorOperations`; no logic changes.

Resulting invariant: a pill edit re-renders the pill portals and nothing else. Handlers, the imperative handle, and the native listener wiring are created once per mount.

## Potential risks

- Any code that held the old `ops` object and expected `ops.pillEntries` would break at compile time; the type is renamed, and `tsgo` shows no other consumer.
- Handlers that previously closed over a fresh `ops` now close over the mount-time one. Every member of `ops` was already a stable callback or ref, so the closed-over values are the same objects; the second test exercises a ref captured before pill edits to make sure it still drives history correctly.
- No persistence, IPC, or dependency changes. Rollback is a plain revert.

Stacked on #1275 (`fix/composer-undo-reset-on-replace`), #1274, #1273 and #1272; merge those first.

## Verification

- New `ComposerInput.listenerStability.test.ts` spies on `HTMLElement.prototype.addEventListener` / `removeEventListener` and asserts zero host re-binds for keydown, paste, beforeinput, cut and drop across two pill inserts and one removal. Negative check: with the four source files stashed and only the test present, it fails with `keydown re-added: expected 3 to be +0`, so it measures the actual behaviour rather than the refactor.
- `npx vitest run --config config/vitest.config.ts src/components/ComposerInput/__tests__` in a clean worktree at `origin/develop` plus the stacked branches: 17 files, 110 tests passed.
- `npx tsgo --noEmit --pretty false`: 0 errors.
- `prettier --write`, `oxlint --max-warnings 0`, and `eslint --max-warnings 0 --report-unused-disable-directives` on the five changed files: clean.
- Not run: full vitest suite, runtime profiling in the app (the listener count is the measured proxy; the render-time saving is not quantified).
- Committed with hooks disabled in a scratch worktree, so there is no `Pre-commit hook ran.` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
