### PR TITLE
fix(chat-tabs): size the pinned right-edge reservation to the visible toggles

### DIFF
--- a/src/config/workstation/tokens.ts
+++ b/src/config/workstation/tokens.ts
@@ -155,6 +155,11 @@ export const TAB_BAR_CONTROLS_ROW_PADDING_FULL = "pl-1 pr-2";
  * Matches the standard tab-bar trailing edge inset.
  */
 export const TAB_BAR_CONTROLS_ROW_PADDING_TRAILING_ONLY = "pl-1 pr-2";
+/**
+ * The `pr-2` above, in pixels. Hosts that reserve window-edge space for
+ * pinned chrome subtract it so the reservation's 1px gap is not doubled.
+ */
+export const TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX = 8;
 
 /** Default: full horizontal padding (most toolbars). */
 export const TAB_BAR_CONTROLS_ROW_CLASS = `${TAB_BAR_CONTROLS_ROW_BASE_CLASS} ${TAB_BAR_CONTROLS_ROW_PADDING_FULL}`;

--- a/src/engines/ChatPanel/ChatPanelHeader.test.ts
+++ b/src/engines/ChatPanel/ChatPanelHeader.test.ts
@@ -27,9 +27,8 @@ vi.mock("@src/components/KeyboardShortcut/ToolbarTooltip", () => ({
 // The header reads the pinned right-edge chrome hooks, which need a router;
 // these tests render outside one and cover the non-pinned (non-macOS) layout.
 vi.mock("@src/hooks/ui/workbench/usePinnedWorkbenchChrome", () => ({
-  getPinnedWorkbenchChromeReservedRight: () => 66,
   usePinnedWorkbenchChromeVisible: () => false,
-  useWorkbenchRightEdgeOwner: () => null,
+  useWorkbenchRightEdgeReservation: () => ({ owner: null, reservedRight: 0 }),
 }));
 vi.mock("./header/ChatPanelCollapsedTabHeading", () => ({
   ChatPanelCollapsedTabHeading: () =>

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -10,9 +10,8 @@ import Tooltip from "@src/components/Tooltip";
 import type { DropdownEnginePosition } from "@src/hooks/dropdown";
 import { getCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import {
-  getPinnedWorkbenchChromeReservedRight,
   usePinnedWorkbenchChromeVisible,
-  useWorkbenchRightEdgeOwner,
+  useWorkbenchRightEdgeReservation,
 } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import {
   ArrowExpand01Icon,
@@ -164,11 +163,9 @@ export function ChatPanelHeader({
   // right edge (`PinnedWorkbenchChrome`); this header then only reserves the
   // space while the chat pane is the one touching that edge.
   const pinnedChrome = usePinnedWorkbenchChromeVisible();
-  const rightEdgeOwner = useWorkbenchRightEdgeOwner();
+  const rightEdge = useWorkbenchRightEdgeReservation();
   const trailingInsetPx =
-    rightEdgeOwner === "chat"
-      ? getPinnedWorkbenchChromeReservedRight()
-      : undefined;
+    rightEdge.owner === "chat" ? rightEdge.reservedRight : undefined;
   if (!showHeader) return null;
 
   const chatFocusLabel = isChatFocus

--- a/src/hooks/ui/workbench/usePinnedWorkbenchChrome.ts
+++ b/src/hooks/ui/workbench/usePinnedWorkbenchChrome.ts
@@ -20,17 +20,39 @@ import {
 import { chatPanelPositionAtom } from "@src/store/ui/workStationAtom";
 import { isMacOS } from "@src/util/platform/tauri";
 
-/** Two 28px icon buttons with the tab bar's 1px gap. */
-export const PINNED_WORKBENCH_CHROME_WIDTH = 28 + 1 + 28;
+/** One 28px icon button. */
+export const PINNED_WORKBENCH_CHROME_BUTTON_WIDTH = 28;
+/** The tab bar's 1px gap between adjacent buttons. */
+export const PINNED_WORKBENCH_CHROME_GAP = 1;
 /** Distance from the window's right edge, matching the tab bars' `pr-2`. */
 export const PINNED_WORKBENCH_CHROME_RIGHT_INSET = 8;
 /** Same vertical anchor as the left group. */
 export const PINNED_WORKBENCH_CHROME_CENTER_TOP = 26;
 
+export type PinnedWorkbenchChromeSlots = 1 | 2;
+
+/**
+ * How many slots the group draws: both toggles while the chat pane shows
+ * beside the workstation, one otherwise. A missing slot is dropped outright
+ * rather than held as a spacer — a spacer only punches a hole between the
+ * surviving toggle and the host's own controls.
+ */
+export function resolvePinnedWorkbenchChromeSlots(options: {
+  chatVisible: boolean;
+  chatPanelMaximized: boolean;
+}): PinnedWorkbenchChromeSlots {
+  return options.chatVisible && !options.chatPanelMaximized ? 2 : 1;
+}
+
 /** Right padding a host needs so its own controls clear the pinned group. */
-export function getPinnedWorkbenchChromeReservedRight(): number {
+export function getPinnedWorkbenchChromeReservedRight(
+  slots: PinnedWorkbenchChromeSlots = 2
+): number {
   return (
-    PINNED_WORKBENCH_CHROME_RIGHT_INSET + PINNED_WORKBENCH_CHROME_WIDTH + 1
+    PINNED_WORKBENCH_CHROME_RIGHT_INSET +
+    slots * PINNED_WORKBENCH_CHROME_BUTTON_WIDTH +
+    (slots - 1) * PINNED_WORKBENCH_CHROME_GAP +
+    PINNED_WORKBENCH_CHROME_GAP
   );
 }
 
@@ -49,16 +71,30 @@ export function usePinnedWorkbenchChromeVisible(): boolean {
 
 export type WorkbenchRightEdgeOwner = "chat" | "workstation";
 
-/** Which pane currently touches the window's right edge, or null when nothing is pinned there. */
-export function useWorkbenchRightEdgeOwner(): WorkbenchRightEdgeOwner | null {
+export interface WorkbenchRightEdgeReservation {
+  /** Which pane touches the window's right edge; null when nothing is pinned there. */
+  owner: WorkbenchRightEdgeOwner | null;
+  /** Right padding that pane must keep clear; 0 when nothing is pinned. */
+  reservedRight: number;
+}
+
+/** Who reserves the right edge for the pinned group, and how much. */
+export function useWorkbenchRightEdgeReservation(): WorkbenchRightEdgeReservation {
   const pinned = usePinnedWorkbenchChromeVisible();
   const stationChatVisibility = useAtomValue(stationChatVisibilityAtom);
   const chatWidth = useAtomValue(chatWidthAtom);
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
   const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
-  if (!pinned) return null;
+  if (!pinned) return { owner: null, reservedRight: 0 };
   const chatVisible = stationChatVisibility["my-station"] && chatWidth > 0;
-  return chatPanelMaximized || (chatVisible && chatPanelPosition === "right")
-    ? "chat"
-    : "workstation";
+  const owner: WorkbenchRightEdgeOwner =
+    chatPanelMaximized || (chatVisible && chatPanelPosition === "right")
+      ? "chat"
+      : "workstation";
+  return {
+    owner,
+    reservedRight: getPinnedWorkbenchChromeReservedRight(
+      resolvePinnedWorkbenchChromeSlots({ chatVisible, chatPanelMaximized })
+    ),
+  };
 }

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
@@ -12,6 +12,7 @@ import { useLocation } from "react-router-dom";
 
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
 import { NoDragRegion } from "@src/components/WindowChrome";
+import { TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX } from "@src/config/workstation/tokens";
 import CaptionBar from "@src/engines/Simulator/components/CaptionBar";
 import { useCurrentTurnLastAgentMessage } from "@src/engines/Simulator/hooks/useCurrentTurnLastAgentMessage";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
@@ -20,9 +21,8 @@ import {
   useShouldOffsetWorkStationTopBar,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import {
-  getPinnedWorkbenchChromeReservedRight,
   usePinnedWorkbenchChromeVisible,
-  useWorkbenchRightEdgeOwner,
+  useWorkbenchRightEdgeReservation,
 } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import {
   ArrowExpand01Icon,
@@ -59,7 +59,7 @@ const AgentStationTopHeader: React.FC = memo(() => {
   const { t } = useTranslation("sessions");
   const shouldOffsetLeftChrome = useShouldOffsetWorkStationTopBar();
   const pinnedChrome = usePinnedWorkbenchChromeVisible();
-  const rightEdgeOwner = useWorkbenchRightEdgeOwner();
+  const rightEdge = useWorkbenchRightEdgeReservation();
   const getStationChatVisible = useAtomValue(activeStationChatVisibleAtom);
   const chatWidth = useAtomValue(chatWidthAtom);
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
@@ -156,9 +156,12 @@ const AgentStationTopHeader: React.FC = memo(() => {
             paddingLeft: shouldOffsetLeftChrome
               ? getCollapsedSidebarChromeOffset()
               : undefined,
+            // The trailing group keeps its own `pr-2`; only the remainder of
+            // the pinned-chrome reservation goes here.
             paddingRight:
-              rightEdgeOwner === "workstation"
-                ? getPinnedWorkbenchChromeReservedRight()
+              rightEdge.owner === "workstation"
+                ? rightEdge.reservedRight -
+                  TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX
                 : undefined,
             WebkitAppRegion: "drag",
           } as React.CSSProperties

--- a/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts
+++ b/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts
@@ -18,6 +18,7 @@ import { ROUTES } from "@src/config/routes";
 import {
   getPinnedWorkbenchChromeReservedRight,
   isPinnedWorkbenchChromePath,
+  resolvePinnedWorkbenchChromeSlots,
 } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import {
   activeStationChatVisibleAtom,
@@ -139,9 +140,12 @@ describe("PinnedWorkbenchChrome", () => {
     expect(store.get(chatPanelMaximizedAtom)).toBe(true);
     expect(query("pinned-workbench-chrome-show-workstation")).not.toBeNull();
     expect(group?.style.right).toBe("8px");
+    // Maximized: the hide-chat slot is gone outright, no spacer left behind.
+    expect(query("pinned-workbench-chrome-chat-visibility")).toBeNull();
+    expect(group?.childElementCount).toBe(1);
   });
 
-  it("keeps a placeholder so the remaining toggle never shifts while the chat is hidden", () => {
+  it("draws only the restore toggle, flush right, while the chat is hidden", () => {
     render();
     act(() => {
       store.set(activeStationChatVisibleAtom, "my-station", false);
@@ -150,14 +154,29 @@ describe("PinnedWorkbenchChrome", () => {
 
     expect(query("pinned-workbench-chrome-chat-visibility")).not.toBeNull();
     expect(query("pinned-workbench-chrome-maximize-chat")).toBeNull();
-    expect(
-      query("pinned-workbench-chrome")?.querySelectorAll(
-        "button, span[aria-hidden]"
-      ).length
-    ).toBe(2);
+    expect(query("pinned-workbench-chrome")?.childElementCount).toBe(1);
   });
 
-  it("reserves the pair plus inset and gap for hosts", () => {
-    expect(getPinnedWorkbenchChromeReservedRight()).toBe(8 + 28 + 1 + 28 + 1);
+  it("reserves inset, the visible slots, and gaps for hosts", () => {
+    expect(getPinnedWorkbenchChromeReservedRight(2)).toBe(8 + 28 + 1 + 28 + 1);
+    expect(getPinnedWorkbenchChromeReservedRight(1)).toBe(8 + 28 + 1);
+    expect(
+      resolvePinnedWorkbenchChromeSlots({
+        chatVisible: true,
+        chatPanelMaximized: false,
+      })
+    ).toBe(2);
+    expect(
+      resolvePinnedWorkbenchChromeSlots({
+        chatVisible: true,
+        chatPanelMaximized: true,
+      })
+    ).toBe(1);
+    expect(
+      resolvePinnedWorkbenchChromeSlots({
+        chatVisible: false,
+        chatPanelMaximized: false,
+      })
+    ).toBe(1);
   });
 });

--- a/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx
+++ b/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx
@@ -43,11 +43,6 @@ import { chatPanelPositionAtom } from "@src/store/ui/workStationAtom";
 
 import { WorkstationMaximizeChatIcon } from "./useWorkstationTrailingSlot";
 
-/** Keeps the other button in place when its sibling has nothing to offer. */
-const Placeholder: React.FC = () => (
-  <span className="inline-block h-7 w-7" aria-hidden />
-);
-
 const PinnedWorkbenchChromeComponent: React.FC = () => {
   const { t } = useTranslation("sessions");
   const visible = usePinnedWorkbenchChromeVisible();
@@ -80,10 +75,8 @@ const PinnedWorkbenchChromeComponent: React.FC = () => {
   const stationAvailable = isChatPanelTabStationAvailable(activeTab);
 
   // Slot A: hide / restore the chat pane. Meaningless while the chat is
-  // maximized (there is no workstation to grow), so it yields its space.
-  const chatVisibilityControl = chatPanelMaximized ? (
-    <Placeholder />
-  ) : (
+  // maximized (there is no workstation to grow), so it is dropped outright.
+  const chatVisibilityControl = chatPanelMaximized ? null : (
     <TabBarTrailingIconButton
       title={
         isChatPanelVisible
@@ -113,10 +106,12 @@ const PinnedWorkbenchChromeComponent: React.FC = () => {
   );
 
   // Slot B: maximize chat while the workstation shows; show the workstation
-  // again while the chat is maximized. Nothing to do while the chat is hidden.
+  // again while the chat is maximized. Nothing to draw while the chat is
+  // hidden — no spacer either, so the restore toggle sits flush right and
+  // the host reserves for one slot (`useWorkbenchRightEdgeReservation`).
   let maximizeControl: React.ReactNode;
   if (!isChatPanelVisible) {
-    maximizeControl = <Placeholder />;
+    maximizeControl = null;
   } else if (chatPanelMaximized) {
     maximizeControl = (
       <TabBarTrailingIconButton

--- a/src/modules/WorkStation/shared/TabBar/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/index.tsx
@@ -42,15 +42,13 @@ import FileTypeIcon from "@src/components/FileTypeIcon";
 import { TAB_PILL_DRAG_OVERLAY_CLASS } from "@src/components/TabPill/TabPillSurface";
 import { TAB_PAIR_SEPARATOR_SLOT_CLASS } from "@src/components/TabPill/config";
 import { NoDragRegion } from "@src/components/WindowChrome";
+import { TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX } from "@src/config/workstation/tokens";
 import SessionRawTranscriptDialog from "@src/engines/ChatPanel/components/SessionRawTranscriptDialog";
 import {
   getCollapsedSidebarChromeOffset,
   useShouldOffsetWorkStationTopBar,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
-import {
-  getPinnedWorkbenchChromeReservedRight,
-  useWorkbenchRightEdgeOwner,
-} from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
+import { useWorkbenchRightEdgeReservation } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import { requestTeamInboxSessionHandoffAtom } from "@src/modules/MainApp/TeamInbox/store";
 import { CHROME_INSET_TRANSITION_CLASSES } from "@src/modules/shared/layouts/viewContainerTokens";
 import { CollapsedSidebarButton } from "@src/scaffold/NavigationSidebar/CollapsedSidebarButton";
@@ -228,7 +226,7 @@ export const TabBar: React.FC<TabBarProps> = memo(
     const shouldOffsetLeftChrome = useShouldOffsetWorkStationTopBar();
     // macOS pins the right-edge collapse toggles in window space; make room
     // whenever the workstation is the pane touching that edge.
-    const rightEdgeOwner = useWorkbenchRightEdgeOwner();
+    const rightEdge = useWorkbenchRightEdgeReservation();
 
     const scrollReveal = useAtomValue(tabScrollRevealAtom);
     const gitStatusMap = useAtomValue(gitFileStatusMapAtom);
@@ -394,9 +392,12 @@ export const TabBar: React.FC<TabBarProps> = memo(
             paddingLeft: shouldOffsetLeftChrome
               ? getCollapsedSidebarChromeOffset()
               : undefined,
+            // The controls row keeps its own `pr-2`; only the remainder of
+            // the pinned-chrome reservation goes here.
             paddingRight:
-              rightEdgeOwner === "workstation"
-                ? getPinnedWorkbenchChromeReservedRight()
+              rightEdge.owner === "workstation"
+                ? rightEdge.reservedRight -
+                  TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX
                 : undefined,
             WebkitAppRegion: "drag",
           } as React.CSSProperties


### PR DESCRIPTION
## Problem

After #1287 pinned the right-edge collapse toggles on macOS, the pinned group kept a 28px invisible spacer for whichever toggle had nothing to show, and every host reserved room for two buttons regardless. Two visible holes resulted: with the chat maximized, a gap between the chat header's own `…` / `+` controls and the single pinned toggle; with the chat hidden, the same spacer sat at the far right of the My Station tab bar. On top of that, the workstation tab bar's controls row and the agent station header carry their own `pr-2`, so their gap to the pinned group was 9px instead of the 1px used everywhere else.

Root cause: the reservation was a constant (`getPinnedWorkbenchChromeReservedRight()` = 66px) and the spacer tried to keep positions stable in states where the surviving toggle is flush right anyway.

## Solution

- `PinnedWorkbenchChrome` draws only the toggles that apply and no spacers. Chat beside the workstation: hide-chat + maximize-chat. Chat maximized: show-workstation only. Chat hidden: restore-chat only. The surviving toggle is flush right in every single-slot state.
- New `resolvePinnedWorkbenchChromeSlots({ chatVisible, chatPanelMaximized })` and `getPinnedWorkbenchChromeReservedRight(slots)` (66px for two, 37px for one). `useWorkbenchRightEdgeOwner` is replaced by `useWorkbenchRightEdgeReservation()`, which returns `{ owner, reservedRight }` so hosts reserve exactly what is drawn.
- Workstation `TabBar` and `AgentStationTopHeader` subtract the new `TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX` (their row's existing `pr-2`) from the reservation, so the gap to the pinned group is 1px on every host. `ChatPanelHeader` already overrides its class padding inline, so it needs no adjustment.

Invariant: on every host, own controls end exactly 1px before the pinned group, and the pinned group contains no empty slots.

## Potential risks

- **Restore toggle moves on show.** While the chat is hidden the restore toggle now sits at `right: 8px`; when the chat returns it becomes hide-chat and shifts left by 29px as maximize-chat appears beside it. #1287's spacer avoided that shift at the cost of the hole; this trades the other way, matching Codex / Claude, where a lone control sits flush right.
- **Reservation now changes with state**, so hosts' `paddingRight` animates through `CHROME_INSET_TRANSITION_CLASSES` when the slot count changes. Expected, but not eyeballed.
- **Not visually verified.** ORG2 is Tauri-only and this session cannot capture the app. The 1px gap on My Station and the agent station header depends on their `pr-2` staying 8px; the constant documents that coupling.
- Windows/Linux unaffected: nothing is pinned there.

## Verification

Ran locally on 2026-09-05 against these files in the live checkout:

```
npx eslint <8 changed files>                      # exit 0
npx vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell src/modules/WorkStation/shared src/engines/ChatPanel/ChatPanelHeader.test.ts src/config
# 69 files, 423 tests passed
pnpm typecheck:fast                                # clean apart from one pre-existing error outside this PR (CanvasPreviewSurface.tsx, caused by another session's uncommitted edit to transientScrollbars.ts in the same checkout)
```

Tests updated: `PinnedWorkbenchChrome.test.ts` asserts a single child (no spacer) when maximized and when hidden, and the slot / reservation arithmetic for all three states; `ChatPanelHeader.test.ts` mocks the renamed reservation hook.

Not run: full `pnpm test`, full `pnpm lint`, any in-app visual check. Commit built with a temp index from a dirty live checkout, so the pre-commit hook trailer is absent by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
