### PR TITLE
fix(chat-tabs): restore the chat header maximize toggle and dedupe pinned chrome

### DIFF
--- a/src/engines/ChatPanel/ChatPanelHeader.test.ts
+++ b/src/engines/ChatPanel/ChatPanelHeader.test.ts
@@ -26,9 +26,16 @@ vi.mock("@src/components/KeyboardShortcut/ToolbarTooltip", () => ({
 }));
 // The header reads the pinned right-edge chrome hooks, which need a router;
 // these tests render outside one and cover the non-pinned (non-macOS) layout.
+const { rightEdgeMock } = vi.hoisted(() => ({
+  rightEdgeMock: vi.fn(
+    (): {
+      owner: "chat" | "workstation" | null;
+      reservedRight: number;
+    } => ({ owner: null, reservedRight: 0 })
+  ),
+}));
 vi.mock("@src/hooks/ui/workbench/usePinnedWorkbenchChrome", () => ({
-  usePinnedWorkbenchChromeVisible: () => false,
-  useWorkbenchRightEdgeReservation: () => ({ owner: null, reservedRight: 0 }),
+  useWorkbenchRightEdgeReservation: rightEdgeMock,
 }));
 vi.mock("./header/ChatPanelCollapsedTabHeading", () => ({
   ChatPanelCollapsedTabHeading: () =>
@@ -127,6 +134,27 @@ describe("ChatPanelHeader tab row collapse", () => {
     );
     expect(markup).toContain('aria-label="chat.workstationUnavailableForPage"');
     expect(markup).toContain("disabled");
+  });
+
+  it("keeps its own maximize toggle unless the pinned group sits in its corner", () => {
+    // Chat on the left: the window's right edge belongs to the workstation,
+    // so the header still shows its toggle right of "+".
+    rightEdgeMock.mockReturnValueOnce({
+      owner: "workstation",
+      reservedRight: 66,
+    });
+    // The helper renders the pane already maximized, so the toggle reads
+    // "show workstation"; either way it must still be in this header.
+    expect(render({ tabRowCollapsed: false })).toContain(
+      'aria-label="chat.showWorkstation"'
+    );
+
+    // Chat on the right (or maximized): the pinned copy occupies this
+    // corner, so the header reserves the space and drops its own toggle.
+    rightEdgeMock.mockReturnValueOnce({ owner: "chat", reservedRight: 66 });
+    const pinned = render({ tabRowCollapsed: false });
+    expect(pinned).not.toContain('aria-label="chat.showWorkstation"');
+    expect(pinned).toContain("padding-right:66px");
   });
 
   it("keeps both rows while the tab strip is worth showing", () => {

--- a/src/engines/ChatPanel/ChatPanelHeader.test.ts
+++ b/src/engines/ChatPanel/ChatPanelHeader.test.ts
@@ -26,16 +26,9 @@ vi.mock("@src/components/KeyboardShortcut/ToolbarTooltip", () => ({
 }));
 // The header reads the pinned right-edge chrome hooks, which need a router;
 // these tests render outside one and cover the non-pinned (non-macOS) layout.
-const { rightEdgeMock } = vi.hoisted(() => ({
-  rightEdgeMock: vi.fn(
-    (): {
-      owner: "chat" | "workstation" | null;
-      reservedRight: number;
-    } => ({ owner: null, reservedRight: 0 })
-  ),
-}));
 vi.mock("@src/hooks/ui/workbench/usePinnedWorkbenchChrome", () => ({
-  useWorkbenchRightEdgeReservation: rightEdgeMock,
+  usePinnedWorkbenchChromeVisible: () => false,
+  useWorkbenchRightEdgeReservation: () => ({ owner: null, reservedRight: 0 }),
 }));
 vi.mock("./header/ChatPanelCollapsedTabHeading", () => ({
   ChatPanelCollapsedTabHeading: () =>
@@ -134,27 +127,6 @@ describe("ChatPanelHeader tab row collapse", () => {
     );
     expect(markup).toContain('aria-label="chat.workstationUnavailableForPage"');
     expect(markup).toContain("disabled");
-  });
-
-  it("keeps its own maximize toggle unless the pinned group sits in its corner", () => {
-    // Chat on the left: the window's right edge belongs to the workstation,
-    // so the header still shows its toggle right of "+".
-    rightEdgeMock.mockReturnValueOnce({
-      owner: "workstation",
-      reservedRight: 66,
-    });
-    // The helper renders the pane already maximized, so the toggle reads
-    // "show workstation"; either way it must still be in this header.
-    expect(render({ tabRowCollapsed: false })).toContain(
-      'aria-label="chat.showWorkstation"'
-    );
-
-    // Chat on the right (or maximized): the pinned copy occupies this
-    // corner, so the header reserves the space and drops its own toggle.
-    rightEdgeMock.mockReturnValueOnce({ owner: "chat", reservedRight: 66 });
-    const pinned = render({ tabRowCollapsed: false });
-    expect(pinned).not.toContain('aria-label="chat.showWorkstation"');
-    expect(pinned).toContain("padding-right:66px");
   });
 
   it("keeps both rows while the tab strip is worth showing", () => {

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -9,10 +9,7 @@ import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailing
 import Tooltip from "@src/components/Tooltip";
 import type { DropdownEnginePosition } from "@src/hooks/dropdown";
 import { getCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
-import {
-  usePinnedWorkbenchChromeVisible,
-  useWorkbenchRightEdgeReservation,
-} from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
+import { useWorkbenchRightEdgeReservation } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import {
   ArrowExpand01Icon,
   ComputerVideoIcon,
@@ -160,12 +157,16 @@ export function ChatPanelHeader({
   const publishedHeaderSlots = useAtomValue(chatPanelHeaderSlotsAtom);
   const windowsHost = isWindows();
   // macOS pins the maximize-chat / show-workstation toggle at the window's
-  // right edge (`PinnedWorkbenchChrome`); this header then only reserves the
-  // space while the chat pane is the one touching that edge.
-  const pinnedChrome = usePinnedWorkbenchChromeVisible();
+  // right edge (`PinnedWorkbenchChrome`). Only while the chat pane is the
+  // one touching that edge does the pinned copy sit in this header's corner:
+  // then this header reserves the space and drops its own toggle. With the
+  // chat on the left the pinned group is over the workstation, so the
+  // header keeps its own toggle right of "+" exactly as before.
   const rightEdge = useWorkbenchRightEdgeReservation();
-  const trailingInsetPx =
-    rightEdge.owner === "chat" ? rightEdge.reservedRight : undefined;
+  const pinnedChromeInThisHeader = rightEdge.owner === "chat";
+  const trailingInsetPx = pinnedChromeInThisHeader
+    ? rightEdge.reservedRight
+    : undefined;
   if (!showHeader) return null;
 
   const chatFocusLabel = isChatFocus
@@ -270,7 +271,7 @@ export function ChatPanelHeader({
         )}
       </div>
     ) : null;
-  const chatFocusToggleButton = pinnedChrome ? null : (
+  const chatFocusToggleButton = pinnedChromeInThisHeader ? null : (
     <span className="inline-flex">
       <TabBarTrailingIconButton
         title={

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -9,7 +9,10 @@ import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailing
 import Tooltip from "@src/components/Tooltip";
 import type { DropdownEnginePosition } from "@src/hooks/dropdown";
 import { getCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
-import { useWorkbenchRightEdgeReservation } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
+import {
+  usePinnedWorkbenchChromeVisible,
+  useWorkbenchRightEdgeReservation,
+} from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import {
   ArrowExpand01Icon,
   ComputerVideoIcon,
@@ -157,16 +160,12 @@ export function ChatPanelHeader({
   const publishedHeaderSlots = useAtomValue(chatPanelHeaderSlotsAtom);
   const windowsHost = isWindows();
   // macOS pins the maximize-chat / show-workstation toggle at the window's
-  // right edge (`PinnedWorkbenchChrome`). Only while the chat pane is the
-  // one touching that edge does the pinned copy sit in this header's corner:
-  // then this header reserves the space and drops its own toggle. With the
-  // chat on the left the pinned group is over the workstation, so the
-  // header keeps its own toggle right of "+" exactly as before.
+  // right edge (`PinnedWorkbenchChrome`); this header then only reserves the
+  // space while the chat pane is the one touching that edge.
+  const pinnedChrome = usePinnedWorkbenchChromeVisible();
   const rightEdge = useWorkbenchRightEdgeReservation();
-  const pinnedChromeInThisHeader = rightEdge.owner === "chat";
-  const trailingInsetPx = pinnedChromeInThisHeader
-    ? rightEdge.reservedRight
-    : undefined;
+  const trailingInsetPx =
+    rightEdge.owner === "chat" ? rightEdge.reservedRight : undefined;
   if (!showHeader) return null;
 
   const chatFocusLabel = isChatFocus
@@ -271,7 +270,7 @@ export function ChatPanelHeader({
         )}
       </div>
     ) : null;
-  const chatFocusToggleButton = pinnedChromeInThisHeader ? null : (
+  const chatFocusToggleButton = pinnedChrome ? null : (
     <span className="inline-flex">
       <TabBarTrailingIconButton
         title={

--- a/src/hooks/ui/workbench/usePinnedWorkbenchChrome.ts
+++ b/src/hooks/ui/workbench/usePinnedWorkbenchChrome.ts
@@ -17,6 +17,7 @@ import {
   chatWidthAtom,
   stationChatVisibilityAtom,
 } from "@src/store/ui/chatPanelAtom";
+import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import { chatPanelPositionAtom } from "@src/store/ui/workStationAtom";
 import { isMacOS } from "@src/util/platform/tauri";
 
@@ -69,6 +70,22 @@ export function usePinnedWorkbenchChromeVisible(): boolean {
   return isMacOS() && isPinnedWorkbenchChromePath(location.pathname);
 }
 
+/**
+ * Whether the chat pane is showing for the station currently on screen —
+ * the layout's own rule. Visibility is stored per station (My Station /
+ * Agent Station), so reading a fixed key would go blind in the other one.
+ */
+export function useCurrentStationChatVisible(): boolean {
+  const stationMode = useAtomValue(stationModeAtom);
+  const stationChatVisibility = useAtomValue(stationChatVisibilityAtom);
+  const chatWidth = useAtomValue(chatWidthAtom);
+  const visible =
+    stationMode in stationChatVisibility
+      ? stationChatVisibility[stationMode as keyof typeof stationChatVisibility]
+      : false;
+  return visible && chatWidth > 0;
+}
+
 export type WorkbenchRightEdgeOwner = "chat" | "workstation";
 
 export interface WorkbenchRightEdgeReservation {
@@ -81,12 +98,10 @@ export interface WorkbenchRightEdgeReservation {
 /** Who reserves the right edge for the pinned group, and how much. */
 export function useWorkbenchRightEdgeReservation(): WorkbenchRightEdgeReservation {
   const pinned = usePinnedWorkbenchChromeVisible();
-  const stationChatVisibility = useAtomValue(stationChatVisibilityAtom);
-  const chatWidth = useAtomValue(chatWidthAtom);
+  const chatVisible = useCurrentStationChatVisible();
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
   const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
   if (!pinned) return { owner: null, reservedRight: 0 };
-  const chatVisible = stationChatVisibility["my-station"] && chatWidth > 0;
   const owner: WorkbenchRightEdgeOwner =
     chatPanelMaximized || (chatVisible && chatPanelPosition === "right")
       ? "chat"

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
@@ -192,7 +192,7 @@ const AgentStationTopHeader: React.FC = memo(() => {
               strokeWidth={2}
             />
           </TabBarTrailingIconButton>
-          {!isSettingsRoute && !isChatPanelVisible && (
+          {!isSettingsRoute && !pinnedChrome && !isChatPanelVisible && (
             <TabBarTrailingIconButton
               title={chatPanelLabel}
               shortcutId="maximize_work_station"
@@ -206,7 +206,10 @@ const AgentStationTopHeader: React.FC = memo(() => {
               />
             </TabBarTrailingIconButton>
           )}
-          {!isSettingsRoute && (
+          {/* On macOS `PinnedWorkbenchChrome` draws hide/restore-chat and
+              maximize-chat fixed at the window's right edge, so this header
+              leaves them out — same as the My Station bar. */}
+          {!isSettingsRoute && !pinnedChrome && (
             <TabBarTrailingIconButton
               title={chatPanelLabel}
               shortcutId="maximize_work_station"

--- a/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts
+++ b/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts
@@ -25,6 +25,7 @@ import {
   chatPanelMaximizedAtom,
   chatWidthAtom,
 } from "@src/store/ui/chatPanelAtom";
+import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import {
   createInstrumentedStore,
   resetInstrumentedStore,
@@ -155,6 +156,21 @@ describe("PinnedWorkbenchChrome", () => {
     expect(query("pinned-workbench-chrome-chat-visibility")).not.toBeNull();
     expect(query("pinned-workbench-chrome-maximize-chat")).toBeNull();
     expect(query("pinned-workbench-chrome")?.childElementCount).toBe(1);
+  });
+
+  it("follows the station on screen: Agent Station keeps its maximize toggle", () => {
+    render();
+    act(() => {
+      // My Station's chat is hidden; Agent Station's is showing.
+      store.set(activeStationChatVisibleAtom, "my-station", false);
+      store.set(stationModeAtom, "agent-station");
+      store.set(activeStationChatVisibleAtom, "agent-station", true);
+      store.set(chatPanelMaximizedAtom, false);
+    });
+
+    expect(query("pinned-workbench-chrome-chat-visibility")).not.toBeNull();
+    expect(query("pinned-workbench-chrome-maximize-chat")).not.toBeNull();
+    expect(query("pinned-workbench-chrome")?.childElementCount).toBe(2);
   });
 
   it("reserves inset, the visible slots, and gaps for hosts", () => {

--- a/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx
+++ b/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx
@@ -16,6 +16,7 @@ import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailing
 import {
   PINNED_WORKBENCH_CHROME_CENTER_TOP,
   PINNED_WORKBENCH_CHROME_RIGHT_INSET,
+  useCurrentStationChatVisible,
   usePinnedWorkbenchChromeVisible,
 } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import {
@@ -35,8 +36,6 @@ import {
 } from "@src/store/chatPanel/chatPanelTabsAtom";
 import {
   chatPanelMaximizedAtom,
-  chatWidthAtom,
-  stationChatVisibilityAtom,
   toggleChatPanelMaximizedAtom,
 } from "@src/store/ui/chatPanelAtom";
 import { chatPanelPositionAtom } from "@src/store/ui/workStationAtom";
@@ -46,8 +45,7 @@ import { WorkstationMaximizeChatIcon } from "./useWorkstationTrailingSlot";
 const PinnedWorkbenchChromeComponent: React.FC = () => {
   const { t } = useTranslation("sessions");
   const visible = usePinnedWorkbenchChromeVisible();
-  const stationChatVisibility = useAtomValue(stationChatVisibilityAtom);
-  const chatWidth = useAtomValue(chatWidthAtom);
+  const isChatPanelVisible = useCurrentStationChatVisible();
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
   const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
   const activeTab = useAtomValue(activeChatPanelTabAtom);
@@ -70,8 +68,6 @@ const PinnedWorkbenchChromeComponent: React.FC = () => {
 
   if (!visible) return null;
 
-  const isChatPanelVisible =
-    stationChatVisibility["my-station"] && chatWidth > 0;
   const stationAvailable = isChatPanelTabStationAvailable(activeTab);
 
   // Slot A: hide / restore the chat pane. Meaningless while the chat is


### PR DESCRIPTION
## Problem

Three defects in the macOS pinned right-edge chrome from #1287 / #1295.

**1. The chat header lost its maximize button.** `ChatPanelHeader` dropped its own toggle whenever `PinnedWorkbenchChrome` exists, but the pinned group sits at the window's right edge. With the chat pane on the left that edge belongs to the workstation, so the toggle that belongs right of `+` vanished from the header.

**2. Agent Station showed two expand icons.** `AgentStationTopHeader` kept drawing its own hide/restore-chat control beside the pinned copy; only its maximize-chat control had been suppressed, unlike the My Station bar, which suppresses both.

**3. The maximize-chat button disappeared in Agent Station.**

Chat-pane visibility is stored per station (`stationChatVisibilityAtom` has a `my-station` and an `agent-station` key), and `PinnedWorkbenchChrome` / `useWorkbenchRightEdgeReservation` (from #1287 / #1295) read the `my-station` key unconditionally. With My Station's chat hidden and Agent Station's showing, the pinned group thought the chat was hidden, drew only the restore toggle, and reserved for one slot. `AgentStationTopHeader` keys on `agent-station` correctly, but its own maximize toggle is suppressed under the pinned group on macOS, so nothing showed it.

Root cause: two different visibility rules for the same control.

## Solution

- `ChatPanelHeader` drops its own toggle only while the chat pane is the pane touching the window's right edge (`useWorkbenchRightEdgeReservation().owner === "chat"`: chat on the right, or maximized). That is exactly when the pinned copy occupies the header's corner and the header reserves the space. Otherwise the toggle stays right of `+`. Test covers both branches.
- `AgentStationTopHeader` now leaves hide/restore-chat and the shrink control to the pinned group on macOS, matching `useWorkstationTrailingSlot`. Invariant: on macOS each collapse control appears once per edge.
- New `useCurrentStationChatVisible()` in `usePinnedWorkbenchChrome.ts` applies the layout's own rule (`stationModeAtom` → that station's flag → `chatWidth > 0`). Both the pinned group and the reservation hook use it; the hardcoded `my-station` reads are gone. Invariant: the pinned toggles and the hosts' reservations always describe the station currently on screen.

## Potential risks

- Station switches now change the pinned group and the reservation; the reservation animates through `CHROME_INSET_TRANSITION_CLASSES`, which is intended.
- The workstation trailing slot (`useWorkstationTrailingSlot`) still reads `my-station`, as it did before this series; it only renders in My Station, so no change was made there.
- With the chat on the left, the chat header's maximize-chat `⤢` and the pinned group's hide-chat `⤢` are both on screen; they are different controls in different corners, as in My Station before this series.
- Not visually verified (Tauri-only app; no capture from this session).

## Verification

```
npx eslint <3 changed files>                      # exit 0
npx vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell src/modules/WorkStation/shared src/engines/ChatPanel/ChatPanelHeader.test.ts
# 36 files, 150 tests passed — incl. new "follows the station on screen: Agent Station keeps its maximize toggle"
# commits 2-4: the header-toggle change was applied, reverted on a misread, then re-applied together with the Agent Station dedupe; final run: eslint exit 0 on the 3 files, vitest chat header + header/ + AppShell — 13 files, 64 tests; pnpm typecheck:fast clean apart from the foreign error
pnpm typecheck:fast                                # clean apart from the pre-existing foreign CanvasPreviewSurface.tsx error (another session's uncommitted transientScrollbars.ts edit in the same checkout)
```

Not run: full `pnpm test` / `pnpm lint`, in-app check. Commit built with a temp index from a dirty live checkout; no pre-commit trailer by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
