### PR TITLE
fix(tables): centralize settings row expansion

### DIFF
--- a/docs/frontend-ui-audit-2026-09-04/TableBody.md
+++ b/docs/frontend-ui-audit-2026-09-04/TableBody.md
@@ -1,0 +1,11 @@
+# TableBody UI audit
+
+| Line                                         | Element                                   | Verdict          | Reason                                                                                                                                                                                      | Suggested change |
+| -------------------------------------------- | ----------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/components/Table/TableBody.tsx:34`      | Interactive row target guard              | keep with reason | Centralizes the controls that must not trigger row behavior, covering native controls and the design-system wrappers used inside settings-table cells.                                      | None.            |
+| `src/components/Table/TableBody.tsx:194`     | Settings row expand/collapse icon mapping | keep with reason | Uses the shared icon barrel and the established right-chevron collapsed / down-chevron expanded convention while preserving the existing non-settings table treatment.                      | None.            |
+| `src/components/Table/TableBody.tsx:228`     | Settings row click behavior               | keep with reason | The shared table primitive now owns expansion for every eligible non-interactive row click, while optional consumer callbacks remain limited to selection or other domain behavior.         | None.            |
+| `src/components/Table/TableBody.tsx:243`     | Compact row expansion button              | keep with reason | This is shared table primitive code with a table-cell-specific 14px control; the native button supplies keyboard and button semantics, while `aria-label` and `aria-expanded` expose state. | None.            |
+| `src/components/SettingsTable/index.tsx:202` | Row-click contract                        | keep with reason | Documents the shared expansion invariant at the public settings-table boundary so consumers do not reimplement it.                                                                          | None.            |
+
+Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.

--- a/src/components/SettingsTable/index.tsx
+++ b/src/components/SettingsTable/index.tsx
@@ -199,7 +199,7 @@ export interface SettingsTableProps<RowData> {
   /** When true, removes horizontal cell padding on outer edges (first-child left, last-child right).
    *  Use for tables nested inside SectionContainer which already provides px-4. */
   noPx?: boolean;
-  /** Row click handler. Clicks on interactive elements (buttons, links, inputs) are ignored. */
+  /** Row click handler. Non-interactive row clicks also toggle expandable rows; buttons, links, and inputs are ignored. */
   onRowClick?: (row: RowData) => void;
   /** Enable row hover highlight. Default: false */
   hover?: boolean;
@@ -277,7 +277,7 @@ function SettingsTableToolbar({
 
   return (
     <div className="flex min-w-0 flex-col gap-2 pt-2 pb-2 @[640px]:flex-row @[640px]:items-center">
-      <div className="order-2 scrollbar-hide w-full min-w-0 overflow-x-auto overflow-y-hidden @[640px]:order-1 @[640px]:w-auto @[640px]:flex-none">
+      <div className="order-2 w-full min-w-0 overflow-x-auto overflow-y-hidden @[640px]:order-1 @[640px]:w-auto @[640px]:flex-none">
         <div className="flex w-max min-w-full items-center gap-2">
           {searchBar?.leftContent}
           {selectFilters?.map((filter) => {
@@ -369,7 +369,7 @@ function SelectFilterRow({
 }) {
   return (
     <div
-      className={`scrollbar-hide min-w-0 overflow-x-auto overflow-y-hidden px-1 pb-1 ${hasSearchBarAbove ? "" : "pt-1"}`}
+      className={`min-w-0 overflow-x-auto overflow-y-hidden px-1 pb-1 ${hasSearchBarAbove ? "" : "pt-1"}`}
     >
       <div className="flex w-max min-w-full items-center gap-2">
         {filters.map((filter) => {

--- a/src/components/Table/TableBody.test.ts
+++ b/src/components/Table/TableBody.test.ts
@@ -99,4 +99,105 @@ describe("Table row interactions", () => {
         ?.checked
     ).toBe(false);
   });
+
+  it("uses right and down chevrons for collapsed and expanded settings rows", () => {
+    act(() => {
+      root.render(
+        createElement(Table<{ id: string }>, {
+          columns: [{ key: "id", dataIndex: "id" }],
+          data: [{ id: "row-1" }],
+          rowKey: "id",
+          pagination: false,
+          showHeader: false,
+          settings: true,
+          expandable: {
+            expandedRowRender: () => createElement("div", null, "Details"),
+          },
+        })
+      );
+    });
+
+    const expandButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Expand row"]'
+    );
+    expect(expandButton).not.toBeNull();
+    expect(
+      expandButton?.querySelector('[data-icon="chevron-right"]')
+    ).not.toBeNull();
+
+    act(() => expandButton?.click());
+
+    const collapseButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Collapse row"]'
+    );
+    expect(collapseButton).not.toBeNull();
+    expect(
+      collapseButton?.querySelector('[data-icon="chevron-down"]')
+    ).not.toBeNull();
+  });
+
+  it("toggles a settings row from non-interactive content when a row callback is present", () => {
+    const onRowClick = vi.fn();
+    const onActionClick = vi.fn();
+
+    act(() => {
+      root.render(
+        createElement(Table<{ id: string }>, {
+          columns: [
+            {
+              key: "name",
+              render: () => createElement("span", null, "Row 1"),
+            },
+            {
+              key: "action",
+              render: () =>
+                createElement(
+                  "button",
+                  { type: "button", onClick: onActionClick },
+                  "Action"
+                ),
+            },
+          ],
+          data: [{ id: "row-1" }],
+          rowKey: "id",
+          pagination: false,
+          showHeader: false,
+          settings: true,
+          onRowClick,
+          expandable: {
+            expandedRowRender: () => createElement("div", null, "Details"),
+          },
+        })
+      );
+    });
+
+    const rowLabel = Array.from(container.querySelectorAll("span")).find(
+      (element) => element.textContent === "Row 1"
+    );
+    const actionButton = Array.from(container.querySelectorAll("button")).find(
+      (element) => element.textContent === "Action"
+    );
+
+    act(() => rowLabel?.click());
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector('button[aria-label="Collapse row"]')
+    ).not.toBeNull();
+
+    act(() => actionButton?.click());
+
+    expect(onActionClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(
+      container.querySelector('button[aria-label="Collapse row"]')
+    ).not.toBeNull();
+
+    act(() => rowLabel?.click());
+
+    expect(onRowClick).toHaveBeenCalledTimes(2);
+    expect(
+      container.querySelector('button[aria-label="Expand row"]')
+    ).not.toBeNull();
+  });
 });

--- a/src/components/Table/TableBody.tsx
+++ b/src/components/Table/TableBody.tsx
@@ -2,6 +2,8 @@ import { Cell, Row, flexRender } from "@tanstack/react-table";
 import React, { useState } from "react";
 
 import {
+  ArrowDown01Icon,
+  ArrowRight01Icon,
   ChevronsDownUpIcon,
   HugeiconsIcon,
   InboxIcon,
@@ -189,6 +191,20 @@ export function TableBody<T>({
         const canExpand =
           expandable?.rowExpandable?.(row.original) ?? !!expandable;
         const isExpanded = expandedRows.has(rowKey);
+        const expandIcon = settings
+          ? isExpanded
+            ? ArrowDown01Icon
+            : ArrowRight01Icon
+          : isExpanded
+            ? ChevronsDownUpIcon
+            : UnfoldMoreIcon;
+        const expandIconName = settings
+          ? isExpanded
+            ? "chevron-down"
+            : "chevron-right"
+          : isExpanded
+            ? "chevrons-down-up"
+            : "chevrons-up-down";
 
         return (
           <React.Fragment key={rowKey}>
@@ -213,7 +229,8 @@ export function TableBody<T>({
                 if (isInteractiveTableTarget(event.target)) return;
                 if (onRowClick) {
                   onRowClick(row.original, index);
-                } else if (canExpand) {
+                }
+                if (canExpand && (settings || !onRowClick)) {
                   setHoverSuppressedRowKey(rowKey);
                   toggleRowExpand(rowKey);
                 }
@@ -235,21 +252,12 @@ export function TableBody<T>({
                         aria-label={isExpanded ? "Collapse row" : "Expand row"}
                         aria-expanded={isExpanded}
                       >
-                        {isExpanded ? (
-                          <HugeiconsIcon
-                            icon={ChevronsDownUpIcon}
-                            data-icon="chevrons-down-up"
-                            size={14}
-                            className="shrink-0"
-                          />
-                        ) : (
-                          <HugeiconsIcon
-                            icon={UnfoldMoreIcon}
-                            data-icon="chevrons-up-down"
-                            size={14}
-                            className="shrink-0"
-                          />
-                        )}
+                        <HugeiconsIcon
+                          icon={expandIcon}
+                          data-icon={expandIconName}
+                          size={14}
+                          className="shrink-0"
+                        />
                       </button>
                     ) : (
                       <span

--- a/src/modules/MainApp/Integrations/ExternalSkillsets/CursorPluginsTab.tsx
+++ b/src/modules/MainApp/Integrations/ExternalSkillsets/CursorPluginsTab.tsx
@@ -140,12 +140,6 @@ const CursorPluginsTab: React.FC = () => {
     };
   }, []);
 
-  const setSingleExpanded = useCallback((plugin: CursorPluginInfo) => {
-    setExpandedKeys((current) =>
-      current.includes(plugin.slug) ? [] : [plugin.slug]
-    );
-  }, []);
-
   const filtered = useMemo(() => {
     if (!searchQuery) return plugins;
     const query = searchQuery.toLowerCase();
@@ -247,7 +241,6 @@ const CursorPluginsTab: React.FC = () => {
             columns={columns}
             rows={filtered}
             getRowKey={(p) => p.slug}
-            onRowClick={setSingleExpanded}
             expandable={{
               rowExpandable: () => true,
               expandedRowKeys: expandedKeys,

--- a/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx
@@ -133,17 +133,6 @@ export default function MyAccountsTableSection({
     string | null
   >(null);
 
-  const setSingleExpandedAccount = useCallback((account: KeyVaultAccount) => {
-    setExpandedAccountKeys((currentKeys) => {
-      const collapsing = currentKeys.includes(account.id);
-      if (collapsing) {
-        setEditRequestedAccountId(null);
-        return [];
-      }
-      return [account.id];
-    });
-  }, []);
-
   const handleEditAccountInline = useCallback(
     (accountId: string) => {
       setExpandedAccountKeys([accountId]);
@@ -406,7 +395,6 @@ export default function MyAccountsTableSection({
       rows={accounts}
       getRowKey={(account) => account.id}
       rowDataTestId={(account) => `key-vault-account-row-${account.id}`}
-      onRowClick={setSingleExpandedAccount}
       expandable={expandable}
       headerHeight="tall"
       className="table-expanded-no-hover table-settings-expanded-compact"

--- a/src/modules/MainApp/Integrations/KeyVault/CliClients/Table/CliClientsTable.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/CliClients/Table/CliClientsTable.tsx
@@ -142,12 +142,6 @@ const CliClientsTable: React.FC<CliClientsTableProps> = ({
     [tIntegrations]
   );
 
-  const setSingleExpandedAgent = useCallback((agent: AvailableAgent) => {
-    setExpandedAgentKeys((currentKeys) =>
-      currentKeys.includes(agent.name) ? [] : [agent.name]
-    );
-  }, []);
-
   const handleViewAgent = useCallback((agent: AvailableAgent) => {
     openAgentConfigInWorkStation({
       variant: "cli",
@@ -432,7 +426,6 @@ const CliClientsTable: React.FC<CliClientsTableProps> = ({
       rows={filtered}
       columns={columns}
       getRowKey={(agent) => agent.name}
-      onRowClick={setSingleExpandedAgent}
       expandable={expandable}
       headerHeight="tall"
       className="table-expanded-no-hover table-settings-expanded-compact"

--- a/src/modules/MainApp/Integrations/KeyVault/Models/Table/ModelsTableSection.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/Models/Table/ModelsTableSection.tsx
@@ -182,16 +182,6 @@ export default function ModelsTableSection({
     [accounts, onUpdateAccountEnabledModels]
   );
 
-  const setSingleExpandedGroup = useCallback(
-    (group: IntegrationsModelGroupRow) => {
-      const rowKey = getIntegrationsGroupRowKey(group);
-      setExpandedGroupKeys((currentKeys) =>
-        currentKeys.includes(rowKey) ? [] : [rowKey]
-      );
-    },
-    []
-  );
-
   const isSearching = modelsSearchQuery.trim().length > 0;
   const expandControl =
     olderCount > 0 && !isSearching ? (
@@ -396,7 +386,6 @@ export default function ModelsTableSection({
       rows={groupRows}
       getRowKey={getIntegrationsGroupRowKey}
       expandable={expandable}
-      onRowClick={setSingleExpandedGroup}
       headerHeight="tall"
       className="table-expanded-no-hover table-settings-expanded-compact"
       searchBar={{

--- a/src/modules/MainApp/Integrations/Routines/Table/RoutinesTable.tsx
+++ b/src/modules/MainApp/Integrations/Routines/Table/RoutinesTable.tsx
@@ -358,11 +358,6 @@ export const RoutinesTable: React.FC<RoutinesTableProps> = ({
               columns={routinesColumns}
               rows={filteredRoutines}
               getRowKey={(routine) => routine.id}
-              onRowClick={(routine) => {
-                const isExpanded = expandedKeys.includes(routine.id);
-                setExpandedKeys(isExpanded ? [] : [routine.id]);
-                onSelectRoutine(isExpanded ? null : routine.id);
-              }}
               rowClassName={selectedRowClassName(
                 (routine: RoutineDefinition) => routine.id,
                 selectedRowId

--- a/src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/WorkspaceMemoryBrowser.tsx
+++ b/src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/WorkspaceMemoryBrowser.tsx
@@ -76,7 +76,6 @@ const WorkspaceMemoryBrowser: React.FC = () => {
     handleShowIndex,
     handleDelete,
     handleClearAll,
-    setSingleExpandedFile,
     loadFileDetail,
     setExpandedFileKeys,
     setSelectedFile,
@@ -389,7 +388,6 @@ const WorkspaceMemoryBrowser: React.FC = () => {
         columns={memoryColumns}
         rows={isLoading ? [] : filteredFiles}
         getRowKey={(entry) => entry.filename}
-        onRowClick={setSingleExpandedFile}
         headerHeight="tall"
         className="table-expanded-no-hover"
         expandable={{

--- a/src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/useWorkspaceMemoryData.ts
+++ b/src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/useWorkspaceMemoryData.ts
@@ -62,7 +62,6 @@ export interface UseWorkspaceMemoryDataReturn {
   handleShowIndex: () => void;
   handleDelete: (filename: string) => void;
   handleClearAll: () => void;
-  setSingleExpandedFile: (entry: WorkspaceMemoryEntry) => void;
   loadFileDetail: (filename: string) => void;
   setExpandedFileKeys: (keys: string[]) => void;
   setSelectedFile: (filename: string | null) => void;
@@ -265,30 +264,6 @@ export function useWorkspaceMemoryData({
     [workspace, mountedRef, setDetail, t]
   );
 
-  const setSingleExpandedFile = useCallback(
-    (entry: WorkspaceMemoryEntry) => {
-      const { filename } = entry;
-      const shouldOpen = !expandedFileKeys.includes(filename);
-      setExpandedFileKeys(shouldOpen ? [filename] : []);
-      if (shouldOpen) {
-        setSelectedFile(filename);
-        setShowIndex(false);
-        loadFileDetail(filename);
-      } else {
-        setSelectedFile(null);
-        setDetail(null);
-      }
-    },
-    [
-      expandedFileKeys,
-      loadFileDetail,
-      setDetail,
-      setExpandedFileKeys,
-      setSelectedFile,
-      setShowIndex,
-    ]
-  );
-
   const handleShowIndex = useCallback(() => {
     if (!workspace) return;
     setSelectedFile(null);
@@ -439,7 +414,6 @@ export function useWorkspaceMemoryData({
     handleShowIndex,
     handleDelete,
     handleClearAll,
-    setSingleExpandedFile,
     loadFileDetail,
     setExpandedFileKeys,
     setSelectedFile,

--- a/src/modules/MainApp/Integrations/RulesMemoryEvolution/Table/RulesMemoryEvolutionTable.tsx
+++ b/src/modules/MainApp/Integrations/RulesMemoryEvolution/Table/RulesMemoryEvolutionTable.tsx
@@ -151,12 +151,6 @@ export const RulesMemoryEvolutionTable: React.FC<
     [t]
   );
 
-  const setSingleExpandedRule = (rule: PolicyInfo) => {
-    const ruleKey = getRuleKey(rule);
-    const shouldOpen = !expandedRuleKeys.includes(ruleKey);
-    setExpandedRuleKeys(shouldOpen ? [ruleKey] : []);
-  };
-
   const renderExpandedRuleCard = (rule: PolicyInfo) => (
     <InlineInfoCard>
       <div className="flex min-w-0 flex-col gap-3">
@@ -359,7 +353,6 @@ export const RulesMemoryEvolutionTable: React.FC<
                     onSelectMarkdownRule(
                       selectedRowId === ruleKey ? null : rule.name
                     );
-                    setSingleExpandedRule(rule);
                   }}
                   headerHeight="tall"
                   className="table-expanded-no-hover table-policy-fixed-layout"

--- a/src/modules/MainApp/Integrations/Skills/Table/SkillsTable.tsx
+++ b/src/modules/MainApp/Integrations/Skills/Table/SkillsTable.tsx
@@ -341,13 +341,9 @@ export const SkillsTable: React.FC<SkillsTableProps> = ({
     </div>
   );
 
-  const handleRowClick = useCallback(
+  const handleRowSelect = useCallback(
     (skill: InstalledSkill) => {
-      const skillIdentity = getInstalledSkillIdentity(skill);
       onSelect(skill.name);
-      setExpandedKeys((current) =>
-        current.includes(skillIdentity) ? [] : [skillIdentity]
-      );
     },
     [onSelect]
   );
@@ -362,7 +358,7 @@ export const SkillsTable: React.FC<SkillsTableProps> = ({
             columns={columns}
             rows={filtered}
             getRowKey={getInstalledSkillIdentity}
-            onRowClick={handleRowClick}
+            onRowClick={handleRowSelect}
             rowClassName={selectedRowClassName(
               (sk: InstalledSkill) => sk.name,
               selectedRowId

--- a/src/modules/MainApp/Settings/subpages/LearningsBrowserPage/LearningsBrowserContent.tsx
+++ b/src/modules/MainApp/Settings/subpages/LearningsBrowserPage/LearningsBrowserContent.tsx
@@ -171,12 +171,6 @@ export const LearningsBrowserContent: React.FC<
     [t]
   );
 
-  const setSingleExpandedLearning = useCallback((row: LearningRecord) => {
-    setExpandedLearningKeys((current) =>
-      current.includes(row.id) ? [] : [row.id]
-    );
-  }, []);
-
   const { columns, selectFilters } = useLearningsTableConfig({
     variant,
     filters,
@@ -218,7 +212,6 @@ export const LearningsBrowserContent: React.FC<
       expandedLearningKeys={expandedLearningKeys}
       t={t}
       onSearchChange={handleSearchChange}
-      onExpandedLearningClick={setSingleExpandedLearning}
       onExpandedRowsChange={(keys) => setExpandedLearningKeys(keys.slice(-1))}
       onLoadMore={() => setVisibleLimit(getNextLearningsLimit)}
       renderExpandedLearningCard={(row) => (

--- a/src/modules/MainApp/Settings/subpages/LearningsBrowserPage/LearningsTable.tsx
+++ b/src/modules/MainApp/Settings/subpages/LearningsBrowserPage/LearningsTable.tsx
@@ -22,7 +22,6 @@ interface LearningsTableProps {
   expandedLearningKeys: string[];
   t: TFunction;
   onSearchChange: (value: string) => void;
-  onExpandedLearningClick: (row: LearningRecord) => void;
   onExpandedRowsChange: (keys: string[]) => void;
   onLoadMore: () => void;
   renderExpandedLearningCard: (row: LearningRecord) => React.ReactNode;
@@ -38,7 +37,6 @@ export const LearningsTable: React.FC<LearningsTableProps> = ({
   expandedLearningKeys,
   t,
   onSearchChange,
-  onExpandedLearningClick,
   onExpandedRowsChange,
   onLoadMore,
   renderExpandedLearningCard,
@@ -64,7 +62,6 @@ export const LearningsTable: React.FC<LearningsTableProps> = ({
       columns={columns}
       rows={visibleItems}
       getRowKey={(row) => row.id}
-      onRowClick={onExpandedLearningClick}
       headerHeight="tall"
       className="table-expanded-no-hover table-layout-fixed"
       expandable={{


### PR DESCRIPTION
## Problem

Settings-table consumers each reimplemented exclusive row expansion because the shared table body invoked an `onRowClick` callback instead of expanding a settings row. This duplicated state transitions across integrations and allowed behavior to drift between tables.

## Solution

Make the shared `TableBody` expand an eligible settings row after calling an optional row callback, while preserving the interactive-target guard. Replace the duplicate consumer expansion callbacks with the primitive behavior, use directional chevrons for settings rows, and add regression coverage for icon state and callback-plus-expansion behavior.

## Potential risks

A non-interactive settings-row click with an `onRowClick` callback now both performs its domain selection and toggles expansion. Controls, links, and inputs remain excluded by the shared guard. There are no persistence, API, or schema changes; reverting commit `6f1acaf76` restores the previous behavior. Full-project type checking was not rerun because the working tree contains unrelated unstaged TypeScript errors; the commit hook confirmed those errors are outside the staged table files.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/components/Table/TableBody.test.ts` — passed: 1 file, 3 tests.
- `pnpm exec eslint src/components/Table/TableBody.tsx src/components/Table/TableBody.test.ts src/components/SettingsTable/index.tsx src/modules/MainApp/Integrations/ExternalSkillsets/CursorPluginsTab.tsx src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx src/modules/MainApp/Integrations/KeyVault/CliClients/Table/CliClientsTable.tsx src/modules/MainApp/Integrations/KeyVault/Models/Table/ModelsTableSection.tsx src/modules/MainApp/Integrations/Routines/Table/RoutinesTable.tsx src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/WorkspaceMemoryBrowser.tsx src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/useWorkspaceMemoryData.ts src/modules/MainApp/Integrations/RulesMemoryEvolution/Table/RulesMemoryEvolutionTable.tsx src/modules/MainApp/Integrations/Skills/Table/SkillsTable.tsx src/modules/MainApp/Settings/subpages/LearningsBrowserPage/LearningsBrowserContent.tsx src/modules/MainApp/Settings/subpages/LearningsBrowserPage/LearningsTable.tsx --max-warnings 0` — passed.
- `git diff --check origin/develop...HEAD` — passed.
- `git merge-tree --write-tree origin/develop HEAD` — clean virtual merge against the latest base.
- Manual visual verification and screenshots were not run because computer-use validation was not requested.

## Audit

`docs/frontend-ui-audit-2026-09-04/TableBody.md`: 0 fix, 5 keep with reason, 0 abstract.