### PR TITLE
test(perf-utils): tolerate transient reclaim in the macOS region walk

### DIFF
--- a/src-tauri/crates/perf-utils/src/app_memory/tests.rs
+++ b/src-tauri/crates/perf-utils/src/app_memory/tests.rs
@@ -269,23 +269,53 @@ fn macos_current_process_has_physical_footprint() {
 }
 
 #[cfg(target_os = "macos")]
+fn private_or_swapped(breakdown: &types::MemoryBreakdown) -> u64 {
+    breakdown
+        .resident_private_bytes
+        .saturating_add(breakdown.swapped_bytes)
+}
+
+#[cfg(target_os = "macos")]
 #[test]
 fn macos_region_walk_splits_current_process() {
     // Dirty a private allocation so the walk has something unambiguous to
     // find. Under memory pressure the kernel may compress these pages
     // immediately, so the invariant is "resident or swapped", never
     // "resident" alone.
+    //
+    // Two transient kernel states can still leave a single walk short of
+    // the buffer, and the shared CI runners hit them:
+    // - a page mid-reclaim is briefly neither resident nor in the
+    //   compressor, so the sum can run a page or two under the allocation;
+    // - a copy-on-write snapshot of the address space (fork-style) taken
+    //   while the buffer is being dirtied leaves the pages written before
+    //   it in a backing object that the walk reports as shared, not
+    //   private.
+    // Re-dirtying moves every page back into a private object and a few
+    // pages of slack absorb reclaim in flight. A struct-layout mismatch
+    // still fails: it yields zero or absurd totals on every walk.
     const PINNED: u64 = 32 * 1024 * 1024;
-    let pinned = vec![7_u8; PINNED as usize];
+    const SLACK_PAGES: u64 = 4;
+    const MAX_WALKS: u8 = 5;
+    let page_size = unsafe { libc::vm_page_size } as u64;
+    let floor = PINNED - SLACK_PAGES * page_size;
+    let pid = std::process::id();
+    let mut pinned = vec![7_u8; PINNED as usize];
     std::hint::black_box(&pinned);
-    let breakdown = macos_region_breakdown(std::process::id());
+    let mut breakdown = macos_region_breakdown(pid);
+    let mut walks = 1;
+    while private_or_swapped(&breakdown) < floor && walks < MAX_WALKS {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        pinned.fill(7 + walks);
+        std::hint::black_box(&pinned);
+        breakdown = macos_region_breakdown(pid);
+        walks += 1;
+    }
     assert_eq!(breakdown.kind, MemoryBreakdownKind::VmRegionWalk);
-    let private = breakdown
-        .resident_private_bytes
-        .saturating_add(breakdown.swapped_bytes);
+    let private = private_or_swapped(&breakdown);
     assert!(
-        private >= PINNED,
-        "private resident {} + swapped {} should cover the pinned 32 MiB",
+        private >= floor,
+        "private resident {} + swapped {} should cover the pinned 32 MiB within {SLACK_PAGES} pages after {walks} walks",
         breakdown.resident_private_bytes,
         breakdown.swapped_bytes
     );
@@ -296,7 +326,7 @@ fn macos_region_walk_splits_current_process() {
     // A struct-layout mismatch would read addresses or sizes as page
     // counts and produce absurd totals; the real split stays in the same
     // order of magnitude as the kernel's own footprint ledger.
-    let usage = macos_rusage(std::process::id()).expect("current process rusage");
+    let usage = macos_rusage(pid).expect("current process rusage");
     let ceiling = usage
         .ri_phys_footprint
         .saturating_mul(2)


### PR DESCRIPTION
## Problem

`app_memory::tests::macos_region_walk_splits_current_process` is flaky on the `macos-latest` runner. Attempt 1 of CI run 34022324236, on #1310 (which does not touch perf-utils), failed with:

```
private resident 33538048 + swapped 0 should cover the pinned 32 MiB
```

The test dirties a 32 MiB private buffer and asserts, with zero slack, that one `PROC_PIDREGIONINFO` walk reports a process-wide `resident_private + swapped` that covers it. Two kernel-side transients break that on a loaded runner:

- A page being reclaimed sits briefly in neither bucket, so the sum can run a page short. The test's own comment already anticipates reclaim; the invariant just left no room for it.
- A copy-on-write snapshot of the address space (fork-style, taken by another actor) while the buffer is being dirtied moves every page written before the snapshot into a backing object behind a shadow. `vm_map_region_top_walk` reports those pages as shared, not private, so the private sum drops by however many pages were already written, and the process's pre-existing private pages (heap, stacks) vanish from the sum the same way. That matches the CI numbers: the entire baseline disappeared, not just one page of the buffer.

I caught the second mechanism locally once in a full parallel run: a sibling 32 MiB region read `share=SM_COW refs=2 depth=1 private=2036 shared=13`, 12 pages short with `swapped 0`. The originator of that snapshot was not identified. lldb breakpoints on `fork`, `vfork` and `__fork` never fired across single-threaded and parallel runs, and `posix_spawn` (what the concurrent `sw_vers` probe uses) does not snapshot the parent. Injecting `fork()` from a sibling test reproduces the failure deterministically.

## Solution

Keep the walk under test unchanged and make the assertion re-establish its precondition instead of trusting a single instant:

- Walk once after dirtying, as before. If the sum is short, sleep 10 ms, re-dirty the whole buffer, and walk again, up to five walks. Re-dirtying moves every page into a fresh private object whether the snapshot holder is still alive (pages copy into a new shadow) or gone (the chain collapses on the write fault).
- Allow four pages of slack, with the page size taken from `libc::vm_page_size`, the walk's own unit, and report the slack and walk count in the failure message.
- The shared-resident and order-of-magnitude ceiling assertions are unchanged; the ceiling now bounds the final sum.

A struct-layout mismatch still fails: shifting the counts by one field yields zero or absurd totals on every walk, which four pages of slack cannot absorb.

## Potential risks

- Under a continuous stream of snapshots faster than a 32 MiB memset (a fork storm inside the test process) the kernel keeps reporting the buffer as shared and the test still fails after five walks. That is a synthetic condition; the CI failure was a single snapshot, and nothing in the perf-utils suite forks.
- The retry adds at most about 60 ms to this one test, and only when the first walk is short.
- Pre-existing limit, unchanged here: swapping only the `pri_private_pages_resident` and `pri_shared_pages_resident` fields passes both the old and the new assertion, because any process's shared-resident total is far larger than 32 MiB. The test guards against shifted layouts, not against that particular swap.
- macOS-only test; the Linux and Windows paths are untouched.

## Verification

Local: Apple Silicon, macOS 26.3 (Darwin 25.3.0), 16 KiB pages, rustc 1.98.0. All temporary probes and edits below were removed before committing; the diff is the test file only.

- `cargo test -p perf_utils --lib app_memory`: 20 passed, 1 ignored.
- `cargo clippy -p perf_utils --all-targets -- -D warnings`: clean.
- Full `perf_utils` lib test binary at default parallelism, 50 consecutive runs: 0 failures.
- Fault injection: a temporary sibling test forking children that live 400 ms, every 3 ms for the first 30 ms, run with `--test-threads=3` alongside a verbatim copy of the old assertion and the new one, 20 runs: old assertion failed 20/20, new assertion failed 0/20. Denser burst (every 1 ms for 60 ms, children live 2 s), 10 runs: old 10/10, new 0/10.
- Layout-mismatch check, temporary edit to `platform/macos.rs` then reverted: inserting a `u32` before `pri_pages_resident` makes the new assertion fail.
- CI on this PR (run 34026557921, `macos-26-arm64`): `Rust (clippy)` green in 21m33s; `perf_utils` lib tests 65 passed, 1 ignored, with `macos_region_walk_splits_current_process ... ok`. `Enforce PR contract` and `Frontend` green; `cargo audit` skipped by CI scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
