### PR TITLE
fix(workstation-browser): group sidebar toggle with browser nav controls

### DIFF
--- a/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
+++ b/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
@@ -45,7 +45,13 @@ const WorkstationTabHeader: React.FC = memo(() => {
     headerSlots?.shellLeadingChromeHidden ?? false;
   const isSourceControlTab =
     activeApp === "code" && activeTab?.type === "source-control";
-  const publishedHeaderPaddingLeftClassName = isSourceControlTab
+  const isBrowserTab = activeApp === "browser";
+  // The Browser app draws its own divider after the back/forward/refresh
+  // buttons (see WebUrlBar), so the sidebar toggle should sit flush against
+  // them here — same gap-px rhythm as the icons within each group — instead
+  // of behind a second, earlier divider.
+  const joinsSidebarGroup = isSourceControlTab || isBrowserTab;
+  const publishedHeaderPaddingLeftClassName = joinsSidebarGroup
     ? "pl-0"
     : "pl-2";
 
@@ -57,9 +63,11 @@ const WorkstationTabHeader: React.FC = memo(() => {
 
   return (
     <div
-      className={`flex h-9 shrink-0 items-center gap-2 pr-2 ${
-        shellLeadingChromeHidden ? "pl-0" : "pl-1.5"
-      } ${headerSlots?.joinWithFollowingRow ? "" : "border-b border-border-2"}`}
+      className={`flex h-9 shrink-0 items-center ${
+        isBrowserTab ? "gap-px" : "gap-2"
+      } pr-2 ${shellLeadingChromeHidden ? "pl-0" : "pl-1.5"} ${
+        headerSlots?.joinWithFollowingRow ? "" : "border-b border-border-2"
+      }`}
       data-tauri-drag-region={windowsHost ? undefined : true}
     >
       {!shellLeadingChromeHidden && (
@@ -72,7 +80,7 @@ const WorkstationTabHeader: React.FC = memo(() => {
             <CodeSidebarHeaderActions />
             <SourceControlHeaderActions />
           </NoDragRegion>
-          {!isSourceControlTab && <HeaderSectionSeparator />}
+          {!joinsSidebarGroup && <HeaderSectionSeparator />}
         </>
       )}
       <PublishedHeaderSlotsView

--- a/src/modules/WorkStation/Browser/Panels/BrowserMainPane/components/WebUrlBar/index.tsx
+++ b/src/modules/WorkStation/Browser/Panels/BrowserMainPane/components/WebUrlBar/index.tsx
@@ -12,6 +12,7 @@ import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
+import { HeaderSectionSeparator } from "@src/components/HeaderSectionSeparator";
 import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip";
 import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import {
@@ -391,6 +392,8 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
             />
           </ToolbarTooltip>
         </div>
+
+        <HeaderSectionSeparator />
 
         {/* URL Input Container */}
         <div


### PR DESCRIPTION
## Problem

In the My Station Browser tab's header, the back/forward/refresh controls
sat behind their own vertical divider, separated from the sidebar-toggle
icon (`src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx`). The
Review (source-control) tab's equivalent nav controls already read as one
group with the sidebar toggle — the Browser tab was the odd one out.

## Solution

- `WorkstationTabHeader.tsx`: extended the existing source-control-only
  "join with sidebar" treatment to the Browser tab too — the shell-level
  divider between the sidebar-toggle region and the published header
  content is now skipped for both tabs, and the row's gap is tightened to
  `gap-px` specifically for the Browser tab so the sidebar icon and the
  back/forward/refresh icons share the same spacing rhythm as the icons
  within each individual group.
- `WebUrlBar/index.tsx`: added the divider back in, but moved to sit right
  after the back/forward/refresh buttons, before the URL input.

Net effect: the header now reads `[sidebar] [back] [forward] [refresh] |
[URL bar]` as one visually grouped cluster, instead of `[sidebar] |
[back] [forward] [refresh] [URL bar]`.

## Potential risks

- The row-gap tightening (`gap-px` vs `gap-2`) is scoped to
  `activeApp === "browser"` only, so the Review/source-control tab and
  every other My Station tab keep their existing spacing — verified by
  reading the unmodified branches of the conditional.
- This is a pure Tailwind-class/JSX layout change with no new state,
  props, or logic branches; no behavioral regression is expected.
- Not visually verified in the running app: ORG2 is a Tauri-only desktop
  app with no web-based preview available in this environment, so this
  was verified by reading the rendered class output and cross-checking
  against the already-shipped Review-tab layout it now matches, rather
  than a screenshot. Recommend a quick eyeball in `tauri dev` on the
  Browser tab before merge.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — no errors reported for either
  changed file.
- `npx prettier --write <files>` — no changes (already formatted).
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <files>` — passed, exit 0.
- `npx eslint --max-warnings 0 --report-unused-disable-directives <files>` —
  passed, exit 0.
- Did not run: full `npm run test` / `check:test-placement` (no test files
  touched, change is a pure layout/class tweak) or a visual screenshot (no
  browser preview available for this Tauri app — see Potential risks).
- This branch was built with a temporary git index isolating only the two
  files above out of a shared, already-dirty `develop` checkout, so no
  pre-commit hooks ran; lint/format were therefore run manually as listed
  above instead of via the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
