### PR TITLE
feat(models): support GPT-6 Astra reasoning variants

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/codex_native/client.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/codex_native/client.rs
@@ -114,7 +114,12 @@ impl CodexNativeClient {
     fn codex_supports_fast_service_tier(model: &str) -> bool {
         matches!(
             model,
-            "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gpt-5.5" | "gpt-5.4"
+            "gpt-6-astra"
+                | "gpt-5.6-sol"
+                | "gpt-5.6-terra"
+                | "gpt-5.6-luna"
+                | "gpt-5.5"
+                | "gpt-5.4"
         )
     }
 
@@ -353,7 +358,12 @@ mod tests {
     #[test]
     fn build_responses_request_preserves_effort_and_ultra_mode_on_the_wire() {
         let messages = [json!({"role": "system", "content": "Keep workspace edits scoped."})];
-        for base in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+        for base in [
+            "gpt-6-astra",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+        ] {
             let efforts: &[&str] = if base == "gpt-5.6-luna" {
                 &["low", "medium", "high", "xhigh", "max"]
             } else {

--- a/src-tauri/crates/agent-core/src/core/providers/model_capabilities.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/model_capabilities.rs
@@ -245,6 +245,12 @@ const FAMILY_RULES: &[FamilyRule] = &[
         thinking: ThinkingSupport::AlwaysOn,
     },
     // ── OpenAI ──
+    // https://developers.openai.com/api/docs/models/gpt-6-astra
+    FamilyRule {
+        pattern: "gpt-6-astra",
+        context_window: 1_050_000,
+        thinking: ThinkingSupport::AlwaysOn,
+    },
     FamilyRule {
         pattern: "gpt-5.6",
         context_window: 1_050_000,
@@ -692,6 +698,7 @@ pub enum ModelFamily {
 const FAMILY_TABLE: &[(&str, ModelFamily)] = &[
     ("claude", ModelFamily::Anthropic),
     ("glm", ModelFamily::Zhipu),
+    ("gpt-6-astra", ModelFamily::OpenAi),
     ("gpt-5", ModelFamily::OpenAi),
     ("o1", ModelFamily::OpenAi),
     ("o3", ModelFamily::OpenAi),

--- a/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/chat.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/chat.rs
@@ -270,7 +270,7 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
-    async fn gpt_5_6_upper_efforts_reach_both_chat_transports() {
+    async fn gpt_upper_efforts_reach_both_chat_transports() {
         crate::test_support::install_crypto_provider_for_tests();
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -290,7 +290,7 @@ mod tests {
                     }))
                 }
             })
-            .expect(12)
+            .expect(16)
             .mount(&server)
             .await;
 
@@ -305,7 +305,12 @@ mod tests {
             "gpt-5.6-sol".to_string(),
         );
         let messages = [serde_json::json!({"role": "user", "content": "hello"})];
-        for base in ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] {
+        for base in [
+            "gpt-6-astra",
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+        ] {
             for effort in ["xhigh", "max"] {
                 for stream in [false, true] {
                     let model = format!("{base}-{effort}");
@@ -329,6 +334,9 @@ mod tests {
                         stream
                     );
                     assert!(body.get("thinking").is_none());
+                    assert!(body.get("temperature").is_none());
+                    assert!(body.get("max_tokens").is_none());
+                    assert_eq!(body["max_completion_tokens"], 1024);
                 }
             }
         }

--- a/src-tauri/crates/agent-core/src/core/providers/openai_compat/types.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_compat/types.rs
@@ -51,6 +51,7 @@ pub(crate) fn chat_token_limit_field_hint(
 ) -> crate::providers::openai_policy::ChatTokenLimitField {
     let model_lower = model.to_lowercase();
     if model_lower.starts_with("gpt-5")
+        || model_lower.starts_with("gpt-6-astra")
         || model_lower.starts_with("o1")
         || model_lower.starts_with("o3")
         || model_lower.starts_with("o4")

--- a/src-tauri/crates/agent-core/src/core/providers/openai_policy.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_policy.rs
@@ -458,6 +458,31 @@ mod tests {
 
     #[test]
     #[serial]
+    fn astra_uses_responses_directly_and_preserves_custom_endpoint_policy() {
+        openai_capability_cache().clear();
+        let model = "gpt-6-astra-high";
+        assert_eq!(
+            resolve_openai_endpoint_policy(openai_spec(), Some("astra-direct"), None, model),
+            OpenAiEndpointPolicy::Responses
+        );
+        let custom = resolve_openai_endpoint_policy(
+            openai_spec(),
+            Some("astra-relay"),
+            Some("https://relay.example/v1"),
+            model,
+        );
+        assert!(matches!(
+            custom,
+            OpenAiEndpointPolicy::ChatCompletions(OpenAiChatWirePolicy {
+                token_limit_field: ChatTokenLimitField::MaxCompletionTokens,
+                send_temperature: false,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    #[serial]
     fn custom_base_url_defaults_to_chat_even_for_future_model_alias() {
         openai_capability_cache().clear();
         let policy = resolve_openai_endpoint_policy(

--- a/src-tauri/crates/agent-core/src/core/providers/openai_responses/client.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_responses/client.rs
@@ -156,6 +156,10 @@ mod tests {
     #[test]
     fn build_responses_request_preserves_upper_efforts_on_the_wire() {
         for (base, efforts) in [
+            (
+                "gpt-6-astra",
+                &["low", "medium", "high", "xhigh", "max"][..],
+            ),
             ("gpt-5.4", &["xhigh"][..]),
             ("gpt-5.5", &["xhigh"][..]),
             ("gpt-5.6-sol", &["xhigh", "max"][..]),
@@ -176,6 +180,8 @@ mod tests {
                     assert_eq!(body["model"], base);
                     assert_eq!(body["reasoning"]["effort"], *effort);
                     assert_eq!(body["stream"], stream);
+                    assert!(body.get("temperature").is_none());
+                    assert!(body.get("top_p").is_none());
                 }
             }
         }

--- a/src-tauri/crates/agent-core/src/core/providers/openai_responses/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_responses/mod.rs
@@ -24,6 +24,11 @@ pub use client::OpenAIResponsesClient;
 pub(crate) fn direct_openai_model_prefers_responses(model: &str) -> bool {
     let model_lower = model.to_lowercase();
 
+    // Astra tool calling requires Responses, including for effort variants.
+    if model_lower.contains("gpt-6-astra") {
+        return true;
+    }
+
     if !model_lower.contains("gpt-5") {
         return false;
     }

--- a/src-tauri/crates/agent-core/src/core/providers/tests/model_capabilities_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/tests/model_capabilities_tests.rs
@@ -101,6 +101,24 @@ fn sonnet_4_6_is_1m() {
 // ── OpenAI family ──
 
 #[test]
+fn astra_has_reasoning_and_a_1050k_context_including_variants_and_aliases() {
+    for model in [
+        "gpt-6-astra",
+        "gpt-6-astra-ultra-fast",
+        "openai/gpt-6-astra-high",
+    ] {
+        let caps = resolve(model, None);
+        assert_eq!(caps.thinking, ThinkingSupport::AlwaysOn, "{model}");
+        assert_eq!(caps.context_window, 1_050_000, "{model}");
+        assert_eq!(
+            classify_family(model, "openrouter"),
+            ModelFamily::OpenAi,
+            "{model}"
+        );
+    }
+}
+
+#[test]
 fn gpt5_is_always_on() {
     let caps = resolve("gpt-5-2025-06-01", None);
     assert_eq!(caps.thinking, ThinkingSupport::AlwaysOn);

--- a/src-tauri/crates/agent-core/src/core/providers/tests/openai_responses_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/tests/openai_responses_tests.rs
@@ -6,6 +6,13 @@ use crate::providers::openai_responses::{
 };
 
 #[test]
+fn direct_openai_model_prefers_responses_for_astra() {
+    for model in ["gpt-6-astra", "GPT-6-ASTRA", "gpt-6-astra-ultra-fast"] {
+        assert!(direct_openai_model_prefers_responses(model), "{model}");
+    }
+}
+
+#[test]
 fn direct_openai_model_prefers_responses_gpt4_models() {
     assert!(!direct_openai_model_prefers_responses("gpt-4o"));
     assert!(!direct_openai_model_prefers_responses("gpt-4-turbo"));

--- a/src-tauri/crates/key-vault/src/commands/crud/models.rs
+++ b/src-tauri/crates/key-vault/src/commands/crud/models.rs
@@ -52,6 +52,7 @@ pub const CLAUDE_CODE_OAUTH_DEFAULT_ENABLED_MODELS: &[&str] = &[
 ];
 
 pub const CODEX_OAUTH_MODELS: &[&str] = &[
+    "gpt-6-astra",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",
@@ -166,19 +167,22 @@ fn codex_model_supports_variants(model: &str) -> bool {
 fn codex_model_supports_fast_tier(model: &str) -> bool {
     matches!(
         model,
-        "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gpt-5.5" | "gpt-5.4"
+        "gpt-6-astra" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gpt-5.5" | "gpt-5.4"
     )
 }
 
 fn codex_model_supports_ultra_tier(model: &str) -> bool {
-    matches!(model, "gpt-5.6-sol" | "gpt-5.6-terra")
+    matches!(model, "gpt-6-astra" | "gpt-5.6-sol" | "gpt-5.6-terra")
 }
 
 fn codex_effort_variants_for_base_model(base_model: &str) -> Vec<ModelVariantInfo> {
     let mut out = Vec::new();
     let supports_fast = codex_model_supports_fast_tier(base_model);
     let mut efforts = vec!["low", "medium", "high", "xhigh"];
-    if matches!(base_model, "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna") {
+    if matches!(
+        base_model,
+        "gpt-6-astra" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+    ) {
         efforts.push("max");
     }
     if codex_model_supports_ultra_tier(base_model) {

--- a/src-tauri/crates/key-vault/src/commands/tests/tests.rs
+++ b/src-tauri/crates/key-vault/src/commands/tests/tests.rs
@@ -353,6 +353,86 @@ fn codex_key_info_exposes_requested_gpt_effort_and_speed_variants() {
 }
 
 #[test]
+fn astra_fallback_catalog_and_saved_account_expose_the_same_efforts() {
+    use crate::commands::crud::KeyInfo;
+    use crate::commands::validate::{resolved_oauth_catalog, OAuthModelCatalogSource};
+    use crate::key_store::{AuthMethod, ModelKey, ModelType};
+
+    let catalog = resolved_oauth_catalog("codex", vec![], OAuthModelCatalogSource::Fallback)
+        .expect("fallback catalog");
+    assert!(catalog.models.iter().any(|model| model == "gpt-6-astra"));
+    let mut key = ModelKey::new(ModelType::Codex);
+    key.auth_method = AuthMethod::Oauth;
+    key.available_models = catalog.models.clone();
+    let saved = KeyInfo::from(key);
+
+    for variants in [&catalog.model_variants, &saved.model_variants] {
+        let astra: Vec<_> = variants
+            .iter()
+            .filter(|variant| variant.base_model == "gpt-6-astra")
+            .collect();
+        assert_eq!(astra.len(), 12);
+        for fast in [false, true] {
+            assert_eq!(
+                astra
+                    .iter()
+                    .filter(|variant| variant.fast == fast)
+                    .map(|variant| variant.reasoning.as_deref().unwrap())
+                    .collect::<Vec<_>>(),
+                vec!["low", "medium", "high", "xhigh", "max", "ultra"]
+            );
+        }
+    }
+    for defaults in [&catalog.default_variants, &saved.default_variants] {
+        assert!(defaults
+            .iter()
+            .any(|variant| variant.base_model == "gpt-6-astra"
+                && variant.model == "gpt-6-astra-medium"));
+    }
+}
+
+#[test]
+fn astra_live_catalog_keeps_provider_efforts_context_and_default() {
+    use crate::commands::validate::{resolved_oauth_catalog, OAuthModelCatalogSource};
+    use crate::types::DiscoveredModel;
+
+    let catalog = resolved_oauth_catalog(
+        "codex",
+        vec![DiscoveredModel {
+            id: "gpt-6-astra".to_string(),
+            context_window: Some(256_000),
+            supported_efforts: vec!["low".to_string(), "high".to_string()],
+            default_effort: Some("high".to_string()),
+            ..DiscoveredModel::default()
+        }],
+        OAuthModelCatalogSource::Live,
+    )
+    .unwrap();
+    assert_eq!(
+        catalog
+            .models
+            .iter()
+            .filter(|model| *model == "gpt-6-astra")
+            .count(),
+        1
+    );
+    let variants: Vec<_> = catalog
+        .model_variants
+        .iter()
+        .filter(|variant| variant.base_model == "gpt-6-astra")
+        .collect();
+    assert_eq!(variants.len(), 4);
+    assert!(variants
+        .iter()
+        .all(|variant| variant.context_window == Some(256_000)
+            && matches!(variant.reasoning.as_deref(), Some("low" | "high"))));
+    assert!(catalog
+        .default_variants
+        .iter()
+        .any(|variant| variant.base_model == "gpt-6-astra" && variant.model == "gpt-6-astra-high"));
+}
+
+#[test]
 fn codex_gpt_5_6_exposes_max_and_limits_ultra_to_sol_and_terra() {
     use crate::commands::crud::KeyInfo;
     use crate::key_store::{AuthMethod, ModelKey, ModelType};

--- a/src-tauri/crates/key-vault/src/providers/openai/mod.rs
+++ b/src-tauri/crates/key-vault/src/providers/openai/mod.rs
@@ -18,7 +18,7 @@ const DEFAULT_API_URL: &str = "https://api.openai.com";
 const DEFAULT_TIMEOUT_SECS: u64 = 15;
 
 // Per-provider model prefixes to filter out fine-tuned / irrelevant models.
-const OPENAI_MODEL_PREFIXES: &[&str] = &["gpt-4", "gpt-5", "codex", "o1", "o3", "o4"];
+const OPENAI_MODEL_PREFIXES: &[&str] = &["gpt-4", "gpt-5", "gpt-6", "codex", "o1", "o3", "o4"];
 const DEEPSEEK_MODEL_PREFIXES: &[&str] = &["deepseek"];
 const GROQ_MODEL_PREFIXES: &[&str] = &["llama", "mixtral", "gemma", "qwen", "deepseek", "mistral"];
 
@@ -277,6 +277,16 @@ impl OpenAIValidator {
             .await
             .map_err(|e| format!("Failed to parse response: {}", e))?;
 
+        Ok(Self::filter_models(data, base_url.is_some(), provider))
+    }
+
+    /// Project the discovery response into the model ids and context metadata
+    /// stored by validation. Custom endpoints retain their full catalog.
+    fn filter_models(
+        data: ModelsResponse,
+        has_custom_url: bool,
+        provider: Option<&str>,
+    ) -> (Vec<String>, HashMap<String, u64>) {
         let models = data.data;
         let mut all_ids: Vec<String> = Vec::with_capacity(models.len());
         let mut contexts: HashMap<String, u64> = HashMap::new();
@@ -287,7 +297,6 @@ impl OpenAIValidator {
             all_ids.push(m.id);
         }
 
-        let has_custom_url = base_url.is_some();
         let (useful_ids, useful_contexts) = if has_custom_url {
             (all_ids, contexts)
         } else {
@@ -312,7 +321,7 @@ impl OpenAIValidator {
             }
         };
 
-        Ok((useful_ids, useful_contexts))
+        (useful_ids, useful_contexts)
     }
 
     /// Verify the API key by sending a minimal chat completion request.

--- a/src-tauri/crates/key-vault/src/providers/tests/openai_tests.rs
+++ b/src-tauri/crates/key-vault/src/providers/tests/openai_tests.rs
@@ -1,6 +1,39 @@
 use crate::providers::openai::OpenAIValidator;
 
 #[test]
+fn discovery_retains_astra_and_its_context_without_widening_other_providers() {
+    let payload = serde_json::json!({"data": [
+        {"id": "gpt-6-astra", "context_length": 1_050_000},
+        {"id": "gpt-5.6-sol"},
+        {"id": "text-embedding-3-large", "context_length": 8192},
+        {"id": "deepseek-chat"}
+    ]});
+    for provider in [None, Some("openai_api")] {
+        let (models, contexts) = OpenAIValidator::filter_models(
+            serde_json::from_value(payload.clone()).unwrap(),
+            false,
+            provider,
+        );
+        assert_eq!(models, vec!["gpt-6-astra", "gpt-5.6-sol"]);
+        assert_eq!(contexts.get("gpt-6-astra"), Some(&1_050_000));
+        assert_eq!(contexts.len(), 1);
+    }
+    let (models, _) = OpenAIValidator::filter_models(
+        serde_json::from_value(payload.clone()).unwrap(),
+        false,
+        Some("deepseek_api"),
+    );
+    assert_eq!(models, vec!["deepseek-chat"]);
+    let (models, contexts) = OpenAIValidator::filter_models(
+        serde_json::from_value(payload).unwrap(),
+        true,
+        Some("openai_api"),
+    );
+    assert_eq!(models.len(), 4);
+    assert_eq!(contexts.len(), 2);
+}
+
+#[test]
 fn test_validate_format() {
     let validator = OpenAIValidator::new();
 

--- a/src/types/model/info.openai.test.ts
+++ b/src/types/model/info.openai.test.ts
@@ -1,0 +1,20 @@
+import { getModelInfo } from "./info";
+
+describe("OpenAI model info", () => {
+  it("uses Astra capabilities instead of the generic GPT fallback", () => {
+    for (const model of [
+      "gpt-6-astra",
+      "gpt-6-astra-ultra-fast",
+      "openai/gpt-6-astra-high",
+    ]) {
+      expect(getModelInfo(model)).toMatchObject({
+        providerKey: "openai",
+        contextWindow: 1050,
+        maxOutput: 128,
+        vision: true,
+        reasoning: true,
+      });
+    }
+    expect(getModelInfo("gpt-4o")?.contextWindow).toBe(128);
+  });
+});

--- a/src/types/model/info.openai.ts
+++ b/src/types/model/info.openai.ts
@@ -1,7 +1,7 @@
 /**
  * Model Info — OpenAI (GPT & o-series)
  *
- * Pattern-matched registry entries for GPT-4.x/5.x and the o1/o3/o4 reasoning line.
+ * Pattern-matched registry entries for GPT-4.x/5.x/6 and the o1/o3/o4 reasoning line.
  *
  * Extracted verbatim from `info.ts` during modularization; consumed by
  * `getModelInfo` in `@src/types/model/info`. See that file for the
@@ -11,6 +11,20 @@ import type { ModelInfoEntry } from "@src/types/model/info.types";
 
 export const OPENAI_MODEL_INFO_ENTRIES: ModelInfoEntry[] = [
   // ─── OpenAI (GPT & o-series) ──────────────────────────────
+  // https://developers.openai.com/api/docs/models/gpt-6-astra
+  {
+    pattern: "gpt-6-astra",
+    info: {
+      provider: "OpenAI",
+      providerKey: "openai",
+      contextWindow: 1050,
+      maxOutput: 128,
+      vision: true,
+      reasoning: true,
+      strengthKeys: ["longContext", "reasoning", "coding"],
+      pricingTier: "premium",
+    },
+  },
   {
     pattern: "gpt-5.5",
     info: {

--- a/src/util/__tests__/modelGrouping.test.ts
+++ b/src/util/__tests__/modelGrouping.test.ts
@@ -7,6 +7,19 @@ import {
 } from "../modelGrouping";
 
 describe("groupModels", () => {
+  it("groups Astra separately from other GPT tiers and keeps it current", () => {
+    const models = [
+      "gpt-6-astra",
+      "gpt-6-astra-high",
+      "gpt-6-astra-ultra-fast",
+    ];
+    const groups = groupModels([...models, "gpt-5.6-sol", "gpt-6"]);
+    const astra = groups.find((group) => group.label === "GPT 6 Astra");
+    expect(astra).toMatchObject({ sortVersion: 600, models });
+    expect(isLegacyGroup(astra!)).toBe(false);
+    expect(groups).toHaveLength(3);
+  });
+
   it("groups Claude models by version (claude-3-5-sonnet-20241022 → Sonnet 3.5)", () => {
     const groups = groupModels(["claude-3-5-sonnet-20241022"]);
     expect(groups).toHaveLength(1);

--- a/src/util/__tests__/modelVariants.test.ts
+++ b/src/util/__tests__/modelVariants.test.ts
@@ -7,6 +7,22 @@ import {
 } from "../modelVariants";
 
 describe("parseModelVariant", () => {
+  it("preserves Astra as the base across all reasoning and speed variants", () => {
+    for (const effort of ["low", "medium", "high", "xhigh", "max", "ultra"]) {
+      for (const fast of [false, true]) {
+        const model = `gpt-6-astra-${effort}${fast ? "-fast" : ""}`;
+        expect(parseModelVariant(model)).toMatchObject({
+          model,
+          baseModel: "gpt-6-astra",
+          reasoning: effort === "xhigh" ? "extra_high" : effort,
+          fast,
+          thinking: false,
+        });
+      }
+    }
+    expect(parseModelVariant("gpt-6-astra")).toBeUndefined();
+  });
+
   it("parses GPT reasoning and fast variants", () => {
     expect(parseModelVariant("gpt-5.5-high-fast")).toEqual({
       model: "gpt-5.5-high-fast",

--- a/src/util/modelGrouping.ts
+++ b/src/util/modelGrouping.ts
@@ -59,6 +59,7 @@ const GPT_TIER_PREFIXES = [
   "nano",
   "mini",
   "codex",
+  "astra",
   "sol",
   "terra",
   "luna",


### PR DESCRIPTION
## Problem

GPT-6 Astra is omitted by OpenAI API discovery and the Codex fallback catalog. Even when added manually, it falls through the generic GPT context metadata and the GPT-5-only endpoint/reasoning checks, so direct tool requests can start on the wrong API and aggregator requests can lose the selected effort. The model picker also lacks an Astra family label.

## Solution

- Admit GPT-6 in OpenAI discovery and add `gpt-6-astra` to the Codex setup/refresh fallback catalog. Keep existing default-enabled models and live account metadata precedence.
- Expose Low, Medium, High, Extra High, Max, and the existing Codex Ultra mode, with standard/fast variants. Ultra sends `max` plus the existing request-local delegation instructions; it is not a new API effort.
- Route direct public OpenAI Astra requests to Responses, classify Astra reasoning for compatible providers, and select `max_completion_tokens` for compatible Chat Completions. Custom endpoints retain their existing endpoint policy.
- Add the GPT 6 Astra group and matching frontend/backend metadata: 1,050,000-token context, 128,000-token maximum output in the frontend descriptor, vision, and reasoning.
- Cover discovery payload projection, fallback/saved-account parity, live metadata precedence, serialized provider requests, streaming/non-streaming compatible requests, grouping, parsing, and model metadata.

Official references: [Astra model specification](https://developers.openai.com/api/docs/models/gpt-6-astra) and [Astra migration guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra). Existing accounts use Refresh Models and enable Astra; this change does not refresh accounts in the background.

## Potential risks

- Account access and Fast availability remain provider-controlled. Astra Fast is unavailable with EU data residency; standard variants remain available. Live Astra API/OAuth calls and regional Fast behavior were not exercised.
- Ultra retains the existing Codex delegation policy and permission checks. Live discovery can expose a narrower effort set, which remains authoritative.
- The API request change is confined to Astra: direct OpenAI uses Responses; compatible Chat Completions uses its completion-token field. Custom gateway protocol requirements still use the existing policy and error negotiation.
- No dependency, schema, IPC, or persistence-format changes. Revert this commit to roll back; any stored Astra selection should be switched to an available model. No historical data cleanup is required.

## Verification

- `cd src-tauri && cargo test -p key_vault --lib --no-fail-fast` — 382 passed.
- `cd src-tauri && cargo test -p agent_core --lib providers:: --no-fail-fast` — 451 passed; 2,749 unrelated tests filtered out. No compiler warnings in either Rust test run.
- `pnpm test src/util/__tests__/modelGrouping.test.ts src/util/__tests__/modelGrouping.thresholds.test.ts src/util/__tests__/modelVariants.test.ts src/types/model/info.openai.test.ts` — 54 passed across four files.
- `pnpm exec tsgo --noEmit --pretty false` — passed.
- Commit hooks ran normally: lint-staged (Oxlint, ESLint, Prettier), TypeScript, commitlint, and `cd src-tauri && cargo clippy --lib --message-format=short -p agent_core -p key_vault` all passed.
- `pnpm exec eslint src/util/modelGrouping.ts src/util/__tests__/modelGrouping.test.ts src/util/__tests__/modelVariants.test.ts src/types/model/info.openai.ts src/types/model/info.openai.test.ts --max-warnings 0` — passed.
- `pnpm exec eslint src/ --ext .ts,.tsx,.js,.jsx --format json` — 6,431 files, zero errors or warnings. Used with the verified zero cycle count to retain the required audit trailer despite the worktree-incompatible trailer helper.
- `pnpm run check:circular` — no cycles across 6,527 modules.
- `pnpm run check:test-placement` — consistent across 495 directories.
- `git diff --cached --check` — passed. Reviewed the full diff for scope, secrets, private paths, generated artifacts, and unrelated formatting.
- No desktop GUI/E2E or live provider inference run. This changes catalog/metadata values without changing component layout; automated grouping/variant tests cover those values, so screenshots would add little evidence. No computer control was used.

## Audit

Architecture checklist: covered compilation, production call-chain wiring, naming, effort-vs-Ultra semantics, fallback branches, provider boundaries, readability, serialized payloads, setup/saved-account parity, and live metadata/default precedence (layers 1–10 within this change). Unrelated domains and session initialization were outside scope.

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Discovery remains explicit setup/refresh; inference remains request-driven | No timers, subscriptions, workers, or retries added | Production call-chain/diff review |
| Memory | keep | One bounded catalog entry and 12 fallback variants; request-local values | No new retained structures or cache lifecycle | Catalog cardinality and request construction tests |
| Scope/isolation | keep | Existing account/endpoint resolution and live metadata precedence | Custom endpoint policy and user selections preserved | Endpoint policy and live catalog tests |
| Rendering/hot path | keep | Static tier/metadata entries; no delta-loop changes | No added work while idle, hidden, closed, signed out, or in a second instance | Parser/grouping and transport tests |

Performance verdict: pass for the scoped catalog/request changes, supported by source review and passing catalog/transport tests. No CPU/RAM improvement is claimed; no resource ownership or lifecycle changed.
