### PR TITLE
test(relative-time): align expectations with localized formatter

### DIFF
--- a/src/features/SessionCreator/components/__tests__/worktreeBranchSource.test.ts
+++ b/src/features/SessionCreator/components/__tests__/worktreeBranchSource.test.ts
@@ -335,15 +335,26 @@ describe("formatBranchTimestamp", () => {
   });
 
   it("formats a recent commit with the shared 'short' relative style", () => {
+    // `formatRelativeTime("short")` is Intl-backed, so the exact strings
+    // ("1 hr. ago", "yesterday") belong to the runtime's ICU data. Derive the
+    // expectations the same way rather than pinning one ICU's spelling.
+    const short = (value: number, unit: Intl.RelativeTimeFormatUnit) =>
+      new Intl.RelativeTimeFormat("en", { style: "short" }).format(value, unit);
+    const shortAuto = (value: number, unit: Intl.RelativeTimeFormatUnit) =>
+      new Intl.RelativeTimeFormat("en", {
+        style: "short",
+        numeric: "auto",
+      }).format(value, unit);
+
     expect(
       formatBranchTimestamp(option({ lastCommitDate: "2026-07-11T11:00:00Z" }))
-    ).toBe("1 hr ago");
+    ).toBe(short(-1, "hour"));
     expect(
       formatBranchTimestamp(option({ lastCommitDate: "2026-07-10T12:00:00Z" }))
-    ).toBe("Yesterday");
+    ).toBe(shortAuto(-1, "day"));
     expect(
       formatBranchTimestamp(option({ lastCommitDate: "2026-07-09T12:00:00Z" }))
-    ).toBe("2 days ago");
+    ).toBe(short(-2, "day"));
   });
 });
 

--- a/src/modules/MainApp/TeamInbox/__tests__/TeamInboxList.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/TeamInboxList.test.ts
@@ -222,6 +222,9 @@ describe("TeamInboxList pagination", () => {
   });
 
   it("places actionable pull requests and assigned work under matching sections", () => {
+    // Pin the clock so the inbox row's relative timestamp is deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T05:00:00.000Z"));
     const markup = renderToStaticMarkup(
       createElement(TeamInboxList, {
         filter: "all",
@@ -280,7 +283,9 @@ describe("TeamInboxList pagination", () => {
     expect(markup).not.toContain("orgii-issu");
     expect(markup).not.toContain("author · #42");
     expect(markup).toContain(">5h<");
-    expect(markup).not.toContain("ago");
+    // The inbox row's own timestamp is the localized narrow relative form
+    // of `occurredAt` (five hours before the pinned clock above).
+    expect(markup).toContain(">5h ago<");
     expect(markup).not.toContain("teamInbox.groups.");
     expect(markup).toMatch(/class="[^"]*text-text-3[^"]*"[^>]*>5h<\/span>/);
     expect(markup).toContain("text-text-2");
@@ -293,5 +298,6 @@ describe("TeamInboxList pagination", () => {
     expect(markup).toContain("rounded-lg");
     expect(markup).toContain("hover:bg-surface-hover");
     expect(markup).not.toContain("min-h-[72px]");
+    vi.useRealTimers();
   });
 });

--- a/src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts
@@ -140,8 +140,10 @@ describe("TeamInboxRow", () => {
         element.className.includes("text-text-2")
     );
     expect(secondaryText).toHaveLength(1);
+    // `formatRelativeTime("nano")` renders the localized immediate label
+    // ("now"), not the old hand-rolled "Now".
     const time = Array.from(container.querySelectorAll("span")).find(
-      (element) => element.textContent === "Now"
+      (element) => element.textContent === "now"
     );
     expect(time?.className).toContain("text-text-3");
     expect(time?.className).not.toContain("text-text-2");


### PR DESCRIPTION
## Problem

The `Frontend (typecheck · lint · test)` job is red on develop for every new PR (first seen on #1291): three tests fail.

| Test | Expected (stale) | Actual |
| --- | --- | --- |
| `worktreeBranchSource.test.ts` › formatBranchTimestamp short style | `1 hr ago` | `1 hr. ago` |
| `TeamInboxList.test.ts` › places actionable PRs and assigned work | markup must not contain `ago` | row renders `1mo ago` (real clock) |
| `TeamInboxRow.test.ts` › shows assignment and synced source | a span reading `Now` | span reads `now` |

Root cause: 6c5ded423 (`fix(i18n): localize relative timestamps`) rewrote `src/util/time/formatRelativeTime.ts` onto `Intl.RelativeTimeFormat` plus the localized `relativeDate.justNow` label, so the `short` style now yields ICU's `1 hr. ago`, the `nano` style gained its `… ago` suffix, and the immediate label became `now`. That commit updated `taskCardTime.test.ts` but not the three tests above, and it was pushed straight to develop, where the push workflows do not run the frontend suite. The last green Frontend job (PR #1288) predates it.

## Solution

Test-only changes; the formatter's new behaviour is the intended product and is untouched.

- `worktreeBranchSource.test.ts`: derive the three `short` expectations from `Intl.RelativeTimeFormat("en", …)` (`-1 hour`, `-1 day` with `numeric: "auto"`, `-2 days`) instead of pinning one ICU's spelling. The test still proves `formatBranchTimestamp` routes through the shared `short` style, and the next ICU bump (`hr.` vs `hr`, `yesterday` casing) cannot re-break it.
- `TeamInboxList.test.ts`: the `not.toContain("ago")` guard only held while `nano` had no suffix, and the row's time was rendered against the real clock (`1mo ago` today, `1y ago` next summer). Pin the clock five hours after the fixture's `occurredAt` and assert the localized row time `>5h ago<` directly; the `>5h<` assertions stay, they check the PR fixture's precomputed `timeAgo` label, a different element.
- `TeamInboxRow.test.ts`: look for the localized immediate label `now`, matching what `taskCardTime.test.ts` already expects.

Invariant after this PR: every test that asserts relative-time output either derives it from Intl or pins the clock; none encode the pre-i18n hand-rolled strings.

## Potential risks

- **ICU drift elsewhere.** `taskCardTime.test.ts` (updated in 6c5ded423) still pins literal narrow strings (`5m ago`, `2h ago`); those are stable across current ICU releases but would need the same treatment if they ever drift. Out of scope here.
- **Fake timers in the inbox list test.** `vi.useFakeTimers()` is scoped to one test and reset with `vi.useRealTimers()` at its end; `renderToStaticMarkup` does not depend on timers. The other nine tests in that file are unchanged and pass.
- **No product behaviour changes.** Only test files are touched, so there is no rollout or compatibility concern.

## Verification

Ran in an isolated worktree off `origin/develop` (6c5ded423):

```
npx vitest run --config config/vitest.config.ts <3 test files> src/modules/MainApp/TeamInbox src/util/time src/features/KanbanBoard/components/TaskCard src/features/SessionCreator
# 52 files, 368 tests passed (the three above failed before the change on the same base)
npx tsgo --noEmit --pretty false          # clean
npx prettier / oxlint --max-warnings 0 / eslint --max-warnings 0 --report-unused-disable-directives   # changed files, clean
npm run check:test-placement              # consistent
```

Also confirmed the three failures reproduce on an untouched `origin/develop` checkout under Node 22 locally and Node 20 in CI (job 101273912113 on #1291), so they are not specific to either runtime.

Not run: full vitest suite locally (CI covers it). The commit was created without git hooks (worktree lacks the husky shim), so there is no "Pre-commit hook ran." trailer; the checks above were run manually instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
