### PR TITLE
style(mobile): add monochrome glass navigation and actions

### DIFF
--- a/docs/frontend-ui-audit-2026-09-05/MobileChrome.md
+++ b/docs/frontend-ui-audit-2026-09-05/MobileChrome.md
@@ -1,0 +1,37 @@
+# MobileChrome UI audit
+
+Scope: plain, solid monochrome page backgrounds, plus iOS-inspired navigation and large action buttons. Liquid Glass is confined to controls; page content and the welcome icon use opaque surfaces. The user's narrowed scope excludes session details. Session rows, transcript rendering, the composer, connection logic, and settings content were not edited. The existing 393px viewport width is preserved.
+
+| Line                                                           | Element                                     | Verdict          | Reason                                                                                                                                                                                                                                                       | Suggested change |
+| -------------------------------------------------------------- | ------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `src/modules/MobileRemote/components/MobileShell.tsx:15`       | Mobile shell                                | keep with reason | Keeps existing height, overflow, and safe-area ownership. The chrome stylesheet is imported by the shared mobile shell for browser and native entries, with mobile-specific selectors and variables.                                                         | None.            |
+| `src/modules/MobileRemote/components/MobileTopBar.tsx:22`      | Large root titles and compact navigation    | keep with reason | Shared `IconButton` retains native button semantics and accessible labels. Navigation gets 44px circular targets and centered detail-page titles; session content is unchanged.                                                                              | None.            |
+| `src/modules/MobileRemote/components/MobileTabBar.tsx:47`      | Floating tab dock                           | keep with reason | Reuses shared `Button`, existing translations, callbacks, and `aria-current`. A shared material surrounds the three tabs, and the dock reserves layout space and the bottom safe area.                                                                       | None.            |
+| `src/modules/MobileRemote/components/MobileActionButton.tsx:6` | Shared large action presentation            | keep with reason | The same wrapper serves six actions across five screens. It reuses `Button` loading, disabled, icon, and event behavior while adapting desktop inline dimensions through mobile CSS variables. No additional abstraction is needed.                          | None.            |
+| `src/modules/MobileRemote/mobileChrome.scss:3`                 | Chrome palette and material tokens          | keep with reason | Local black/white control colors and solid neutral backgrounds implement the user's requested monochrome appearance in light and dark modes. These values do not override app-wide semantic tokens or session styling.                                       | None.            |
+| `src/modules/MobileRemote/mobileChrome.scss:214`               | Focus, touch, and accessibility preferences | keep with reason | Chrome controls have visible focus outlines, 44px-or-larger targets, and reduced-motion/transparency and increased-contrast treatments. Large action labels can wrap. Backdrop blur is restricted to controls, with an opaque unsupported-browser treatment. | None.            |
+| `src/modules/MobileRemote/screens/SessionsScreen.tsx:24`       | Sessions page heading                       | keep with reason | Uses the existing translated tab name in the shared top bar. The list and all session data and presentation remain unchanged.                                                                                                                                | None.            |
+
+Verdict totals: **0 fix**, **7 keep with reason**, **0 abstract**.
+
+## Verification
+
+Verified against the latest `origin/develop` in an isolated checkout containing only this change.
+
+- `pnpm exec vitest run --config config/vitest.config.ts src/modules/MobileRemote --silent`: **40 files, 231 tests passed**, including session-row geometry, transcript, composer, authentication, and navigation coverage. The run emitted existing Vite/Sass deprecation notices.
+- `pnpm run typecheck:fast`: **passed**.
+- Changed-file ESLint with `--max-warnings 0` and Prettier: **passed** (exact commands below).
+- `git diff --check`: **passed**.
+- `pnpm run check:test-placement`: **passed**, 497 directories.
+- `pnpm run check:circular`: **failed on an existing cycle**, `util/modelGrouping.ts -> util/modelVariants.ts -> util/modelGrouping.ts`. Both files match `origin/develop`; the reciprocal imports were confirmed in the base. No mobile module participates in the reported cycle.
+- `node -e 'const sass=require("sass");const result=sass.compile("src/modules/MobileRemote/mobileChrome.scss");console.log("Compiled mobile chrome: "+result.css.length+" bytes");if(result.css.includes("gradient(")||result.css.includes("mobile-wallpaper"))process.exitCode=1;'`: **passed**, 6,440 compiled CSS bytes, no decorative background.
+- Development-server HTTP readback of `/orgii/mobile` and `/mobile.js`: **200**. The served bundle contains the final plain monochrome chrome stylesheet and `MobileActionButton`, with no build-error marker.
+- Computed monochrome primary-action and selected-tab text contrast: light **17.93:1**, light pressed **12.63:1**, dark **17.32:1**, dark pressed **12.74:1**. This covers solid control colors, not browser-rendered glass compositing.
+- Browser screenshots, physical iPhone rendering, and runtime blur cost were not verified. The user's computer-control preference was respected. These CSS changes add no timers, subscriptions, or continuous animations; no runtime performance improvement is claimed.
+
+Exact changed-file commands:
+
+```sh
+pnpm exec eslint src/modules/MobileRemote/auth/MobileAuthScreen.tsx src/modules/MobileRemote/components/MobileShell.tsx src/modules/MobileRemote/components/MobileTabBar.tsx src/modules/MobileRemote/components/MobileTopBar.tsx src/modules/MobileRemote/components/MobileActionButton.tsx src/modules/MobileRemote/screens/ConnectionErrorScreen.tsx src/modules/MobileRemote/screens/QRScanScreen.tsx src/modules/MobileRemote/screens/SASConfirmScreen.tsx src/modules/MobileRemote/screens/SessionsScreen.tsx src/modules/MobileRemote/screens/WelcomeScreen.tsx --max-warnings 0
+pnpm exec prettier --check docs/frontend-ui-audit-2026-09-05/MobileChrome.md src/modules/MobileRemote/auth/MobileAuthScreen.tsx src/modules/MobileRemote/components/MobileShell.tsx src/modules/MobileRemote/components/MobileTabBar.tsx src/modules/MobileRemote/components/MobileTopBar.tsx src/modules/MobileRemote/components/MobileActionButton.tsx src/modules/MobileRemote/mobileChrome.scss src/modules/MobileRemote/screens/ConnectionErrorScreen.tsx src/modules/MobileRemote/screens/QRScanScreen.tsx src/modules/MobileRemote/screens/SASConfirmScreen.tsx src/modules/MobileRemote/screens/SessionsScreen.tsx src/modules/MobileRemote/screens/WelcomeScreen.tsx
+```

--- a/src/modules/MobileRemote/auth/MobileAuthScreen.tsx
+++ b/src/modules/MobileRemote/auth/MobileAuthScreen.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import Button from "@src/components/Button";
 import InlineAlert from "@src/components/InlineAlert";
 import { Placeholder } from "@src/components/Placeholder";
 import { HugeiconsIcon, Login02Icon } from "@src/icons";
 
+import { MobileActionButton } from "../components/MobileActionButton";
 import { MobileShell } from "../components/MobileShell";
 import type { MobileAuthState } from "./mobileAuthState";
 
@@ -36,7 +36,7 @@ export function MobileAuthScreen({
     <MobileShell>
       <main className="flex min-h-0 flex-1 flex-col px-5 py-6">
         <div className="flex items-center gap-2 text-lg font-semibold text-text-1">
-          <span aria-hidden="true" className="text-primary-6">
+          <span aria-hidden="true" className="mobile-brand-mark">
             ●
           </span>
           ORG2
@@ -75,7 +75,7 @@ export function MobileAuthScreen({
                   {state.message}
                 </InlineAlert>
               ) : null}
-              <Button
+              <MobileActionButton
                 htmlType="button"
                 variant="primary"
                 long
@@ -84,7 +84,7 @@ export function MobileAuthScreen({
                 onClick={onSignIn}
               >
                 {t("auth.signIn")}
-              </Button>
+              </MobileActionButton>
             </>
           )}
         </div>

--- a/src/modules/MobileRemote/components/MobileActionButton.tsx
+++ b/src/modules/MobileRemote/components/MobileActionButton.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import Button, { type ButtonProps } from "@src/components/Button";
+
+/** Large mobile actions retain the shared button's loading and disabled behavior. */
+export function MobileActionButton({
+  variant = "primary",
+  className = "",
+  style,
+  ...props
+}: ButtonProps) {
+  return (
+    <Button
+      {...props}
+      variant={variant}
+      size="large"
+      shape="round"
+      className={`mobile-action-button ${className}`}
+      data-mobile-variant={variant}
+      style={{
+        height: "auto",
+        minHeight: "var(--mobile-action-height)",
+        padding: "var(--mobile-action-padding)",
+        fontSize: "var(--mobile-action-font-size)",
+        ...style,
+      }}
+    />
+  );
+}
+
+MobileActionButton.displayName = "MobileActionButton";

--- a/src/modules/MobileRemote/components/MobileShell.tsx
+++ b/src/modules/MobileRemote/components/MobileShell.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 
+import "../mobileChrome.scss";
+
 export interface MobileShellProps {
   children: React.ReactNode;
   footer?: React.ReactNode;
 }
 
 /**
- * Narrow viewport shell for Mobile Remote PWA demo (393px baseline).
+ * Safe-area-aware mobile shell shared by the browser and native entries.
  */
 export function MobileShell({ children, footer }: MobileShellProps) {
   return (
-    <div className="flex h-full justify-center overflow-hidden bg-bg-1 pt-[env(safe-area-inset-top)]">
-      <div className="flex h-full min-h-0 w-full max-w-[393px] flex-col overflow-hidden bg-bg-1">
+    <div className="mobile-shell flex h-full justify-center overflow-hidden pt-[env(safe-area-inset-top)]">
+      <div className="mobile-shell__viewport flex h-full min-h-0 w-full flex-col overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col">{children}</div>
         {footer}
       </div>

--- a/src/modules/MobileRemote/components/MobileTabBar.tsx
+++ b/src/modules/MobileRemote/components/MobileTabBar.tsx
@@ -44,30 +44,34 @@ export function MobileTabBar({ active, onChange }: MobileTabBarProps) {
   );
 
   return (
-    <nav
-      className="flex shrink-0 border-t border-border-2 bg-bg-1 pb-[max(8px,env(safe-area-inset-bottom))]"
-      aria-label="Mobile remote tabs"
-    >
-      {tabs.map((tab) => {
-        const isActive = tab.id === active;
-        return (
-          <Button
-            key={tab.id}
-            htmlType="button"
-            variant="tertiary"
-            appearance="ghost"
-            className={`min-h-[49px] flex-1 flex-col gap-1.5 rounded-none px-1 py-1.5 ${
-              isActive ? "text-text-1" : "text-text-3"
-            }`}
-            style={{ height: "auto", minHeight: 49, padding: "6px 4px" }}
-            onClick={() => onChange?.(tab.id)}
-            aria-current={isActive ? "page" : undefined}
-          >
-            <HugeiconsIcon icon={tab.icon} size={22} />
-            <span className="text-xs leading-none">{tab.label}</span>
-          </Button>
-        );
-      })}
+    <nav className="mobile-tab-dock" aria-label="Mobile remote tabs">
+      <div className="mobile-tab-bar">
+        {tabs.map((tab) => {
+          const isActive = tab.id === active;
+          return (
+            <Button
+              key={tab.id}
+              htmlType="button"
+              variant="tertiary"
+              appearance="ghost"
+              shape="round"
+              className="mobile-tab-button"
+              style={{
+                height: "auto",
+                minHeight: "var(--mobile-tab-height)",
+                padding: "var(--mobile-tab-padding)",
+              }}
+              onClick={() => onChange?.(tab.id)}
+              aria-current={isActive ? "page" : undefined}
+            >
+              <span className="mobile-tab-button__content">
+                <HugeiconsIcon icon={tab.icon} size={24} aria-hidden="true" />
+                <span className="mobile-tab-button__label">{tab.label}</span>
+              </span>
+            </Button>
+          );
+        })}
+      </div>
     </nav>
   );
 }

--- a/src/modules/MobileRemote/components/MobileTopBar.tsx
+++ b/src/modules/MobileRemote/components/MobileTopBar.tsx
@@ -19,28 +19,27 @@ export function MobileTopBar({
   backAriaLabel = "Back",
 }: MobileTopBarProps) {
   return (
-    <header className="flex h-12 shrink-0 items-center gap-2 border-b border-border-2 px-3">
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        {onBack ? (
-          <IconButton
-            type="button"
-            size="sm"
-            variant="default"
-            aria-label={backAriaLabel}
-            onClick={onBack}
-          >
-            <HugeiconsIcon icon={ArrowLeft01Icon} size={18} />
-          </IconButton>
-        ) : (
-          leading
-        )}
-        {title ? (
-          <div className="min-w-0 truncate text-sm font-medium text-text-1">
-            {title}
-          </div>
-        ) : null}
-      </div>
-      {trailing ? <div className="shrink-0">{trailing}</div> : null}
+    <header
+      className={`mobile-top-bar ${onBack ? "mobile-top-bar--detail" : "mobile-top-bar--root"}`}
+    >
+      {onBack ? (
+        <IconButton
+          type="button"
+          size="sm"
+          variant="default"
+          className="mobile-chrome-icon-button"
+          aria-label={backAriaLabel}
+          onClick={onBack}
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} size={22} />
+        </IconButton>
+      ) : leading ? (
+        <div className="mobile-top-bar__leading">{leading}</div>
+      ) : null}
+      {title ? <h1 className="mobile-top-bar__title">{title}</h1> : null}
+      {trailing ? (
+        <div className="mobile-top-bar__trailing">{trailing}</div>
+      ) : null}
     </header>
   );
 }

--- a/src/modules/MobileRemote/mobileChrome.scss
+++ b/src/modules/MobileRemote/mobileChrome.scss
@@ -1,0 +1,278 @@
+// Mobile-only chrome. Session rows, transcript typography, and the composer
+// continue to use their existing design tokens and surfaces.
+.mobile-shell {
+  --mobile-accent: #171717;
+  --mobile-accent-pressed: #333;
+  --mobile-on-accent: #fff;
+  --mobile-chrome-muted: #595959;
+  --mobile-glass: rgb(255 255 255 / 62%);
+  --mobile-glass-solid: #f5f5f5;
+  --mobile-glass-edge: rgb(0 0 0 / 10%);
+  --mobile-glass-highlight: rgb(255 255 255 / 92%);
+  --mobile-glass-shadow: 0 8px 28px rgb(0 0 0 / 10%), 0 2px 6px rgb(0 0 0 / 4%);
+  --mobile-glass-blur: blur(20px);
+  --mobile-selected: rgb(0 0 0 / 7%);
+  --mobile-canvas: #ededed;
+  --mobile-touch-size: 44px;
+  --mobile-action-height: 54px;
+  --mobile-action-padding: 14px 22px;
+  --mobile-action-font-size: 17px;
+  --mobile-tab-height: 56px;
+  --mobile-tab-padding: 7px 12px;
+
+  background: var(--mobile-canvas);
+
+  // This palette belongs to navigation only; it never replaces the app's
+  // semantic colors inherited by session content or status indicators.
+  @media (prefers-color-scheme: dark) {
+    --mobile-accent: #f5f5f5;
+    --mobile-accent-pressed: #d4d4d4;
+    --mobile-on-accent: #111;
+    --mobile-chrome-muted: #bdbdbd;
+    --mobile-glass: rgb(28 28 28 / 68%);
+    --mobile-glass-solid: #202020;
+    --mobile-glass-edge: rgb(255 255 255 / 12%);
+    --mobile-glass-highlight: rgb(255 255 255 / 24%);
+    --mobile-glass-shadow:
+      0 8px 28px rgb(0 0 0 / 28%), 0 2px 6px rgb(0 0 0 / 16%);
+    --mobile-selected: rgb(255 255 255 / 10%);
+    --mobile-canvas: #101010;
+  }
+}
+
+.mobile-shell__viewport {
+  max-width: 393px;
+  background: var(--mobile-canvas);
+}
+
+.mobile-top-bar {
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  color: var(--mobile-accent);
+}
+
+.mobile-top-bar--root {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  padding: 22px 22px 16px;
+
+  .mobile-top-bar__title {
+    order: 2;
+    flex: 0 0 100%;
+    font-size: 34px;
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.035em;
+  }
+}
+
+.mobile-top-bar--detail {
+  display: grid;
+  grid-template-columns: var(--mobile-touch-size) minmax(0, 1fr) var(
+      --mobile-touch-size
+    );
+  align-items: center;
+  gap: 10px;
+  min-height: 68px;
+  padding: 10px 16px;
+
+  .mobile-top-bar__title {
+    grid-column: 2;
+    font-size: 17px;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.02em;
+    text-align: center;
+  }
+}
+
+.mobile-top-bar__title {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-top-bar__leading {
+  min-width: 0;
+  flex: 1;
+}
+
+.mobile-top-bar__trailing {
+  grid-column: 3;
+  flex-shrink: 0;
+}
+
+// Blur is confined to navigation controls, never applied to scrolling content.
+.mobile-chrome-icon-button,
+.mobile-top-bar__trailing > button,
+.mobile-tab-bar,
+.mobile-action-button[data-mobile-variant="tertiary"] {
+  border: 1px solid var(--mobile-glass-edge);
+  background: var(--mobile-glass-solid);
+  box-shadow:
+    inset 0 1px 0 var(--mobile-glass-highlight),
+    var(--mobile-glass-shadow);
+
+  @supports (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    background: var(--mobile-glass);
+    -webkit-backdrop-filter: var(--mobile-glass-blur);
+    backdrop-filter: var(--mobile-glass-blur);
+  }
+}
+
+.mobile-chrome-icon-button,
+.mobile-top-bar__trailing > button {
+  width: var(--mobile-touch-size);
+  height: var(--mobile-touch-size);
+  border-radius: 50%;
+  color: var(--mobile-accent);
+}
+
+.mobile-welcome-icon {
+  border: 1px solid var(--mobile-glass-edge);
+  background: var(--mobile-glass-solid);
+}
+
+.mobile-welcome-icon,
+.mobile-brand-mark {
+  color: var(--mobile-accent);
+}
+
+.mobile-tab-dock {
+  flex-shrink: 0;
+  padding: 10px 20px max(12px, env(safe-area-inset-bottom));
+}
+
+.mobile-tab-bar {
+  display: flex;
+  gap: 4px;
+  padding: 5px;
+  border-radius: 999px;
+}
+
+.mobile-tab-button {
+  min-width: 0;
+  flex: 1;
+  color: var(--mobile-chrome-muted);
+
+  &[aria-current="page"] {
+    color: var(--mobile-on-accent);
+    background: var(--mobile-accent);
+    box-shadow: inset 0 1px 0 var(--mobile-glass-highlight);
+  }
+}
+
+.mobile-tab-button__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.mobile-tab-button__label {
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+}
+
+.mobile-action-button {
+  width: 100%;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+
+  // Shared Button uses a truncating label for dense desktop controls. Large
+  // mobile actions must wrap when translated or when text is enlarged.
+  > span,
+  .truncate {
+    overflow: visible;
+    white-space: normal;
+  }
+
+  &[data-mobile-variant="primary"] {
+    color: var(--mobile-on-accent);
+    background: var(--mobile-accent);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 24%),
+      0 6px 16px color-mix(in srgb, var(--mobile-accent) 20%, transparent);
+  }
+
+  &[data-mobile-variant="tertiary"] {
+    color: var(--mobile-accent);
+  }
+}
+
+.mobile-shell
+  :is(
+    .mobile-action-button,
+    .mobile-tab-button,
+    .mobile-chrome-icon-button,
+    .mobile-top-bar__trailing > button
+  ) {
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+
+  &:focus-visible {
+    outline: 3px solid var(--mobile-accent);
+    outline-offset: 3px;
+  }
+
+  &:active:not(:disabled) {
+    background: var(--mobile-selected);
+  }
+}
+
+.mobile-shell
+  .mobile-action-button[data-mobile-variant="primary"]:active:not(:disabled),
+.mobile-shell .mobile-tab-button[aria-current="page"]:active:not(:disabled) {
+  background: var(--mobile-accent-pressed);
+}
+
+@media (hover: hover) {
+  .mobile-shell
+    :is(
+      .mobile-tab-button,
+      .mobile-chrome-icon-button,
+      .mobile-top-bar__trailing > button
+    ):hover:not(:disabled) {
+    background: var(--mobile-selected);
+  }
+
+  .mobile-shell
+    .mobile-action-button[data-mobile-variant="primary"]:hover:not(:disabled),
+  .mobile-shell .mobile-tab-button[aria-current="page"]:hover:not(:disabled) {
+    background: var(--mobile-accent-pressed);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce), (prefers-contrast: more) {
+  .mobile-shell {
+    --mobile-glass: var(--mobile-glass-solid);
+    --mobile-glass-blur: none;
+    --mobile-glass-edge: var(--mobile-chrome-muted);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-shell
+    :is(
+      .mobile-action-button,
+      .mobile-tab-button,
+      .mobile-chrome-icon-button,
+      .mobile-top-bar__trailing > button
+    ) {
+    transition: none;
+  }
+}

--- a/src/modules/MobileRemote/screens/ConnectionErrorScreen.tsx
+++ b/src/modules/MobileRemote/screens/ConnectionErrorScreen.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import Button from "@src/components/Button";
 import { Placeholder } from "@src/components/Placeholder";
+
+import { MobileActionButton } from "../components/MobileActionButton";
 
 /** M-04 Connection Error */
 export interface ConnectionErrorScreenProps {
@@ -24,13 +25,13 @@ export function ConnectionErrorScreen({
         subtitle={message}
       />
       {onRetry ? (
-        <Button
+        <MobileActionButton
           variant="primary"
           className="mt-6 w-full max-w-xs"
           onClick={onRetry}
         >
           {t("actions.retry", { ns: "common", defaultValue: "Retry" })}
-        </Button>
+        </MobileActionButton>
       ) : null}
     </div>
   );

--- a/src/modules/MobileRemote/screens/QRScanScreen.tsx
+++ b/src/modules/MobileRemote/screens/QRScanScreen.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import Button from "@src/components/Button";
 import InlineAlert from "@src/components/InlineAlert";
 import Textarea from "@src/components/Textarea";
 
+import { MobileActionButton } from "../components/MobileActionButton";
 import { MobileTopBar } from "../components/MobileTopBar";
 import { parseMobileRemoteWsUrl } from "../connection/parseMobileRemoteWsUrl";
 import type { MobileConnectionConfig } from "../connection/types";
@@ -59,14 +59,14 @@ export function QRScanScreen({ onBack, onAcceptPairing }: QRScanScreenProps) {
           </InlineAlert>
         ) : null}
         <div className="mt-4">
-          <Button
+          <MobileActionButton
             variant="primary"
             className="w-full"
             disabled={payload.trim().length === 0}
             onClick={handleSubmit}
           >
             {t("pairing.connect")}
-          </Button>
+          </MobileActionButton>
         </div>
       </div>
     </>

--- a/src/modules/MobileRemote/screens/SASConfirmScreen.tsx
+++ b/src/modules/MobileRemote/screens/SASConfirmScreen.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import Button from "@src/components/Button";
-
+import { MobileActionButton } from "../components/MobileActionButton";
 import { MobileTopBar } from "../components/MobileTopBar";
 
 export interface SASConfirmScreenProps {
@@ -28,9 +27,9 @@ export function SASConfirmScreen({
           <p className="font-mono text-xl text-text-1">{phrase}</p>
         </div>
         <div className="mt-6">
-          <Button variant="primary" className="w-full" onClick={onConfirm}>
+          <MobileActionButton onClick={onConfirm}>
             {t("pairing.confirm")}
-          </Button>
+          </MobileActionButton>
         </div>
       </div>
     </>

--- a/src/modules/MobileRemote/screens/SessionsScreen.tsx
+++ b/src/modules/MobileRemote/screens/SessionsScreen.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 
 import { LIST_PANEL_SECTION_HEADER } from "@src/components/ListPanel/tokens";
 
@@ -14,12 +15,14 @@ export interface SessionsScreenProps {
 
 /** M-05 Sessions / Online (M-06 offline banner when presence offline). */
 export function SessionsScreen({ onSelectSession }: SessionsScreenProps) {
+  const { t } = useTranslation("mobileRemote");
   const { connection, sessions } = useMobileRemote();
   const offline = connection.presence === "offline";
 
   return (
     <>
       <MobileTopBar
+        title={t("tabs.sessions")}
         leading={
           <DesktopPresenceLabel
             desktopName={connection.desktopName ?? "Desktop"}

--- a/src/modules/MobileRemote/screens/WelcomeScreen.tsx
+++ b/src/modules/MobileRemote/screens/WelcomeScreen.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import Button from "@src/components/Button";
 import { Camera01Icon, HugeiconsIcon, SmartPhone01Icon } from "@src/icons";
+
+import { MobileActionButton } from "../components/MobileActionButton";
 
 export interface WelcomeScreenProps {
   onOpenPairing?: () => void;
@@ -19,7 +20,7 @@ export function WelcomeScreen({
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-6 pb-16 text-center">
       <div
-        className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-fill-2 text-primary-6"
+        className="mobile-welcome-icon mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         aria-hidden="true"
       >
         <HugeiconsIcon icon={SmartPhone01Icon} size={32} />
@@ -29,7 +30,7 @@ export function WelcomeScreen({
       </h1>
       <p className="mb-10 text-sm text-text-3">{t("welcome.subtitle")}</p>
       <div className="flex w-full max-w-xs flex-col gap-3">
-        <Button
+        <MobileActionButton
           variant="primary"
           className="w-full"
           icon={
@@ -38,11 +39,11 @@ export function WelcomeScreen({
           onClick={onOpenPairing}
         >
           {t("welcome.scanQr")}
-        </Button>
+        </MobileActionButton>
         {onScanDemo ? (
-          <Button variant="tertiary" className="w-full" onClick={onScanDemo}>
+          <MobileActionButton variant="tertiary" onClick={onScanDemo}>
             {t("welcome.tryDemo")}
-          </Button>
+          </MobileActionButton>
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## Problem

Mobile Remote uses compact desktop-sized navigation and action buttons. Its chrome needs a consistent monochrome iPhone-style presentation with larger touch targets.

## Solution

Use plain light/dark backgrounds, a floating glass tab dock, round navigation controls, larger page headings, and a shared large-action button built on the existing Button component. Glass effects are limited to controls. Preserve the 393px viewport, session rows, session details, transcript, composer, and connection behavior.

## Potential risks

- Safari/iPhone rendering, narrow-screen and enlarged-text layout, and backdrop-blur cost have not been visually verified. Screenshots are missing because computer control was not authorized.
- Monochrome navigation also removes the stop control's red tint; its stop icon and accessible label remain.
- No dependency, persistence, API, or data changes. Reverting this commit restores the previous chrome.
- The repository dependency check reports an existing cycle between `modelGrouping.ts` and `modelVariants.ts`; both files match the base branch.

## Verification

Run in an isolated checkout based on `develop` at `6d2b69f02`, containing only this PR:

- `pnpm exec vitest run --config config/vitest.config.ts src/modules/MobileRemote --silent` — 40 files, 231 tests passed.
- `pnpm run typecheck:fast` — passed.
- Commit hooks (`npx lint-staged`, oxlint, ESLint/Prettier, typecheck, commitlint) — passed without bypass; the commit includes the generated verification trailer.
- Changed-file ESLint and Prettier — passed; exact file-list commands are recorded in the [UI audit](https://github.com/Harry19081/ORG2/blob/dev/mobile-monochrome-glass/docs/frontend-ui-audit-2026-09-05/MobileChrome.md#verification).
- `pnpm run check:test-placement` — passed, 497 directories.
- `git diff --cached --check` — passed.
- `pnpm run check:circular` — reports only the existing model-utility cycle described above.
- Sass compilation and local HTTP bundle readback passed; final chrome CSS has no decorative background gradients.
- Final base refresh found `develop` at `73101c80c`; those newer commits do not touch Mobile Remote or the PR rules, and GitHub reports this PR mergeable. Local checks above ran against `6d2b69f02`; GitHub CI is running.
- UI screenshots, physical iPhone checks, and rendered light/dark/loading/error-state checks were not run. No runtime performance claim is made.

UI audit: 0 fix, 7 keep with reason, 0 further abstractions.
