### PR TITLE
fix(UI): format app theme style

### DIFF
--- a/src/config/appearance/globalThemes.ts
+++ b/src/config/appearance/globalThemes.ts
@@ -128,6 +128,20 @@ export function normalizeGlobalThemeId(
   );
 }
 
+/**
+ * The persisted global theme preference. `localStorage["theme"]` is the
+ * hand-off between the settings store (which writes it on every change) and
+ * the code paths that cannot read the store: startup CSS init and the native
+ * appearance sync. Falls back to the default when storage is unavailable.
+ */
+export function readStoredGlobalThemePreference(): GlobalThemePreference {
+  try {
+    return normalizeGlobalThemePreference(localStorage.getItem("theme"));
+  } catch {
+    return DEFAULT_GLOBAL_THEME_PREFERENCE;
+  }
+}
+
 export function normalizeGlobalThemePreference(
   value: string | null | undefined
 ): GlobalThemePreference {

--- a/src/util/core/init/themeInit.ts
+++ b/src/util/core/init/themeInit.ts
@@ -1,6 +1,7 @@
 import {
   GLOBAL_THEMES,
   getGlobalTheme,
+  readStoredGlobalThemePreference,
   resolveGlobalThemePreference,
 } from "@src/config/appearance/globalThemes";
 import { createLogger } from "@src/hooks/logger";
@@ -50,8 +51,9 @@ const initTheme = (): Promise<void> => {
     const startTime = performance.now();
 
     // Get theme from localStorage (supports legacy CSS path and legacy light/dark)
-    const storedTheme = localStorage.getItem("theme");
-    const themeId = resolveGlobalThemePreference(storedTheme);
+    const themeId = resolveGlobalThemePreference(
+      readStoredGlobalThemePreference()
+    );
     const theme = getGlobalTheme(themeId).baseCssPath;
 
     // Check if the preloaded CSS matches the user's theme preference

--- a/src/util/ui/theme/__tests__/swapThemeCss.test.ts
+++ b/src/util/ui/theme/__tests__/swapThemeCss.test.ts
@@ -13,7 +13,23 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { swapThemeCss } from "../swapThemeCss";
+import { resolveNativeTheme, swapThemeCss } from "../swapThemeCss";
+
+const { platform, setTheme } = vi.hoisted(() => ({
+  platform: { macos: false, windows: false },
+  setTheme: vi.fn(async (_theme: "light" | "dark" | null) => {}),
+}));
+
+vi.mock("@src/util/platform/tauri", () => ({
+  isMacOS: () => platform.macos,
+  isWindows: () => platform.windows,
+}));
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ setTheme }),
+}));
+vi.mock("@src/util/platform/macosRootTint", () => ({
+  syncMacosRootTint: vi.fn(async () => {}),
+}));
 
 const THEME_LINK_SELECTOR = "link[data-orgii-theme]";
 
@@ -51,6 +67,10 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
+  platform.macos = false;
+  platform.windows = false;
+  setTheme.mockClear();
+  localStorage.removeItem("theme");
 });
 
 describe("swapThemeCss with animation frames never firing", () => {
@@ -122,5 +142,87 @@ describe("swapThemeCss with working animation frames", () => {
     expect(document.documentElement.dataset.theme).toBe("dark");
     expect(oldLink.isConnected).toBe(false);
     expect(themeLinks()).toHaveLength(1);
+  });
+});
+
+describe("resolveNativeTheme", () => {
+  it("pins an explicit preference to the painted scheme", () => {
+    expect(resolveNativeTheme("light", "light")).toBe("light");
+    expect(resolveNativeTheme("dark", "dark")).toBe("dark");
+  });
+
+  it("leaves a follow-system preference unpinned", () => {
+    expect(resolveNativeTheme("light", "system")).toBeNull();
+    expect(resolveNativeTheme("dark", "system")).toBeNull();
+  });
+});
+
+/**
+ * The native appearance sync. On macOS Tauri's `setTheme` sets the app-wide
+ * NSAppearance, which decides how AppKit draws the inactive traffic lights
+ * (lightened under DarkAqua, darkened under Aqua) and what WKWebView reports
+ * for `prefers-color-scheme`. These tests pin the contract: explicit
+ * preferences pin the scheme, "follow system" passes `null`, Windows keeps
+ * pinning the resolved scheme, and other hosts never call it.
+ */
+describe("syncThemeAppearance native theme", () => {
+  async function syncActiveTheme(cssPath: string): Promise<void> {
+    insertActiveThemeLink(cssPath);
+    // Same-path swap: syncs the appearance synchronously, then the dynamic
+    // window-API import and the setTheme call settle on the microtask queue.
+    await swapThemeCss(cssPath);
+    await vi.advanceTimersByTimeAsync(0);
+  }
+
+  it("pins an explicit light preference on macOS", async () => {
+    platform.macos = true;
+    localStorage.setItem("theme", "light");
+
+    await syncActiveTheme("/orgii_main.css");
+
+    expect(setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("pins an explicit dark preference on macOS", async () => {
+    platform.macos = true;
+    localStorage.setItem("theme", "dark");
+
+    await syncActiveTheme("/orgii_dark.css");
+
+    expect(setTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("follows the OS on macOS when the preference is system", async () => {
+    platform.macos = true;
+    localStorage.setItem("theme", "system");
+
+    await syncActiveTheme("/orgii_dark.css");
+
+    expect(setTheme).toHaveBeenCalledWith(null);
+  });
+
+  it("treats a missing stored preference as follow-system on macOS", async () => {
+    platform.macos = true;
+
+    await syncActiveTheme("/orgii_main.css");
+
+    expect(setTheme).toHaveBeenCalledWith(null);
+  });
+
+  it("keeps pinning the painted scheme on Windows", async () => {
+    platform.windows = true;
+    localStorage.setItem("theme", "system");
+
+    await syncActiveTheme("/orgii_main.css");
+
+    expect(setTheme).toHaveBeenCalledWith("light");
+  });
+
+  it("never touches the native theme on other hosts", async () => {
+    localStorage.setItem("theme", "dark");
+
+    await syncActiveTheme("/orgii_dark.css");
+
+    expect(setTheme).not.toHaveBeenCalled();
   });
 });

--- a/src/util/ui/theme/swapThemeCss.ts
+++ b/src/util/ui/theme/swapThemeCss.ts
@@ -7,8 +7,14 @@
  * loading, creating a mixed light/dark state. This utility avoids that
  * by keeping the old CSS active until the new one is fully loaded.
  */
+import {
+  type GlobalThemePreference,
+  type SystemColorScheme,
+  THEME_PREFERENCE,
+  readStoredGlobalThemePreference,
+} from "@src/config/appearance/globalThemes";
 import { syncMacosRootTint } from "@src/util/platform/macosRootTint";
-import { isWindows } from "@src/util/platform/tauri";
+import { isMacOS, isWindows } from "@src/util/platform/tauri";
 
 import { applySkinTokensForVariant } from "./applySkinTokens";
 
@@ -33,8 +39,34 @@ function isActiveThemeDark(cssPath: string): boolean {
 }
 
 /**
- * Keep CSS chrome, the active skin, and the Windows system backdrop on the same
- * color scheme.
+ * The native theme to pin for a painted variant.
+ *
+ * Tauri's `setTheme` is app-wide on macOS (it sets `NSApp.appearance`), and
+ * WKWebView derives `prefers-color-scheme` from that effective appearance. A
+ * "follow system" preference must therefore stay unpinned (`null`): pinning
+ * the resolved scheme would freeze the very media query the system mode
+ * watches, so an OS flip would never reach the app again. An explicit
+ * light/dark preference pins its own scheme so the window chrome AppKit draws
+ * — inactive traffic lights above all — matches what the page paints.
+ */
+export function resolveNativeTheme(
+  colorScheme: SystemColorScheme,
+  preference: GlobalThemePreference
+): SystemColorScheme | null {
+  return preference === THEME_PREFERENCE.SYSTEM ? null : colorScheme;
+}
+
+/**
+ * Keep CSS chrome, the active skin, and the native window appearance on the
+ * same color scheme.
+ *
+ * On macOS the window is transparent and the page paints the light theme in
+ * CSS, so without this AppKit still believes the window is whatever the OS
+ * is. macOS 26 draws the inactive traffic lights relative to that appearance
+ * — lightened in a DarkAqua window, darkened in an Aqua window — so a light
+ * page under a DarkAqua window shows white dots on white and the buttons
+ * vanish whenever another window has focus. Windows keeps pinning the
+ * resolved scheme, which is what its translucent backdrop expects.
  *
  * The skin tokens are applied here, in the same tick the new stylesheet is
  * promoted, rather than being left to React. `useAppSkin` reacts to the variant
@@ -57,10 +89,15 @@ export function syncThemeAppearance(cssPath: string): void {
   // native macOS layer mirrors (no-op off macOS).
   void syncMacosRootTint();
 
-  if (!isWindows()) return;
+  const nativeTheme = isMacOS()
+    ? resolveNativeTheme(colorScheme, readStoredGlobalThemePreference())
+    : isWindows()
+      ? colorScheme
+      : undefined;
+  if (nativeTheme === undefined) return;
 
   void import("@tauri-apps/api/window")
-    .then(({ getCurrentWindow }) => getCurrentWindow().setTheme(colorScheme))
+    .then(({ getCurrentWindow }) => getCurrentWindow().setTheme(nativeTheme))
     .catch(() => {
       // Browser previews and windows closing during a theme swap have no
       // native backdrop to synchronize.


### PR DESCRIPTION
## Problem

On macOS the traffic lights disappear whenever the ORGII window is not key (another window or app has focus) while the app is on the light theme, most visibly with the sidebar collapsed. Other apps show grey dots in that state.