### PR TITLE
fix(chat-results): match result typography to input

### DIFF
--- a/src/engines/ChatPanel/blocks/TerminalBlock/shellReplay.test.ts
+++ b/src/engines/ChatPanel/blocks/TerminalBlock/shellReplay.test.ts
@@ -41,5 +41,13 @@ describe("TerminalBlock shell replay", () => {
     expect(markup).toContain("bounded replay tail");
     expect(markup).not.toContain("legacy output must not win");
     expect(markup).toContain("max-height:min(320px, 30vh)");
+    expect(markup).toContain(
+      "--simulator-shell-font-family:var(--app-font-family)"
+    );
+    expect(markup).toContain(
+      "--simulator-shell-font-size:var(--chat-code-font-size, 13px)"
+    );
+    expect(markup).toContain("--simulator-shell-letter-spacing:normal");
+    expect(markup).toContain("--simulator-shell-line-height:1.5");
   });
 });

--- a/src/engines/ChatPanel/blocks/primitives/_block-output.scss
+++ b/src/engines/ChatPanel/blocks/primitives/_block-output.scss
@@ -1,34 +1,22 @@
 /**
  * BlockOutput Styles
  *
- * Matches TerminalCommand text styling (font-size 12px, line-height 1.5).
+ * Matches the chat command/input row typography (app font, chat code size,
+ * line-height 1.5).
  * Shared by TerminalBlock, ToolCallBlock, and any block using BlockOutput.
  */
 .block-output {
-  // Pre block — match terminal-command
+  // Pre block — match the command/input row rather than terminal chrome.
   &__pre {
-    font-family: var(
-      --code-font-family,
-      "SF Mono",
-      "Menlo",
-      "Monaco",
-      "Consolas",
-      monospace
-    ) !important;
+    font-family: var(--app-font-family) !important;
     font-size: var(--chat-code-font-size, 13px) !important;
     line-height: 1.5 !important;
   }
 
-  // Line — match terminal-command / ChatCodeBlock
+  // Line — repeat the family because the global element reset assigns a
+  // font directly to nested div/span nodes.
   &__line {
-    font-family: var(
-      --code-font-family,
-      "SF Mono",
-      "Menlo",
-      "Monaco",
-      "Consolas",
-      monospace
-    );
+    font-family: var(--app-font-family);
     font-size: var(--chat-code-font-size, 13px);
     line-height: 1.5;
   }

--- a/src/engines/ChatPanel/blocks/primitives/blockOutputTypography.test.ts
+++ b/src/engines/ChatPanel/blocks/primitives/blockOutputTypography.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("BlockOutput typography", () => {
+  it("uses the application font for chat result text", () => {
+    const styles = readFileSync(
+      resolve(__dirname, "_block-output.scss"),
+      "utf8"
+    );
+
+    expect(styles).toMatch(
+      /&__pre\s*\{[\s\S]*?font-family:\s*var\(--app-font-family\)\s*!important;/
+    );
+    expect(styles).toMatch(
+      /&__line\s*\{[\s\S]*?font-family:\s*var\(--app-font-family\);/
+    );
+    expect(styles).not.toContain("--code-font-family");
+  });
+});

--- a/src/engines/SessionCore/replay/components/ShellReplayOutput/index.tsx
+++ b/src/engines/SessionCore/replay/components/ShellReplayOutput/index.tsx
@@ -362,6 +362,16 @@ const ShellReplayOutputComponent: React.FC<ShellReplayOutputProps> = ({
     variant === "chat"
       ? "simulator-shell-surface min-h-0 min-w-0 overflow-y-auto overflow-x-auto px-2 py-1"
       : "simulator-shell-surface min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-3 pb-[100px] pt-2";
+  const chatTypographyVariables =
+    variant === "chat"
+      ? {
+          ["--simulator-shell-font-size" as string]:
+            "var(--chat-code-font-size, 13px)",
+          ["--simulator-shell-font-family" as string]: "var(--app-font-family)",
+          ["--simulator-shell-letter-spacing" as string]: "normal",
+          ["--simulator-shell-line-height" as string]: "1.5",
+        }
+      : undefined;
 
   return (
     <div
@@ -369,6 +379,7 @@ const ShellReplayOutputComponent: React.FC<ShellReplayOutputProps> = ({
       className={surfaceClassName}
       style={{
         ...typographyVariables,
+        ...chatTypographyVariables,
         ...(variant === "chat" ? { maxHeight: "min(320px, 30vh)" } : {}),
       }}
       onScroll={handleScroll}


### PR DESCRIPTION
## Problem

Chat result sections use a different typeface from their command or input rows. Standard result output forces the code font, while replay-backed chat output inherits terminal typography settings, so the same result appears inconsistent between the chat pane and Agent Station.

## Solution

Use the application UI font for shared text-shaped chat results while preserving the existing chat code size and line height. For replay-backed shell results, override the chat variant with the same application font, size, letter spacing, and line height; standalone simulator terminal surfaces continue to honor terminal typography settings. Focused tests lock both rendering paths to this contract.

## Potential risks

Plain-text output rendered through the shared `BlockOutput` primitive now uses a proportional application font, so column-aligned text may occupy different widths. True TUI output still uses the xterm renderer and remains monospace. This change does not affect persistence, IPC, data formats, dependencies, concurrency, or lifecycle behavior, and rollback is a single commit revert.

Visual verification in the running desktop app was not performed because repository policy requires explicit opt-in for desktop control. The supplied screenshot was used as the before-state reference.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/blocks/primitives/blockOutputTypography.test.ts src/engines/ChatPanel/blocks/TerminalBlock/shellReplay.test.ts` — passed, 2 files and 2 tests
- `pnpm run typecheck:fast` — passed
- `pnpm exec eslint src/engines/SessionCore/replay/components/ShellReplayOutput/index.tsx src/engines/ChatPanel/blocks/TerminalBlock/shellReplay.test.ts src/engines/ChatPanel/blocks/primitives/blockOutputTypography.test.ts --max-warnings 0 --report-unused-disable-directives` — passed
- `pnpm run check:test-placement` — passed across 497 directories
- Commit hooks — lint-staged and staged-file TypeScript checks passed
- `git diff --check origin/develop...HEAD` — passed
- Running-app screenshot comparison — not run because desktop control was not explicitly enabled