### PR TITLE
feat(providers): complete Fable 5.1 support

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/messages.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/messages.rs
@@ -435,7 +435,9 @@ fn anthropic_thinking_block(tool_call: &Value) -> Option<Value> {
     let anthropic = tool_call.get("extra_content")?.get("anthropic")?;
     let thinking = anthropic.get("thinking")?.as_str()?;
     let signature = anthropic.get("signature")?.as_str()?;
-    if thinking.is_empty() || signature.is_empty() {
+    // Fable 5.1 can sign an empty visible summary. The opaque signature,
+    // not the amount of display text, determines whether to replay it.
+    if signature.is_empty() {
         return None;
     }
     Some(serde_json::json!({

--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/request.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/request.rs
@@ -9,6 +9,8 @@
 
 use serde_json::{json, Value};
 
+use crate::providers::model_capabilities::is_claude_fable_5_1;
+
 use super::client::{AnthropicAuthMode, AnthropicClient};
 use super::messages::extract_system;
 use super::thinking::build_thinking_params;
@@ -51,7 +53,8 @@ pub(super) fn prepare_request(
     let parsed = crate::providers::thinking_mode::parse_model_variant(model);
     let resolved_model =
         crate::providers::model_hints::wire_model_name(client.provider_spec, &parsed.base_model);
-    let (system, anthropic_messages) = extract_system(messages, skip_cache_write);
+    let fable_51 = is_claude_fable_5_1(&resolved_model);
+    let (system, mut anthropic_messages) = extract_system(messages, skip_cache_write);
 
     // Extract tool_choice override (from side_query structured output)
     // before converting tools to Anthropic format.
@@ -97,8 +100,20 @@ pub(super) fn prepare_request(
     }
 
     let tool_choice = if let Some(ovr) = tool_choice_override {
-        // Forced tool_choice from structured output
-        Some(ovr)
+        if fable_51 && matches!(ovr["type"].as_str(), Some("tool" | "any")) {
+            // Forced choices return 400 on 5.1. Follow its migration guide:
+            // request auto plus an explicit instruction on the current turn.
+            // The side-query caller still validates the returned tool call.
+            let instruction = if let Some(name) = ovr["name"].as_str() {
+                format!("Call the {name} tool to answer this request. Your response must begin with that tool call; do not answer in plain text.")
+            } else {
+                "Call at least one of the available tools to answer this request. Your response must begin with a tool call; do not answer in plain text.".to_string()
+            };
+            anthropic_messages.push(json!({ "role": "system", "content": instruction }));
+            Some(json!({ "type": "auto" }))
+        } else {
+            Some(ovr)
+        }
     } else if clean_tools.is_some() {
         Some(json!({"type": "auto"}))
     } else {
@@ -137,6 +152,7 @@ const CLAUDE_OAUTH_BETA: &str = "oauth-2025-04-20";
 const INTERLEAVED_THINKING_BETA: &str = "interleaved-thinking-2025-05-14";
 const TOOL_STREAMING_BETA: &str = "fine-grained-tool-streaming-2025-05-14";
 const EFFORT_BETA: &str = "effort-2025-11-24";
+const THINKING_BINDING_BETA: &str = "thinking-binding-controls-2026-08-01";
 const CLAUDE_OAUTH_USER_AGENT: &str = "claude-cli/2.1.78 (orgii, cli)";
 
 fn claude_output_config(effort: Option<&str>) -> Option<Value> {
@@ -158,11 +174,14 @@ fn model_uses_effort_beta(model: &str, provider_name: &str) -> bool {
     )
 }
 
-/// Join a base beta list with the optional effort beta.
-fn beta_header_value(base: &[&str], effort: bool) -> String {
+/// Join base betas with the required effort and thinking-binding controls.
+fn beta_header_value(base: &[&str], effort: bool, thinking_binding: bool) -> String {
     let mut parts: Vec<&str> = base.to_vec();
     if effort {
         parts.push(EFFORT_BETA);
+    }
+    if thinking_binding && !parts.contains(&THINKING_BINDING_BETA) {
+        parts.push(THINKING_BINDING_BETA);
     }
     parts.join(",")
 }
@@ -226,7 +245,12 @@ pub(super) fn apply_headers(
     // `extra_headers` (applied below) may carry a caller-supplied
     // `anthropic-beta`; never emit our own alongside it — reqwest appends
     // rather than replaces, and a duplicated beta header breaks requests.
-    let beta_overridden = client.config.extra_headers.contains_key("anthropic-beta");
+    let thinking_binding = is_claude_fable_5_1(resolved_model);
+    let beta_overridden = client
+        .config
+        .extra_headers
+        .keys()
+        .any(|key| key.eq_ignore_ascii_case("anthropic-beta"));
     let effort = model_uses_effort_beta(resolved_model, client.provider_spec.name);
 
     req = match client.auth_mode {
@@ -235,7 +259,11 @@ pub(super) fn apply_headers(
             if !beta_overridden {
                 req = req.header(
                     "anthropic-beta",
-                    beta_header_value(&[PROMPT_CACHING_BETA, EXTENDED_CACHE_TTL_BETA], effort),
+                    beta_header_value(
+                        &[PROMPT_CACHING_BETA, EXTENDED_CACHE_TTL_BETA],
+                        effort,
+                        thinking_binding,
+                    ),
                 );
             }
             req
@@ -245,7 +273,11 @@ pub(super) fn apply_headers(
             if !beta_overridden {
                 req = req.header(
                     "anthropic-beta",
-                    beta_header_value(&[PROMPT_CACHING_BETA, EXTENDED_CACHE_TTL_BETA], effort),
+                    beta_header_value(
+                        &[PROMPT_CACHING_BETA, EXTENDED_CACHE_TTL_BETA],
+                        effort,
+                        thinking_binding,
+                    ),
                 );
             }
             req
@@ -271,6 +303,7 @@ pub(super) fn apply_headers(
                             EXTENDED_CACHE_TTL_BETA,
                         ],
                         effort,
+                        thinking_binding,
                     ),
                 );
             }
@@ -278,8 +311,28 @@ pub(super) fn apply_headers(
         }
     };
 
+    let mut custom_betas = Vec::new();
     for (key, value) in &client.config.extra_headers {
-        req = req.header(key, value);
+        if key.eq_ignore_ascii_case("anthropic-beta") {
+            custom_betas.extend(
+                value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|part| !part.is_empty()),
+            );
+        } else {
+            req = req.header(key, value);
+        }
+    }
+    if beta_overridden {
+        // Even a custom beta list must enable the binding control serialized
+        // in the body. Emit one header, including for mixed-case config keys.
+        custom_betas.sort_unstable();
+        custom_betas.dedup();
+        req = req.header(
+            "anthropic-beta",
+            beta_header_value(&custom_betas, false, thinking_binding),
+        );
     }
     req
 }
@@ -372,11 +425,11 @@ mod tests {
     #[test]
     fn beta_header_value_appends_effort_only_when_enabled() {
         assert_eq!(
-            beta_header_value(&[PROMPT_CACHING_BETA], false),
+            beta_header_value(&[PROMPT_CACHING_BETA], false, false),
             PROMPT_CACHING_BETA
         );
         assert_eq!(
-            beta_header_value(&[PROMPT_CACHING_BETA], true),
+            beta_header_value(&[PROMPT_CACHING_BETA], true, false),
             format!("{PROMPT_CACHING_BETA},{EFFORT_BETA}")
         );
     }
@@ -388,6 +441,7 @@ mod tests {
     #[test]
     fn effort_capability_stays_in_lockstep_with_key_vault() {
         for model in [
+            "claude-fable-5-1",
             "claude-fable-5",
             "claude-opus-5",
             "claude-opus-4-8",
@@ -420,3 +474,7 @@ mod tests {
         assert!(parts.iter().all(|part| part.parse::<u64>().is_ok()));
     }
 }
+
+#[cfg(test)]
+#[path = "tests/fable51_request_tests.rs"]
+mod fable51_tests;

--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/stream_parser.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/stream_parser.rs
@@ -425,9 +425,9 @@ fn handle_error_event(
 ///
 /// The block list preserves the source-order interleave Anthropic emitted;
 /// `tool_calls` is the order-insensitive flat copy used by message-history
-/// consumers. Empty text/thinking segments and malformed tool calls
-/// (missing id/name from stream interruption) are dropped — they carry
-/// no information and would only pollute the UI.
+/// consumers. Empty text/thinking segments are omitted from visible blocks,
+/// but signed thinking (including empty summaries) is retained on tool calls
+/// for replay. Malformed tool calls missing id/name are dropped.
 pub(super) fn finalize_blocks(
     state: &mut StreamState,
 ) -> (Vec<AssistantBlock>, Vec<ToolCallRequest>) {
@@ -447,15 +447,15 @@ pub(super) fn finalize_blocks(
                 }
             }
             BlockAcc::Thinking { text, signature } => {
+                if let Some(sig) = signature {
+                    pending_anthropic_thinking = Some(serde_json::json!({
+                        "anthropic": {
+                            "thinking": text,
+                            "signature": sig,
+                        }
+                    }));
+                }
                 if !text.is_empty() {
-                    if let Some(sig) = signature {
-                        pending_anthropic_thinking = Some(serde_json::json!({
-                            "anthropic": {
-                                "thinking": text,
-                                "signature": sig,
-                            }
-                        }));
-                    }
                     blocks.push(AssistantBlock::Reasoning { text });
                 }
             }

--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/streaming.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/streaming.rs
@@ -564,9 +564,6 @@ fn build_non_streaming_response(parsed: MessagesResponse) -> LLMResponse {
                 signature,
             } => {
                 if let Some(ref thought) = thinking {
-                    if thought.is_empty() {
-                        continue;
-                    }
                     if let Some(sig) = signature {
                         pending_anthropic_thinking = Some(serde_json::json!({
                             "anthropic": {
@@ -574,6 +571,10 @@ fn build_non_streaming_response(parsed: MessagesResponse) -> LLMResponse {
                                 "signature": sig,
                             }
                         }));
+                    }
+                    // Empty summaries still carry signed history (Fable 5.1).
+                    if thought.is_empty() {
+                        continue;
                     }
                     reasoning.push_str(thought);
                     blocks.push(AssistantBlock::Reasoning {
@@ -622,3 +623,7 @@ fn build_non_streaming_response(parsed: MessagesResponse) -> LLMResponse {
         retry_after_ms: None,
     }
 }
+
+#[cfg(test)]
+#[path = "tests/thinking_history_tests.rs"]
+mod thinking_history_tests;

--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/tests/fable51_request_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/tests/fable51_request_tests.rs
@@ -1,0 +1,311 @@
+//! Serialized request contracts from the Fable 5.1 migration guide.
+use super::*;
+use crate::providers::registry::find_by_name;
+use crate::providers::traits::ProviderConfig;
+use std::collections::HashMap;
+
+fn client(auth_mode: AnthropicAuthMode, extra_headers: HashMap<String, String>) -> AnthropicClient {
+    crate::test_support::install_crypto_provider_for_tests();
+    AnthropicClient::new_with_auth_mode(
+        ProviderConfig {
+            api_key: "test-key".into(),
+            api_base: Some("https://example.invalid/v1".into()),
+            extra_headers,
+            is_azure: auth_mode == AnthropicAuthMode::AzureBearer,
+        },
+        find_by_name("anthropic").unwrap(),
+        "claude-fable-5-1".into(),
+        auth_mode,
+    )
+}
+
+fn serialized_request(
+    client: &AnthropicClient,
+    model: &str,
+    messages: &[Value],
+    tools: Option<&[Value]>,
+    stream: bool,
+) -> (Value, reqwest::header::HeaderMap) {
+    let prepared = prepare_request(client, messages, tools, model, 8192, 0.7, stream, true);
+    let request = apply_headers(
+        client,
+        &prepared.resolved_model,
+        client.client.post(&prepared.url),
+    )
+    .json(&prepared.body)
+    .build()
+    .unwrap();
+    let body = serde_json::from_slice(request.body().unwrap().as_bytes().unwrap()).unwrap();
+    (body, request.headers().clone())
+}
+
+fn tool() -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": "emit_result",
+            "description": "Emit structured output",
+            "parameters": { "type": "object", "properties": { "answer": { "type": "string" } } }
+        }
+    })
+}
+
+fn tools_with_choice(choice: Value) -> Vec<Value> {
+    vec![
+        tool(),
+        json!({ (crate::core::side_query::TOOL_CHOICE_OVERRIDE_KEY): choice }),
+    ]
+}
+
+#[test]
+fn documented_efforts_reach_wire_in_all_auth_and_stream_modes() {
+    for auth in [
+        AnthropicAuthMode::ApiKey,
+        AnthropicAuthMode::AzureBearer,
+        AnthropicAuthMode::ClaudeOauth,
+    ] {
+        let client = client(auth, HashMap::new());
+        for stream in [false, true] {
+            for effort in ["low", "medium", "high", "xhigh", "max"] {
+                // Both plain side queries and normal tool-enabled chat must
+                // honor the chosen effort and always-on thinking.
+                for tools in [None, Some(vec![tool()])] {
+                    let (body, headers) = serialized_request(
+                        &client,
+                        &format!("claude-fable-5-1-{effort}"),
+                        &[json!({"role": "user", "content": "hello"})],
+                        tools.as_deref(),
+                        stream,
+                    );
+                    assert_eq!(body["model"], "claude-fable-5-1");
+                    assert_eq!(body["stream"], stream);
+                    assert_eq!(body["output_config"], json!({"effort": effort}));
+                    assert_eq!(
+                        body["thinking"],
+                        json!({
+                            "type": "adaptive", "display": "summarized",
+                            "block_binding": {"prefix_mismatch_behavior": "drop_block"}
+                        })
+                    );
+                    assert!(body.get("temperature").is_none());
+                    assert!(body.get("effort").is_none());
+                    assert_eq!(headers.get_all("anthropic-beta").iter().count(), 1);
+                    assert!(headers["anthropic-beta"]
+                        .to_str()
+                        .unwrap()
+                        .split(',')
+                        .any(|v| v == THINKING_BINDING_BETA));
+                    match auth {
+                        AnthropicAuthMode::ApiKey => assert_eq!(headers["x-api-key"], "test-key"),
+                        _ => assert_eq!(headers["authorization"], "Bearer test-key"),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn saved_aliases_and_baseline_never_disable_fable_51_thinking() {
+    let client = client(AnthropicAuthMode::ApiKey, HashMap::new());
+    for (suffix, effort) in [
+        ("", None),
+        ("-baseline", None),
+        ("-thinking-none", None),
+        ("-ultracode", Some("max")),
+        ("-thinking-ultracode", Some("max")),
+    ] {
+        let (body, _) = serialized_request(
+            &client,
+            &format!("claude-fable-5-1{suffix}"),
+            &[],
+            None,
+            false,
+        );
+        assert_eq!(body["model"], "claude-fable-5-1");
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"].as_str(), effort);
+    }
+}
+
+#[test]
+fn forced_choices_become_auto_with_current_turn_instructions() {
+    let client = client(AnthropicAuthMode::ApiKey, HashMap::new());
+    let messages = vec![json!({"role": "user", "content": "Extract the answer"})];
+    for choice in [
+        json!({"type": "tool", "name": "emit_result"}),
+        json!({"type": "any"}),
+    ] {
+        let tools = tools_with_choice(choice.clone());
+        let original_tools = tools.clone();
+        for stream in [false, true] {
+            let (body, _) = serialized_request(
+                &client,
+                "claude-fable-5-1-high",
+                &messages,
+                Some(&tools),
+                stream,
+            );
+            assert_eq!(body["tool_choice"], json!({"type": "auto"}));
+            assert_eq!(body["tools"].as_array().unwrap().len(), 1);
+            assert_eq!(body["tools"][0]["name"], "emit_result");
+            assert_eq!(
+                body["messages"][0]["content"][0]["text"],
+                "Extract the answer"
+            );
+            assert_eq!(body["messages"].as_array().unwrap().len(), 2);
+            assert_eq!(body["messages"][1]["role"], "system");
+            let instruction = body["messages"][1]["content"].as_str().unwrap();
+            assert!(instruction.contains("must begin with"));
+            if choice["type"] == "tool" {
+                assert!(instruction.contains("emit_result"));
+            }
+        }
+        assert_eq!(tools, original_tools);
+    }
+    assert_eq!(
+        messages,
+        vec![json!({"role": "user", "content": "Extract the answer"})]
+    );
+}
+
+#[test]
+fn auto_and_none_choices_do_not_inject_instructions() {
+    let client = client(AnthropicAuthMode::ApiKey, HashMap::new());
+    for choice in [json!({"type": "auto"}), json!({"type": "none"})] {
+        let tools = tools_with_choice(choice.clone());
+        let (body, _) = serialized_request(
+            &client,
+            "claude-fable-5-1",
+            &[json!({"role": "user", "content": "hello"})],
+            Some(&tools),
+            false,
+        );
+        assert_eq!(body["tool_choice"], choice);
+        assert_eq!(body["messages"].as_array().unwrap().len(), 1);
+    }
+}
+
+#[test]
+fn custom_beta_headers_cannot_disable_binding_controls_or_duplicate_headers() {
+    for auth in [
+        AnthropicAuthMode::ApiKey,
+        AnthropicAuthMode::AzureBearer,
+        AnthropicAuthMode::ClaudeOauth,
+    ] {
+        for custom in [
+            "custom-beta",
+            "custom-beta, thinking-binding-controls-2026-08-01",
+        ] {
+            let client = client(
+                auth,
+                HashMap::from([
+                    ("Anthropic-Beta".into(), custom.into()),
+                    ("anthropic-beta".into(), "second-beta".into()),
+                    ("x-custom".into(), "preserved".into()),
+                ]),
+            );
+            let (_, headers) = serialized_request(&client, "claude-fable-5-1", &[], None, false);
+            assert_eq!(headers.get_all("anthropic-beta").iter().count(), 1);
+            let betas: Vec<_> = headers["anthropic-beta"]
+                .to_str()
+                .unwrap()
+                .split(',')
+                .collect();
+            assert_eq!(
+                betas
+                    .iter()
+                    .filter(|&&v| v == THINKING_BINDING_BETA)
+                    .count(),
+                1
+            );
+            assert!(betas.contains(&"custom-beta"));
+            assert!(betas.contains(&"second-beta"));
+            assert_eq!(headers["x-custom"], "preserved");
+        }
+    }
+}
+
+#[test]
+fn changed_prefix_keeps_signed_blocks_for_provider_binding_validation() {
+    let client = client(AnthropicAuthMode::ApiKey, HashMap::new());
+    let messages = vec![
+        json!({"role": "system", "content": "Updated system prompt or compacted summary"}),
+        json!({"role": "user", "content": "Original request"}),
+        json!({"role": "assistant", "content": null, "tool_calls": [{
+            "id": "call_1", "type": "function",
+            "function": {"name": "emit_result", "arguments": "{}"},
+            "extra_content": {"anthropic": {"thinking": "", "signature": "opaque-signature"}}
+        }]}),
+        json!({"role": "tool", "tool_call_id": "call_1", "content": "Done"}),
+    ];
+    let original = messages.clone();
+    let (body, headers) = serialized_request(
+        &client,
+        "claude-fable-5-1",
+        &messages,
+        Some(&[tool()]),
+        true,
+    );
+    assert_eq!(
+        body["messages"][1]["content"][0],
+        json!({"type": "thinking", "thinking": "", "signature": "opaque-signature"})
+    );
+    assert_eq!(body["messages"][1]["content"][1]["type"], "tool_use");
+    assert_eq!(body["messages"][2]["content"][0]["type"], "tool_result");
+    assert_eq!(
+        body["thinking"]["block_binding"]["prefix_mismatch_behavior"],
+        "drop_block"
+    );
+    assert!(headers["anthropic-beta"]
+        .to_str()
+        .unwrap()
+        .contains(THINKING_BINDING_BETA));
+    assert_eq!(messages, original);
+}
+
+#[test]
+fn other_models_keep_their_request_contract() {
+    let client = client(AnthropicAuthMode::ApiKey, HashMap::new());
+    let tools = tools_with_choice(json!({"type": "tool", "name": "emit_result"}));
+    let (body, headers) = serialized_request(
+        &client,
+        "claude-fable-5-ultracode",
+        &[],
+        Some(&tools),
+        false,
+    );
+    assert_eq!(body["output_config"]["effort"], "ultracode");
+    assert_eq!(body["tool_choice"]["type"], "tool");
+    assert!(body.get("thinking").is_none());
+    assert!(!headers["anthropic-beta"]
+        .to_str()
+        .unwrap()
+        .contains(THINKING_BINDING_BETA));
+
+    for model in ["claude-fable-5-10", "claude-opus-4-8", "claude-haiku-4-5"] {
+        let (body, headers) = serialized_request(&client, model, &[], Some(&tools), false);
+        assert_eq!(body["tool_choice"]["type"], "tool");
+        assert!(body["thinking"].get("block_binding").is_none());
+        assert!(!headers["anthropic-beta"]
+            .to_str()
+            .unwrap()
+            .contains(THINKING_BINDING_BETA));
+    }
+}
+
+#[test]
+fn qualified_and_snapshot_ids_receive_fable_51_compatibility() {
+    let client = client(AnthropicAuthMode::ApiKey, HashMap::new());
+    for model in [
+        "anthropic/claude-fable-5-1-high",
+        "claude-fable-5-1-20260901-high",
+        "anthropic.claude-fable-5-1-v1:0",
+    ] {
+        let (body, _) = serialized_request(&client, model, &[], None, false);
+        assert_eq!(
+            body["thinking"]["block_binding"]["prefix_mismatch_behavior"], "drop_block",
+            "{model}"
+        );
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/tests/thinking_history_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/tests/thinking_history_tests.rs
@@ -1,0 +1,80 @@
+use super::*;
+use serde_json::json;
+
+fn assert_replayable_signed_summary(tool_calls: &[crate::providers::traits::ToolCallRequest]) {
+    assert_eq!(tool_calls.len(), 1);
+    let call = &tool_calls[0];
+    assert_eq!(
+        call.thought_signature,
+        Some(json!({
+            "anthropic": { "thinking": "", "signature": "opaque-signature" }
+        }))
+    );
+
+    // The turn executor persists this extra_content shape without modifying
+    // it; run it through the next request's history conversion as well.
+    let (_, messages) = super::super::messages::extract_system(
+        &[
+            json!({"role": "user", "content": "Read the file"}),
+            json!({"role": "assistant", "content": null, "tool_calls": [{
+                "id": call.id, "type": "function",
+                "function": {"name": call.name, "arguments": call.arguments.to_string()},
+                "extra_content": call.thought_signature
+            }]}),
+        ],
+        true,
+    );
+    assert_eq!(
+        messages[1]["content"][0],
+        json!({
+            "type": "thinking", "thinking": "", "signature": "opaque-signature"
+        })
+    );
+    assert_eq!(messages[1]["content"][1]["type"], "tool_use");
+}
+
+#[test]
+fn non_streaming_empty_signed_summary_survives_ingestion_and_replay() {
+    let parsed: MessagesResponse = serde_json::from_value(json!({
+        "content": [
+            {"type": "thinking", "thinking": "", "signature": "opaque-signature"},
+            {"type": "tool_use", "id": "call_1", "name": "read_file", "input": {"path": "README.md"}}
+        ],
+        "stop_reason": "tool_use"
+    })).unwrap();
+    let response = build_non_streaming_response(parsed);
+    assert_replayable_signed_summary(&response.tool_calls);
+    assert!(response.reasoning_content.is_none());
+    assert_eq!(
+        response.blocks.len(),
+        1,
+        "no empty reasoning row is rendered"
+    );
+}
+
+#[test]
+fn streamed_signature_without_thinking_text_survives_ingestion_and_replay() {
+    let mut state = StreamState::default();
+    for frame in [
+        json!({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
+        json!({"type": "content_block_delta", "index": 0, "delta": {"type": "signature_delta", "signature": "opaque-signature"}}),
+        json!({"type": "content_block_stop", "index": 0}),
+        json!({"type": "content_block_start", "index": 1, "content_block": {"type": "tool_use", "id": "call_1", "name": "read_file", "input": {}}}),
+        json!({"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": "{\"path\":\"README.md\"}"}}),
+        json!({"type": "content_block_stop", "index": 1}),
+    ] {
+        handle_event(
+            serde_json::from_value(frame).unwrap(),
+            &mut state,
+            &|_| {},
+            "claude-fable-5-1",
+        );
+    }
+    let (blocks, tool_calls) = finalize_blocks(&mut state);
+    assert_replayable_signed_summary(&tool_calls);
+    assert!(
+        state.block_accumulators.is_empty(),
+        "finalization drains per-response state"
+    );
+    assert_eq!(blocks.len(), 1, "no empty reasoning row is rendered");
+}

--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/thinking.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/thinking.rs
@@ -20,7 +20,9 @@
 
 use serde_json::{json, Value};
 
-use crate::providers::model_capabilities::{ModelCapabilities, ThinkingSupport};
+use crate::providers::model_capabilities::{
+    is_claude_fable_5_1, ModelCapabilities, ThinkingSupport,
+};
 use crate::providers::registry::provider_id;
 use crate::providers::thinking_mode::{
     anthropic_effort, anthropic_max_tokens_floor, anthropic_thinking_param,
@@ -83,6 +85,33 @@ pub(super) fn build_thinking_params(
             effort: None,
             temperature: Some(temperature),
             max_tokens,
+        };
+    }
+
+    if is_claude_fable_5_1(base_model) {
+        // Always-on thinking also applies to plain side queries. ORG2 rebuilds
+        // system/tools and compacts history; let the provider drop only the
+        // thinking invalidated by those changes, instead of rejecting with 400.
+        // https://platform.claude.com/docs/en/models/fable-5-1/migration-guide
+        let level = match level {
+            // Preserve saved selections from the old fallback catalog.
+            Some(ReasoningLevel::Ultracode) => Some(ReasoningLevel::Max),
+            level => level,
+        };
+        return ThinkingOutcome {
+            thinking: Some(json!({
+                "type": "adaptive",
+                "display": "summarized",
+                "block_binding": { "prefix_mismatch_behavior": "drop_block" }
+            })),
+            effort: anthropic_effort(mode, level).map(str::to_string),
+            temperature: None,
+            max_tokens: match directive {
+                ThinkingDirective::PlainText => {
+                    max_tokens.saturating_add(ALWAYS_ON_THINKING_PAD_TOKENS)
+                }
+                ThinkingDirective::Auto => max_tokens.max(ALWAYS_ON_THINKING_PAD_TOKENS + 1024),
+            },
         };
     }
 

--- a/src-tauri/crates/agent-core/src/core/providers/model_capabilities.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/model_capabilities.rs
@@ -564,6 +564,14 @@ const FAMILY_RULES: &[FamilyRule] = &[
     },
 ];
 
+/// Fable 5.1 request compatibility, including qualified ids and snapshots.
+pub(crate) fn is_claude_fable_5_1(model: &str) -> bool {
+    model
+        .to_ascii_lowercase()
+        .split_once("claude-fable-5-1")
+        .is_some_and(|(_, rest)| rest.is_empty() || rest.starts_with('-') || rest.starts_with(':'))
+}
+
 /// Resolve capabilities for `model`, optionally consulting the KeyVault
 /// entry for `account_id`.
 ///

--- a/src-tauri/crates/key-vault/src/commands/crud/models.rs
+++ b/src-tauri/crates/key-vault/src/commands/crud/models.rs
@@ -134,7 +134,12 @@ fn effort_variants_for_base_model(
     let mut variants = Vec::new();
     let has_thinking_toggle = claude_model_has_thinking_toggle(base_model);
     let lower = base_model.to_lowercase();
-    let rungs = if lower.contains("fable-5") {
+    // Fable 5.1 documents only low/medium/high/xhigh/max. Do not inherit
+    // Fable 5's legacy ultracode fallback; live discovery still wins.
+    let is_fable_51 = lower
+        .split_once("claude-fable-5-1")
+        .is_some_and(|(_, rest)| rest.is_empty() || rest.starts_with('-') || rest.starts_with(':'));
+    let rungs = if lower.contains("fable-5") && !is_fable_51 {
         FABLE_EFFORT_RUNGS
     } else {
         ANTHROPIC_EFFORT_RUNGS

--- a/src-tauri/crates/key-vault/src/commands/tests/tests.rs
+++ b/src-tauri/crates/key-vault/src/commands/tests/tests.rs
@@ -260,13 +260,10 @@ fn claude_native_key_info_exposes_output_config_effort_variants() {
     }));
 }
 
-/// Claude Fable 5.1 (`claude-fable-5-1`) is the newest Claude model. It ships
-/// in the baked Claude Code OAuth catalog and, being the same family as Fable
-/// 5, must get the Fable effort ladder (the five Anthropic rungs plus
-/// `ultracode`) rather than the generic Anthropic one. The `-1` minor-version
-/// segment must not be mistaken for an effort suffix.
+/// Fable 5.1's documented ladder has five levels, unlike Fable 5's legacy
+/// fallback. The minor-version segment must not become an effort suffix.
 #[test]
-fn claude_fable_5_1_is_catalogued_and_gets_the_fable_effort_ladder() {
+fn claude_fable_5_1_is_catalogued_with_five_documented_efforts() {
     use crate::commands::crud::KeyInfo;
     use crate::commands::crud::{
         CLAUDE_CODE_OAUTH_DEFAULT_ENABLED_MODELS, CLAUDE_CODE_OAUTH_MODELS,
@@ -296,12 +293,71 @@ fn claude_fable_5_1_is_catalogued_and_gets_the_fable_effort_ladder() {
             "claude-fable-5-1-high",
             "claude-fable-5-1-xhigh",
             "claude-fable-5-1-max",
-            "claude-fable-5-1-ultracode",
         ]
     );
     assert!(info.default_variants.iter().any(|variant| {
         variant.base_model == "claude-fable-5-1" && variant.model == "claude-fable-5-1-high"
     }));
+}
+
+#[test]
+fn fable_51_api_and_oauth_fallbacks_agree_and_live_metadata_wins() {
+    use crate::commands::crud::KeyInfo;
+    use crate::commands::validate::{resolved_oauth_catalog, OAuthModelCatalogSource};
+    use crate::key_store::{ModelKey, ModelType};
+    use crate::types::DiscoveredModel;
+
+    let mut key = ModelKey::new(ModelType::AnthropicApi);
+    key.available_models = vec!["claude-fable-5-1".into()];
+    let info = KeyInfo::from(key);
+    let api_variants: Vec<_> = info
+        .model_variants
+        .iter()
+        .map(|v| v.model.as_str())
+        .collect();
+    assert_eq!(
+        api_variants,
+        vec![
+            "claude-fable-5-1-low",
+            "claude-fable-5-1-medium",
+            "claude-fable-5-1-high",
+            "claude-fable-5-1-xhigh",
+            "claude-fable-5-1-max",
+        ]
+    );
+
+    for efforts in [vec![], vec!["medium".to_string(), "max".to_string()]] {
+        let catalog = resolved_oauth_catalog(
+            "claude_code",
+            vec![DiscoveredModel {
+                id: "claude-fable-5-1".into(),
+                supported_efforts: efforts.clone(),
+                context_window: Some(1_000_000),
+                default_effort: Some("medium".into()),
+                ..DiscoveredModel::default()
+            }],
+            OAuthModelCatalogSource::Live,
+        )
+        .unwrap();
+        let variants: Vec<_> = catalog
+            .model_variants
+            .iter()
+            .map(|v| v.model.as_str())
+            .collect();
+        if efforts.is_empty() {
+            assert_eq!(variants, api_variants);
+        } else {
+            assert_eq!(
+                variants,
+                vec!["claude-fable-5-1-medium", "claude-fable-5-1-max"]
+            );
+        }
+        assert!(catalog
+            .model_variants
+            .iter()
+            .all(|v| v.context_window == Some(1_000_000)));
+        assert_eq!(catalog.default_variants[0].model, "claude-fable-5-1-medium");
+    }
 }
 
 #[test]

--- a/src-tauri/crates/orgtrack-core/src/model_pricing_catalog.json
+++ b/src-tauri/crates/orgtrack-core/src/model_pricing_catalog.json
@@ -1,6 +1,6 @@
 {
-  "_comment": "Bundled model-price catalog. Rates are approximate published list prices in USD per 1,000,000 tokens (per Mtok). input/output are per-token rates; cache_write is the 5-minute cache-creation rate; cache_read is the cache-hit rate. For providers that do not price cache writes separately, cache_write mirrors input. Sources (2026-07-16; claude-fable-5-1 rates added 2026-09-02): platform.claude.com/docs/en/about-claude/pricing, developers.openai.com/api/docs/pricing, cursor.com/docs/models-and-pricing, api-docs.deepseek.com/quick_start/pricing, platform.minimax.io/docs/guides/pricing-paygo, docs.z.ai/guides/overview/pricing. Notes: claude-sonnet-5 carries introductory pricing (2/10) through 2026-08-31, standard 3/15 from 2026-09-01. The op-*/opus-*/composer/grok/default ids are model labels observed in imported Cursor sessions; 'default' is Cursor Auto. This file is reference data compiled into the binary via include_str! - no user data.",
-  "_updated": "2026-09-02",
+  "_comment": "Bundled model-price catalog. Rates are approximate published list prices in USD per 1,000,000 tokens (per Mtok). input/output are per-token rates; cache_write is the 5-minute cache-creation rate; cache_read is the cache-hit rate. For providers that do not price cache writes separately, cache_write mirrors input. Sources (2026-07-16; claude-fable-5-1 rates verified 2026-09-05 at platform.claude.com/docs/en/models/fable-5-1/overview): platform.claude.com/docs/en/about-claude/pricing, developers.openai.com/api/docs/pricing, cursor.com/docs/models-and-pricing, api-docs.deepseek.com/quick_start/pricing, platform.minimax.io/docs/guides/pricing-paygo, docs.z.ai/guides/overview/pricing. Notes: claude-sonnet-5 carries introductory pricing (2/10) through 2026-08-31, standard 3/15 from 2026-09-01. The op-*/opus-*/composer/grok/default ids are model labels observed in imported Cursor sessions; 'default' is Cursor Auto. This file is reference data compiled into the binary via include_str! - no user data.",
+  "_updated": "2026-09-05",
   "default": {
     "input": 3.0,
     "output": 15.0,
@@ -314,7 +314,7 @@
       "input": 10.0,
       "output": 50.0,
       "cache_write": 12.5,
-      "cache_read": 1.0
+      "cache_read": 0.25
     },
     {
       "id": "claude-fable-5",

--- a/src-tauri/crates/orgtrack-core/src/pricing.rs
+++ b/src-tauri/crates/orgtrack-core/src/pricing.rs
@@ -330,17 +330,19 @@ mod tests {
         );
     }
 
-    /// `claude-fable-5-1` is priced identically to Fable 5 ($10 / $50), but it
-    /// needs its own row: without one, the longest-prefix fallback would quietly
-    /// hand 5.1 traffic whatever Fable 5's row says, and the two would drift
-    /// apart the first time Anthropic reprices either line.
+    /// Fable 5.1 keeps Fable 5's $10/$50 input/output rates but reduces cache
+    /// reads to $0.25/Mtok. Its own row must win over the Fable 5 prefix.
     #[test]
     fn fable_5_1_has_its_own_row() {
         let pricing = resolve_pricing(Some("claude-fable-5-1"));
         assert_eq!(pricing.input_per_mtok, 10.0);
         assert_eq!(pricing.output_per_mtok, 50.0);
         assert_eq!(pricing.cache_creation_per_mtok, 12.5);
-        assert_eq!(pricing.cache_read_per_mtok, 1.0);
+        assert_eq!(pricing.cache_read_per_mtok, 0.25);
+        assert_eq!(
+            resolve_pricing(Some("claude-fable-5")).cache_read_per_mtok,
+            1.0
+        );
 
         // Effort-suffixed variant ids reach the same row via prefix fallback,
         // and must not collapse onto the shorter `claude-fable-5` entry.

--- a/src/types/model/info.anthropic.test.ts
+++ b/src/types/model/info.anthropic.test.ts
@@ -1,0 +1,20 @@
+import { getModelInfo } from "./info";
+
+describe("Anthropic model info", () => {
+  it("uses Fable 5.1 output limits before the generic Fable fallback", () => {
+    for (const model of [
+      "claude-fable-5-1",
+      "claude-fable-5-1-max",
+      "anthropic/claude-fable-5-1-xhigh",
+    ]) {
+      expect(getModelInfo(model)).toMatchObject({
+        providerKey: "anthropic",
+        contextWindow: 1000,
+        maxOutput: 128,
+        vision: true,
+        reasoning: true,
+      });
+    }
+    expect(getModelInfo("claude-fable-5")?.maxOutput).toBe(32);
+  });
+});

--- a/src/types/model/info.anthropic.ts
+++ b/src/types/model/info.anthropic.ts
@@ -191,6 +191,20 @@ export const ANTHROPIC_MODEL_INFO_ENTRIES: ModelInfoEntry[] = [
       pricingTier: "budget",
     },
   },
+  // Fable 5.1: https://platform.claude.com/docs/en/models/fable-5-1/overview
+  {
+    pattern: "claude-fable-5-1",
+    info: {
+      provider: "Anthropic",
+      providerKey: "anthropic",
+      contextWindow: 1000,
+      maxOutput: 128,
+      vision: true,
+      reasoning: true,
+      strengthKeys: ["coding", "agentic", "reasoning", "planning"],
+      pricingTier: "expensive",
+    },
+  },
   // claude-fable-5 / claude-mythos: 1M context window (Anthropic).
   {
     pattern: "claude-fable",


### PR DESCRIPTION
## Problem

Fable 5.1 is already discoverable, but ORG2 inherits incompatible Fable 5 defaults: the fallback catalog offers `ultracode`, plain side queries lose the selected effort, structured side queries send forced tool choices that 5.1 rejects, and edited/compacted histories can fail its thinking-signature check. Static metadata also understates maximum output and overstates cached-input pricing.

## Solution

- Synthesize `low`, `medium`, `high`, `xhigh`, and `max`, retaining the `high` default and authoritative live capability metadata. Saved `ultracode` aliases remain readable and send `max`; no stored selections are deleted.
- Use always-on adaptive thinking, summarized display, and the chosen effort for both plain and tool-enabled requests. Enable `drop_block` with its required thinking-binding beta so the API can discard invalidated reasoning after system/tool/history changes. Preserve opaque signed blocks for provider validation, including empty visible summaries. Both response finalizers and the history converter previously dropped those valid blocks; the fix retains their signatures in the existing tool-call metadata format.
- Translate forced `tool`/`any` choices to `auto` with an explicit instruction appended for the current request. Existing side-query extraction, empty-result handling, and text fallback remain in place.
- Apply the same request construction to streaming/non-streaming and API-key, Azure Bearer, and Claude OAuth paths. Merge custom beta headers case-insensitively into one header so they cannot accidentally omit the required binding beta.
- Record 1M context, 128K maximum output, and $0.25/Mtok cache reads, keeping Fable 5 metadata unchanged.

Checked Anthropic's [migration guide](https://platform.claude.com/docs/en/models/fable-5-1/migration-guide), [effort reference](https://platform.claude.com/docs/en/build-with-claude/effort), and [model specifications/pricing](https://platform.claude.com/docs/en/models/fable-5-1/overview).

## Potential risks

- Prompting for tool use cannot guarantee a tool call. Structured side queries can still return the existing text fallback or fail to produce usable structured output.
- `drop_block` trades invalid-prefix errors for lost prior reasoning; repeated history changes may increase token cost and latency. This PR does not redesign conversation persistence or measure live cache behavior.
- Native Anthropic-compatible gateways must support the new binding control and mid-conversation system messages. Live Anthropic/OAuth/Azure/gateway calls were not run because no Anthropic API key was available in the environment; account entitlement and server-side signature validation remain unverified.
- Bundled Fable 5.1 cached-input cost estimates decrease. No dependencies, lockfiles, database schemas, persistence formats, change, and no historical records are rewritten. Previously discarded signatures cannot be reconstructed; this fixes newly received history. Reverting this PR restores the prior catalog, pricing, and request behavior.

## Verification

- `cargo test -p key_vault -p orgtrack_core --lib` — 383 KeyVault tests and 592 OrgTrack tests passed; 8 existing OrgTrack tests ignored.
- `pnpm test src/types/model/info.anthropic.test.ts src/util/__tests__/modelGrouping.test.ts src/util/__tests__/modelVariants.test.ts src/util/__tests__/formatModelName.test.ts` — 71 passed.
- `pnpm run typecheck:fast` — passed for the whole frontend.
- `pnpm exec eslint src/ --ext .ts,.tsx,.js,.jsx --format json` — 6,432 files, zero errors or warnings.
- `pnpm run check:circular` — zero cycles across 6,528 modules.
- `pnpm run check:test-placement` — passed across 495 directories.
- Normal commit hooks — lint-staged (Oxlint, ESLint, Prettier), TypeScript, scoped Rust Clippy, and commitlint passed. The commit trailer records the independently measured full-frontend lint/cycle counts above.
- `git diff --check` — passed. Reviewed the entire feature diff for unrelated changes, credentials, personal paths, generated files, and caches.
- `cargo clippy -p agent_core -p key_vault -p orgtrack_core --all-targets -- -D warnings` — passed.
- `cargo test -p agent_core --lib providers::` — 461 passed, including serialized auth/stream/effort matrices and raw JSON/SSE signed-history replay regressions.
- No desktop/UI automation or live provider calls ran. Screenshots are not useful for this metadata/protocol change: no components, layout, themes, or loading/error-state rendering changed. API entitlement, gateway acceptance, cryptographic binding enforcement, and prompt-cache behavior require live validation.

## Architecture review

Covered all ten layers within this change: compilation; production call-chain wiring; naming; effort/model-version semantics; defaults and legacy aliases; provider ownership; readability; serialized HTTP bodies/headers; API/OAuth discovery parity; and symmetry across stream modes, auth modes, qualified ids, and neighboring models. Tests inspect requests built by `prepare_request` and `apply_headers`, including signed history, rather than only testing predicates. Broader FSM, database, React, and cloud-sync internals are outside this feature's scope. Live wire validation remains the limitation above.

## Performance review

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Both chat paths retain the same send/retry loops | No new timers, polling, workers, or network calls | Call-chain review and provider suite |
| Memory | keep | Compatibility values live within one prepared request; custom betas are bounded by configured headers | No new retained maps, histories, or caches | Input-immutability and header tests |
| Scope/isolation | keep | Auth and model are resolved on the existing client | No new process-wide or cross-account state | API-key/Azure/OAuth matrix and neighboring-model controls |
| Rendering/hot path | keep | Changes run at request preparation, not per SSE delta | Finalizers retain signed metadata without adding empty UI blocks; the per-delta loop is unchanged | Raw JSON/SSE ingestion-to-replay fixtures and request matrix |

Performance verdict: pass for the changed client resource lifecycle. No CPU, latency, or prompt-cache improvement is claimed; live provider performance remains unmeasured.
