### PR TITLE
fix(model-parsing): remove circular dependency

### DIFF
--- a/src/util/modelGrouping.ts
+++ b/src/util/modelGrouping.ts
@@ -8,7 +8,11 @@
  * - "current" = latest generation
  * - "older"   = previous generation
  */
-import { isModelVariantSuffixToken } from "./modelVariants";
+import {
+  extractGptModelTier,
+  isModelVariantSuffixToken,
+  stripCursorHostedModelPrefix,
+} from "./modelNameGrammar";
 
 export interface ModelGroup {
   label: string;
@@ -53,32 +57,6 @@ interface ParsedGroup {
   sortVersion: number;
 }
 
-/** Longest-first so codex-max wins over codex. */
-const GPT_TIER_PREFIXES = [
-  "codex-max",
-  "codex-mini",
-  "nano",
-  "mini",
-  "codex",
-  "astra",
-  "sol",
-  "terra",
-  "luna",
-] as const;
-
-function extractGptTier(rest: string): string | undefined {
-  for (const tier of GPT_TIER_PREFIXES) {
-    if (rest === tier || rest.startsWith(`${tier}-`)) {
-      return tier;
-    }
-  }
-  return undefined;
-}
-
-export function extractGptModelTier(rest: string): string | undefined {
-  return extractGptTier(rest);
-}
-
 function formatGptTierLabel(tier: string): string {
   return tier
     .split("-")
@@ -87,32 +65,6 @@ function formatGptTierLabel(tier: string): string {
 }
 
 const CURSOR_TIER_MODELS = new Set(["default", "auto", "premium"]);
-
-export const CURSOR_HOSTED_MODEL_PREFIX = "cursor-";
-
-/** Strip KeyVault's `cursor-` hosted prefix before family/variant parsing. */
-export function stripCursorHostedModelPrefix(modelName: string): {
-  isCursorHosted: boolean;
-  coreModelName: string;
-} {
-  const lower = modelName.toLowerCase();
-  if (lower.startsWith(CURSOR_HOSTED_MODEL_PREFIX)) {
-    return {
-      isCursorHosted: true,
-      coreModelName: modelName.slice(CURSOR_HOSTED_MODEL_PREFIX.length),
-    };
-  }
-  return { isCursorHosted: false, coreModelName: modelName };
-}
-
-export function withCursorHostedModelPrefix(
-  coreModelName: string,
-  isCursorHosted: boolean
-): string {
-  return isCursorHosted
-    ? `${CURSOR_HOSTED_MODEL_PREFIX}${coreModelName}`
-    : coreModelName;
-}
 
 function formatCursorTierLabel(modelName: string): string {
   return modelName.charAt(0).toUpperCase() + modelName.slice(1);
@@ -245,7 +197,7 @@ function parseModelGroup(modelName: string): ParsedGroup {
             sortVersion: versionStringToSortVersion(versionMatch[1]),
           };
         }
-        const tier = extractGptTier(rest);
+        const tier = extractGptModelTier(rest);
         const distinctTokens = tier
           ? rest
               .slice(tier.length)

--- a/src/util/modelNameGrammar.ts
+++ b/src/util/modelNameGrammar.ts
@@ -1,0 +1,69 @@
+/** Shared model-ID grammar used by grouping and effort-variant parsing. */
+
+/** Longest-first so codex-max wins over codex. */
+const GPT_TIER_PREFIXES = [
+  "codex-max",
+  "codex-mini",
+  "nano",
+  "mini",
+  "codex",
+  "astra",
+  "sol",
+  "terra",
+  "luna",
+] as const;
+
+const MODEL_VARIANT_SUFFIX_TOKENS = new Set<string>([
+  "none",
+  "low",
+  "medium",
+  "high",
+  "extra",
+  "extra-high",
+  "xhigh",
+  "ultra",
+  "max",
+  "ultracode",
+  "minimal",
+  "thinking",
+  "fast",
+]);
+
+const CURSOR_HOSTED_MODEL_PREFIX = "cursor-";
+
+export function extractGptModelTier(rest: string): string | undefined {
+  for (const tier of GPT_TIER_PREFIXES) {
+    if (rest === tier || rest.startsWith(`${tier}-`)) {
+      return tier;
+    }
+  }
+  return undefined;
+}
+
+export function isModelVariantSuffixToken(token: string): boolean {
+  return MODEL_VARIANT_SUFFIX_TOKENS.has(token.toLowerCase());
+}
+
+/** Strip KeyVault's `cursor-` hosted prefix before family/variant parsing. */
+export function stripCursorHostedModelPrefix(modelName: string): {
+  isCursorHosted: boolean;
+  coreModelName: string;
+} {
+  const lower = modelName.toLowerCase();
+  if (lower.startsWith(CURSOR_HOSTED_MODEL_PREFIX)) {
+    return {
+      isCursorHosted: true,
+      coreModelName: modelName.slice(CURSOR_HOSTED_MODEL_PREFIX.length),
+    };
+  }
+  return { isCursorHosted: false, coreModelName: modelName };
+}
+
+export function withCursorHostedModelPrefix(
+  coreModelName: string,
+  isCursorHosted: boolean
+): string {
+  return isCursorHosted
+    ? `${CURSOR_HOSTED_MODEL_PREFIX}${coreModelName}`
+    : coreModelName;
+}

--- a/src/util/modelVariants.ts
+++ b/src/util/modelVariants.ts
@@ -1,8 +1,9 @@
 import {
   extractGptModelTier,
+  isModelVariantSuffixToken,
   stripCursorHostedModelPrefix,
   withCursorHostedModelPrefix,
-} from "./modelGrouping";
+} from "./modelNameGrammar";
 
 export const MODEL_REASONING_LEVEL = {
   NONE: "none",
@@ -48,22 +49,6 @@ const GPT_BASE_PATTERN = /^(gpt-\d+(?:\.\d+)?)(?:-(.+))?$/i;
 const COMPOSER_BASE_PATTERN = /^(composer-\d+(?:\.\d+)?)(?:-(.+))?$/i;
 const O_SERIES_BASE_PATTERN = /^o(\d+(?:\.\d+)?)(?:-(.+))?$/i;
 
-const VARIANT_SUFFIX_TOKENS = new Set<string>([
-  "none",
-  "low",
-  "medium",
-  "high",
-  "extra",
-  "extra-high",
-  "xhigh",
-  "ultra",
-  "max",
-  "ultracode",
-  "minimal",
-  "thinking",
-  "fast",
-]);
-
 function normalizeReasoning(
   value: string | undefined
 ): ModelReasoningLevel | undefined {
@@ -95,7 +80,7 @@ function collectSuffixTokens(
   const suffixTokens: string[] = [];
   while (baseSegments.length > minBaseLength) {
     const last = baseSegments.at(-1);
-    if (!last || !VARIANT_SUFFIX_TOKENS.has(last)) break;
+    if (!last || !isModelVariantSuffixToken(last)) break;
     suffixTokens.unshift(last);
     baseSegments.pop();
   }
@@ -255,10 +240,6 @@ function parseOSeriesVariant(model: string): ModelVariantMetadata | undefined {
       ? `${versionRoot}-${baseSegments.join("-")}`
       : versionRoot;
   return buildVariant(model, baseModel, suffixTokens);
-}
-
-export function isModelVariantSuffixToken(token: string): boolean {
-  return VARIANT_SUFFIX_TOKENS.has(token.toLowerCase());
 }
 
 export function parseModelVariant(


### PR DESCRIPTION
## Problem

`modelGrouping.ts` imported the model-variant suffix classifier from `modelVariants.ts`, while `modelVariants.ts` already imported GPT-tier and Cursor-prefix parsing helpers from `modelGrouping.ts`. This created a runtime import cycle and caused `pnpm check:circular` to fail.

## Solution

Move the shared model-ID grammar into a dependency-free `modelNameGrammar.ts` leaf module. Model grouping and variant parsing now consume the same GPT-tier, effort-suffix, and Cursor-prefix definitions without importing each other. Parsing behavior is unchanged.

## Potential risks

The change relocates internal helper exports, so an untracked consumer using a deep import from the old modules would need to use the new module path. A repository-wide search found no such consumers. There are no dependency, persistence, wire-protocol, concurrency, lifecycle, platform, rollout, or data-format changes; rollback is a normal commit revert.

## Verification

- `pnpm check:circular` — passed; no circular dependencies across 6,588 modules
- `pnpm typecheck` — passed
- `pnpm typecheck:fast` — passed
- `pnpm lint` — passed
- `pnpm exec vitest run --config config/vitest.config.ts src/util/__tests__/modelGrouping.test.ts src/util/__tests__/modelVariants.test.ts src/util/__tests__/formatModelName.test.ts src/util/__tests__/variantEditOptions.test.ts` — passed; 75 tests
- `pnpm exec prettier --check src/util/modelNameGrammar.ts src/util/modelGrouping.ts src/util/modelVariants.ts` — passed
- `pnpm check:unused-exports` — not clean at repository baseline: it reports 1,764 pre-existing unused exports; none are from `modelNameGrammar.ts`
- UI screenshots were not taken because this is an internal dependency-boundary change with no visual behavior change

## Architecture audit

Compilation, dependency ownership, naming, semantic separation, default branches, shared-module boundaries, and new-developer clarity were reviewed for the affected model-parsing scope. The new leaf module has no incoming domain dependency and no duplicate definitions remain. Wire serialization, initialization parity, and resolver symmetry are not touched by this change.