### PR TITLE
fix(workstation): keep hot tabs warm and restore rebuilt tab state

### DIFF
--- a/src/hooks/tabHost/useRetainedTabPool.test.ts
+++ b/src/hooks/tabHost/useRetainedTabPool.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RETENTION_POOLS } from "@src/store/workstation/tabs/tabRetention";
+import type { WorkStationTab } from "@src/store/workstation/tabs/types";
+
+import { useRetainedTabPool } from "./useRetainedTabPool";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function tab(id: string, type: WorkStationTab["type"]): WorkStationTab {
+  return { id, type, title: id, data: {} };
+}
+
+const REVIEW = tab("source-control:changes", "source-control");
+const FILE = tab("file:a.ts", "file");
+const WORK_ITEMS = tab("project-workitems:1", "project-workitems");
+const LINEAR = tab("project-linear-projects:1", "project-linear-projects");
+const LINEAR_ITEMS = tab(
+  "project-linear-work-items:1",
+  "project-linear-work-items"
+);
+
+interface HarnessProps {
+  poolId: "source-control" | "project-trio";
+  tabs: WorkStationTab[];
+  activeTabId: string | null;
+  onResult: (ids: string[]) => void;
+}
+
+function Harness({ poolId, tabs, activeTabId, onResult }: HarnessProps) {
+  const retained = useRetainedTabPool(poolId, tabs, activeTabId);
+  useEffect(() => {
+    onResult([...retained].sort());
+  }, [onResult, retained]);
+  return null;
+}
+
+describe("useRetainedTabPool", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: string[] = [];
+  const onResult = (ids: string[]) => {
+    latest = ids;
+  };
+
+  const render = (props: Omit<HarnessProps, "onResult">) => {
+    act(() => {
+      root.render(createElement(Harness, { ...props, onResult }));
+    });
+    return latest;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    latest = [];
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps the Review tab mounted after leaving it, until its grace runs out", () => {
+    const tabs = [REVIEW, FILE];
+    expect(
+      render({ poolId: "source-control", tabs, activeTabId: REVIEW.id })
+    ).toEqual([REVIEW.id]);
+
+    // Switch to a file tab: Review stays warm (hidden, not rebuilt).
+    expect(
+      render({ poolId: "source-control", tabs, activeTabId: FILE.id })
+    ).toEqual([REVIEW.id]);
+
+    // Come back within the window: still the same mounted instance.
+    expect(
+      render({ poolId: "source-control", tabs, activeTabId: REVIEW.id })
+    ).toEqual([REVIEW.id]);
+
+    // Leave and stay away past the grace: released.
+    render({ poolId: "source-control", tabs, activeTabId: FILE.id });
+    act(() => {
+      vi.advanceTimersByTime(RETENTION_POOLS["source-control"].graceMs);
+    });
+    expect(latest).toEqual([]);
+  });
+
+  it("never includes tabs of types outside the pool", () => {
+    const tabs = [REVIEW, FILE, WORK_ITEMS];
+    expect(
+      render({ poolId: "source-control", tabs, activeTabId: FILE.id })
+    ).toEqual([]);
+    expect(
+      render({ poolId: "source-control", tabs, activeTabId: WORK_ITEMS.id })
+    ).toEqual([]);
+  });
+
+  it("caps the project trio at its warm limit, evicting the oldest", () => {
+    const tabs = [WORK_ITEMS, LINEAR, LINEAR_ITEMS];
+    render({ poolId: "project-trio", tabs, activeTabId: WORK_ITEMS.id });
+    render({ poolId: "project-trio", tabs, activeTabId: LINEAR.id });
+    expect(
+      render({ poolId: "project-trio", tabs, activeTabId: LINEAR_ITEMS.id })
+    ).toEqual([LINEAR.id, LINEAR_ITEMS.id].sort());
+    expect(latest.length).toBe(RETENTION_POOLS["project-trio"].maxWarm);
+  });
+
+  it("drops a retained tab the moment it is closed", () => {
+    render({
+      poolId: "source-control",
+      tabs: [REVIEW, FILE],
+      activeTabId: REVIEW.id,
+    });
+    render({
+      poolId: "source-control",
+      tabs: [REVIEW, FILE],
+      activeTabId: FILE.id,
+    });
+    expect(latest).toEqual([REVIEW.id]);
+    expect(
+      render({ poolId: "source-control", tabs: [FILE], activeTabId: FILE.id })
+    ).toEqual([]);
+  });
+});

--- a/src/hooks/tabHost/useRetainedTabPool.ts
+++ b/src/hooks/tabHost/useRetainedTabPool.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+
+import { useKeepAliveWindow } from "@src/hooks/ui/useKeepAliveWindow";
+import {
+  RETENTION_POOLS,
+  type RetentionPoolId,
+  selectRetentionPoolTabIds,
+} from "@src/store/workstation/tabs/tabRetention";
+import type { WorkStationTab } from "@src/store/workstation/tabs/types";
+
+/**
+ * Which tabs of one retention pool may stay mounted right now.
+ *
+ * Applies the pool's window from `tabRetention.ts` (grace period + warm
+ * cap) to the tabs currently in the pane: the active pool tab is always
+ * included, recently deactivated ones stay until their grace runs out or the
+ * cap evicts them, and a tab that leaves `tabs` (closed) drops at once.
+ * Tabs of types outside the pool are never included — hosts render those
+ * active-only and rebuild them from view state.
+ *
+ * A host calls this once per pool it renders and hides (rather than
+ * unmounts) the returned tabs while they are not active.
+ */
+export function useRetainedTabPool(
+  poolId: RetentionPoolId,
+  tabs: readonly WorkStationTab[],
+  activeTabId: string | null
+): ReadonlySet<string> {
+  const pool = RETENTION_POOLS[poolId];
+  const presentKeys = useMemo(
+    () => selectRetentionPoolTabIds(tabs, poolId),
+    [poolId, tabs]
+  );
+  const activeKey =
+    activeTabId !== null && presentKeys.includes(activeTabId)
+      ? activeTabId
+      : null;
+  return useKeepAliveWindow(activeKey, presentKeys, {
+    graceMs: pool.graceMs,
+    maxWarm: pool.maxWarm,
+  });
+}

--- a/src/hooks/tabHost/useTabViewState.test.ts
+++ b/src/hooks/tabHost/useTabViewState.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  clearTabViewStates,
+  getTabViewState,
+} from "@src/store/workstation/tabs/tabViewState";
+
+import { useTabViewState } from "./useTabViewState";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+type Setter = (next: number | ((previous: number) => number)) => void;
+
+interface ProbeProps {
+  tabId: string;
+  slot: string;
+  /** Receives the setter after each commit so tests can drive updates. */
+  onSetter: (setter: Setter) => void;
+}
+
+function Probe({ tabId, slot, onSetter }: ProbeProps) {
+  const [value, setValue] = useTabViewState<number>(tabId, slot, 0);
+  useEffect(() => {
+    onSetter(setValue);
+  }, [onSetter, setValue]);
+  return createElement("span", null, String(value));
+}
+
+describe("useTabViewState", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let setter: Setter | null;
+  const onSetter = (next: Setter) => {
+    setter = next;
+  };
+
+  const render = (tabId: string, slot = "count") =>
+    act(() => {
+      root.render(createElement(Probe, { tabId, slot, onSetter }));
+    });
+  const update = (next: number | ((previous: number) => number)) =>
+    act(() => setter?.(next));
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    clearTabViewStates();
+    setter = null;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("survives the component being unmounted and rebuilt for the same tab", () => {
+    render("tab:1");
+    expect(container.textContent).toBe("0");
+
+    update(5);
+    expect(container.textContent).toBe("5");
+    expect(getTabViewState("tab:1", "count")).toBe(5);
+
+    // Tab switch: the renderer goes away entirely…
+    act(() => root.unmount());
+    root = createRoot(container);
+    // …and comes back rebuilt from the store, not from a hidden DOM tree.
+    render("tab:1");
+    expect(container.textContent).toBe("5");
+  });
+
+  it("supports functional updates", () => {
+    render("tab:1");
+    update((previous) => previous + 2);
+    update((previous) => previous + 2);
+    expect(container.textContent).toBe("4");
+    expect(getTabViewState("tab:1", "count")).toBe(4);
+  });
+
+  it("re-reads when the mounted renderer is handed a different tab", () => {
+    render("tab:1");
+    update(3);
+
+    render("tab:2");
+    expect(container.textContent).toBe("0");
+    update(9);
+
+    render("tab:1");
+    expect(container.textContent).toBe("3");
+    expect(getTabViewState("tab:2", "count")).toBe(9);
+  });
+
+  it("persists nothing for an empty tab id", () => {
+    render("");
+    update(7);
+    expect(container.textContent).toBe("7");
+    expect(getTabViewState("", "count")).toBeUndefined();
+  });
+});

--- a/src/hooks/tabHost/useTabViewState.ts
+++ b/src/hooks/tabHost/useTabViewState.ts
@@ -1,0 +1,80 @@
+import { useCallback, useState } from "react";
+
+import {
+  getTabViewState,
+  setTabViewState,
+} from "@src/store/workstation/tabs/tabViewState";
+
+type Updater<T> = T | ((previous: T) => T);
+
+interface TabViewStateEntry<T> {
+  tabId: string;
+  slot: string;
+  value: T;
+}
+
+function resolveInitial<T>(initial: T | (() => T)): T {
+  return typeof initial === "function" ? (initial as () => T)() : initial;
+}
+
+function readEntry<T>(
+  tabId: string,
+  slot: string,
+  initial: T | (() => T)
+): TabViewStateEntry<T> {
+  const saved = getTabViewState<T>(tabId, slot);
+  return {
+    tabId,
+    slot,
+    value: saved === undefined ? resolveInitial(initial) : saved,
+  };
+}
+
+/**
+ * `useState` whose value survives the component being unmounted and rebuilt
+ * for the same tab.
+ *
+ * WorkStation hosts mount only the active tab, so any `useState` in a tab
+ * renderer resets on every tab switch. This hook seeds from the tab's saved
+ * view state (`@src/store/workstation/tabs/tabViewState`) and writes every
+ * update back, so the next mount for that tab id picks up where the user
+ * left off. The store drops the slot when the tab closes.
+ *
+ * `tabId` may change while the component stays mounted — renderers of the
+ * same tab type are reused across tabs (`UnifiedTabContent` is not keyed) —
+ * in which case the value is re-read for the new tab during render. An
+ * empty `tabId` behaves like plain `useState` and persists nothing.
+ */
+export function useTabViewState<T>(
+  tabId: string,
+  slot: string,
+  initial: T | (() => T)
+): [T, (next: Updater<T>) => void] {
+  const [entry, setEntry] = useState<TabViewStateEntry<T>>(() =>
+    readEntry(tabId, slot, initial)
+  );
+
+  let current = entry;
+  if (entry.tabId !== tabId || entry.slot !== slot) {
+    // Adjust state during render: the renderer was handed a different tab.
+    current = readEntry(tabId, slot, initial);
+    setEntry(current);
+  }
+
+  const setValue = useCallback((next: Updater<T>) => {
+    setEntry((previous) => {
+      const value =
+        typeof next === "function"
+          ? (next as (previous: T) => T)(previous.value)
+          : next;
+      if (Object.is(value, previous.value)) return previous;
+      // Written from inside the updater so the store is current even if the
+      // renderer unmounts before this update commits (a tab switch in the
+      // same tick). The write is idempotent, so a re-run updater is harmless.
+      setTabViewState(previous.tabId, previous.slot, value);
+      return { ...previous, value };
+    });
+  }, []);
+
+  return [current.value, setValue];
+}

--- a/src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerContentRouter.tsx
+++ b/src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerContentRouter.tsx
@@ -1,9 +1,13 @@
 import React, { Suspense, useMemo } from "react";
 
 import { Placeholder } from "@src/components/Placeholder";
-import { useKeepAliveWindow } from "@src/hooks/ui/useKeepAliveWindow";
+import { useRetainedTabPool } from "@src/hooks/tabHost/useRetainedTabPool";
 import { UnifiedTabContent } from "@src/modules/WorkStation/TabContent/UnifiedTabContent";
 import { NoTabsPlaceholder } from "@src/modules/WorkStation/shared";
+import {
+  RETENTION_POOLS,
+  isTabInRetentionPool,
+} from "@src/store/workstation/tabs/tabRetention";
 
 import type { ProjectManagerContentRouterProps } from "../types";
 
@@ -30,28 +34,20 @@ export const STORY_MANAGER_SUSPENSE_LOADING_FALLBACK = (
  * dispatcher:
  *   - The "keep-alive trio" (project-workitems / project-linear-projects /
  *     project-linear-work-items) is mounted for the active trio tab plus a
- *     bounded window of recently active ones (`PROJECT_TRIO_KEEP_ALIVE`),
- *     hidden with `display:none` when inactive, so flipping between two lists
- *     keeps their in-tab state and scroll position. Older trio tabs unmount:
- *     each one is a full non-virtualized table, and every open one used to stay
- *     resident for the life of the host. Each pane still renders through
- *     `UnifiedTabContent`; the list data itself lives in atoms and survives.
+ *     bounded window of recently active ones — the `project-trio` pool in
+ *     `tabRetention.ts` — hidden with `display:none` when inactive, so
+ *     flipping between two lists keeps their in-tab state and scroll
+ *     position. Older trio tabs unmount: each one is a full non-virtualized
+ *     table, and every open one used to stay resident for the life of the
+ *     host. Each pane still renders through `UnifiedTabContent`; the list
+ *     data itself lives in atoms and survives.
  *   - `chat-session` and `git-commit-detail` keep bespoke inline branches: the
  *     project host needs `<ChatView secondary />` (the unified chat renderer
  *     uses `readOnly`, which is wrong here), and git-commit-detail is mounted
  *     directly from tab data.
  */
-/**
- * Two warm trio tabs cover the "compare two lists" flip; a tab left for 60 s
- * is rebuilt from its atoms on the next visit.
- */
-export const PROJECT_TRIO_KEEP_ALIVE = { graceMs: 60_000, maxWarm: 2 } as const;
-
-const TRIO_TAB_TYPES = new Set([
-  "project-workitems",
-  "project-linear-projects",
-  "project-linear-work-items",
-]);
+/** The trio's window lives in the shared retention policy. */
+export const PROJECT_TRIO_KEEP_ALIVE = RETENTION_POOLS["project-trio"];
 
 export function ProjectManagerContentRouter({
   repoPath,
@@ -61,19 +57,13 @@ export function ProjectManagerContentRouter({
 }: ProjectManagerContentRouterProps) {
   const hasNoTabs = tabs.length === 0;
   const persistentWorkItemTabs = useMemo(
-    () => tabs.filter((tab) => TRIO_TAB_TYPES.has(tab.type)),
+    () => tabs.filter((tab) => isTabInRetentionPool(tab, "project-trio")),
     [tabs]
   );
-  const trioTabIds = useMemo(
-    () => persistentWorkItemTabs.map((tab) => tab.id),
-    [persistentWorkItemTabs]
-  );
-  const activeTrioTabId =
-    activeTab && TRIO_TAB_TYPES.has(activeTab.type) ? activeTab.id : null;
-  const mountedTrioTabIds = useKeepAliveWindow(
-    activeTrioTabId,
-    trioTabIds,
-    PROJECT_TRIO_KEEP_ALIVE
+  const mountedTrioTabIds = useRetainedTabPool(
+    "project-trio",
+    tabs,
+    activeTab?.id ?? null
   );
 
   const activeContent = renderActiveContent({
@@ -132,11 +122,7 @@ function renderActiveContent({
 
   // The keep-alive trio is rendered by the persistent multiplexer below, so the
   // active-content slot renders nothing for it.
-  if (
-    activeTab.type === "project-workitems" ||
-    activeTab.type === "project-linear-projects" ||
-    activeTab.type === "project-linear-work-items"
-  ) {
+  if (isTabInRetentionPool(activeTab, "project-trio")) {
     return null;
   }
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx
@@ -45,6 +45,11 @@ import {
   editorWordWrapAtom,
 } from "@src/store/ui";
 import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
+import {
+  deleteGitDiffEditDraft,
+  restoreGitDiffEditDraft,
+  setGitDiffEditDraft,
+} from "@src/store/workstation/codeEditor/gitDiffEditDrafts";
 import type { GitFile } from "@src/types/git/types";
 import { isBinaryByExtension } from "@src/util/file/binaryDetection";
 import {
@@ -241,13 +246,25 @@ const GitDiffContentInner: React.FC<GitDiffContentProps> = ({
   // View mode state for diff display
   const [viewMode, setViewMode] = useAtom(diffViewModeAtom);
 
-  // Local state for edited content
+  // Local state for edited content. The buffer is mirrored into
+  // `gitDiffEditDrafts` (keyed by file path) because this component is
+  // unmounted on every tab switch; the draft is restored below once the
+  // working-tree content it was written against is known again.
   const [editedContent, setEditedContent] = useState<string | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  // Reset edited content when git file changes
+  // Reset edited content when the git file changes (not on mount — mount
+  // goes straight to the draft restore), and queue a draft restore for the
+  // new path.
+  const lastGitFilePathRef = useRef(gitFile?.path);
+  const pendingDraftRestorePathRef = useRef<string | null>(
+    gitFile?.path ?? null
+  );
   useEffect(() => {
+    if (lastGitFilePathRef.current === gitFile?.path) return;
+    lastGitFilePathRef.current = gitFile?.path;
+    pendingDraftRestorePathRef.current = gitFile?.path ?? null;
     setEditedContent(null);
     setHasUnsavedChanges(false);
   }, [gitFile?.path]);
@@ -265,6 +282,25 @@ const GitDiffContentInner: React.FC<GitDiffContentProps> = ({
     gitFile,
     repoPath,
   });
+
+  // Pick up a draft saved by a previous mount once the working-tree content
+  // for the pending path is known. `restoreGitDiffEditDraft` discards a
+  // draft whose base no longer matches, so newer on-disk content wins and
+  // the restored (or cleared) unsaved flag is published to the tab bar by
+  // the `onUnsavedChange` effect above.
+  const effectiveGitFilePath = effectiveGitFile?.path;
+  const effectiveNewContent = effectiveGitFile?.newContent;
+  useEffect(() => {
+    const pendingPath = pendingDraftRestorePathRef.current;
+    if (!pendingPath) return;
+    if (effectiveGitFilePath !== pendingPath) return;
+    if (effectiveNewContent === undefined) return;
+    pendingDraftRestorePathRef.current = null;
+    const draft = restoreGitDiffEditDraft(pendingPath, effectiveNewContent);
+    if (draft === null) return;
+    setEditedContent(draft);
+    setHasUnsavedChanges(true);
+  }, [effectiveGitFilePath, effectiveNewContent]);
 
   // Check if the file has merge conflict markers — reads from effective
   // content so the self-fetched diff feeds into conflict detection.
@@ -354,6 +390,13 @@ const GitDiffContentInner: React.FC<GitDiffContentProps> = ({
     const currentGitFile = gitFileRef.current;
     setEditedContent(newContent);
     setHasUnsavedChanges(newContent !== currentGitFile?.newContent);
+    if (currentGitFile?.path) {
+      setGitDiffEditDraft(
+        currentGitFile.path,
+        currentGitFile.newContent ?? "",
+        newContent
+      );
+    }
     // Notify parent of content change (for conflict resolution)
     if (currentGitFile?.path) {
       callbackRefs.current.onContentChange?.(currentGitFile.path, newContent);
@@ -396,6 +439,8 @@ const GitDiffContentInner: React.FC<GitDiffContentProps> = ({
   );
 
   const handleDiscard = useCallback(() => {
+    const currentPath = gitFileRef.current?.path;
+    if (currentPath) deleteGitDiffEditDraft(currentPath);
     setEditedContent(null);
     setHasUnsavedChanges(false);
   }, []);
@@ -411,6 +456,7 @@ const GitDiffContentInner: React.FC<GitDiffContentProps> = ({
     try {
       // Write file using Tauri fs
       await writeTextFile(gitFile.path, editedContent);
+      deleteGitDiffEditDraft(gitFile.path);
       setHasUnsavedChanges(false);
       // Refresh git status so source control panel updates immediately
       forceRefresh();

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SearchEditorContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SearchEditorContent/index.tsx
@@ -12,11 +12,12 @@
  *
  * This is the content rendered when a "search" tab is active in the editor.
  */
-import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import { Placeholder } from "@src/components/Placeholder";
+import { useTabViewState } from "@src/hooks/tabHost/useTabViewState";
 import { FilterIcon, HugeiconsIcon } from "@src/icons";
 
 import { SearchFilters } from "../../../shared";
@@ -82,9 +83,18 @@ export const SearchEditorContent: React.FC<SearchEditorContentProps> = memo(
   }) => {
     const { t } = useTranslation();
 
-    // Search mode state
-    const [searchMode, setSearchMode] = useState<SearchMode>("regex");
-    const [showFilters, setShowFilters] = useState(false);
+    // Search mode + filter drawer live in the tab's view state: the content
+    // is unmounted on every tab switch and rebuilt from stores on return.
+    const [searchMode, setSearchMode] = useTabViewState<SearchMode>(
+      sessionScopeId,
+      "searchMode",
+      "regex"
+    );
+    const [showFilters, setShowFilters] = useTabViewState(
+      sessionScopeId,
+      "showFilters",
+      false
+    );
 
     // Search hook - unified with sidebar search execution pipeline
     const { query, setQuery, options, setOptions, results, loading, error } =
@@ -131,7 +141,7 @@ export const SearchEditorContent: React.FC<SearchEditorContentProps> = memo(
 
     const handleToggleFilters = useCallback(() => {
       setShowFilters((prev) => !prev);
-    }, []);
+    }, [setShowFilters]);
 
     useEffect(() => {
       if (!onQueryChangeForTitle) {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/AllChangesView.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/AllChangesView.tsx
@@ -5,6 +5,12 @@
  * the old `GitAllChangesContent` component so it can be reused both inside
  * the unified Source Control tab (under the All Changes pill) and by
  * MessageViewer's chat-side preview.
+ *
+ * The view is unmounted whenever Source Control stops being the active tab
+ * and rebuilt on the next visit. Its list view state (expanded sections,
+ * scroll offset, handled focus request) is saved per tab through
+ * `viewStateKey` so the rebuild lands where the user left off instead of
+ * collapsing every file and scrolling back to the top.
  */
 import { useAtomValue } from "jotai";
 import React, {
@@ -17,14 +23,24 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 
-import { DiffSectionList } from "@src/modules/WorkStation/shared";
+import {
+  DiffSectionList,
+  type DiffSectionListViewState,
+} from "@src/modules/WorkStation/shared";
 import {
   diffViewModeAtom,
   sourceControlFocusTargetAtom,
 } from "@src/store/workstation/codeEditor";
+import {
+  getTabViewState,
+  setTabViewState,
+} from "@src/store/workstation/tabs/tabViewState";
 import type { GitFile } from "@src/types/git/types";
 
 import { useAllChangesFiles } from "./allChanges/useAllChangesFiles";
+
+/** Slot under the owning tab's view state that holds the list snapshot. */
+export const ALL_CHANGES_VIEW_STATE_SLOT = "allChanges";
 
 export interface AllChangesViewProps {
   /** All git files to display */
@@ -41,6 +57,11 @@ export interface AllChangesViewProps {
   onFileSelect?: (path: string) => void;
   /** Monotonic signal from the global header collapse-all action. */
   collapseAllSignal?: number;
+  /**
+   * Tab id whose view state carries this list across remounts. Omit for
+   * embedded previews that should always start fresh.
+   */
+  viewStateKey?: string;
 }
 
 const AllChangesView: React.FC<AllChangesViewProps> = ({
@@ -51,6 +72,7 @@ const AllChangesView: React.FC<AllChangesViewProps> = ({
   repoPath,
   onFileSelect,
   collapseAllSignal,
+  viewStateKey,
 }) => {
   const { t } = useTranslation();
   const focusTarget = useAtomValue(sourceControlFocusTargetAtom);
@@ -63,8 +85,29 @@ const AllChangesView: React.FC<AllChangesViewProps> = ({
     getSectionRef,
   } = useAllChangesFiles({ files, repoId, repoPath });
 
+  // Read once per mount; the list rebuilds itself from this snapshot.
+  const [restoredViewState] = useState<DiffSectionListViewState | null>(() =>
+    viewStateKey
+      ? (getTabViewState<DiffSectionListViewState>(
+          viewStateKey,
+          ALL_CHANGES_VIEW_STATE_SLOT
+        ) ?? null)
+      : null
+  );
+  const handleViewStateChange = useCallback(
+    (viewState: DiffSectionListViewState) => {
+      if (!viewStateKey) return;
+      setTabViewState(viewStateKey, ALL_CHANGES_VIEW_STATE_SLOT, viewState);
+    },
+    [viewStateKey]
+  );
+
   const previousCollapseAllSignalRef = useRef(collapseAllSignal);
-  const lastScrolledFocusNonceRef = useRef<number | null>(null);
+  // Seeded from the snapshot so a remount for the same focus request does
+  // not scroll back to the focused file over the restored offset.
+  const lastScrolledFocusNonceRef = useRef<number | null>(
+    restoredViewState?.focusNonce ?? null
+  );
   const filesKey = files
     .map((file) =>
       JSON.stringify([
@@ -154,6 +197,8 @@ const AllChangesView: React.FC<AllChangesViewProps> = ({
       onFileSelect={onFileSelect}
       onRequestContent={handleRequestContent}
       onExpansionChange={handleExpansionChange}
+      viewState={restoredViewState}
+      onViewStateChange={handleViewStateChange}
       showRenamePath
       compactHeaderGutter
       hideBottomPadding

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/allChanges/useAllChangesFiles.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/allChanges/useAllChangesFiles.ts
@@ -45,7 +45,11 @@ export function useAllChangesFiles({
   repoId,
   repoPath,
 }: UseAllChangesFilesOptions): UseAllChangesFilesResult {
-  const [filesWithDiffs, setFilesWithDiffs] = useState<GitFile[]>([]);
+  // Seeded from `files` so the first render already has sections: the view
+  // is rebuilt on every Source Control visit, and an empty first frame both
+  // flashed the "no changes" placeholder and mounted the list before its
+  // restored view state had rows to apply to.
+  const [filesWithDiffs, setFilesWithDiffs] = useState<GitFile[]>(files);
 
   const statsLoadedPathsRef = useRef<Set<string>>(new Set());
   const contentLoadedPathsRef = useRef<Set<string>>(new Set());

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
@@ -22,6 +22,7 @@ import type { PrIdentity } from "@src/store/workstation/codeEditor/workstationSe
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 import type { GitFile } from "@src/types/git/types";
 
+import { useSourceControlIssueDetailTab } from "../useSourceControlIssueDetailTab";
 import AllChangesView from "./AllChangesView";
 import FocusView from "./FocusView";
 
@@ -69,6 +70,12 @@ interface SourceControlMainContentProps {
   collapseAllSignal?: number;
   /** Source Control navigation shown when no detail is selected. */
   emptyFocusActions: QuickAction[];
+  /**
+   * Owning tab id. The pane is unmounted when the tab is not active; view
+   * state (All Changes expansion + scroll, issue sub-tab) is saved under this
+   * key so the next mount restores it.
+   */
+  viewStateKey?: string;
 }
 
 const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
@@ -87,6 +94,7 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
   repoPath,
   collapseAllSignal,
   emptyFocusActions,
+  viewStateKey,
 }) => {
   const scopeKey = workstationRepoScopeKey(repoId, repoPath);
   const {
@@ -98,6 +106,10 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
     repoId,
     stateScopeKey: scopeKey,
   });
+  const [issueDetailTab, setIssueDetailTab] = useSourceControlIssueDetailTab(
+    viewStateKey,
+    selectedIssueState.issue?.html_url
+  );
 
   // `historySelection` keeps a stable reference across renders (it comes from
   // the persisted tab payload), so memoizing on it directly gives a stable
@@ -163,6 +175,8 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
           timelineLoading={selectedIssueState.timelineLoading}
           interaction={interaction}
           assigneeConfig={assigneeConfig}
+          activeTab={issueDetailTab}
+          onTabChange={setIssueDetailTab}
         />
       </Suspense>
     );
@@ -231,6 +245,7 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
           repoPath={repoPath}
           onFileSelect={onFileSelect}
           collapseAllSignal={collapseAllSignal}
+          viewStateKey={viewStateKey}
         />
       )}
     </div>

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
@@ -21,6 +21,7 @@ import {
   type SourceControlMainTabData,
   deriveSourceControlMainProps,
 } from "./sourceControlMainProps";
+import { useSourceControlIssueDetailTab } from "./useSourceControlIssueDetailTab";
 
 const SourceControlMainContent = React.lazy(
   () => import("./SourceControlMainContent")
@@ -50,6 +51,11 @@ export interface SourceControlMainPaneProps {
   onFileSelect?: (path: string) => void;
   onCloseFocus?: () => void;
   onGitDiffUnsavedChange?: (hasUnsaved: boolean) => void;
+  /**
+   * Owning tab id; per-tab view state is saved under it so this active-only
+   * pane restores expansion, scroll, and sub-tab selection on remount.
+   */
+  viewStateKey?: string;
 }
 
 const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
@@ -67,6 +73,7 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
   onFileSelect,
   onCloseFocus,
   onGitDiffUnsavedChange,
+  viewStateKey,
 }) => {
   const scopeKey = workstationRepoScopeKey(repoId, repoPath);
   const {
@@ -78,6 +85,10 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
     repoId: repoId ?? undefined,
     stateScopeKey: scopeKey,
   });
+  const [issueDetailTab, setIssueDetailTab] = useSourceControlIssueDetailTab(
+    viewStateKey,
+    selectedIssueState.issue?.html_url
+  );
 
   const { mode, staged, historySelection, allFiles, focusGitFile, hasFocus } =
     deriveSourceControlMainProps({
@@ -116,6 +127,8 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
           timelineLoading={selectedIssueState.timelineLoading}
           interaction={interaction}
           assigneeConfig={assigneeConfig}
+          activeTab={issueDetailTab}
+          onTabChange={setIssueDetailTab}
         />
       </Suspense>
     );
@@ -152,6 +165,7 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
           repoPath={repoPath}
           collapseAllSignal={sourceControlCollapseAllSignal}
           emptyFocusActions={sourceControlQuickActions}
+          viewStateKey={viewStateKey}
         />
       </Suspense>
     </div>

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/useSourceControlIssueDetailTab.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/useSourceControlIssueDetailTab.ts
@@ -1,0 +1,40 @@
+import { useCallback } from "react";
+
+import { useTabViewState } from "@src/hooks/tabHost/useTabViewState";
+import type { ThreadDetailTab } from "@src/modules/shared/components/ThreadDetailTabs";
+
+interface IssueDetailTabSelection {
+  issueUrl: string;
+  activeTab: ThreadDetailTab;
+}
+
+/**
+ * Sub-tab (Conversation / Linked …) of an issue shown inside the Source
+ * Control tab. Kept in the owning tab's view state so it survives the pane
+ * being unmounted on a tab switch, and scoped to the issue URL so selecting
+ * a different issue starts back on Conversation, as the panel's own local
+ * state did.
+ */
+export function useSourceControlIssueDetailTab(
+  viewStateKey: string | undefined,
+  issueUrl: string | undefined
+): [ThreadDetailTab, (next: ThreadDetailTab) => void] {
+  const [selection, setSelection] =
+    useTabViewState<IssueDetailTabSelection | null>(
+      viewStateKey ?? "",
+      "issueDetailTab",
+      null
+    );
+  const activeTab: ThreadDetailTab =
+    selection && issueUrl && selection.issueUrl === issueUrl
+      ? selection.activeTab
+      : "conversation";
+  const setActiveTab = useCallback(
+    (next: ThreadDetailTab) => {
+      if (!issueUrl) return;
+      setSelection({ issueUrl, activeTab: next });
+    },
+    [issueUrl, setSelection]
+  );
+  return [activeTab, setActiveTab];
+}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
@@ -43,6 +43,7 @@ import { workStationPrimarySidebarCollapsedAtom } from "@src/store/ui/workStatio
 import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import { workstationSelectedIssueAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
 import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
+import { isRetainedTabType } from "@src/store/workstation/tabs/tabRetention";
 import type { GitFile } from "@src/types/git/types";
 
 import { CodeEditorDefaultHeader } from "./components/CodeEditorDefaultHeader";
@@ -83,6 +84,8 @@ const LazyFallback = () => (
   <Placeholder variant="loading" placement="detail-panel" fillParentHeight />
 );
 
+const NO_RETAINED_TABS: ReadonlySet<string> = new Set();
+
 // ============================================
 // Main Component
 // ============================================
@@ -98,6 +101,7 @@ const EditorContent: React.FC<EditorContentProps> = memo(
     onFileSelectWithLine,
     onCursorPositionChange,
     terminalState,
+    retainedTabIds = NO_RETAINED_TABS,
     sourceControlHeaderLeadingSlot,
     sourceControlHeaderTrailingSlot,
     sourceControlFilterMode = "uncommitted",
@@ -168,16 +172,48 @@ const EditorContent: React.FC<EditorContentProps> = memo(
     // its fast interval; otherwise it relaxes to halve idle git load.
     useSourceControlAttention(isSourceControlActive);
 
-    const sourceControlTab = isSourceControlActive ? activeTab : null;
+    // The Source Control tab is pinned, so it is normally always present. The
+    // main pane is driven from the persisted tab (not `activeTab`) because
+    // the retention policy keeps it mounted while another tab is on screen.
+    const sourceControlTab = useMemo(
+      () => tabs.find((tab) => tab.type === "source-control") ?? null,
+      [tabs]
+    );
+    // Mounted while active or retained (`tabRetention.ts`: hidden for a
+    // bounded grace window after leaving, then released and rebuilt from
+    // view state on the next visit).
+    const mountSourceControlPane =
+      sourceControlTab !== null &&
+      (isSourceControlActive || retainedTabIds.has(sourceControlTab.id));
+    const sourceControlPaneVisible =
+      isSourceControlActive && !isTerminalTabActive;
 
-    // Only build the All Changes input while Source Control is visible. Leaving
-    // the tab unmounts its editors, content cache, and subscriptions.
+    // Kept populated while the pane is mounted so a hidden Review does not
+    // flash empty when it comes back.
     const sourceControlBaseFiles = useMemo(() => {
-      if (!sourceControlTab) return [];
+      if (!sourceControlTab || !mountSourceControlPane) return [];
       const gitStatusFiles = Array.from(gitFilesByPath.values());
       if (gitStatusFiles.length > 0) return gitStatusFiles;
       return (sourceControlTab.data.files ?? []) as GitFile[];
-    }, [sourceControlTab, gitFilesByPath]);
+    }, [sourceControlTab, mountSourceControlPane, gitFilesByPath]);
+
+    // Registry-rendered tabs the policy retains (none today in the editor
+    // host — the table in `tabRetention.ts` is the switch). Each gets its
+    // own keyed layer so activating it reuses the mounted instance.
+    const retainedRegistryTabs = useMemo(
+      () =>
+        tabs.filter(
+          (tab) =>
+            retainedTabIds.has(tab.id) &&
+            isRetainedTabType(tab.type) &&
+            tab.type !== "source-control" &&
+            tab.type !== "terminal"
+        ),
+      [retainedTabIds, tabs]
+    );
+    const activeTabHasRetainedLayer =
+      activeTab !== null &&
+      retainedRegistryTabs.some((tab) => tab.id === activeTab.id);
 
     // ============================================
     // Tab Content Sync (extracted hook - side effects only)
@@ -427,7 +463,9 @@ const EditorContent: React.FC<EditorContentProps> = memo(
                     actions={editorQuickActions}
                   />
                 ) : activeTab ? (
-                  <UnifiedTabContent tab={activeTab} paneId="main" isActive />
+                  activeTabHasRetainedLayer ? null : (
+                    <UnifiedTabContent tab={activeTab} paneId="main" isActive />
+                  )
                 ) : (
                   // Preserve TabContentRenderer's `!activeTab` branch: an empty
                   // read-only editor. `showAppPlaceholder` already covers
@@ -455,8 +493,41 @@ const EditorContent: React.FC<EditorContentProps> = memo(
               </div>
             )}
 
-            {isSourceControlActive && sourceControlTab && (
-              <div className="absolute inset-0 z-20 flex min-h-0 flex-col">
+            {retainedRegistryTabs.map((tab) => {
+              const visible = tab.id === activeTabId && !isTerminalTabActive;
+              return (
+                <div
+                  key={tab.id}
+                  className={`absolute inset-0 flex min-h-0 flex-col ${
+                    visible
+                      ? "z-10 opacity-100"
+                      : "pointer-events-none z-0 opacity-0"
+                  }`}
+                  aria-hidden={!visible}
+                >
+                  <UnifiedTabContent
+                    tab={tab}
+                    paneId="main"
+                    isActive={visible}
+                  />
+                </div>
+              );
+            })}
+
+            {/*
+              Retained Source Control main pane: shown/hidden (opacity, not
+              display:none, so its scroll offsets survive) rather than
+              unmounted while the policy keeps it warm.
+            */}
+            {mountSourceControlPane && sourceControlTab && (
+              <div
+                className={`absolute inset-0 flex min-h-0 flex-col ${
+                  sourceControlPaneVisible
+                    ? "z-20 opacity-100"
+                    : "pointer-events-none z-0 opacity-0"
+                }`}
+                aria-hidden={!sourceControlPaneVisible}
+              >
                 <Suspense fallback={<LazyFallback />}>
                   <SourceControlMainPane
                     tabData={sourceControlTab.data as SourceControlMainTabData}
@@ -475,6 +546,7 @@ const EditorContent: React.FC<EditorContentProps> = memo(
                     onFileSelect={onFileSelect}
                     onCloseFocus={handleSourceControlCloseFocus}
                     onGitDiffUnsavedChange={handleGitDiffUnsavedChange}
+                    viewStateKey={sourceControlTab.id}
                   />
                 </Suspense>
               </div>

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/types.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/types.ts
@@ -49,6 +49,13 @@ export interface EditorContentProps {
   // Terminal tab
   terminalState: UseTerminalStateReturn;
 
+  /**
+   * Tabs the retention policy keeps mounted-but-hidden while inactive
+   * (`useRetainedTabPool`); the host renders them in hidden layers instead
+   * of rebuilding them on the next visit. Omit for active-only behaviour.
+   */
+  retainedTabIds?: ReadonlySet<string>;
+
   // Source Control header controls
   sourceControlHeaderLeadingSlot?: ReactNode;
   sourceControlHeaderTrailingSlot?: ReactNode;

--- a/src/modules/WorkStation/CodeEditor/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/index.tsx
@@ -12,6 +12,7 @@ import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { ActionSystemProvider } from "@src/ActionSystem";
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { usePinnedTabs } from "@src/hooks/tabHost/usePinnedTabs";
+import { useRetainedTabPool } from "@src/hooks/tabHost/useRetainedTabPool";
 import { useWorkStationPanels } from "@src/hooks/tabHost/useWorkStationPanels";
 import { useWorkStationTabs } from "@src/hooks/tabHost/useWorkStationTabs";
 import { useEditorRepoCacheSync } from "@src/hooks/ui/tabs";
@@ -103,6 +104,21 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
     // file-row clicks can be wired to `handleGitFileSelect`.
     const { activeTab, tabs } = useWorkStationTabs();
     const setLayout = useSetAtom(workstationLayoutAtom);
+    // Tabs the retention policy keeps mounted-but-hidden after you leave
+    // them (`tabRetention.ts`). Computed once here so the main pane and the
+    // sidebar slot hide/show the same instances in lockstep.
+    const retainedTabIds = useRetainedTabPool(
+      "source-control",
+      tabs,
+      activeTab?.id ?? null
+    );
+    const retainedTabs = useMemo(
+      () => tabs.filter((tab) => retainedTabIds.has(tab.id)),
+      [retainedTabIds, tabs]
+    );
+    const sourceControlSurfaceMounted =
+      activeTab?.type === "source-control" ||
+      retainedTabs.some((tab) => tab.type === "source-control");
 
     // === Local state, status-bar sync, and misc handlers ===
     const {
@@ -199,6 +215,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
       currentBranch,
       gitDiffState,
       activeTab,
+      sourceControlSurfaceMounted,
       setPrimaryPanel,
       handleGitFileSelect,
     });
@@ -317,6 +334,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
       () => (
         <SidebarSlot
           activeTab={activeTab}
+          retainedTabs={retainedTabs}
           repoPath={repoPath}
           repoId={selectedRepoId}
           isMultiRoot={workspaceFolders.length > 1}
@@ -336,6 +354,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
         handleGitFilesChange,
         handleSourceControlHistorySelectionChange,
         repoPath,
+        retainedTabs,
         selectedRepoId,
         tabSidebarExtraContext,
         workspaceFolders.length,
@@ -416,6 +435,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
             isBinary={codeEditorState.isBinary}
             onCursorPositionChange={handleCursorPositionChange}
             terminalState={terminalState}
+            retainedTabIds={retainedTabIds}
             sourceControlHeaderLeadingSlot={editorSourceControlScopePicker}
             sourceControlHeaderTrailingSlot={editorSourceControlHeaderSlot}
             sourceControlFilterMode={editorSourceControlFilterMode}
@@ -446,6 +466,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
         handleAllChangesClick,
         handleCursorPositionChange,
         terminalState,
+        retainedTabIds,
         editorSourceControlScopePicker,
         editorSourceControlHeaderSlot,
         editorSourceControlFilterMode,

--- a/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
+++ b/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
@@ -47,6 +47,14 @@ interface UseSourceControlSetupParams {
   currentBranch: string | undefined;
   gitDiffState: UseGitDiffStateReturn;
   activeTab: WorkStationTab | undefined | null;
+  /**
+   * True while the Source Control surface is mounted — active, or kept warm
+   * by the tab retention policy. Worktree loading follows this rather than
+   * "active" so leaving and returning to a retained Review does not clear
+   * and refetch the worktree list (which flips the scope identity and paints
+   * a loading overlay over the sidebar). Defaults to "active".
+   */
+  sourceControlSurfaceMounted?: boolean;
   setPrimaryPanel: (updater: (prev: PanelState) => PanelState) => void;
   handleGitFileSelect: (file: GitFile) => void;
 }
@@ -80,6 +88,7 @@ export function useSourceControlSetup({
   currentBranch,
   gitDiffState,
   activeTab,
+  sourceControlSurfaceMounted,
   setPrimaryPanel,
   handleGitFileSelect,
 }: UseSourceControlSetupParams): UseSourceControlSetupReturn {
@@ -92,6 +101,8 @@ export function useSourceControlSetup({
   const { isGitInitialized } = useRepoGitInitialization(repoPath);
   const resolvedRepoId = repoId ?? repoPath;
   const isSourceControlActive = activeTab?.type === "source-control";
+  const isSourceControlMounted =
+    sourceControlSurfaceMounted ?? isSourceControlActive;
   const {
     worktrees,
     mainDiffSummary,
@@ -101,7 +112,7 @@ export function useSourceControlSetup({
   } = useGitWorktrees({
     repoId: resolvedRepoId,
     repoPath,
-    enabled: isGitInitialized === true && isSourceControlActive,
+    enabled: isGitInitialized === true && isSourceControlMounted,
   });
   const { scope, setScope } = useSourceControlScope({
     repoPath,

--- a/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
@@ -5,9 +5,10 @@
  * callbacks from `workstationIssueCallbackAtom`, then delegates to the
  * existing `IssueDetailPanel` component.
  */
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, { memo, useMemo } from "react";
 
 import { Placeholder } from "@src/components/Placeholder";
+import { useTabViewState } from "@src/hooks/tabHost/useTabViewState";
 import { usePublishWorkstationTabHeader } from "@src/hooks/tabHost/useWorkstationTabHeader";
 import {
   IssueDetailExternalLinkButton,
@@ -31,20 +32,13 @@ const GitHubIssueDetailTabRenderer: React.FC<UnifiedTabContentProps> = memo(
     const tabData = tab.data as unknown as GitHubIssueDetailTabData;
     const { selectedState, interaction, assigneeConfig } =
       useGitHubIssueDetailState(tabData);
-    const issueIdentity = `${tabData.repoPath}:${tabData.issueNumber}`;
-    const [tabSelection, setTabSelection] = useState<{
-      issueIdentity: string;
-      activeTab: ThreadDetailTab;
-    }>({ issueIdentity, activeTab: "conversation" });
-    const activeTab =
-      tabSelection.issueIdentity === issueIdentity
-        ? tabSelection.activeTab
-        : "conversation";
-    const handleTabChange = useCallback(
-      (nextTab: ThreadDetailTab) => {
-        setTabSelection({ issueIdentity, activeTab: nextTab });
-      },
-      [issueIdentity]
+    // The tab id is unique per repo + issue number, and the renderer is
+    // unmounted on every tab switch, so the sub-tab selection lives in the
+    // tab's view state rather than component state.
+    const [activeTab, handleTabChange] = useTabViewState<ThreadDetailTab>(
+      tab.id,
+      "activeTab",
+      "conversation"
     );
     const linkedCount = useMemo(() => {
       const issue = selectedState.issue;

--- a/src/modules/WorkStation/shared/DiffSectionList/index.tsx
+++ b/src/modules/WorkStation/shared/DiffSectionList/index.tsx
@@ -1,5 +1,17 @@
-import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
-import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  type StateSnapshot,
+  Virtuoso,
+  type VirtuosoHandle,
+} from "react-virtuoso";
 
 import { Placeholder } from "@src/components/Placeholder";
 import type { DiffViewMode } from "@src/types/git/types";
@@ -7,6 +19,16 @@ import type { DiffViewMode } from "@src/types/git/types";
 import DiffFileSection from "../DiffFileSection";
 import type { DiffFileSectionData } from "../DiffFileSection";
 import { getDefaultDiffSectionExpanded } from "./expansion";
+import {
+  type DiffSectionListViewState,
+  type RememberedExpansion,
+  createRestoredExpansions,
+  pruneRestoredExpansions,
+  seedRestoredExpansion,
+  snapshotExpansions,
+} from "./viewState";
+
+export type { DiffSectionListViewState } from "./viewState";
 
 export interface DiffSectionListItem<TFile extends DiffFileSectionData> {
   key: string;
@@ -40,14 +62,20 @@ interface DiffSectionListProps<TFile extends DiffFileSectionData> {
   compactHeaderGutter?: boolean;
   /** When true, removes the bottom scroll padding (for contexts that have no bottom panel). */
   hideBottomPadding?: boolean;
+  /**
+   * View state saved by a previous mount of this list (expansion overrides,
+   * scroll offset, handled focus nonce). Read once at mount; the list is
+   * rebuilt from it instead of being kept alive hidden.
+   */
+  viewState?: DiffSectionListViewState | null;
+  /**
+   * Receives a fresh snapshot whenever an override changes and, on unmount,
+   * with the final scroll offset. Callers persist it per tab.
+   */
+  onViewStateChange?: (viewState: DiffSectionListViewState) => void;
 }
 
 const DEFAULT_COLLAPSE_THRESHOLD = 10;
-
-interface RememberedExpansion {
-  signal: number;
-  expanded: boolean;
-}
 
 function DiffListFooter() {
   return <div className="h-[100px]" aria-hidden />;
@@ -77,11 +105,30 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
   flat = false,
   compactHeaderGutter = false,
   hideBottomPadding = false,
+  viewState,
+  onViewStateChange,
 }: DiffSectionListProps<TFile>) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const rememberedExpansionsRef = useRef(
     new Map<string, RememberedExpansion>()
   );
+
+  // ── Restorable view state ──────────────────────────────────────────────
+  // Everything below is read once at mount: the list is rebuilt from the
+  // snapshot a previous mount saved (see `viewState.ts`), not kept alive.
+  const restoredExpansionsRef = useRef(createRestoredExpansions(viewState));
+  const [restoredScroll] = useState<StateSnapshot | undefined>(
+    () => viewState?.scroll ?? undefined
+  );
+  const lastScrollRef = useRef<StateSnapshot | null>(viewState?.scroll ?? null);
+  const handledFocusNonceRef = useRef<number | null>(
+    viewState?.focusNonce ?? null
+  );
+  const scrollerRef = useRef<HTMLElement | null>(null);
+  const onViewStateChangeRef = useRef(onViewStateChange);
+  useLayoutEffect(() => {
+    onViewStateChangeRef.current = onViewStateChange;
+  });
 
   const keyedSections = useMemo(
     () =>
@@ -99,6 +146,37 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
     .map(({ renderKey }) => renderKey)
     .join("\0");
 
+  // Row → live expansion signal, rebuilt lazily per snapshot so a snapshot
+  // costs O(rows) rather than O(rows × overrides). Kept in a ref (updated in
+  // a layout effect, ahead of any unmount cleanup) so `emitViewState` stays
+  // stable for the handlers and the unmount snapshot.
+  const signalForRef = useRef<() => (renderKey: string) => number | undefined>(
+    () => () => undefined
+  );
+  useLayoutEffect(() => {
+    signalForRef.current = () => {
+      const signals = new Map<string, number>();
+      for (const { section, renderKey } of keyedSections) {
+        const isFocused = focusedPath === section.file.path;
+        signals.set(renderKey, collapseSignal + (isFocused ? focusedNonce : 0));
+      }
+      return (renderKey: string) => signals.get(renderKey);
+    };
+  }, [collapseSignal, focusedNonce, focusedPath, keyedSections]);
+
+  const emitViewState = useCallback(() => {
+    const listener = onViewStateChangeRef.current;
+    if (!listener) return;
+    listener({
+      expanded: snapshotExpansions(
+        rememberedExpansionsRef.current,
+        signalForRef.current()
+      ),
+      scroll: lastScrollRef.current,
+      focusNonce: handledFocusNonceRef.current,
+    });
+  }, []);
+
   // Expansion state belongs to this mounted list, not to recycled rows. Prune
   // removed files and discard all remembered overrides on a collapse signal so
   // virtual row unmount/remount does not either lose or leak state.
@@ -108,10 +186,17 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
     for (const key of rememberedExpansions.keys()) {
       if (!validKeys.has(key)) rememberedExpansions.delete(key);
     }
+    pruneRestoredExpansions(restoredExpansionsRef.current, validKeys);
   }, [keyedSections, keyedSectionsSignature]);
 
+  // Only a *change* of the collapse signal invalidates overrides. Running on
+  // mount too would wipe the overrides just restored from `viewState`.
+  const previousCollapseSignalRef = useRef(collapseSignal);
   useEffect(() => {
+    if (previousCollapseSignalRef.current === collapseSignal) return;
+    previousCollapseSignalRef.current = collapseSignal;
     rememberedExpansionsRef.current.clear();
+    restoredExpansionsRef.current.clear();
   }, [collapseSignal]);
 
   const handleExpansionChange = useCallback(
@@ -126,12 +211,57 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
         expanded,
       });
       onExpansionChange?.(file, expanded);
+      emitViewState();
     },
-    [onExpansionChange]
+    [emitViewState, onExpansionChange]
   );
+
+  // Snapshot the scroll offset (plus measured sizes) each time scrolling
+  // settles. This is an event callback, so reading the handle here is safe,
+  // and it works no matter when Virtuoso mounted — the list often renders a
+  // placeholder first and only mounts Virtuoso once sections arrive, so a
+  // handle captured at this component's mount would be null.
+  const handleIsScrolling = useCallback(
+    (scrolling: boolean) => {
+      if (scrolling) return;
+      virtuosoRef.current?.getState((snapshot) => {
+        lastScrollRef.current = snapshot;
+        emitViewState();
+      });
+    },
+    [emitViewState]
+  );
+
+  const handleScrollerRef = useCallback(
+    (element: HTMLElement | Window | null) => {
+      scrollerRef.current = element instanceof HTMLElement ? element : null;
+    },
+    []
+  );
+
+  // Final snapshot when the list goes away. Layout cleanup runs while the
+  // scroller is still attached, so a scroll that had not settled yet is
+  // captured from the element (keeping the last measured sizes). A mount
+  // the user never scrolled keeps the previously saved offset — the restored
+  // scroll may not have been applied yet, and a fresh `0` would clobber it.
+  useLayoutEffect(() => {
+    return () => {
+      const scroller = scrollerRef.current;
+      if (scroller && scroller.isConnected && scroller.scrollTop > 0) {
+        lastScrollRef.current = {
+          ranges: lastScrollRef.current?.ranges ?? [],
+          scrollTop: scroller.scrollTop,
+        };
+      }
+      emitViewState();
+    };
+  }, [emitViewState]);
 
   useEffect(() => {
     if (!focusedPath) return;
+    // A remount for the nonce that already scrolled restores the saved
+    // offset instead of jumping back to the focused row.
+    if (handledFocusNonceRef.current === focusedNonce) return;
     const focusedIndex = keyedSections.findIndex(
       ({ section }) => section.file.path === focusedPath
     );
@@ -156,6 +286,20 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
 
     return () => window.cancelAnimationFrame(frame);
   }, [focusedPath, focusedNonce, getSectionRef, keyedSections]);
+
+  // Once the focus scroll for this nonce has run, later remounts for the
+  // same nonce must not repeat it. Recorded separately from the effect above
+  // so section-list changes within a mount keep re-targeting as before.
+  useEffect(() => {
+    if (!focusedPath) return;
+    if (handledFocusNonceRef.current === focusedNonce) return;
+    const hasFocusedRow = keyedSections.some(
+      ({ section }) => section.file.path === focusedPath
+    );
+    if (!hasFocusedRow) return;
+    handledFocusNonceRef.current = focusedNonce;
+    emitViewState();
+  }, [emitViewState, focusedNonce, focusedPath, keyedSections]);
 
   if (loading && sections.length === 0) {
     return (
@@ -188,6 +332,9 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
           data={keyedSections}
           computeItemKey={(_index, item) => item.renderKey}
           overscan={600}
+          restoreStateFrom={restoredScroll}
+          isScrolling={handleIsScrolling}
+          scrollerRef={handleScrollerRef}
           {...(hideBottomPadding ? {} : { components: DIFF_LIST_COMPONENTS })}
           itemContent={(_index, { section, renderKey }) => {
             const isFocused = focusedPath === section.file.path;
@@ -198,7 +345,12 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
             const expandedOverride =
               rememberedExpansion?.signal === expansionSignal
                 ? rememberedExpansion.expanded
-                : undefined;
+                : seedRestoredExpansion(
+                    rememberedExpansionsRef.current,
+                    restoredExpansionsRef.current,
+                    renderKey,
+                    expansionSignal
+                  );
 
             return (
               <DiffFileSection

--- a/src/modules/WorkStation/shared/DiffSectionList/viewState.test.ts
+++ b/src/modules/WorkStation/shared/DiffSectionList/viewState.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type RememberedExpansion,
+  createRestoredExpansions,
+  pruneRestoredExpansions,
+  seedRestoredExpansion,
+  snapshotExpansions,
+} from "./viewState";
+
+describe("snapshotExpansions", () => {
+  it("keeps only overrides whose signal still matches the row's signal", () => {
+    const remembered = new Map<string, RememberedExpansion>([
+      ["a-", { signal: 0, expanded: true }],
+      ["b-", { signal: 1, expanded: true }], // invalidated by collapse-all
+      ["focused-", { signal: 3, expanded: false }], // collapse 0 + nonce 3
+    ]);
+    const signalFor = (key: string) => (key === "focused-" ? 3 : 0);
+    expect(snapshotExpansions(remembered, signalFor)).toEqual({
+      "a-": true,
+      "focused-": false,
+    });
+  });
+
+  it("drops overrides for rows that no longer exist", () => {
+    const remembered = new Map<string, RememberedExpansion>([
+      ["gone-", { signal: 0, expanded: true }],
+    ]);
+    expect(snapshotExpansions(remembered, () => undefined)).toEqual({});
+  });
+});
+
+describe("seedRestoredExpansion", () => {
+  it("re-applies a restored override with the row's live signal, once", () => {
+    const remembered = new Map<string, RememberedExpansion>();
+    const restored = createRestoredExpansions({
+      expanded: { "a-": true },
+      scroll: null,
+      focusNonce: null,
+    });
+
+    expect(seedRestoredExpansion(remembered, restored, "a-", 2)).toBe(true);
+    expect(remembered.get("a-")).toEqual({ signal: 2, expanded: true });
+    expect(restored.has("a-")).toBe(false);
+    // Already remembered: nothing pending, nothing overwritten.
+    expect(
+      seedRestoredExpansion(remembered, restored, "a-", 2)
+    ).toBeUndefined();
+  });
+
+  it("never overrides an expansion the user set in this mount", () => {
+    const remembered = new Map<string, RememberedExpansion>([
+      ["a-", { signal: 0, expanded: false }],
+    ]);
+    const restored = new Map([["a-", true]]);
+    expect(
+      seedRestoredExpansion(remembered, restored, "a-", 0)
+    ).toBeUndefined();
+    expect(remembered.get("a-")).toEqual({ signal: 0, expanded: false });
+  });
+
+  it("returns undefined for rows without a pending override", () => {
+    expect(
+      seedRestoredExpansion(new Map(), new Map(), "a-", 0)
+    ).toBeUndefined();
+  });
+});
+
+describe("createRestoredExpansions / pruneRestoredExpansions", () => {
+  it("starts empty without a snapshot", () => {
+    expect(createRestoredExpansions(null).size).toBe(0);
+    expect(createRestoredExpansions(undefined).size).toBe(0);
+  });
+
+  it("does not prune while the list is still empty (not yet populated)", () => {
+    const restored = createRestoredExpansions({
+      expanded: { "a-": true },
+      scroll: null,
+      focusNonce: null,
+    });
+    pruneRestoredExpansions(restored, new Set());
+    expect(restored.get("a-")).toBe(true);
+  });
+
+  it("prunes pending overrides for rows that left the list", () => {
+    const restored = createRestoredExpansions({
+      expanded: { "a-": true, "b-": false },
+      scroll: null,
+      focusNonce: null,
+    });
+    pruneRestoredExpansions(restored, new Set(["b-"]));
+    expect([...restored.keys()]).toEqual(["b-"]);
+  });
+});

--- a/src/modules/WorkStation/shared/DiffSectionList/viewState.ts
+++ b/src/modules/WorkStation/shared/DiffSectionList/viewState.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure helpers behind `DiffSectionList`'s restorable view state.
+ *
+ * The list is unmounted whenever its tab stops being active and rebuilt on
+ * the next visit, so the per-row expansion overrides and the scroll offset
+ * have to be carried across mounts by the caller (see
+ * `@src/store/workstation/tabs/tabViewState`). These helpers turn the
+ * list's internal "remembered expansion" map — whose entries are only valid
+ * while their `signal` matches the row's current expansion signal — into a
+ * signal-free snapshot, and seed a fresh mount's map from such a snapshot.
+ */
+import type { StateSnapshot } from "react-virtuoso";
+
+export interface RememberedExpansion {
+  signal: number;
+  expanded: boolean;
+}
+
+export interface DiffSectionListViewState {
+  /** Per-row expansion overrides, keyed by the row's render key. */
+  expanded: Record<string, boolean>;
+  /** Virtuoso scroll offset + measured sizes; `null` when never scrolled. */
+  scroll: StateSnapshot | null;
+  /**
+   * Focus nonce whose scroll-into-view already ran. A remount for the same
+   * nonce restores the saved scroll instead of jumping back to the focused
+   * row; a new nonce scrolls as usual.
+   */
+  focusNonce: number | null;
+}
+
+/**
+ * Collect the overrides that are currently in effect. An entry whose signal
+ * no longer matches the row's signal was invalidated by a collapse-all (or a
+ * focus request) and is dropped rather than resurrected on the next mount.
+ */
+export function snapshotExpansions(
+  remembered: ReadonlyMap<string, RememberedExpansion>,
+  signalFor: (renderKey: string) => number | undefined
+): Record<string, boolean> {
+  const expanded: Record<string, boolean> = {};
+  for (const [renderKey, entry] of remembered) {
+    if (entry.signal === signalFor(renderKey)) {
+      expanded[renderKey] = entry.expanded;
+    }
+  }
+  return expanded;
+}
+
+/** Overrides waiting to be re-applied to rows as they first render. */
+export function createRestoredExpansions(
+  viewState: DiffSectionListViewState | null | undefined
+): Map<string, boolean> {
+  return new Map(Object.entries(viewState?.expanded ?? {}));
+}
+
+/**
+ * Re-apply a restored override to `remembered` the first time its row
+ * renders, stamping it with that row's live signal so the list treats it
+ * exactly like an override the user made in this mount. Returns the
+ * override, or `undefined` when the row has none pending.
+ */
+export function seedRestoredExpansion(
+  remembered: Map<string, RememberedExpansion>,
+  restored: Map<string, boolean>,
+  renderKey: string,
+  signal: number
+): boolean | undefined {
+  if (remembered.has(renderKey)) return undefined;
+  const expanded = restored.get(renderKey);
+  if (expanded === undefined) return undefined;
+  restored.delete(renderKey);
+  remembered.set(renderKey, { signal, expanded });
+  return expanded;
+}
+
+/**
+ * Drop pending overrides for rows that left the list. An empty key set means
+ * the list has not been populated yet (it mounts empty and fills from an
+ * effect), not that every row is gone — nothing is pruned then, or the
+ * restored overrides would be wiped before their rows ever render.
+ */
+export function pruneRestoredExpansions(
+  restored: Map<string, boolean>,
+  validKeys: ReadonlySet<string>
+): void {
+  if (validKeys.size === 0) return;
+  for (const key of restored.keys()) {
+    if (!validKeys.has(key)) restored.delete(key);
+  }
+}

--- a/src/modules/WorkStation/shared/SidebarModules/SidebarSlot.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SidebarSlot.tsx
@@ -2,21 +2,26 @@
  * SidebarSlot
  *
  * Resolves and renders tab-specific sidebars from `registry.ts`. The slot owns
- * default-sidebar fallback and descriptor-level keep-alive behavior so hosts do
- * not need one-off warm-mount branches for individual tab types.
+ * default-sidebar fallback and the retained-sidebar behaviour so hosts do not
+ * need one-off warm-mount branches for individual tab types.
+ *
+ * Which sidebars stay mounted after their tab is left is not a per-sidebar
+ * flag: the host passes the tabs the shared retention policy currently keeps
+ * warm (`@src/store/workstation/tabs/tabRetention`, via
+ * `useRetainedTabPool`), and this slot keeps exactly those sidebars mounted —
+ * hidden with `visibility:hidden` so their scroll offsets survive — in
+ * lockstep with the host's main pane.
  */
-import React, { memo, useEffect, useMemo, useState } from "react";
+import React, { memo, useMemo } from "react";
 
 import type {
   SourceControlHistorySelection,
   WorkStationTab,
-  WorkStationTabType,
 } from "@src/store/workstation/tabs";
 import type { GitFile } from "@src/types/git/types";
 
 import {
   type TabSidebarRuntimeContext,
-  getInitialKeepAliveTabsByType,
   getTabSidebarDescriptor,
   hasTabSidebar,
 } from "./registry";
@@ -27,6 +32,11 @@ type TabSidebarExtraContext = Partial<
 
 interface TabSidebarOptions {
   activeTab: WorkStationTab | null;
+  /**
+   * Tabs the retention policy keeps mounted-but-hidden (the active tab
+   * included when it is retained). Their sidebars are kept warm here.
+   */
+  retainedTabs?: readonly WorkStationTab[];
   repoPath: string | null;
   repoId: string | null;
   isMultiRoot?: boolean;
@@ -47,6 +57,8 @@ interface TabSidebarRendererProps {
   context: TabSidebarRuntimeContext;
 }
 
+const NO_RETAINED_TABS: readonly WorkStationTab[] = [];
+
 function shouldRenderSidebar(tab: WorkStationTab): boolean {
   if (!hasTabSidebar(tab.type)) return false;
 
@@ -66,7 +78,7 @@ function buildSidebarContext({
   onGitFilesChange,
   onGitHistorySelectionChange,
   extraContext,
-}: Omit<TabSidebarOptions, "activeTab"> & {
+}: Omit<TabSidebarOptions, "activeTab" | "retainedTabs"> & {
   repoPath: string;
 }): TabSidebarRuntimeContext {
   return {
@@ -94,6 +106,7 @@ TabSidebarRenderer.displayName = "TabSidebarRenderer";
 export const SidebarSlot: React.FC<SidebarSlotProps> = memo(
   ({
     activeTab,
+    retainedTabs = NO_RETAINED_TABS,
     repoPath,
     repoId,
     isMultiRoot,
@@ -103,54 +116,6 @@ export const SidebarSlot: React.FC<SidebarSlotProps> = memo(
     extraContext,
     defaultSidebar,
   }) => {
-    const initialWarmTabsByType = useMemo(() => {
-      const entries = Object.entries(getInitialKeepAliveTabsByType()) as Array<
-        [WorkStationTabType, WorkStationTab]
-      >;
-
-      return entries.reduce<
-        Partial<Record<WorkStationTabType, WorkStationTab>>
-      >((accumulator, [tabType, tab]) => {
-        if (shouldRenderSidebar(tab)) {
-          accumulator[tabType] = tab;
-        }
-        return accumulator;
-      }, {});
-    }, []);
-
-    const [warmTabsByType, setWarmTabsByType] = useState<
-      Partial<Record<WorkStationTabType, WorkStationTab>>
-    >(initialWarmTabsByType);
-
-    const activeDescriptor = activeTab
-      ? getTabSidebarDescriptor(activeTab.type)
-      : undefined;
-    const activeSidebarRenderable = Boolean(
-      activeTab && shouldRenderSidebar(activeTab)
-    );
-    const activeKeepAlive = Boolean(
-      activeTab && activeDescriptor?.keepAlive && activeSidebarRenderable
-    );
-
-    useEffect(() => {
-      if (
-        !activeTab ||
-        !activeDescriptor?.keepAlive ||
-        !activeSidebarRenderable
-      ) {
-        return;
-      }
-
-      const frameId = window.requestAnimationFrame(() => {
-        setWarmTabsByType((prev) => {
-          if (prev[activeTab.type] === activeTab) return prev;
-          return { ...prev, [activeTab.type]: activeTab };
-        });
-      });
-
-      return () => window.cancelAnimationFrame(frameId);
-    }, [activeDescriptor?.keepAlive, activeSidebarRenderable, activeTab]);
-
     const context = useMemo(() => {
       if (!repoPath) return null;
       return buildSidebarContext({
@@ -172,31 +137,37 @@ export const SidebarSlot: React.FC<SidebarSlotProps> = memo(
       repoPath,
     ]);
 
-    const activeWarmTab =
-      activeTab && activeKeepAlive ? warmTabsByType[activeTab.type] : undefined;
+    // Retained tabs that own a sidebar get a persistent keyed layer each.
+    const warmSidebarTabs = useMemo(
+      () => retainedTabs.filter((tab) => shouldRenderSidebar(tab)),
+      [retainedTabs]
+    );
+    const activeSidebarRenderable = Boolean(
+      activeTab && shouldRenderSidebar(activeTab)
+    );
+    const activeHasWarmLayer =
+      activeTab !== null &&
+      warmSidebarTabs.some((tab) => tab.id === activeTab.id);
     const shouldRenderDirectActiveSidebar =
-      activeTab && context && activeSidebarRenderable && !activeWarmTab;
+      activeTab && context && activeSidebarRenderable && !activeHasWarmLayer;
 
     const activeSidebar = shouldRenderDirectActiveSidebar ? (
       <TabSidebarRenderer tab={activeTab} context={context} />
     ) : null;
 
     const warmSidebars = context
-      ? Object.entries(warmTabsByType).flatMap(([tabType, warmTab]) => {
-          if (!warmTab) return [];
-          const descriptor = getTabSidebarDescriptor(warmTab.type);
-          if (!descriptor?.keepAlive) return [];
-          const isActiveWarmSidebar =
-            activeKeepAlive && activeTab?.type === tabType;
-          return [
+      ? warmSidebarTabs.map((tab) => {
+          const visible = tab.id === activeTab?.id;
+          return (
             <div
-              key={warmTab.type}
+              key={tab.id}
               className="absolute inset-0 flex min-h-0 flex-col"
-              style={{ display: isActiveWarmSidebar ? undefined : "none" }}
+              style={visible ? undefined : { visibility: "hidden" }}
+              aria-hidden={!visible}
             >
-              <TabSidebarRenderer tab={warmTab} context={context} />
-            </div>,
-          ];
+              <TabSidebarRenderer tab={tab} context={context} />
+            </div>
+          );
         })
       : [];
 
@@ -210,7 +181,7 @@ export const SidebarSlot: React.FC<SidebarSlotProps> = memo(
           <div className="absolute inset-0 flex min-h-0 flex-col">
             {activeSidebar}
           </div>
-        ) : activeWarmTab ? null : (
+        ) : activeHasWarmLayer ? null : (
           <div className="absolute inset-0 flex min-h-0 flex-col">
             {defaultSidebar}
           </div>

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlTabSidebar.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlTabSidebar.tsx
@@ -21,9 +21,8 @@ const SourceControlTabSidebar: TabSidebarComponent = (props) => (
 
 SourceControlTabSidebar.displayName = "SourceControlTabSidebar";
 
-registerTabSidebar("source-control", {
-  component: SourceControlTabSidebar,
-  keepAlive: false,
-});
+// Kept warm alongside the Review main pane per `tabRetention.ts`; the
+// sidebar slot reads the policy, so nothing is declared here.
+registerTabSidebar("source-control", SourceControlTabSidebar);
 
 export { SourceControlTabSidebar };

--- a/src/modules/WorkStation/shared/SidebarModules/registry.ts
+++ b/src/modules/WorkStation/shared/SidebarModules/registry.ts
@@ -12,8 +12,10 @@
  *
  * Conventions:
  *   - Each component must own its internal state (selection, filter, refs).
- *   - The component is mounted lazily once the tab becomes active and stays
- *     mounted (host's keep-alive policy decides when to unmount).
+ *   - The component is mounted lazily once the tab becomes active. Whether
+ *     it stays mounted-but-hidden after the tab is left is decided by the
+ *     shared tab retention policy (`@src/store/workstation/tabs/tabRetention`),
+ *     read by `SidebarSlot` — not declared per sidebar.
  *   - Components receive only domain inputs — never tab data dictionaries.
  */
 import type { ComponentType } from "react";
@@ -56,8 +58,6 @@ export type TabSidebarComponent = ComponentType<TabSidebarProps>;
 
 export interface TabSidebarDescriptor {
   component: TabSidebarComponent;
-  keepAlive?: boolean;
-  keepAliveInitialTab?: WorkStationTab;
 }
 
 const REGISTRY = new Map<WorkStationTabType, TabSidebarDescriptor>();
@@ -86,20 +86,6 @@ export function getTabSidebarDescriptor(
   tabType: WorkStationTabType
 ): TabSidebarDescriptor | undefined {
   return REGISTRY.get(tabType);
-}
-
-export function getInitialKeepAliveTabsByType(): Partial<
-  Record<WorkStationTabType, WorkStationTab>
-> {
-  const result: Partial<Record<WorkStationTabType, WorkStationTab>> = {};
-
-  for (const [tabType, descriptor] of REGISTRY.entries()) {
-    if (descriptor.keepAlive && descriptor.keepAliveInitialTab) {
-      result[tabType] = descriptor.keepAliveInitialTab;
-    }
-  }
-
-  return result;
 }
 
 /**

--- a/src/modules/WorkStation/shared/index.ts
+++ b/src/modules/WorkStation/shared/index.ts
@@ -32,7 +32,10 @@ export type { NewTerminalSessionOptions } from "./TerminalNewSessionSplitButton"
 export { default as DiffFileSection } from "./DiffFileSection";
 export type { DiffFileSectionData } from "./DiffFileSection";
 export { default as DiffSectionList } from "./DiffSectionList";
-export type { DiffSectionListItem } from "./DiffSectionList";
+export type {
+  DiffSectionListItem,
+  DiffSectionListViewState,
+} from "./DiffSectionList";
 export { default as DiffFileNavigationList } from "./DiffFileNavigationList";
 export type { DiffFileNavigationItem } from "./DiffFileNavigationList";
 export {

--- a/src/store/workstation/codeEditor/gitDiffEditDrafts.test.ts
+++ b/src/store/workstation/codeEditor/gitDiffEditDrafts.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_GIT_DIFF_EDIT_DRAFTS,
+  clearGitDiffEditDrafts,
+  deleteGitDiffEditDraft,
+  hasGitDiffEditDraft,
+  restoreGitDiffEditDraft,
+  setGitDiffEditDraft,
+} from "./gitDiffEditDrafts";
+
+const FILE = "/repo/src/a.ts";
+
+describe("gitDiffEditDrafts", () => {
+  beforeEach(() => {
+    clearGitDiffEditDrafts();
+  });
+
+  it("restores a draft onto the base content it was written against", () => {
+    setGitDiffEditDraft(FILE, "base", "edited");
+    expect(restoreGitDiffEditDraft(FILE, "base")).toBe("edited");
+    // Restoring is not consuming: a second mount for the same base sees it too.
+    expect(restoreGitDiffEditDraft(FILE, "base")).toBe("edited");
+  });
+
+  it("discards a draft whose base no longer matches the working tree", () => {
+    setGitDiffEditDraft(FILE, "base", "edited");
+    expect(restoreGitDiffEditDraft(FILE, "changed on disk")).toBeNull();
+    expect(hasGitDiffEditDraft(FILE)).toBe(false);
+    // …and does not come back even for the original base afterwards.
+    expect(restoreGitDiffEditDraft(FILE, "base")).toBeNull();
+  });
+
+  it("does not keep a draft equal to its base", () => {
+    setGitDiffEditDraft(FILE, "base", "edited");
+    setGitDiffEditDraft(FILE, "base", "base");
+    expect(hasGitDiffEditDraft(FILE)).toBe(false);
+  });
+
+  it("forgets a draft on explicit delete (save / discard / tab close)", () => {
+    setGitDiffEditDraft(FILE, "base", "edited");
+    deleteGitDiffEditDraft(FILE);
+    expect(restoreGitDiffEditDraft(FILE, "base")).toBeNull();
+  });
+
+  it("ignores empty paths", () => {
+    setGitDiffEditDraft("", "base", "edited");
+    expect(restoreGitDiffEditDraft("", "base")).toBeNull();
+  });
+
+  it("keeps at most the configured number of files", () => {
+    for (let index = 0; index <= MAX_GIT_DIFF_EDIT_DRAFTS; index += 1) {
+      setGitDiffEditDraft(`/repo/${index}.ts`, "base", `edit ${index}`);
+    }
+    expect(hasGitDiffEditDraft("/repo/0.ts")).toBe(false);
+    expect(
+      restoreGitDiffEditDraft(`/repo/${MAX_GIT_DIFF_EDIT_DRAFTS}.ts`, "base")
+    ).toBe(`edit ${MAX_GIT_DIFF_EDIT_DRAFTS}`);
+  });
+});

--- a/src/store/workstation/codeEditor/gitDiffEditDrafts.ts
+++ b/src/store/workstation/codeEditor/gitDiffEditDrafts.ts
@@ -1,0 +1,78 @@
+/**
+ * In-progress edits made in a working-tree diff editor (`GitDiffContent`).
+ *
+ * The diff editor is unmounted whenever its tab stops being active — the
+ * Source Control Focus view and `git-diff` tabs are rebuilt from stores on
+ * every visit rather than hidden behind `display:none`. Component-local
+ * `editedContent` died with the subtree, so switching to another tab and
+ * back silently discarded unsaved edits while the tab bar kept showing the
+ * unsaved dot. The draft now lives here, keyed by the absolute file path.
+ *
+ * Invariant: a draft is only ever restored onto the working-tree content it
+ * was written against. `restoreGitDiffEditDraft` compares the stored base with
+ * the current content and discards the draft when they differ (the file was
+ * saved or changed on disk in between), so a stale draft can never resurrect
+ * over newer content. Saving or discarding in the editor deletes the draft;
+ * closing a `git-diff` tab deletes its file's draft (close means discard,
+ * matching the pre-existing close behaviour).
+ */
+import { BoundedMap } from "@src/util/collections/BoundedMap";
+
+export interface GitDiffEditDraft {
+  /** Working-tree content the edit started from. */
+  baseContent: string;
+  /** The user's edited buffer. */
+  editedContent: string;
+}
+
+/** Files with a live draft at once; the LRU tail is dropped beyond this. */
+export const MAX_GIT_DIFF_EDIT_DRAFTS = 32;
+
+const drafts = new BoundedMap<string, GitDiffEditDraft>({
+  maxSize: MAX_GIT_DIFF_EDIT_DRAFTS,
+  name: "gitDiffEditDrafts",
+});
+
+/** Record the current edit buffer for `filePath` against `baseContent`. */
+export function setGitDiffEditDraft(
+  filePath: string,
+  baseContent: string,
+  editedContent: string
+): void {
+  if (!filePath) return;
+  if (editedContent === baseContent) {
+    drafts.delete(filePath);
+    return;
+  }
+  drafts.set(filePath, { baseContent, editedContent });
+}
+
+/**
+ * Return the draft for `filePath` when it was written against
+ * `baseContent`; otherwise drop the stale draft and return `null`.
+ */
+export function restoreGitDiffEditDraft(
+  filePath: string,
+  baseContent: string
+): string | null {
+  const draft = drafts.get(filePath);
+  if (!draft) return null;
+  if (draft.baseContent !== baseContent) {
+    drafts.delete(filePath);
+    return null;
+  }
+  return draft.editedContent;
+}
+
+/** Forget the draft for `filePath` (save, discard, tab close). */
+export function deleteGitDiffEditDraft(filePath: string): void {
+  drafts.delete(filePath);
+}
+
+export function hasGitDiffEditDraft(filePath: string): boolean {
+  return drafts.has(filePath);
+}
+
+export function clearGitDiffEditDrafts(): void {
+  drafts.clear();
+}

--- a/src/store/workstation/codeEditor/index.ts
+++ b/src/store/workstation/codeEditor/index.ts
@@ -46,3 +46,6 @@ export * from "./outputIntegration";
 
 // GitHub Issues list, detail, and callback atoms
 export * from "./workstationIssueAtom";
+
+// Git diff editor drafts (survive tab switches, keyed by file path)
+export * from "./gitDiffEditDrafts";

--- a/src/store/workstation/tabs/__tests__/tabMutations.viewState.test.ts
+++ b/src/store/workstation/tabs/__tests__/tabMutations.viewState.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Close mutations release the session-only state a tab owned: its saved
+ * view state (`tabViewState`) and, for a working-tree `git-diff` tab, the
+ * in-progress diff edit for its file (`gitDiffEditDrafts`). Uses the real
+ * stores rather than mocks so the contract is the observable one.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearGitDiffEditDrafts,
+  hasGitDiffEditDraft,
+  setGitDiffEditDraft,
+} from "@src/store/workstation/codeEditor/gitDiffEditDrafts";
+
+import {
+  closeAllTabs,
+  closeOtherTabs,
+  closeSavedTabs,
+  closeTab,
+  switchTab,
+} from "../tabMutations";
+import {
+  clearTabViewStates,
+  getTabViewState,
+  setTabViewState,
+} from "../tabViewState";
+import type { PanelState, WorkStationTab } from "../types";
+
+function tab(
+  overrides: Partial<WorkStationTab> & { id: string }
+): WorkStationTab {
+  return {
+    type: "file",
+    title: overrides.id,
+    data: {},
+    ...overrides,
+  };
+}
+
+const DIFF_FILE = "/repo/src/a.ts";
+
+function seeded(): PanelState {
+  setTabViewState("file:a.ts", "scroll", 10);
+  setTabViewState("source-control:changes", "allChanges", { expanded: {} });
+  setTabViewState("git-diff:a", "scroll", 3);
+  setGitDiffEditDraft(DIFF_FILE, "base", "edited");
+  return {
+    tabs: [
+      tab({ id: "file:a.ts" }),
+      tab({
+        id: "source-control:changes",
+        type: "source-control",
+        pinned: true,
+        closable: false,
+      }),
+      tab({
+        id: "git-diff:a",
+        type: "git-diff",
+        data: { filePath: DIFF_FILE },
+      }),
+    ],
+    activeTabId: "file:a.ts",
+  };
+}
+
+describe("tab view state + diff draft cleanup on close", () => {
+  beforeEach(() => {
+    clearTabViewStates();
+    clearGitDiffEditDrafts();
+  });
+
+  it("switching tabs keeps every tab's view state (the tab is rebuilt from it)", () => {
+    const state = seeded();
+    switchTab(state, "source-control:changes");
+    expect(getTabViewState("file:a.ts", "scroll")).toBe(10);
+    expect(hasGitDiffEditDraft(DIFF_FILE)).toBe(true);
+  });
+
+  it("closeTab drops only the closed tab's view state", () => {
+    const state = seeded();
+    closeTab(state, "file:a.ts");
+    expect(getTabViewState("file:a.ts", "scroll")).toBeUndefined();
+    expect(
+      getTabViewState("source-control:changes", "allChanges")
+    ).toBeDefined();
+    expect(hasGitDiffEditDraft(DIFF_FILE)).toBe(true);
+  });
+
+  it("closing a git-diff tab discards its file's edit draft", () => {
+    const state = seeded();
+    closeTab(state, "git-diff:a");
+    expect(getTabViewState("git-diff:a", "scroll")).toBeUndefined();
+    expect(hasGitDiffEditDraft(DIFF_FILE)).toBe(false);
+  });
+
+  it("closing a timeline diff tab leaves the working-tree draft alone", () => {
+    const state: PanelState = {
+      tabs: [
+        tab({
+          id: "git-diff:timeline",
+          type: "git-diff",
+          data: { filePath: DIFF_FILE, isTimeline: true },
+        }),
+      ],
+      activeTabId: "git-diff:timeline",
+    };
+    setGitDiffEditDraft(DIFF_FILE, "base", "edited");
+    closeTab(state, "git-diff:timeline");
+    expect(hasGitDiffEditDraft(DIFF_FILE)).toBe(true);
+  });
+
+  it("closeOtherTabs keeps the retained tab's view state", () => {
+    const state = seeded();
+    closeOtherTabs(state, "source-control:changes");
+    expect(
+      getTabViewState("source-control:changes", "allChanges")
+    ).toBeDefined();
+    expect(getTabViewState("file:a.ts", "scroll")).toBeUndefined();
+    expect(getTabViewState("git-diff:a", "scroll")).toBeUndefined();
+    expect(hasGitDiffEditDraft(DIFF_FILE)).toBe(false);
+  });
+
+  it("closeSavedTabs keeps view state for dirty tabs only", () => {
+    const state = seeded();
+    state.tabs[0] = { ...state.tabs[0], hasUnsavedChanges: true };
+    closeSavedTabs(state);
+    expect(getTabViewState("file:a.ts", "scroll")).toBe(10);
+    expect(
+      getTabViewState("source-control:changes", "allChanges")
+    ).toBeUndefined();
+    expect(hasGitDiffEditDraft(DIFF_FILE)).toBe(false);
+  });
+
+  it("closeAllTabs clears everything", () => {
+    const state = seeded();
+    closeAllTabs(state);
+    expect(getTabViewState("file:a.ts", "scroll")).toBeUndefined();
+    expect(
+      getTabViewState("source-control:changes", "allChanges")
+    ).toBeUndefined();
+    expect(hasGitDiffEditDraft(DIFF_FILE)).toBe(false);
+  });
+});

--- a/src/store/workstation/tabs/__tests__/tabRetention.test.ts
+++ b/src/store/workstation/tabs/__tests__/tabRetention.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  RETENTION_POOLS,
+  getTabRetentionPool,
+  isRetainedTabType,
+  isTabInRetentionPool,
+  selectRetentionPoolTabIds,
+} from "../tabRetention";
+import type { WorkStationTabType } from "../types";
+
+describe("tabRetention policy", () => {
+  it("preserves the pinned Review tab in its own single-slot pool", () => {
+    expect(getTabRetentionPool("source-control")).toBe(
+      RETENTION_POOLS["source-control"]
+    );
+    expect(RETENTION_POOLS["source-control"].maxWarm).toBe(1);
+    expect(isRetainedTabType("source-control")).toBe(true);
+  });
+
+  it("preserves the Project Manager list trio in one shared pool", () => {
+    for (const type of [
+      "project-workitems",
+      "project-linear-projects",
+      "project-linear-work-items",
+    ] as const) {
+      expect(getTabRetentionPool(type)?.id).toBe("project-trio");
+    }
+    expect(RETENTION_POOLS["project-trio"].maxWarm).toBe(2);
+  });
+
+  it("rebuilds everything else by default", () => {
+    const rebuilt: WorkStationTabType[] = [
+      "file",
+      "git-diff",
+      "terminal",
+      "browser-session",
+      "chat-session",
+      "github-pr-detail",
+      "search",
+    ];
+    for (const type of rebuilt) {
+      expect(isRetainedTabType(type)).toBe(false);
+      expect(getTabRetentionPool(type)).toBeNull();
+    }
+  });
+
+  it("bounds every pool with a finite grace and a positive warm cap", () => {
+    for (const pool of Object.values(RETENTION_POOLS)) {
+      expect(Number.isFinite(pool.graceMs)).toBe(true);
+      expect(pool.maxWarm).toBeGreaterThan(0);
+    }
+  });
+
+  it("selects only a pool's tabs, in pane order", () => {
+    const tabs = [
+      { id: "file:a", type: "file" as const },
+      { id: "project-workitems:1", type: "project-workitems" as const },
+      { id: "source-control:changes", type: "source-control" as const },
+      {
+        id: "project-linear-projects:1",
+        type: "project-linear-projects" as const,
+      },
+    ];
+    expect(selectRetentionPoolTabIds(tabs, "project-trio")).toEqual([
+      "project-workitems:1",
+      "project-linear-projects:1",
+    ]);
+    expect(selectRetentionPoolTabIds(tabs, "source-control")).toEqual([
+      "source-control:changes",
+    ]);
+    expect(isTabInRetentionPool(tabs[0], "source-control")).toBe(false);
+  });
+});

--- a/src/store/workstation/tabs/__tests__/tabViewState.test.ts
+++ b/src/store/workstation/tabs/__tests__/tabViewState.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_TAB_VIEW_STATE_TABS,
+  clearTabViewStates,
+  deleteTabViewState,
+  getTabViewState,
+  getTabViewStateCount,
+  setTabViewState,
+} from "../tabViewState";
+
+describe("tabViewState", () => {
+  beforeEach(() => {
+    clearTabViewStates();
+  });
+
+  it("returns undefined for a tab that never saved anything", () => {
+    expect(getTabViewState("tab:1", "scroll")).toBeUndefined();
+  });
+
+  it("round-trips slots independently per tab", () => {
+    setTabViewState("tab:1", "scroll", 120);
+    setTabViewState("tab:1", "expanded", { a: true });
+    setTabViewState("tab:2", "scroll", 7);
+
+    expect(getTabViewState("tab:1", "scroll")).toBe(120);
+    expect(getTabViewState("tab:1", "expanded")).toEqual({ a: true });
+    expect(getTabViewState("tab:2", "scroll")).toBe(7);
+    expect(getTabViewState("tab:2", "expanded")).toBeUndefined();
+  });
+
+  it("overwrites a slot in place", () => {
+    setTabViewState("tab:1", "scroll", 1);
+    setTabViewState("tab:1", "scroll", 2);
+    expect(getTabViewState("tab:1", "scroll")).toBe(2);
+    expect(getTabViewStateCount()).toBe(1);
+  });
+
+  it("drops every slot of a tab on delete", () => {
+    setTabViewState("tab:1", "scroll", 1);
+    setTabViewState("tab:1", "expanded", {});
+    deleteTabViewState("tab:1");
+    expect(getTabViewState("tab:1", "scroll")).toBeUndefined();
+    expect(getTabViewState("tab:1", "expanded")).toBeUndefined();
+    expect(getTabViewStateCount()).toBe(0);
+  });
+
+  it("ignores empty tab ids so unkeyed callers persist nothing", () => {
+    setTabViewState("", "scroll", 1);
+    expect(getTabViewState("", "scroll")).toBeUndefined();
+    expect(getTabViewStateCount()).toBe(0);
+  });
+
+  it("evicts the least recently used tab beyond the cap", () => {
+    for (let index = 0; index < MAX_TAB_VIEW_STATE_TABS; index += 1) {
+      setTabViewState(`tab:${index}`, "scroll", index);
+    }
+    // Touch the oldest so it becomes most-recently-used.
+    expect(getTabViewState("tab:0", "scroll")).toBe(0);
+    setTabViewState("tab:overflow", "scroll", -1);
+
+    expect(getTabViewStateCount()).toBe(MAX_TAB_VIEW_STATE_TABS);
+    expect(getTabViewState("tab:0", "scroll")).toBe(0);
+    expect(getTabViewState("tab:1", "scroll")).toBeUndefined();
+    expect(getTabViewState("tab:overflow", "scroll")).toBe(-1);
+  });
+});

--- a/src/store/workstation/tabs/index.ts
+++ b/src/store/workstation/tabs/index.ts
@@ -89,6 +89,13 @@ export {
   clearPendingCodeEditorTabForSession,
 } from "./pendingCodeEditorTab";
 
+export {
+  getTabViewState,
+  setTabViewState,
+  deleteTabViewState,
+  clearTabViewStates,
+} from "./tabViewState";
+
 // ============================================
 // Tab Factory System
 // ============================================

--- a/src/store/workstation/tabs/tabMutations.ts
+++ b/src/store/workstation/tabs/tabMutations.ts
@@ -4,13 +4,33 @@
  * Pure functions for mutating tab state within a pane.
  * All functions return new state objects (immutable).
  */
+import { deleteGitDiffEditDraft } from "@src/store/workstation/codeEditor/gitDiffEditDrafts";
 import {
   clearSearchTabSessionStates,
   deleteSearchTabSessionState,
 } from "@src/store/workstation/codeEditor/search";
 
+import { clearTabViewStates, deleteTabViewState } from "./tabViewState";
 import { TAB_RETURN_TARGET_DATA_KEY } from "./types";
 import type { PanelState, WorkStationTab } from "./types";
+
+/**
+ * Drop the session-only state a tab owned once it leaves the pool: its
+ * search session cache, its saved view state, and — for a working-tree
+ * `git-diff` tab — the in-progress diff edit for its file (closing the tab
+ * is the discard gesture; the Source Control tab is pinned and never reaches
+ * here, so its Focus-view drafts survive until saved or discarded).
+ */
+function releaseClosedTabResources(tab: WorkStationTab): void {
+  if (tab.id.startsWith("search:")) {
+    deleteSearchTabSessionState(tab.id);
+  }
+  deleteTabViewState(tab.id);
+  if (tab.type === "git-diff" && !tab.data.isTimeline) {
+    const filePath = tab.data.filePath;
+    if (typeof filePath === "string") deleteGitDiffEditDraft(filePath);
+  }
+}
 
 // ============================================
 // Tab Mutations
@@ -130,9 +150,7 @@ export function closeTab(state: PanelState, tabId: string): PanelState {
   if (closedIndex === -1) return state ?? { tabs: [], activeTabId: null };
   const target = tabs[closedIndex];
   const newTabs = tabs.filter((tab) => tab.id !== tabId);
-  if (tabId.startsWith("search:")) {
-    deleteSearchTabSessionState(tabId);
-  }
+  releaseClosedTabResources(target);
 
   // If closing the active tab, select another
   let newActiveTabId = state?.activeTabId ?? null;
@@ -241,11 +259,14 @@ export function updateTabData(
  * `useLaunchpadTab`).
  */
 export function closeAllTabs(state: PanelState): PanelState {
-  const hadSearchTabs = (state?.tabs ?? []).some((tab) =>
-    tab.id.startsWith("search:")
-  );
+  const tabs = state?.tabs ?? [];
+  const hadSearchTabs = tabs.some((tab) => tab.id.startsWith("search:"));
   if (hadSearchTabs) {
     clearSearchTabSessionStates();
+  }
+  clearTabViewStates();
+  for (const tab of tabs) {
+    releaseClosedTabResources(tab);
   }
   return {
     tabs: [],
@@ -263,9 +284,7 @@ export function closeOtherTabs(state: PanelState, tabId: string): PanelState {
   if (!targetTab) return state ?? { tabs: [], activeTabId: null };
 
   for (const tab of tabs) {
-    if (tab.id !== tabId && tab.id.startsWith("search:")) {
-      deleteSearchTabSessionState(tab.id);
-    }
+    if (tab.id !== tabId) releaseClosedTabResources(tab);
   }
 
   return {
@@ -292,9 +311,7 @@ export function closeSavedTabs(state: PanelState): PanelState {
 
   for (const tab of tabs) {
     const keptTab = keptTabs.find((kept) => kept.id === tab.id);
-    if (!keptTab && tab.id.startsWith("search:")) {
-      deleteSearchTabSessionState(tab.id);
-    }
+    if (!keptTab) releaseClosedTabResources(tab);
   }
 
   return {

--- a/src/store/workstation/tabs/tabRetention.ts
+++ b/src/store/workstation/tabs/tabRetention.ts
@@ -1,0 +1,91 @@
+/**
+ * Tab retention policy — the one place that says which WorkStation tabs are
+ * PRESERVED (kept mounted but hidden after you leave them) and which are
+ * REBUILT from stores on the next visit.
+ *
+ * Default is rebuild: a content host mounts only the active tab, and a tab
+ * renderer that needs continuity keeps it in per-tab view state
+ * (`tabViewState.ts`, `useTabViewState`). That is the right default for
+ * surfaces that multiply (one xterm per terminal tab, one webview per
+ * browser tab, twelve `ChatHistory` cells in a simulator grid) — hidden DOM
+ * there grows without bound.
+ *
+ * A handful of tabs are visited constantly, exist once, and are cheap to
+ * keep: the pinned Review (Source Control) pane and the Project Manager
+ * list trio. Rebuilding those on every visit costs a lazy-chunk suspend, a
+ * refetch, and a visible flash for no memory win. Those opt in here.
+ *
+ * To widen or narrow the preserved set, edit `RETAINED_TAB_TYPES` (and add
+ * a pool if the new type should not share a window with an existing one).
+ * Hosts pick up the change through `useRetainedTabPool`; the sidebar slot
+ * keeps a retained tab's sidebar warm alongside its main pane.
+ *
+ * Retention is bounded, never monotonic: a pool keeps at most `maxWarm`
+ * tabs and drops a tab left hidden for longer than `graceMs`, after which
+ * it rebuilds from view state like any other tab.
+ *
+ * Contract for a type listed here: its renderer must gate side effects
+ * (header publishing, focus, polling) on the `isActive` prop it receives,
+ * because it stays mounted while another tab is on screen.
+ */
+import type { WorkStationTab, WorkStationTabType } from "./types";
+
+export type RetentionPoolId = "source-control" | "project-trio";
+
+export interface RetentionPool {
+  id: RetentionPoolId;
+  /** How long a hidden tab in this pool stays mounted after deactivation. */
+  graceMs: number;
+  /** Upper bound on mounted tabs in this pool, including the active one. */
+  maxWarm: number;
+}
+
+export const RETENTION_POOLS: Readonly<Record<RetentionPoolId, RetentionPool>> =
+  {
+    /** The pinned Review tab: one instance, flipped to and from constantly. */
+    "source-control": { id: "source-control", graceMs: 60_000, maxWarm: 1 },
+    /**
+     * Project Manager lists: two warm tabs cover the "compare two lists"
+     * flip; each is a full non-virtualized table, so no more than that.
+     */
+    "project-trio": { id: "project-trio", graceMs: 60_000, maxWarm: 2 },
+  };
+
+/** Tab types that are preserved, and the pool whose window bounds them. */
+const RETAINED_TAB_TYPES: Readonly<
+  Partial<Record<WorkStationTabType, RetentionPoolId>>
+> = {
+  "source-control": "source-control",
+  "project-workitems": "project-trio",
+  "project-linear-projects": "project-trio",
+  "project-linear-work-items": "project-trio",
+};
+
+/** The pool a tab type is preserved in, or `null` when it is rebuilt. */
+export function getTabRetentionPool(
+  tabType: WorkStationTabType
+): RetentionPool | null {
+  const poolId = RETAINED_TAB_TYPES[tabType];
+  return poolId ? RETENTION_POOLS[poolId] : null;
+}
+
+export function isRetainedTabType(tabType: WorkStationTabType): boolean {
+  return RETAINED_TAB_TYPES[tabType] !== undefined;
+}
+
+export function isTabInRetentionPool(
+  tab: Pick<WorkStationTab, "type">,
+  poolId: RetentionPoolId
+): boolean {
+  return RETAINED_TAB_TYPES[tab.type] === poolId;
+}
+
+/** Ids of the tabs in `tabs` that belong to `poolId`, in tab order. */
+export function selectRetentionPoolTabIds(
+  tabs: readonly Pick<WorkStationTab, "id" | "type">[],
+  poolId: RetentionPoolId
+): string[] {
+  return tabs
+    .filter((tab) => isTabInRetentionPool(tab, poolId))
+    .map((tab) => tab.id);
+}

--- a/src/store/workstation/tabs/tabViewState.ts
+++ b/src/store/workstation/tabs/tabViewState.ts
@@ -1,0 +1,67 @@
+/**
+ * Session-only per-tab view state.
+ *
+ * WorkStation content hosts mount only the active tab (`EditorMainPane`
+ * renders `UnifiedTabContent` for `activeTab` alone). Leaving a tab unmounts
+ * its subtree and coming back rebuilds it from tab data plus stores — there
+ * is deliberately no hidden DOM tree kept warm behind `display:none`. Tab
+ * data is persisted to localStorage and is the wrong home for ephemeral
+ * view state (expanded diff sections, a list's scroll offset, a detail
+ * sub-tab selection), so that state lives here instead:
+ *
+ *   - keyed by tab id, one slot map per tab;
+ *   - in memory only — it never reaches localStorage;
+ *   - dropped when the tab closes (the close mutations in `tabMutations.ts`
+ *     call `deleteTabViewState`), and LRU-bounded so a long session cannot
+ *     accumulate it for tabs that were never closed.
+ *
+ * Components read a slot once at mount and write it on change; see
+ * `@src/hooks/tabHost/useTabViewState` for the `useState`-shaped wrapper.
+ */
+import { BoundedMap } from "@src/util/collections/BoundedMap";
+
+/** Tabs whose view state stays resident at once. */
+export const MAX_TAB_VIEW_STATE_TABS = 128;
+
+type TabViewStateSlots = Map<string, unknown>;
+
+const tabViewStates = new BoundedMap<string, TabViewStateSlots>({
+  maxSize: MAX_TAB_VIEW_STATE_TABS,
+  name: "tabViewState",
+});
+
+/** Read one slot of a tab's view state; `undefined` when nothing was saved. */
+export function getTabViewState<T>(tabId: string, slot: string): T | undefined {
+  if (!tabId) return undefined;
+  return tabViewStates.get(tabId)?.get(slot) as T | undefined;
+}
+
+/** Save one slot of a tab's view state. Empty tab ids are ignored. */
+export function setTabViewState<T>(
+  tabId: string,
+  slot: string,
+  value: T
+): void {
+  if (!tabId) return;
+  const slots = tabViewStates.get(tabId);
+  if (slots) {
+    slots.set(slot, value);
+    return;
+  }
+  tabViewStates.set(tabId, new Map([[slot, value]]));
+}
+
+/** Drop every slot saved for a tab — called when the tab leaves the pool. */
+export function deleteTabViewState(tabId: string): void {
+  tabViewStates.delete(tabId);
+}
+
+/** Drop all saved view state (close-all, tests). */
+export function clearTabViewStates(): void {
+  tabViewStates.clear();
+}
+
+/** Number of tabs with saved view state (tests / diagnostics). */
+export function getTabViewStateCount(): number {
+  return tabViewStates.size;
+}


### PR DESCRIPTION
## Problem

Switching away from a WorkStation tab and back reset it. The code-editor host mounts only the active tab, so every switch unmounted the tab's subtree and rebuilt it on return. The Review (Source Control) tab was the worst case: its keep-alive overlay from issue #16 was removed in 52e778c2e (`perf(source-control): lazy load diffs and release memory`) without moving any of its view state into a store, so every return collapsed all files in All Changes, scrolled to the top, and re-suspended the Source Control sidebar into a loading placeholder. Focus-mode edits in the diff editor were silently discarded on switch while the tab kept showing its unsaved dot. Search mode/filters and the issue-detail sub-tab reset the same way. The sidebar kept flashing even once the pane was preserved because the worktree loader under it was gated on "Review is active", so leaving cleared the worktree list and returning refetched it, which flipped the scope identity and painted the full-pane loading overlay.

There was also no single place that said which tabs are preserved: the Project Manager list trio had its own keep-alive window, and the sidebar registry carried a separate monotonic `keepAlive` flag.

## Solution

One declarative retention policy, with reconstruct-from-store as the fallback for everything it does not cover.

- `src/store/workstation/tabs/tabRetention.ts` maps tab type to a bounded retention pool (grace window + warm cap). Review is in a single-slot pool; the Project Manager trio shares a two-slot pool. Everything else keeps the rebuild default. Widening or narrowing the preserved set is a table edit.
- `useRetainedTabPool` turns a pool plus the pane's tabs into the ids that may stay mounted. The code editor computes it once and passes it to both the main pane (Review overlay plus a generic keyed hidden layer for any retained registry type) and `SidebarSlot`, so pane and sidebar hide/show the same instances in lockstep. Hidden layers use opacity/visibility, not `display:none`, so scroll offsets survive. The sidebar registry's `keepAlive` descriptor flag is removed; the Project Manager router reads the trio pool from the same table.
- The worktree loader in `useSourceControlSetup` now follows "Review surface mounted" (active or retained) instead of "active", which removes the sidebar overlay flash.
- For tabs that are rebuilt (or a retained tab past its grace): a session-only per-tab view-state store (`tabViewState.ts`, LRU-bounded, released from all four close mutations) with a `useTabViewState` hook. `DiffSectionList` snapshots expansion overrides, the Virtuoso scroll state, and the handled focus nonce, and rebuilds from them; `AllChangesView` persists that per tab. Search mode/filters and the issue sub-tab use the hook.
- Diff-editor edits persist in `gitDiffEditDrafts.ts`, keyed by file path with a base-content guard so a stale draft never restores over content that changed on disk. Save, discard, and closing a `git-diff` tab drop the draft.
- Two latent bugs fixed on the way: the list's collapse-signal effect cleared overrides on mount, and `useAllChangesFiles` started empty and filled from an effect, which flashed the "no changes" placeholder and pruned restored state before rows existed.

## Potential risks

- Behaviour change: Review (pane + sidebar) now stays mounted for up to 60 s after you leave it. That is one instance and its diff bodies are only loaded for expanded sections, so the memory cost is bounded, but it is a reversal of the July release-on-leave choice for this one tab.
- A retained tab's renderer must gate side effects on `isActive`. Only Review and the PM trio are listed; four registry renderers publish a workstation header unconditionally and must not be added to the table until guarded (documented in the policy file).
- Virtuoso scroll restore uses saved item sizes; if a diff body is still loading when the list rebuilds after the grace window, the position can settle slightly off.
- The `keepAlive` field was removed from `TabSidebarDescriptor`; the only other user is the archived Benchmark sidebar under `.archive/`, which is tsconfig-excluded.
- Draft persistence for the Focus view survives clearing the focus and re-focusing the same file, by design; closing a `git-diff` tab discards, matching prior behaviour.
- Not verified in the running Tauri app; all evidence is tests and static checks.

## Verification

Commit was built with a temporary index from a live checkout, so the pre-commit hook did not run and there is no `Pre-commit hook ran.` trailer. Run manually on the 34 changed files:

- `pnpm typecheck:fast` (tsgo): clean for this change. It reports one pre-existing error in `CanvasPreviewSurface.tsx` from unrelated uncommitted work in the same checkout.
- `eslint --max-warnings 0 --report-unused-disable-directives <files>`: clean.
- `oxlint -c .oxlintrc.json --max-warnings 0 <files>`: clean.
- `prettier --check <files>`: clean.
- `pnpm run check:test-placement`: consistent across 499 directories.
- `pnpm run check:circular`: no cycle introduced; one pre-existing cycle `util/modelGrouping.ts <-> util/modelVariants.ts` from #1266 is unrelated.
- `vitest run` over `src/store/workstation`, `src/modules/WorkStation`, `src/hooks/tabHost`, `src/modules/ProjectManager/ProjectManagerLayout`: 164 files, 1146 tests passed, including 7 new test files (retention policy, pool hook with fake timers, view-state store, hook remount in jsdom, close-mutation cleanup, diff drafts, list snapshot helpers).
- Full `pnpm test` on the live checkout: 1512 of 1514 files passed, 11360 of 11363 tests. The 3 failures are in `CanvasInlineCard/canvasBuilder.test.ts` and `staticHtmlCanvas.test.ts`, whose sources carry unrelated uncommitted edits in the same checkout; none of those files are in this PR.
- Not run: the Tauri app (no manual click-through), Rust tests (no Rust changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
