### PR TITLE
feat(tabs): restore recently closed tabs

### DIFF
--- a/docs/frontend-ui-audit-2026-09-04/ChatPanelPlusMenu.md
+++ b/docs/frontend-ui-audit-2026-09-04/ChatPanelPlusMenu.md
@@ -1,0 +1,7 @@
+# ChatPanelPlusMenu UI audit
+
+| Line                        | Element                      | Verdict          | Reason                                                                                                                         | Suggested change |
+| --------------------------- | ---------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `ChatPanelPlusMenu.tsx:175` | Recently closed tabs section | keep with reason | Reuses `RecentlyClosedTabsMenuSection`, the same bounded and accessible menu scaffold used by the My Station new-tab dropdown. | None.            |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-04/RecentlyClosedTabsMenuSection.md
+++ b/docs/frontend-ui-audit-2026-09-04/RecentlyClosedTabsMenuSection.md
@@ -1,0 +1,9 @@
+# RecentlyClosedTabsMenuSection UI audit
+
+| Line                                         | Element                     | Verdict          | Reason                                                                                                                                          | Suggested change |
+| -------------------------------------------- | --------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `RecentlyClosedTabsMenuSection/index.tsx:29` | Section separator and label | keep with reason | Reuses the shared dropdown separator and section-label tokens, so spacing, borders, typography, and themes stay aligned with existing menus.    | None.            |
+| `RecentlyClosedTabsMenuSection/index.tsx:38` | Restore action rows         | keep with reason | This shared menu scaffold owns native menu-item buttons and applies the canonical `menuActionItem` token, preserving keyboard/button semantics. | None.            |
+| `RecentlyClosedTabsMenuSection/index.tsx:30` | Labeled menu group          | keep with reason | `role="group"` and `aria-labelledby` expose the non-interactive section heading while each restore row remains an actual button.                | None.            |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-04/TabBarPlusMenu.md
+++ b/docs/frontend-ui-audit-2026-09-04/TabBarPlusMenu.md
@@ -1,0 +1,7 @@
+# TabBarPlusMenu UI audit
+
+| Line                    | Element                      | Verdict          | Reason                                                                                                                          | Suggested change |
+| ----------------------- | ---------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `TabBarPlusMenu.tsx:83` | Recently closed tabs section | keep with reason | Reuses `RecentlyClosedTabsMenuSection`, keeping the My Station and Chat Pane section structure and interaction styling aligned. | None.            |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.

--- a/src/components/RecentlyClosedTabsMenuSection/RecentlyClosedTabsMenuSection.test.ts
+++ b/src/components/RecentlyClosedTabsMenuSection/RecentlyClosedTabsMenuSection.test.ts
@@ -1,0 +1,55 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { RecentlyClosedTabsMenuSection } from ".";
+
+describe("RecentlyClosedTabsMenuSection", () => {
+  it("hides the section when the history is empty", () => {
+    const markup = renderToStaticMarkup(
+      createElement(RecentlyClosedTabsMenuSection, {
+        tabs: [],
+        label: "Recent",
+        onRestore: vi.fn(),
+      })
+    );
+
+    expect(markup).toBe("");
+  });
+
+  it("renders bounded history entries as menu actions", () => {
+    const markup = renderToStaticMarkup(
+      createElement(RecentlyClosedTabsMenuSection, {
+        tabs: [{ id: "tab-a", title: "Tab A" }],
+        label: "Recent",
+        onRestore: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('data-recently-closed-tab-id="tab-a"');
+    expect(markup).toContain('role="menuitem"');
+    expect(markup).toContain("Tab A");
+    expect(markup).toContain('data-icon="work-history"');
+  });
+
+  it("uses a supplied session identity icon instead of the history icon", () => {
+    const markup = renderToStaticMarkup(
+      createElement(RecentlyClosedTabsMenuSection, {
+        tabs: [
+          {
+            id: "session-a",
+            title: "Codex session",
+            leadingIcon: createElement("span", {
+              "data-session-icon": "codex",
+            }),
+          },
+        ],
+        label: "Recent",
+        onRestore: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('data-session-icon="codex"');
+    expect(markup).not.toContain('data-icon="work-history"');
+  });
+});

--- a/src/components/RecentlyClosedTabsMenuSection/index.tsx
+++ b/src/components/RecentlyClosedTabsMenuSection/index.tsx
@@ -1,0 +1,62 @@
+import React, { useId } from "react";
+
+import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
+import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
+import { HugeiconsIcon, WorkHistoryIcon } from "@src/icons";
+
+export interface RecentlyClosedTabMenuItem {
+  id: string;
+  title: string;
+  leadingIcon?: React.ReactNode;
+}
+
+interface RecentlyClosedTabsMenuSectionProps {
+  tabs: readonly RecentlyClosedTabMenuItem[];
+  label: string;
+  onRestore: (tabId: string) => void;
+}
+
+export function RecentlyClosedTabsMenuSection({
+  tabs,
+  label,
+  onRestore,
+}: RecentlyClosedTabsMenuSectionProps): React.ReactNode {
+  const labelId = useId();
+
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className={DROPDOWN_CLASSES.menuGroupSeparator} aria-hidden />
+      <div role="group" aria-labelledby={labelId}>
+        <div id={labelId} className={DROPDOWN_CLASSES.sectionLabel}>
+          {label}
+        </div>
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="menuitem"
+            className={DROPDOWN_CLASSES.menuActionItem}
+            data-recently-closed-tab-id={tab.id}
+            onClick={() => onRestore(tab.id)}
+          >
+            <span className="flex min-w-0 flex-1 items-center gap-2">
+              {tab.leadingIcon ?? (
+                <HugeiconsIcon
+                  icon={WorkHistoryIcon}
+                  data-icon="work-history"
+                  size={HEADER_ICON_SIZE.sm}
+                  strokeWidth={1.8}
+                />
+              )}
+              <span className="truncate">{tab.title}</span>
+            </span>
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/engines/ChatPanel/ChatPanelTabBar/ChatPanelPlusMenu.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/ChatPanelPlusMenu.tsx
@@ -2,6 +2,7 @@
  * ChatPanelPlusMenu — the "+" button and its dropdown, placed in the chat
  * panel header toolbar (right of the "..." menu on Launchpad).
  */
+import { useAtomValue, useSetAtom } from "jotai";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -10,6 +11,7 @@ import {
   DROPDOWN_CLASSES,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
+import { RecentlyClosedTabsMenuSection } from "@src/components/RecentlyClosedTabsMenuSection";
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
 import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import {
@@ -22,8 +24,14 @@ import {
   MessageAdd02Icon,
   PictureInPicture01Icon,
 } from "@src/icons";
+import {
+  type ChatPanelTab,
+  recentlyClosedChatPanelTabsAtom,
+  restoreRecentlyClosedChatPanelTabAtom,
+} from "@src/store/chatPanel/chatPanelTabsAtom";
 import { isMacOS } from "@src/util/platform/tauri";
 
+import { SessionIdentityIconById } from "../components/SessionIdentityIcon";
 import { CHAT_PANEL_HEADER_NO_DRAG_STYLE } from "../header";
 
 // ─── Plus-menu dropdown ───────────────────────────────────────────────────────
@@ -35,6 +43,8 @@ interface PlusMenuContentProps {
   onNewProject: () => void;
   onNewWorkItem: () => void;
   onOpenSideChat: () => void;
+  recentlyClosedTabs: readonly ChatPanelTab[];
+  onRestoreTab: (tabId: string) => void;
   onClose: () => void;
 }
 
@@ -45,6 +55,8 @@ export function PlusMenuContent({
   onNewProject,
   onNewWorkItem,
   onOpenSideChat,
+  recentlyClosedTabs,
+  onRestoreTab,
   onClose,
 }: PlusMenuContentProps) {
   const { t } = useTranslation(["sessions", "navigation"]);
@@ -161,6 +173,24 @@ export function PlusMenuContent({
             ) : null}
           </button>
         ))}
+        <RecentlyClosedTabsMenuSection
+          tabs={recentlyClosedTabs.map((tab) => ({
+            id: tab.id,
+            title: tab.title,
+            leadingIcon:
+              tab.type === "session" && tab.sessionId ? (
+                <SessionIdentityIconById
+                  sessionId={tab.sessionId}
+                  isSelected={false}
+                />
+              ) : undefined,
+          }))}
+          label={t("navigation:workstation.plusMenu.recentlyClosed")}
+          onRestore={(tabId) => {
+            onClose();
+            onRestoreTab(tabId);
+          }}
+        />
       </div>
     </div>
   );
@@ -187,6 +217,8 @@ export function ChatPanelPlusMenu({
 }: ChatPanelPlusMenuProps): React.ReactNode {
   const { t } = useTranslation("sessions");
   const [menuOpen, setMenuOpen] = useState(false);
+  const recentlyClosedTabs = useAtomValue(recentlyClosedChatPanelTabsAtom);
+  const restoreTab = useSetAtom(restoreRecentlyClosedChatPanelTabAtom);
   const closeMenu = useCallback(() => setMenuOpen(false), []);
   const plusLabel = t("chat.tabs.newTab", "New tab");
 
@@ -200,6 +232,8 @@ export function ChatPanelPlusMenu({
           onNewProject={onNewProject}
           onNewWorkItem={onNewWorkItem}
           onOpenSideChat={onOpenSideChat}
+          recentlyClosedTabs={recentlyClosedTabs}
+          onRestoreTab={restoreTab}
           onClose={closeMenu}
         />
       }

--- a/src/engines/ChatPanel/ChatPanelTabBar/ChatPanelTabBar.test.ts
+++ b/src/engines/ChatPanel/ChatPanelTabBar/ChatPanelTabBar.test.ts
@@ -27,6 +27,13 @@ vi.mock("@src/components/IntegrationIcon", () => ({
     }),
 }));
 
+vi.mock("../components/SessionIdentityIcon", () => ({
+  default: ({ sessionId }: { sessionId: string }) =>
+    createElement("span", { "data-session-identity-icon": sessionId }),
+  SessionIdentityIconById: ({ sessionId }: { sessionId: string }) =>
+    createElement("span", { "data-session-identity-icon": sessionId }),
+}));
+
 vi.mock(
   "@src/modules/ProjectManager/WorkItems/components/WorkItemHoverCard",
   () => ({
@@ -319,6 +326,15 @@ describe("ChatPanelTabBar", () => {
         onNewProject: vi.fn(),
         onNewWorkItem: vi.fn(),
         onOpenSideChat: vi.fn(),
+        recentlyClosedTabs: [
+          {
+            id: "closed-chat",
+            type: "session",
+            title: "Closed chat",
+            sessionId: "codexapp-closed-chat",
+          },
+        ],
+        onRestoreTab: vi.fn(),
         onClose: vi.fn(),
       })
     );
@@ -328,5 +344,11 @@ describe("ChatPanelTabBar", () => {
     expect(markup).toContain("sessions:creator.createTarget.project");
     expect(markup).toContain("chat.startPage.newWorkItem.title");
     expect(markup).toContain("sessions:chat.sideChat.title");
+    expect(markup).toContain("navigation:workstation.plusMenu.recentlyClosed");
+    expect(markup).toContain('data-recently-closed-tab-id="closed-chat"');
+    expect(markup).toContain(
+      'data-session-identity-icon="codexapp-closed-chat"'
+    );
+    expect(markup).not.toContain('data-icon="work-history"');
   });
 });

--- a/src/engines/ChatPanel/components/SessionIdentityIcon.test.ts
+++ b/src/engines/ChatPanel/components/SessionIdentityIcon.test.ts
@@ -1,9 +1,13 @@
+import { Provider, createStore } from "jotai";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
+import { sessionsAtom } from "@src/store/session";
+
 import SessionIdentityIcon, {
   SESSION_IDENTITY_ICON_SIZE,
+  SessionIdentityIconById,
   resolveSessionIdentityIconColorClass,
   resolveSessionIdentityIconSource,
 } from "./SessionIdentityIcon";
@@ -21,6 +25,38 @@ describe("SessionIdentityIcon", () => {
     expect(markup).toContain("inline-flex h-4 w-4");
     expect(markup).toContain('width="14"');
     expect(markup).toContain('height="14"');
+  });
+
+  it("resolves the stored provider icon from only a session ID", () => {
+    const store = createStore();
+    const session = {
+      session_id: "session-provider-icon",
+      status: "completed",
+      created_at: "2026-09-04T00:00:00.000Z",
+      updated_at: "2026-09-04T00:00:00.000Z",
+      agentIconId: "codex",
+    };
+    store.set(sessionsAtom, [session]);
+
+    const resolvedMarkup = renderToStaticMarkup(
+      React.createElement(
+        Provider,
+        { store },
+        React.createElement(SessionIdentityIconById, {
+          sessionId: session.session_id,
+          isSelected: false,
+        })
+      )
+    );
+    const expectedMarkup = renderToStaticMarkup(
+      React.createElement(SessionIdentityIcon, {
+        session,
+        sessionId: session.session_id,
+        isSelected: false,
+      })
+    );
+
+    expect(resolvedMarkup).toBe(expectedMarkup);
   });
 });
 

--- a/src/engines/ChatPanel/components/SessionIdentityIcon.tsx
+++ b/src/engines/ChatPanel/components/SessionIdentityIcon.tsx
@@ -4,11 +4,17 @@ import React, { memo } from "react";
 import AnyIcon from "@src/components/AnyIcon";
 import { sessionHydrationByIdAtom } from "@src/engines/SessionCore";
 import { useCloudSessionPendingPlayEntry } from "@src/features/Org2Cloud/useCloudSessionDownloadSurface";
-import type { Session } from "@src/store/session";
+import { type Session, sessionByIdAtom } from "@src/store/session";
 import { resolveSessionRowIconPresentation } from "@src/util/session/sessionSidebarRow";
 
 interface SessionIdentityIconProps {
   session: Session | null | undefined;
+  sessionId: string;
+  isSelected?: boolean;
+  className?: string;
+}
+
+interface SessionIdentityIconByIdProps {
   sessionId: string;
   isSelected?: boolean;
   className?: string;
@@ -74,5 +80,22 @@ const SessionIdentityIcon: React.FC<SessionIdentityIconProps> = memo(
 );
 
 SessionIdentityIcon.displayName = "SessionIdentityIcon";
+
+/** Resolve and render the canonical identity icon for a session ID. */
+export const SessionIdentityIconById = memo(function SessionIdentityIconById({
+  sessionId,
+  isSelected = true,
+  className,
+}: SessionIdentityIconByIdProps) {
+  const session = useAtomValue(sessionByIdAtom(sessionId));
+  return (
+    <SessionIdentityIcon
+      session={session}
+      sessionId={sessionId}
+      isSelected={isSelected}
+      className={className}
+    />
+  );
+});
 
 export default SessionIdentityIcon;

--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -349,7 +349,8 @@
       "newBrowserTab": "Neuer Browser-Tab",
       "newPrivateBrowserTab": "Neuer privater Browser-Tab",
       "workItems": "Arbeitsaufgaben",
-      "projects": "Projekte"
+      "projects": "Projekte",
+      "recentlyClosed": "Kürzlich"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -66,7 +66,8 @@
       "newBrowserTab": "New browser tab",
       "newPrivateBrowserTab": "New private browser tab",
       "workItems": "Work items",
-      "projects": "Projects"
+      "projects": "Projects",
+      "recentlyClosed": "Recent"
     },
     "startPage": {
       "title": "Start",

--- a/src/i18n/locales/es/navigation.json
+++ b/src/i18n/locales/es/navigation.json
@@ -349,7 +349,8 @@
       "newBrowserTab": "Nueva pestaña del navegador",
       "newPrivateBrowserTab": "Nueva pestaña privada del navegador",
       "workItems": "Elementos de trabajo",
-      "projects": "Proyectos"
+      "projects": "Proyectos",
+      "recentlyClosed": "Recientes"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/fr/navigation.json
+++ b/src/i18n/locales/fr/navigation.json
@@ -349,7 +349,8 @@
       "newBrowserTab": "Nouvel onglet de navigateur",
       "newPrivateBrowserTab": "Nouvel onglet de navigation privée",
       "workItems": "Éléments de travail",
-      "projects": "Projets"
+      "projects": "Projets",
+      "recentlyClosed": "Récents"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/ja/navigation.json
+++ b/src/i18n/locales/ja/navigation.json
@@ -347,7 +347,8 @@
       "newBrowserTab": "新しいブラウザタブ",
       "newPrivateBrowserTab": "新しいプライベートブラウザタブ",
       "workItems": "作業項目",
-      "projects": "プロジェクト"
+      "projects": "プロジェクト",
+      "recentlyClosed": "最近"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/ko/navigation.json
+++ b/src/i18n/locales/ko/navigation.json
@@ -347,7 +347,8 @@
       "newBrowserTab": "새 브라우저 탭",
       "newPrivateBrowserTab": "새 시크릿 브라우저 탭",
       "workItems": "작업 항목",
-      "projects": "프로젝트"
+      "projects": "프로젝트",
+      "recentlyClosed": "최근"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/pl/navigation.json
+++ b/src/i18n/locales/pl/navigation.json
@@ -347,7 +347,8 @@
       "newBrowserTab": "Nowa karta przeglądarki",
       "newPrivateBrowserTab": "Nowa prywatna karta przeglądarki",
       "workItems": "Elementy pracy",
-      "projects": "Projekty"
+      "projects": "Projekty",
+      "recentlyClosed": "Ostatnie"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/pt/navigation.json
+++ b/src/i18n/locales/pt/navigation.json
@@ -349,7 +349,8 @@
       "newBrowserTab": "Nova aba do navegador",
       "newPrivateBrowserTab": "Nova aba privada do navegador",
       "workItems": "Itens de trabalho",
-      "projects": "Projetos"
+      "projects": "Projetos",
+      "recentlyClosed": "Recentes"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/ru/navigation.json
+++ b/src/i18n/locales/ru/navigation.json
@@ -347,7 +347,8 @@
       "newBrowserTab": "Новая вкладка браузера",
       "newPrivateBrowserTab": "Новая приватная вкладка браузера",
       "workItems": "Рабочие задачи",
-      "projects": "Проекты"
+      "projects": "Проекты",
+      "recentlyClosed": "Недавние"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/tr/navigation.json
+++ b/src/i18n/locales/tr/navigation.json
@@ -347,7 +347,8 @@
       "newBrowserTab": "Yeni tarayıcı sekmesi",
       "newPrivateBrowserTab": "Yeni gizli tarayıcı sekmesi",
       "workItems": "İş öğeleri",
-      "projects": "Projeler"
+      "projects": "Projeler",
+      "recentlyClosed": "Son"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/vi/navigation.json
+++ b/src/i18n/locales/vi/navigation.json
@@ -347,7 +347,8 @@
       "newBrowserTab": "Thẻ trình duyệt mới",
       "newPrivateBrowserTab": "Thẻ trình duyệt ẩn danh mới",
       "workItems": "Mục công việc",
-      "projects": "Dự án"
+      "projects": "Dự án",
+      "recentlyClosed": "Gần đây"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/zh-Hant/navigation.json
+++ b/src/i18n/locales/zh-Hant/navigation.json
@@ -439,7 +439,8 @@
       "newBrowserTab": "新增瀏覽器分頁",
       "newPrivateBrowserTab": "新增私密瀏覽器分頁",
       "workItems": "工作項目",
-      "projects": "專案"
+      "projects": "專案",
+      "recentlyClosed": "最近"
     }
   },
   "collaboration": {

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -439,7 +439,8 @@
       "newBrowserTab": "新建浏览器标签页",
       "newPrivateBrowserTab": "新建隐私浏览器标签页",
       "workItems": "工作项",
-      "projects": "项目"
+      "projects": "项目",
+      "recentlyClosed": "最近"
     }
   },
   "collaboration": {

--- a/src/modules/WorkStation/AppShell/TabBarPlusMenu/TabBarPlusMenu.tsx
+++ b/src/modules/WorkStation/AppShell/TabBarPlusMenu/TabBarPlusMenu.tsx
@@ -6,6 +6,7 @@
  * while the extracted item renderer keeps this coordinator focused on menu
  * state and repository diff data.
  */
+import { useAtomValue, useSetAtom } from "jotai";
 import React, { memo, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -14,12 +15,18 @@ import {
   DROPDOWN_CLASSES,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
+import { RecentlyClosedTabsMenuSection } from "@src/components/RecentlyClosedTabsMenuSection";
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
 import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
+import { SessionIdentityIconById } from "@src/engines/ChatPanel/components/SessionIdentityIcon";
 import { useActiveRepoRef } from "@src/hooks/git/useActiveRepoRef";
 import { useWorkingTreeDiffTotals } from "@src/hooks/git/useWorkingTreeDiffTotals";
 import { Add01Icon, HugeiconsIcon } from "@src/icons";
 import { CODE_EDITOR_TOUR_TARGETS } from "@src/scaffold/Tutorials/codeEditorTourConfig";
+import {
+  recentlyClosedWorkstationTabsAtom,
+  restoreRecentlyClosedWorkstationTabAtom,
+} from "@src/store/workstation";
 
 import {
   LAUNCHPAD_ACTION_IDS,
@@ -47,6 +54,8 @@ const TabBarPlusMenuComponent: React.FC<TabBarPlusMenuProps> = ({
   const { repoId, repoPath } = useActiveRepoRef();
   const { additions, deletions } = useWorkingTreeDiffTotals(repoId, repoPath);
   const [menuVisible, setMenuVisible] = useState(false);
+  const recentlyClosedTabs = useAtomValue(recentlyClosedWorkstationTabsAtom);
+  const restoreTab = useSetAtom(restoreRecentlyClosedWorkstationTabAtom);
 
   // ⌘T (`new_tab`) is exclusively bound to opening this menu. Only one
   // TabBarPlusMenu is mounted at a time per surface, so there is no double-fire.
@@ -71,6 +80,30 @@ const TabBarPlusMenuComponent: React.FC<TabBarPlusMenuProps> = ({
           additions={additions}
           deletions={deletions}
           onActionComplete={() => setMenuVisible(false)}
+        />
+        <RecentlyClosedTabsMenuSection
+          tabs={recentlyClosedTabs.map((tab) => {
+            const sessionId =
+              tab.type === "chat-session" &&
+              typeof tab.data.sessionId === "string"
+                ? tab.data.sessionId
+                : null;
+            return {
+              id: tab.id,
+              title: tab.title,
+              leadingIcon: sessionId ? (
+                <SessionIdentityIconById
+                  sessionId={sessionId}
+                  isSelected={false}
+                />
+              ) : undefined,
+            };
+          })}
+          label={t("workstation.plusMenu.recentlyClosed")}
+          onRestore={(tabId) => {
+            setMenuVisible(false);
+            restoreTab(tabId);
+          }}
         />
       </div>
     </div>

--- a/src/shared/tabs/recentlyClosedTabs.test.ts
+++ b/src/shared/tabs/recentlyClosedTabs.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RECENTLY_CLOSED_TABS_LIMIT,
+  prependRecentlyClosedTabs,
+  removeRecentlyClosedTab,
+} from "./recentlyClosedTabs";
+
+describe("recently closed tab history", () => {
+  it("keeps newest unique entries first and enforces the bound", () => {
+    const initial = Array.from(
+      { length: RECENTLY_CLOSED_TABS_LIMIT },
+      (_, index) => ({ id: `tab-${index}` })
+    );
+
+    expect(
+      prependRecentlyClosedTabs(initial, [
+        { id: "tab-1" },
+        { id: "tab-new" },
+      ]).map((tab) => tab.id)
+    ).toEqual(["tab-new", "tab-1", "tab-0", "tab-2", "tab-3"]);
+  });
+
+  it("removes an entry after it is restored", () => {
+    expect(
+      removeRecentlyClosedTab([{ id: "tab-a" }, { id: "tab-b" }], "tab-a")
+    ).toEqual([{ id: "tab-b" }]);
+  });
+});

--- a/src/shared/tabs/recentlyClosedTabs.ts
+++ b/src/shared/tabs/recentlyClosedTabs.ts
@@ -1,0 +1,33 @@
+export const RECENTLY_CLOSED_TABS_LIMIT = 5;
+
+interface TabIdentity {
+  id: string;
+}
+
+/**
+ * Put newly closed tabs at the front, de-duplicate reopened/reclosed entries,
+ * and keep the app-lifetime history bounded.
+ *
+ * `closedTabs` follows close order (oldest to newest). Bulk close callers can
+ * therefore pass their natural iteration order and the last closed tab becomes
+ * the first restore option.
+ */
+export function prependRecentlyClosedTabs<T extends TabIdentity>(
+  current: readonly T[],
+  closedTabs: readonly T[]
+): T[] {
+  if (closedTabs.length === 0) return [...current];
+
+  const closedIds = new Set(closedTabs.map((tab) => tab.id));
+  return [
+    ...[...closedTabs].reverse(),
+    ...current.filter((tab) => !closedIds.has(tab.id)),
+  ].slice(0, RECENTLY_CLOSED_TABS_LIMIT);
+}
+
+export function removeRecentlyClosedTab<T extends TabIdentity>(
+  current: readonly T[],
+  tabId: string
+): T[] {
+  return current.filter((tab) => tab.id !== tabId);
+}

--- a/src/store/chatPanel/__tests__/chatPanelRecentlyClosedTabs.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelRecentlyClosedTabs.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createInstrumentedStore,
+  resetInstrumentedStore,
+} from "@src/util/core/state/instrumentedStore";
+
+import {
+  recentlyClosedChatPanelTabsAtom,
+  restoreRecentlyClosedChatPanelTabAtom,
+} from "../chatPanelRecentlyClosedTabs";
+import { createSessionTab } from "../chatPanelTabFactories";
+import { closeAndDestroyChatPanelTabAtom } from "../chatPanelTabLifecycleAtoms";
+import { chatPanelTabsAtom } from "../chatPanelTabsState";
+
+describe("Chat Panel recently closed tabs", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetInstrumentedStore();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("records an explicit close and restores the same tab payload", async () => {
+    const store = createInstrumentedStore();
+    const tab = createSessionTab({
+      sessionId: "session-recent",
+      title: "Recent session",
+    });
+    store.set(chatPanelTabsAtom, { tabs: [tab], activeTabId: tab.id });
+
+    await store.set(closeAndDestroyChatPanelTabAtom, tab.id);
+
+    expect(store.get(recentlyClosedChatPanelTabsAtom)).toEqual([tab]);
+
+    expect(store.set(restoreRecentlyClosedChatPanelTabAtom, tab.id)).toBe(
+      tab.id
+    );
+    expect(store.get(chatPanelTabsAtom)).toMatchObject({
+      tabs: [tab],
+      activeTabId: tab.id,
+    });
+    expect(store.get(recentlyClosedChatPanelTabsAtom)).toEqual([]);
+  });
+
+  it("does not offer the automatically reseeded sole Launchpad", async () => {
+    const store = createInstrumentedStore();
+    const state = store.get(chatPanelTabsAtom);
+
+    await store.set(closeAndDestroyChatPanelTabAtom, state.activeTabId);
+
+    expect(store.get(recentlyClosedChatPanelTabsAtom)).toEqual([]);
+  });
+});

--- a/src/store/chatPanel/chatPanelRecentlyClosedTabs.ts
+++ b/src/store/chatPanel/chatPanelRecentlyClosedTabs.ts
@@ -1,0 +1,68 @@
+import { atom } from "jotai";
+
+import {
+  prependRecentlyClosedTabs,
+  removeRecentlyClosedTab,
+} from "@src/shared/tabs/recentlyClosedTabs";
+
+import { addChatPanelTerminalTabAtom } from "./chatPanelTabOpen/session";
+import { appendAndActivateChatPanelTabAtom } from "./chatPanelTabPresentationAtoms";
+import { activateChatPanelTabAtom } from "./chatPanelTabPresentationAtoms";
+import type { ChatPanelTab } from "./chatPanelTabsModel";
+import { chatPanelTabsAtom } from "./chatPanelTabsState";
+import { createChatPanelTerminalAtom } from "./chatPanelTerminalAtom";
+
+/** App-lifetime, bounded restore history for tabs explicitly closed by a user. */
+export const recentlyClosedChatPanelTabsAtom = atom<ChatPanelTab[]>([]);
+recentlyClosedChatPanelTabsAtom.debugLabel = "recentlyClosedChatPanelTabsAtom";
+
+export const recordRecentlyClosedChatPanelTabsAtom = atom(
+  null,
+  (_get, set, tabs: readonly ChatPanelTab[]) => {
+    if (tabs.length === 0) return;
+    set(recentlyClosedChatPanelTabsAtom, (current) =>
+      prependRecentlyClosedTabs(current, tabs)
+    );
+  }
+);
+recordRecentlyClosedChatPanelTabsAtom.debugLabel =
+  "recordRecentlyClosedChatPanelTabsAtom";
+
+/** Restore one tab and consume its history entry. Terminal tabs get a fresh PTY. */
+export const restoreRecentlyClosedChatPanelTabAtom = atom(
+  null,
+  (get, set, tabId: string): string | null => {
+    const closedTab = get(recentlyClosedChatPanelTabsAtom).find(
+      (tab) => tab.id === tabId
+    );
+    if (!closedTab) return null;
+
+    const openTab = get(chatPanelTabsAtom).tabs.find(
+      (tab) => tab.id === closedTab.id
+    );
+    let restoredTabId = closedTab.id;
+
+    if (openTab) {
+      set(activateChatPanelTabAtom, openTab.id);
+    } else if (closedTab.type === "terminal") {
+      const terminalSessionId = set(
+        createChatPanelTerminalAtom,
+        closedTab.title
+      );
+      restoredTabId = set(addChatPanelTerminalTabAtom, {
+        terminalSessionId,
+        title: closedTab.title,
+        cliCommand: closedTab.cliCommand,
+      });
+    } else {
+      set(appendAndActivateChatPanelTabAtom, { tab: closedTab });
+    }
+
+    set(recentlyClosedChatPanelTabsAtom, (current) =>
+      removeRecentlyClosedTab(current, tabId)
+    );
+    return restoredTabId;
+  }
+);
+restoreRecentlyClosedChatPanelTabAtom.debugLabel =
+  "restoreRecentlyClosedChatPanelTabAtom";

--- a/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
@@ -11,6 +11,7 @@ import {
 } from "@src/store/ui/chatPanelAtom";
 import type { WorkManagementSection } from "@src/store/workstation";
 
+import { recordRecentlyClosedChatPanelTabsAtom } from "./chatPanelRecentlyClosedTabs";
 import {
   buildDefaultLaunchpadTab,
   getChatPanelWorkItemTabKey,
@@ -431,10 +432,18 @@ export const closeAndDestroyChatPanelTabAtom = atom(
   async (get, set, tabId: string): Promise<void> => {
     const state = get(chatPanelTabsAtom);
     const tab = state.tabs.find((candidate) => candidate.id === tabId);
+    const closesSoleStartPage =
+      state.tabs.length === 1 && tab?.type === "start-page";
     // Destroy PTY before removing the tab so the terminal session ID is still
     // reachable during cleanup.
     if (tab?.type === "terminal" && tab.terminalSessionId) {
       await set(destroyChatPanelTerminalAtom, tab.terminalSessionId);
+    }
+    const tabStillOpen = get(chatPanelTabsAtom).tabs.some(
+      (candidate) => candidate.id === tab?.id
+    );
+    if (tab && tabStillOpen && !closesSoleStartPage) {
+      set(recordRecentlyClosedChatPanelTabsAtom, [tab]);
     }
     set(closeChatPanelTabAtom, tabId);
   }
@@ -460,7 +469,10 @@ export const closeOtherChatPanelTabsAtom = atom(
       )
     );
 
-    for (const tab of tabsToClose) {
+    const openIds = new Set(get(chatPanelTabsAtom).tabs.map((tab) => tab.id));
+    const tabsStillOpen = tabsToClose.filter((tab) => openIds.has(tab.id));
+    set(recordRecentlyClosedChatPanelTabsAtom, tabsStillOpen);
+    for (const tab of tabsStillOpen) {
       set(closeChatPanelTabAtom, tab.id);
     }
 

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -96,3 +96,8 @@ export {
   moveChatPanelTabToWorkstationAtom,
   moveWorkstationPrTabToChatPanelAtom,
 } from "./chatPanelTabPlacementAtom";
+export {
+  recentlyClosedChatPanelTabsAtom,
+  recordRecentlyClosedChatPanelTabsAtom,
+  restoreRecentlyClosedChatPanelTabAtom,
+} from "./chatPanelRecentlyClosedTabs";

--- a/src/store/workstation/browser/tabs/__tests__/sharedWorkspaceIntegration.test.ts
+++ b/src/store/workstation/browser/tabs/__tests__/sharedWorkspaceIntegration.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
 import { workstationTabsStateAtom } from "@src/store/workstation/tabs/atoms";
+import { recentlyClosedWorkstationTabsAtom } from "@src/store/workstation/tabs/recentlyClosedTabs";
 import { emptyWorkstationTabsState } from "@src/store/workstation/tabs/storage";
 import type {
   WorkStationTab,
@@ -197,6 +198,7 @@ describe("browserTabsAtom shared-resource integration", () => {
 
     expect(store.get(workstationTabsStateAtom).shared.tabs).toEqual([]);
     expect(store.get(sharedBrowserTabsAtom)).toEqual([]);
+    expect(store.get(recentlyClosedWorkstationTabsAtom)).toEqual([browserTab]);
   });
 
   it("removes a browser resource globally only through the explicit owner action", () => {

--- a/src/store/workstation/browser/tabs/index.ts
+++ b/src/store/workstation/browser/tabs/index.ts
@@ -23,6 +23,7 @@ import {
   workstationLayoutAtom,
   workstationTabsStateAtom,
 } from "@src/store/workstation/tabs/atoms";
+import { recordRecentlyClosedWorkstationTabsAtom } from "@src/store/workstation/tabs/recentlyClosedTabs";
 import {
   closeOtherTabs as closeOtherTabsMutation,
   closeSavedTabs as closeSavedTabsMutation,
@@ -324,7 +325,11 @@ export const removeBrowserResourceTabAtom = atom(
  * Close a browser tab in the current workspace. The live BrowserContext owner
  * observes the disappearance and then removes the global resource explicitly.
  */
-export const closeBrowserTabAtom = atom(null, (_get, set, tabId: string) => {
+export const closeBrowserTabAtom = atom(null, (get, set, tabId: string) => {
+  const tab = get(browserTabsAtom).tabs.find(
+    (candidate) => candidate.id === tabId
+  );
+  if (tab) set(recordRecentlyClosedWorkstationTabsAtom, [tab]);
   set(removeBrowserResourceTabAtom, tabId);
 });
 
@@ -361,6 +366,10 @@ export const closeOtherBrowserTabsAtom = atom(
     const next = closeOtherTabsMutation(state, tabId);
     const nextIds = new Set(next.tabs.map((tab) => tab.id));
     set(
+      recordRecentlyClosedWorkstationTabsAtom,
+      state.tabs.filter((tab) => !nextIds.has(tab.id))
+    );
+    set(
       removeSharedWorkstationTabsAtom,
       state.tabs.filter((tab) => !nextIds.has(tab.id)).map((tab) => tab.id)
     );
@@ -374,6 +383,10 @@ export const closeSavedBrowserTabsAtom = atom(null, (get, set) => {
   const state = get(browserTabsAtom);
   const next = closeSavedTabsMutation(state);
   const nextIds = new Set(next.tabs.map((tab) => tab.id));
+  set(
+    recordRecentlyClosedWorkstationTabsAtom,
+    state.tabs.filter((tab) => !nextIds.has(tab.id))
+  );
   set(
     removeSharedWorkstationTabsAtom,
     state.tabs.filter((tab) => !nextIds.has(tab.id)).map((tab) => tab.id)

--- a/src/store/workstation/tabRegistry/atoms.test.ts
+++ b/src/store/workstation/tabRegistry/atoms.test.ts
@@ -15,13 +15,16 @@ import {
   WORKSTATION_V3_SHARED_KEY,
   emptyWorkstationTabsState,
 } from "@src/store/workstation/tabs/storage";
+import { workstationNewBrowserSessionRequestAtom } from "@src/store/workstation/workstationTabBarAtoms";
 
+import { recentlyClosedWorkstationTabsAtom } from "../tabs/recentlyClosedTabs";
 import {
   closeActiveWorkStationTabAtom,
   closeOtherTabsAtom,
   closeProjectOrgWorkStationTabsAtom,
   closeSavedTabsAtom,
   closeTabAtom,
+  restoreRecentlyClosedWorkstationTabAtom,
 } from "./atoms";
 
 function tab(id: string, orgId?: string): WorkStationTab {
@@ -79,6 +82,30 @@ describe("closeTabAtom", () => {
 
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
   });
+
+  it("records and restores a closed tab in the current workspace", () => {
+    const store = createStore();
+    const closedTab = tab("project-org:recent");
+    const retainedTab = tab("project-org:retained");
+    store.set(workstationLayoutAtom, {
+      mainPane: {
+        tabs: [retainedTab, closedTab],
+        activeTabId: closedTab.id,
+      },
+    });
+
+    store.set(closeTabAtom, { tabId: closedTab.id });
+
+    expect(store.get(recentlyClosedWorkstationTabsAtom)).toEqual([closedTab]);
+    expect(
+      store.set(restoreRecentlyClosedWorkstationTabAtom, closedTab.id)
+    ).toBe(closedTab.id);
+    expect(store.get(workstationLayoutAtom).mainPane).toEqual({
+      tabs: [retainedTab, closedTab],
+      activeTabId: closedTab.id,
+    });
+    expect(store.get(recentlyClosedWorkstationTabsAtom)).toEqual([]);
+  });
 });
 
 describe("closeProjectOrgWorkStationTabsAtom", () => {
@@ -128,7 +155,10 @@ describe("live shared-resource close semantics", () => {
   it("tears down a browser resource through the unified TabBar close path", () => {
     const store = createStore();
     const state = emptyWorkstationTabsState();
-    const browser = createBrowserSessionTab("browser-1", "Example");
+    const browser = createBrowserSessionTab("browser-1", "Example", {
+      url: "https://example.com/docs",
+      incognito: true,
+    });
     const local = fileTab("file:/a.ts");
     state.shared.tabs = [browser];
     state.sessionWorkspaces.A = {
@@ -158,6 +188,15 @@ describe("live shared-resource close semantics", () => {
     expect(
       JSON.parse(localStorage.getItem(WORKSTATION_V3_SHARED_KEY) ?? "null")
     ).toEqual({ tabs: [] });
+
+    expect(store.get(recentlyClosedWorkstationTabsAtom)).toEqual([browser]);
+    store.set(restoreRecentlyClosedWorkstationTabAtom, browser.id);
+    expect(store.get(workstationNewBrowserSessionRequestAtom)).toEqual({
+      tick: 1,
+      url: "https://example.com/docs",
+      isPrivate: true,
+    });
+    expect(store.get(recentlyClosedWorkstationTabsAtom)).toEqual([]);
 
     store.set(workstationActiveSessionIdAtom, "B");
     expect(store.get(workstationLayoutAtom).mainPane.tabs).toEqual([]);

--- a/src/store/workstation/tabRegistry/atoms.ts
+++ b/src/store/workstation/tabRegistry/atoms.ts
@@ -19,11 +19,18 @@ import {
   closeSavedTabs as closeSavedTabsMutation,
   closeTab as closeTabMutation,
   closeWorkstationTabsAtom,
+  openTab as openTabMutation,
   presentedWorkstationWorkspaceKeyAtom,
   reorderTabs as reorderTabsMutation,
   switchTab as switchTabMutation,
   workstationLayoutAtom,
 } from "../tabs";
+import {
+  recentlyClosedWorkstationTabsAtom,
+  recordRecentlyClosedWorkstationTabsAtom,
+  removeRecentlyClosedWorkstationTabAtom,
+} from "../tabs/recentlyClosedTabs";
+import { requestNewBrowserSessionAtom } from "../workstationTabBarAtoms";
 import type {
   TabCloseOtherRequest,
   TabCloseRequest,
@@ -90,11 +97,16 @@ focusTabAtom.debugLabel = "focusTabAtom";
 export const closeTabAtom = atom(null, (get, set, request: TabCloseRequest) => {
   const layout = get(workstationLayoutAtom);
   if (!layout) return;
+  const tab = layout.mainPane.tabs.find(
+    (candidate) => candidate.id === request.tabId
+  );
+  if (!tab) return;
   const closesSoleLaunchpad =
     get(stationModeAtom) === "my-station" &&
     layout.mainPane.tabs.length === 1 &&
     layout.mainPane.tabs[0]?.id === request.tabId &&
     layout.mainPane.tabs[0].type === "start";
+  set(recordRecentlyClosedWorkstationTabsAtom, [tab]);
   closePresentedTabs(
     get,
     set,
@@ -171,12 +183,13 @@ export const closeOtherTabsAtom = atom(
   (get, set, request: TabCloseOtherRequest) => {
     const layout = get(workstationLayoutAtom);
     if (!layout) return;
-    closePresentedTabs(
-      get,
-      set,
-      closeOtherTabsMutation(layout.mainPane, request.keepTabId),
-      layout.mainPane
+    const nextPane = closeOtherTabsMutation(layout.mainPane, request.keepTabId);
+    const nextIds = new Set(nextPane.tabs.map((tab) => tab.id));
+    set(
+      recordRecentlyClosedWorkstationTabsAtom,
+      layout.mainPane.tabs.filter((tab) => !nextIds.has(tab.id))
     );
+    closePresentedTabs(get, set, nextPane, layout.mainPane);
   }
 );
 closeOtherTabsAtom.debugLabel = "closeOtherTabsAtom";
@@ -184,11 +197,44 @@ closeOtherTabsAtom.debugLabel = "closeOtherTabsAtom";
 export const closeSavedTabsAtom = atom(null, (get, set) => {
   const layout = get(workstationLayoutAtom);
   if (!layout) return;
-  closePresentedTabs(
-    get,
-    set,
-    closeSavedTabsMutation(layout.mainPane),
-    layout.mainPane
+  const nextPane = closeSavedTabsMutation(layout.mainPane);
+  const nextIds = new Set(nextPane.tabs.map((tab) => tab.id));
+  set(
+    recordRecentlyClosedWorkstationTabsAtom,
+    layout.mainPane.tabs.filter((tab) => !nextIds.has(tab.id))
   );
+  closePresentedTabs(get, set, nextPane, layout.mainPane);
 });
 closeSavedTabsAtom.debugLabel = "closeSavedTabsAtom";
+
+/** Restore a closed tab into the currently presented My Station workspace. */
+export const restoreRecentlyClosedWorkstationTabAtom = atom(
+  null,
+  (get, set, tabId: string): string | null => {
+    const tab = get(recentlyClosedWorkstationTabsAtom).find(
+      (candidate) => candidate.id === tabId
+    );
+    if (!tab) return null;
+    const layout = get(workstationLayoutAtom);
+    if (!layout) return null;
+    const isAlreadyOpen = layout.mainPane.tabs.some(
+      (candidate) => candidate.id === tab.id
+    );
+
+    if (tab.type === "browser-session" && !isAlreadyOpen) {
+      const url = typeof tab.data.url === "string" ? tab.data.url : undefined;
+      const isPrivate = tab.data.incognito === true;
+      set(requestNewBrowserSessionAtom, { url, isPrivate });
+    } else {
+      set(
+        workstationLayoutAtom,
+        setMainPane(layout, openTabMutation(layout.mainPane, tab))
+      );
+    }
+
+    set(removeRecentlyClosedWorkstationTabAtom, tabId);
+    return tab.id;
+  }
+);
+restoreRecentlyClosedWorkstationTabAtom.debugLabel =
+  "restoreRecentlyClosedWorkstationTabAtom";

--- a/src/store/workstation/tabRegistry/index.ts
+++ b/src/store/workstation/tabRegistry/index.ts
@@ -15,4 +15,5 @@ export {
   closeOtherTabsAtom,
   closeSavedTabsAtom,
   reorderTabAtom,
+  restoreRecentlyClosedWorkstationTabAtom,
 } from "./atoms";

--- a/src/store/workstation/tabs/index.ts
+++ b/src/store/workstation/tabs/index.ts
@@ -76,6 +76,11 @@ export {
 export { workstationWorkspaceId } from "./storage";
 
 export {
+  recentlyClosedWorkstationTabsAtom,
+  recordRecentlyClosedWorkstationTabsAtom,
+} from "./recentlyClosedTabs";
+
+export {
   queueFileOpens,
   consumePendingFileOpens,
   clearPendingFileOpensForSession,

--- a/src/store/workstation/tabs/recentlyClosedTabs.ts
+++ b/src/store/workstation/tabs/recentlyClosedTabs.ts
@@ -1,0 +1,36 @@
+import { atom } from "jotai";
+
+import {
+  prependRecentlyClosedTabs,
+  removeRecentlyClosedTab,
+} from "@src/shared/tabs/recentlyClosedTabs";
+
+import type { WorkStationTab } from "./types";
+
+/** App-lifetime, bounded restore history for tabs explicitly closed by a user. */
+export const recentlyClosedWorkstationTabsAtom = atom<WorkStationTab[]>([]);
+recentlyClosedWorkstationTabsAtom.debugLabel =
+  "recentlyClosedWorkstationTabsAtom";
+
+export const recordRecentlyClosedWorkstationTabsAtom = atom(
+  null,
+  (_get, set, tabs: readonly WorkStationTab[]) => {
+    if (tabs.length === 0) return;
+    set(recentlyClosedWorkstationTabsAtom, (current) =>
+      prependRecentlyClosedTabs(current, tabs)
+    );
+  }
+);
+recordRecentlyClosedWorkstationTabsAtom.debugLabel =
+  "recordRecentlyClosedWorkstationTabsAtom";
+
+export const removeRecentlyClosedWorkstationTabAtom = atom(
+  null,
+  (_get, set, tabId: string) => {
+    set(recentlyClosedWorkstationTabsAtom, (current) =>
+      removeRecentlyClosedTab(current, tabId)
+    );
+  }
+);
+removeRecentlyClosedWorkstationTabAtom.debugLabel =
+  "removeRecentlyClosedWorkstationTabAtom";


### PR DESCRIPTION
## Problem

Users can close tabs in Chat Pane or My Station but have no quick way to recover them. The tab close paths discard presentation state immediately, and resource-owning browser or terminal tabs cannot be restored safely by reopening a stale tab snapshot.

## Solution

Add a shared, app-lifetime recently closed history capped at five entries per surface. Explicit user closes record the authoritative tab payload, while automatic cleanup and revocation paths remain excluded.

Both + menus show a localized "Recent" section only when history exists. Restoring a regular tab reopens and activates its snapshot, restoring a browser requests a new session with the previous URL and privacy mode, and restoring a Chat Pane terminal creates a fresh PTY. Session rows use the canonical Claude, ORG2, Codex, or other provider identity icon. A restored or already-open entry is consumed to prevent duplicates.

## Potential risks

History is intentionally in memory and resets when the app restarts; there is no persistence-format or migration impact. Browser and Chat Pane terminal restoration creates a new live resource rather than reviving a closed process, so ephemeral runtime state is not preserved. Session icon metadata can be unavailable while a session is hydrating; the existing canonical icon resolver then applies its normal session-ID or generic fallback. No backend, wire protocol, dependency, or database changes are included.

No rendered desktop screenshot was captured because local desktop-control permission was not granted. Static render tests cover the visible populated, empty, and provider-icon states.

## Verification

Passed:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/tabs/recentlyClosedTabs.test.ts src/components/RecentlyClosedTabsMenuSection/RecentlyClosedTabsMenuSection.test.ts src/engines/ChatPanel/components/SessionIdentityIcon.test.ts src/store/chatPanel/__tests__/chatPanelRecentlyClosedTabs.test.ts src/store/workstation/tabRegistry/atoms.test.ts src/store/workstation/browser/tabs/__tests__/sharedWorkspaceIntegration.test.ts src/engines/ChatPanel/ChatPanelTabBar/ChatPanelTabBar.test.ts` - 39 tests across 7 files
- `pnpm run typecheck`
- Targeted `pnpm exec eslint --max-warnings 0 --report-unused-disable-directives` across all changed TypeScript and TSX files
- `pnpm run check:circular` - no circular dependencies across 6,516 modules
- `pnpm run check:test-placement` - consistent across 492 directories
- `pnpm exec prettier --check src/i18n/locales/*/navigation.json src/components/RecentlyClosedTabsMenuSection/RecentlyClosedTabsMenuSection.test.ts`
- `for f in src/i18n/locales/*/navigation.json; do jq empty "$f" || exit 1; done`
- `git diff --check`
- Commit hooks: lint-staged, oxlint, ESLint autofix, Prettier, and staged-file TypeScript check

Not run: rendered desktop validation, because computer-use permission was not enabled.

## Audit

Architecture audit covered all 10 layers. Compilation, live call-chain wiring, names, bounded state ownership, defaults, shared-module boundaries, and developer readability were reviewed. Wire serialization, initialization parity, and multi-field resolver symmetry are not affected because this change is frontend-only, app-lifetime state with no external payload or initialization path.

Frontend UI audit: 0 fixes, 5 keep-with-reason findings, 0 abstractions. Reports are included under `docs/frontend-ui-audit-2026-09-04/`.

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | No timers, polling, listeners, workers, or I/O added | History changes only on explicit close/restore actions | Call-chain review |
| Memory | keep | Two per-store arrays capped at five entries | Shared bounded prepend/de-duplication helper | Bound/order unit test |
| Scope/isolation | keep | Jotai atoms remain scoped to their owning store | Chat Pane and My Station histories are separate | Store-level restore tests |
| Rendering/hot path | keep | At most five menu rows and session subscriptions | Canonical per-session icon resolver; empty section returns null | Static render and icon-resolution tests |

Performance verdict: pass.
