### PR TITLE
refactor(work-management): unify routine list details

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/RoutineRunsSurface.md
+++ b/docs/frontend-ui-audit-2026-09-07/RoutineRunsSurface.md
@@ -1,0 +1,17 @@
+# RoutineRunsSurface UI audit
+
+| Line                                  | Element                       | Verdict          | Reason                                                                                                                                   | Suggested change |
+| ------------------------------------- | ----------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `RoutineRunsSurface.tsx:131`          | Runs navigation list          | keep with reason | Reuses `CompactListPanel`, the same keyboard-accessible list primitive used by PR and Issue split panes.                                 | None.            |
+| `RoutineRunsSurface.tsx:206`          | Run detail pane               | keep with reason | Reuses `DetailPaneLayout` and its standard header, placeholder, and close action contract.                                               | None.            |
+| `RoutineRunsSurface.tsx:245`          | Work Item action row          | keep with reason | The raw button is a domain-specific full-width action inside the detail body; it is not a selectable navigation row or a toolbar action. | None.            |
+| `RoutineRunsSurface.tsx:370`          | Split list header             | keep with reason | Reuses the two-row `SplitListHeader` composition already used by compact PR and Issue lists.                                             | None.            |
+| `RoutineRunsSurface.tsx:382`          | Split-list search             | keep with reason | Reuses `WorkManagementSearchInput` with fill width in the compact left-pane row.                                                         | None.            |
+| `RoutineRunsSurface.tsx:395`          | Fullscreen list header        | keep with reason | Reuses the standard full-width header with left context and a fixed-width right control group.                                           | None.            |
+| `RoutineRunsSurface.tsx:461`          | Runs master-detail layout     | keep with reason | Reuses `InboxListDetailLayout` rather than introducing a Routine-specific splitter or width policy.                                      | None.            |
+| `RoutineWebhooksPanel.tsx:203`        | Webhook detail pane           | keep with reason | Reuses `DetailPaneLayout`; existing install, rotate, copy, replay, and refresh controls remain design-system buttons.                    | None.            |
+| `RoutineWebhooksPanel.tsx:470`        | Webhooks navigation list      | keep with reason | Reuses `CompactListPanel` and the same selected-row semantics as the Runs list.                                                          | None.            |
+| `RoutineWebhooksPanel.tsx:481`        | Webhooks master-detail layout | keep with reason | Reuses `InboxListDetailLayout`, preserving the split/fullscreen behavior when switching Routine tabs.                                    | None.            |
+| `WorkManagementDatasetSwitch.tsx:133` | Runs dataset option           | keep with reason | Extends the existing shared dataset selector and icon pattern; no parallel Routine-only selector is introduced.                          | None.            |
+
+Verdict totals: **0 fix**, **11 keep with reason**, **0 abstract**.

--- a/src/modules/MainApp/WorkManagement/RoutineRunsSurface.test.ts
+++ b/src/modules/MainApp/WorkManagement/RoutineRunsSurface.test.ts
@@ -1,0 +1,68 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import RoutineRunsSurface, { searchRoutineRuns } from "./RoutineRunsSurface";
+import { WorkManagementSplitHeaderContext } from "./workManagementSplitHeaderContext";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/hooks/navigation", () => ({
+  useRoutineResultNavigation: () => vi.fn(),
+}));
+
+describe("RoutineRunsSurface", () => {
+  it("uses the shared Work Management list-detail layout", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        WorkManagementSplitHeaderContext.Provider,
+        {
+          value: {
+            splitDatasetControl: createElement("span", {
+              "data-testid": "split-dataset-control",
+            }),
+            surfaceDatasetControl: createElement("span", {
+              "data-testid": "surface-dataset-control",
+            }),
+          },
+        },
+        createElement(RoutineRunsSurface)
+      )
+    );
+
+    expect(markup).toContain('data-layout-mode="split"');
+    expect(markup).toContain('data-testid="routine-runs-compact-list"');
+    expect(markup).toContain('data-testid="routine-run-detail-pane"');
+    expect(markup).toContain('data-split-list-header="true"');
+    expect(markup).toContain('data-testid="split-dataset-control"');
+    expect(markup).not.toContain('data-testid="surface-dataset-control"');
+    expect(markup).toContain('data-split-list-header-row="secondary"');
+    expect(markup).toContain("mx-0.5");
+    expect(markup).toContain('data-testid="routine-search"');
+    expect(markup).toContain("w-full min-w-0");
+    expect(markup).toContain('data-testid="routine-runs-refresh"');
+    expect(markup).toContain('data-testid="split-list-fullscreen-toggle"');
+  });
+
+  it("searches runs across their visible identity and status fields", () => {
+    const runs = [
+      {
+        id: "run-42",
+        routineName: "Nightly triage",
+        routineRevision: 3,
+        scopeId: "org2/core",
+        status: "succeeded",
+        rootWorkItemId: "WI-42",
+        createdBy: "scheduler",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    ];
+
+    expect(searchRoutineRuns(runs, "nightly")).toEqual(runs);
+    expect(searchRoutineRuns(runs, "wi-42")).toEqual(runs);
+    expect(searchRoutineRuns(runs, "failed")).toEqual([]);
+  });
+});

--- a/src/modules/MainApp/WorkManagement/RoutineRunsSurface.tsx
+++ b/src/modules/MainApp/WorkManagement/RoutineRunsSurface.tsx
@@ -2,13 +2,18 @@
  * RoutineRunsSurface
  *
  * The Runs navigation surface (orgtrack/v1 §7.2): rows from
- * `pm_routine_runs`, newest first, each expandable into the run's
- * generated WorkItem graph with portable states. Status comes from the
- * durable ordered projection (`project_routine_run_status`), not from a
- * cached copy — a run whose items moved since the row was written shows
- * its recomputed status once expanded.
+ * `pm_routine_runs`, newest first, with the selected run's generated WorkItem
+ * graph shown in the shared Work Management detail pane. Status comes from the
+ * durable ordered projection (`project_routine_run_status`), not from a cached
+ * copy.
  */
-import React, { Suspense, useCallback, useEffect, useState } from "react";
+import React, {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -16,18 +21,26 @@ import {
   type RoutineRunSummary,
   projectApi,
 } from "@src/api/http/project";
-import Button from "@src/components/Button";
+import { HeaderSectionSeparator } from "@src/components/HeaderSectionSeparator";
 import Message from "@src/components/Message";
 import { Placeholder } from "@src/components/Placeholder";
 import TabPill from "@src/components/TabPill";
 import { useRoutineResultNavigation } from "@src/hooks/navigation";
-import {
-  ArrowDown01Icon,
-  ArrowRight01Icon,
-  HugeiconsIcon,
-  PlayCircleIcon,
-  Refresh04Icon,
-} from "@src/icons";
+import { usePublishWorkstationTabHeader } from "@src/hooks/tabHost/useWorkstationTabHeader";
+import { HugeiconsIcon, PlayCircleIcon } from "@src/icons";
+import CompactListPanel, {
+  type CompactListPanelEntry,
+} from "@src/modules/shared/components/CompactListPanel";
+import { WorkManagementRefreshButton } from "@src/modules/shared/components/WorkManagementRefreshButton";
+import { WorkManagementSearchInput } from "@src/modules/shared/components/WorkManagementSearchInput";
+import DetailPaneLayout, {
+  DetailPanePlaceholder,
+} from "@src/modules/shared/layouts/DetailPaneLayout";
+import InboxListDetailLayout from "@src/modules/shared/layouts/InboxListDetailLayout";
+import SplitListFullscreenButton from "@src/modules/shared/layouts/SplitListFullscreenButton";
+import SplitListHeader from "@src/modules/shared/layouts/SplitListHeader";
+
+import { useWorkManagementSplitHeader } from "./workManagementSplitHeaderContext";
 
 const RoutineWebhooksPanel = React.lazy(() => import("./RoutineWebhooksPanel"));
 
@@ -39,6 +52,25 @@ const STATUS_TONE: Record<string, string> = {
   cancelled: "text-text-3",
 };
 
+export function searchRoutineRuns(
+  runs: readonly RoutineRunSummary[],
+  query: string
+): RoutineRunSummary[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return [...runs];
+
+  return runs.filter((run) =>
+    [
+      run.routineName,
+      run.id,
+      run.scopeId,
+      run.rootWorkItemId,
+      run.status,
+      run.createdBy,
+    ].some((value) => value?.toLocaleLowerCase().includes(normalizedQuery))
+  );
+}
+
 const RunStatusLabel: React.FC<{ status: string }> = ({ status }) => (
   <span
     className={`text-[12px] font-medium ${STATUS_TONE[status] ?? "text-text-2"}`}
@@ -47,39 +79,82 @@ const RunStatusLabel: React.FC<{ status: string }> = ({ status }) => (
   </span>
 );
 
-interface RunRowProps {
-  run: RoutineRunSummary;
+interface RoutineRunsListProps {
+  runs: readonly RoutineRunSummary[];
+  selectedRunId: string | null;
+  loading: boolean;
+  emptyContent: React.ReactNode;
+  onSelectRun: (run: RoutineRunSummary) => void;
 }
 
-const RunRow: React.FC<RunRowProps> = ({ run }) => {
+const RoutineRunsList: React.FC<RoutineRunsListProps> = ({
+  runs,
+  selectedRunId,
+  loading,
+  emptyContent,
+  onSelectRun,
+}) => {
   const { t } = useTranslation("sessions");
-  const [expanded, setExpanded] = useState(false);
+  const entries = useMemo<CompactListPanelEntry[]>(
+    () =>
+      runs.map((run) => ({
+        key: run.id,
+        title: run.routineName,
+        titlePrefix: `rev ${run.routineRevision}`,
+        time: new Date(run.createdAt).toLocaleString(),
+        metadata: (
+          <span className="truncate">
+            {run.id} · {run.scopeId}
+          </span>
+        ),
+        leading: (
+          <HugeiconsIcon
+            icon={PlayCircleIcon}
+            data-icon="play-circle"
+            size={14}
+            strokeWidth={1.8}
+            aria-hidden="true"
+          />
+        ),
+        leadingClassName: STATUS_TONE[run.status] ?? "text-text-3",
+        ariaLabel: `${run.routineName}, ${run.status}, ${run.scopeId}`,
+        dataAttributes: {
+          "data-testid": "routine-run-row",
+          "data-run-id": run.id,
+        },
+        onSelect: () => onSelectRun(run),
+      })),
+    [onSelectRun, runs]
+  );
+
+  return (
+    <CompactListPanel
+      ariaLabel={t("kanban.sidebar.runs", { defaultValue: "Runs" })}
+      entries={entries}
+      selectedEntryKey={selectedRunId}
+      loading={loading}
+      emptyContent={emptyContent}
+      testId="routine-runs-compact-list"
+    />
+  );
+};
+
+interface RoutineRunDetailPaneProps {
+  run: RoutineRunSummary | null;
+  onClose: () => void;
+}
+
+const RoutineRunDetailPane: React.FC<RoutineRunDetailPaneProps> = ({
+  run,
+  onClose,
+}) => {
+  const { t } = useTranslation(["sessions", "projects", "common"]);
   const [detail, setDetail] = useState<RoutineRunStatus | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
   const openResult = useRoutineResultNavigation();
 
-  const openWorkItem = useCallback(
-    (workItemId: string) => {
-      void openResult({
-        workItemId,
-        projectSlug: run.scopeId,
-      }).catch(() =>
-        Message.error(
-          t("kanban.openRoutineWorkItemError", {
-            defaultValue: "Could not open the Work Item",
-          })
-        )
-      );
-    },
-    [openResult, run.scopeId, t]
-  );
-
-  const toggle = useCallback(() => {
-    setExpanded((previous) => !previous);
-  }, []);
-
   useEffect(() => {
-    if (!expanded || detail) return;
+    if (!run) return;
     let cancelled = false;
     projectApi
       .routineRunStatus(run.id)
@@ -87,93 +162,121 @@ const RunRow: React.FC<RunRowProps> = ({ run }) => {
         if (!cancelled) setDetail(status);
       })
       .catch((error: unknown) => {
-        if (!cancelled)
+        if (!cancelled) {
           setDetailError(
             error instanceof Error ? error.message : String(error)
           );
+        }
       });
     return () => {
       cancelled = true;
     };
-  }, [expanded, detail, run.id]);
+  }, [run]);
 
-  const Chevron = expanded ? ArrowDown01Icon : ArrowRight01Icon;
-  const liveStatus = detail?.status ?? run.status;
+  const openWorkItem = useCallback(
+    (workItemId: string) => {
+      if (!run) return;
+      void openResult({
+        workItemId,
+        projectSlug: run.scopeId,
+      }).catch(() =>
+        Message.error(
+          t("sessions:kanban.openRoutineWorkItemError", {
+            defaultValue: "Could not open the Work Item",
+          })
+        )
+      );
+    },
+    [openResult, run, t]
+  );
+
+  if (!run) {
+    return (
+      <DetailPaneLayout testId="routine-run-detail-pane">
+        <DetailPanePlaceholder
+          variant="empty"
+          title={t("common:teamInbox.empty.selectTitle")}
+          subtitle={t("common:teamInbox.empty.selectSubtitle")}
+        />
+      </DetailPaneLayout>
+    );
+  }
 
   return (
-    <div className="border-b border-border-1">
-      <button
-        type="button"
-        onClick={toggle}
-        data-testid={`routine-run-row-${run.id}`}
-        className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-fill-1"
-      >
-        <HugeiconsIcon
-          icon={Chevron}
-          size={14}
-          strokeWidth={1.75}
-          className="shrink-0 text-text-3"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-medium text-text-1">
-            {run.routineName}
-            <span className="ml-1 text-[11px] text-text-3">
-              rev {run.routineRevision}
-            </span>
+    <DetailPaneLayout
+      testId="routine-run-detail-pane"
+      header={{
+        title: run.routineName,
+        subtitle: `rev ${run.routineRevision}`,
+        icon: PlayCircleIcon,
+        actions: <RunStatusLabel status={detail?.status ?? run.status} />,
+      }}
+      onClose={onClose}
+      closeTestId="routine-run-detail-close"
+    >
+      {detailError ? (
+        <DetailPanePlaceholder variant="error" subtitle={detailError} />
+      ) : !detail ? (
+        <DetailPanePlaceholder variant="loading" />
+      ) : (
+        <div
+          className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"
+          data-testid={`routine-run-detail-${run.id}`}
+        >
+          <div className="rounded-lg bg-fill-1 px-3 py-2.5 text-[12px] text-text-2">
+            <div className="font-medium text-text-1">{detail.id}</div>
+            <div className="mt-1 text-text-3">
+              {detail.scopeId}
+              {detail.rootWorkItemId ? ` · ${detail.rootWorkItemId}` : ""}
+            </div>
           </div>
-          <div className="truncate text-[11px] text-text-3">
-            {run.id} · {run.scopeId}
-            {run.rootWorkItemId ? ` · ${run.rootWorkItemId}` : ""}
-          </div>
-        </div>
-        <RunStatusLabel status={liveStatus} />
-        <span className="shrink-0 text-[11px] text-text-3">
-          {new Date(run.createdAt).toLocaleString()}
-        </span>
-      </button>
-      {expanded && (
-        <div className="px-11 pb-3">
-          {detailError ? (
-            <div className="text-[12px] text-danger-6">{detailError}</div>
-          ) : !detail ? (
-            <div className="text-[12px] text-text-3">…</div>
-          ) : detail.workItems.length === 0 ? (
-            <div className="text-[12px] text-text-3">—</div>
-          ) : (
-            <ul className="flex flex-col gap-1">
-              {detail.workItems.map((item) => (
-                <li key={item.shortId} className="text-[12px]">
-                  <button
-                    type="button"
-                    className="flex w-full items-center gap-2 rounded px-1 py-1 text-left hover:bg-fill-1"
-                    onClick={() => openWorkItem(item.shortId)}
-                    data-testid={`routine-run-work-item-${item.shortId}`}
-                  >
-                    <span className="font-medium text-primary-6">
-                      {item.shortId}
-                    </span>
-                    <span className="min-w-0 flex-1 truncate text-text-2">
-                      {item.title}
-                    </span>
-                    <span className="text-text-3">
-                      {item.portableState ?? item.status}
-                    </span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
+          <section className="flex flex-col gap-2">
+            <h3 className="text-[12px] font-medium text-text-1">
+              {t("projects:workspace.workItems")}
+            </h3>
+            {detail.workItems.length === 0 ? (
+              <Placeholder variant="empty" />
+            ) : (
+              <ul className="flex flex-col gap-1">
+                {detail.workItems.map((item) => (
+                  <li key={item.shortId}>
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] hover:bg-fill-1"
+                      onClick={() => openWorkItem(item.shortId)}
+                      data-testid={`routine-run-work-item-${item.shortId}`}
+                    >
+                      <span className="font-medium text-primary-6">
+                        {item.shortId}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-text-2">
+                        {item.title}
+                      </span>
+                      <span className="shrink-0 text-text-3">
+                        {item.portableState ?? item.status}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
         </div>
       )}
-    </div>
+    </DetailPaneLayout>
   );
 };
 
 const RoutineRunsSurface: React.FC = () => {
   const { t } = useTranslation("sessions");
+  const { splitDatasetControl, surfaceDatasetControl } =
+    useWorkManagementSplitHeader();
   const [runs, setRuns] = useState<RoutineRunSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [activeView, setActiveView] = useState<"runs" | "webhooks">("runs");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [listFullscreen, setListFullscreen] = useState(false);
 
   const load = useCallback(() => {
     projectApi
@@ -190,90 +293,187 @@ const RoutineRunsSurface: React.FC = () => {
   }, []);
 
   useEffect(() => {
+    if (activeView !== "runs") return;
     load();
     // Runs advance while the surface is hidden; refetch when the window
     // regains focus rather than polling.
     window.addEventListener("focus", load);
     return () => window.removeEventListener("focus", load);
-  }, [load]);
+  }, [activeView, load]);
+
+  const publishedHeader = React.useMemo(() => ({ hidden: true }), []);
+  usePublishWorkstationTabHeader({
+    host: "workManagement",
+    content: publishedHeader,
+  });
+
+  const runsLabel = t("kanban.sidebar.runs", { defaultValue: "Runs" });
+  const refreshLabel = t("common:actions.refresh", {
+    defaultValue: "Refresh",
+  });
+  const visibleRuns = useMemo(
+    () => (runs ? searchRoutineRuns(runs, searchQuery) : []),
+    [runs, searchQuery]
+  );
+  const selectedRun =
+    visibleRuns.find((run) => run.id === selectedRunId) ?? null;
+
+  const handleSelectRun = useCallback((run: RoutineRunSummary) => {
+    setSelectedRunId(run.id);
+    setListFullscreen(false);
+  }, []);
+  const handleToggleListPresentation = useCallback(() => {
+    setListFullscreen((current) => !current);
+  }, []);
+  const handleCloseDetail = useCallback(() => setSelectedRunId(null), []);
+  const handleSelectWebhookDetail = useCallback(
+    () => setListFullscreen(false),
+    []
+  );
+
+  const tabs = [
+    { key: "runs", label: runsLabel },
+    {
+      key: "webhooks",
+      label: t("webhooks.title", { defaultValue: "Webhooks" }),
+    },
+  ];
+  const datasetTabs = (
+    <TabPill
+      tabs={tabs}
+      activeTab={activeView}
+      onChange={(key) => setActiveView(key as "runs" | "webhooks")}
+      variant="pill"
+      color="fill"
+      fillWidth={false}
+      size="small"
+      height={28}
+    />
+  );
+  const headerActions = (
+    <div className="flex shrink-0 items-center gap-px">
+      {activeView === "runs" ? (
+        <WorkManagementRefreshButton
+          label={refreshLabel}
+          loading={false}
+          onRefresh={load}
+          dataTestId="routine-runs-refresh"
+        />
+      ) : null}
+      <SplitListFullscreenButton
+        isFullscreen={listFullscreen}
+        onToggle={handleToggleListPresentation}
+      />
+    </div>
+  );
+  const splitListHeader = !listFullscreen ? (
+    <SplitListHeader
+      primary={
+        <div className="flex min-w-0 flex-1 items-center gap-px">
+          {splitDatasetControl}
+          {splitDatasetControl ? (
+            <HeaderSectionSeparator className="mx-0.5" />
+          ) : null}
+          {datasetTabs}
+        </div>
+      }
+      secondary={
+        <div className="flex min-w-0 flex-1 items-center gap-px">
+          <WorkManagementSearchInput
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placement="header"
+            fillWidth
+            dataTestId="routine-search"
+          />
+          {headerActions}
+        </div>
+      }
+    />
+  ) : null;
+  const fullListHeader = listFullscreen ? (
+    <SplitListHeader
+      fullWidth
+      primary={
+        <div className="flex min-w-0 flex-1 items-center gap-px">
+          {surfaceDatasetControl}
+          {surfaceDatasetControl ? (
+            <HeaderSectionSeparator className="mx-0.5" />
+          ) : null}
+          {datasetTabs}
+          <div className="ml-auto flex min-w-0 items-center gap-px">
+            <WorkManagementSearchInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+              placement="header"
+              dataTestId="routine-search"
+            />
+            {headerActions}
+          </div>
+        </div>
+      }
+    />
+  ) : null;
+
+  const runsEmptyContent = error ? (
+    <Placeholder
+      variant="error"
+      placement="sidebar"
+      title={error}
+      fillParentHeight
+    />
+  ) : runs && runs.length === 0 ? (
+    <Placeholder
+      variant="empty"
+      placement="sidebar"
+      title={t("kanban.runsEmpty", { defaultValue: "No routine runs yet" })}
+      fillParentHeight
+    />
+  ) : (
+    <Placeholder variant="no-results" placement="sidebar" fillParentHeight />
+  );
+  const runsList = (
+    <RoutineRunsList
+      runs={visibleRuns}
+      selectedRunId={selectedRun?.id ?? null}
+      loading={runs === null && !error}
+      emptyContent={runsEmptyContent}
+      onSelectRun={handleSelectRun}
+    />
+  );
 
   return (
     <div
       className="flex h-full min-h-0 flex-col overflow-hidden"
       data-testid="routine-runs-surface"
     >
-      <div className="flex h-[40px] shrink-0 items-center justify-between border-b border-border-1 px-4">
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-1.5 text-[13px] font-medium text-text-1">
-            <HugeiconsIcon
-              icon={PlayCircleIcon}
-              data-icon="play-circle"
-              size={14}
-              strokeWidth={1.75}
-              className="text-text-3"
-            />
-            {t("kanban.sidebar.runs", { defaultValue: "Runs" })}
-          </div>
-          <TabPill
-            tabs={[
-              {
-                key: "runs",
-                label: t("kanban.sidebar.runs", { defaultValue: "Runs" }),
-              },
-              {
-                key: "webhooks",
-                label: t("webhooks.title", { defaultValue: "Webhooks" }),
-              },
-            ]}
-            activeTab={activeView}
-            onChange={(key) => setActiveView(key as "runs" | "webhooks")}
-            variant="pill"
-            color="fill"
-            fillWidth={false}
-            size="small"
-          />
-        </div>
-        {activeView === "runs" && (
-          <Button
-            htmlType="button"
-            variant="tertiary"
-            size="small"
-            iconOnly
-            icon={
-              <HugeiconsIcon
-                icon={Refresh04Icon}
-                data-icon="refresh-cw"
-                size={13}
-                strokeWidth={1.75}
-              />
-            }
-            onClick={load}
-            data-testid="routine-runs-refresh"
-          />
-        )}
-      </div>
       {activeView === "webhooks" ? (
         <Suspense fallback={<Placeholder variant="loading" fillParentHeight />}>
-          <RoutineWebhooksPanel />
+          <RoutineWebhooksPanel
+            query={searchQuery}
+            listHeader={splitListHeader}
+            fullHeader={fullListHeader}
+            listFullscreen={listFullscreen}
+            onSelectDetail={handleSelectWebhookDetail}
+          />
         </Suspense>
       ) : (
-        <div className="min-h-0 flex-1 overflow-y-auto">
-          {error ? (
-            <Placeholder variant="error" title={error} fillParentHeight />
-          ) : runs === null ? (
-            <Placeholder variant="loading" fillParentHeight />
-          ) : runs.length === 0 ? (
-            <Placeholder
-              variant="empty"
-              title={t("kanban.runsEmpty", {
-                defaultValue: "No routine runs yet",
-              })}
-              fillParentHeight
+        <InboxListDetailLayout
+          testId="routine-runs-list-detail-layout"
+          defaultSplit
+          listFullscreen={listFullscreen}
+          listHeader={splitListHeader}
+          fullHeader={fullListHeader}
+          listContent={runsList}
+          fullContent={runsList}
+          detailContent={
+            <RoutineRunDetailPane
+              key={selectedRun?.id ?? "empty"}
+              run={selectedRun}
+              onClose={handleCloseDetail}
             />
-          ) : (
-            runs.map((run) => <RunRow key={run.id} run={run} />)
-          )}
-        </div>
+          }
+        />
       )}
     </div>
   );

--- a/src/modules/MainApp/WorkManagement/RoutineWebhooksPanel.test.ts
+++ b/src/modules/MainApp/WorkManagement/RoutineWebhooksPanel.test.ts
@@ -1,0 +1,45 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import RoutineWebhooksPanel, {
+  searchPortableRoutines,
+} from "./RoutineWebhooksPanel";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("searchPortableRoutines", () => {
+  it("uses the shared Work Management list-detail layout", () => {
+    const markup = renderToStaticMarkup(
+      createElement(RoutineWebhooksPanel, {
+        listHeader: createElement("span", {
+          "data-testid": "webhook-list-header",
+        }),
+      })
+    );
+
+    expect(markup).toContain('data-layout-mode="split"');
+    expect(markup).toContain('data-testid="webhook-list-header"');
+    expect(markup).toContain('data-testid="routine-webhooks-compact-list"');
+    expect(markup).toContain('data-testid="routine-webhook-detail-pane"');
+  });
+
+  it("searches webhook routines by name and stable identifiers", () => {
+    const routines = [
+      {
+        name: "Nightly triage",
+        routineId: "routine-42",
+        revision: 3,
+        enabled: true,
+        specHash: "abc123",
+        updatedAt: 1,
+      },
+    ];
+
+    expect(searchPortableRoutines(routines, "nightly")).toEqual(routines);
+    expect(searchPortableRoutines(routines, "abc123")).toEqual(routines);
+    expect(searchPortableRoutines(routines, "deploy")).toEqual([]);
+  });
+});

--- a/src/modules/MainApp/WorkManagement/RoutineWebhooksPanel.tsx
+++ b/src/modules/MainApp/WorkManagement/RoutineWebhooksPanel.tsx
@@ -1,9 +1,15 @@
 /**
  * Webhook management for portable routines. Install/rotate return the
- * plaintext secret exactly once — shown until the row reloads, never
+ * plaintext secret exactly once — shown until the detail reloads, never
  * persisted on the frontend.
  */
-import React, { useCallback, useEffect, useState } from "react";
+import React, {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -16,13 +22,15 @@ import {
 import Button from "@src/components/Button";
 import Message from "@src/components/Message";
 import { Placeholder } from "@src/components/Placeholder";
-import {
-  ArrowDown01Icon,
-  ArrowRight01Icon,
-  Copy01Icon,
-  HugeiconsIcon,
-  Refresh04Icon,
-} from "@src/icons";
+import { Copy01Icon, HugeiconsIcon, Link01Icon } from "@src/icons";
+import CompactListPanel, {
+  type CompactListPanelEntry,
+} from "@src/modules/shared/components/CompactListPanel";
+import { WorkManagementRefreshButton } from "@src/modules/shared/components/WorkManagementRefreshButton";
+import DetailPaneLayout, {
+  DetailPanePlaceholder,
+} from "@src/modules/shared/layouts/DetailPaneLayout";
+import InboxListDetailLayout from "@src/modules/shared/layouts/InboxListDetailLayout";
 import { copyText } from "@src/util/data/clipboard";
 
 const DELIVERY_STATUS_TONE: Record<string, string> = {
@@ -33,13 +41,30 @@ const DELIVERY_STATUS_TONE: Record<string, string> = {
   skipped: "text-text-3",
 };
 
-interface WebhookRowProps {
-  routine: PortableRoutineSummary;
+export function searchPortableRoutines(
+  routines: readonly PortableRoutineSummary[],
+  query: string
+): PortableRoutineSummary[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return [...routines];
+
+  return routines.filter((routine) =>
+    [routine.name, routine.routineId, routine.specHash].some((value) =>
+      value.toLocaleLowerCase().includes(normalizedQuery)
+    )
+  );
 }
 
-const WebhookRow: React.FC<WebhookRowProps> = ({ routine }) => {
-  const { t } = useTranslation("sessions");
-  const [expanded, setExpanded] = useState(false);
+interface WebhookDetailPaneProps {
+  routine: PortableRoutineSummary | null;
+  onClose: () => void;
+}
+
+const WebhookDetailPane: React.FC<WebhookDetailPaneProps> = ({
+  routine,
+  onClose,
+}) => {
+  const { t } = useTranslation(["sessions", "common"]);
   const [status, setStatus] = useState<RoutineWebhookStatus | null>(null);
   const [installInfo, setInstallInfo] =
     useState<RoutineWebhookInstallInfo | null>(null);
@@ -49,85 +74,79 @@ const WebhookRow: React.FC<WebhookRowProps> = ({ routine }) => {
   const [busy, setBusy] = useState(false);
 
   const loadStatus = useCallback(() => {
+    if (!routine) return;
     projectApi
       .routineWebhookStatus(routine.name)
       .then(setStatus)
       .catch((error: unknown) => {
         Message.error(error instanceof Error ? error.message : String(error));
       });
-  }, [routine.name]);
+  }, [routine]);
 
   const loadDeliveries = useCallback(() => {
+    if (!routine) return;
     projectApi
       .listRoutineWebhookDeliveries(routine.name, 50)
       .then(setDeliveries)
       .catch(() => setDeliveries([]));
-  }, [routine.name]);
+  }, [routine]);
 
   useEffect(() => {
     loadStatus();
-  }, [loadStatus]);
+    loadDeliveries();
+  }, [loadDeliveries, loadStatus]);
 
-  useEffect(() => {
-    if (expanded && deliveries === null) loadDeliveries();
-  }, [expanded, deliveries, loadDeliveries]);
+  const runAction = useCallback(async (action: () => Promise<void>) => {
+    setBusy(true);
+    try {
+      await action();
+    } catch (error) {
+      Message.error(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
 
-  const runAction = useCallback(
-    async (action: () => Promise<void>) => {
-      setBusy(true);
-      try {
-        await action();
-      } catch (error) {
-        Message.error(error instanceof Error ? error.message : String(error));
-      } finally {
-        setBusy(false);
-      }
-    },
-    [setBusy]
-  );
+  const handleInstall = useCallback(() => {
+    if (!routine) return;
+    void runAction(async () => {
+      const info = await projectApi.installRoutineWebhook(routine.name);
+      setInstallInfo(info);
+      loadStatus();
+    });
+  }, [loadStatus, routine, runAction]);
 
-  const handleInstall = useCallback(
-    () =>
-      runAction(async () => {
-        const info = await projectApi.installRoutineWebhook(routine.name);
-        setInstallInfo(info);
-        loadStatus();
-      }),
-    [loadStatus, routine.name, runAction]
-  );
+  const handleRotate = useCallback(() => {
+    if (!routine) return;
+    void runAction(async () => {
+      const info = await projectApi.rotateRoutineWebhook(routine.name);
+      setInstallInfo(info);
+      loadStatus();
+    });
+  }, [loadStatus, routine, runAction]);
 
-  const handleRotate = useCallback(
-    () =>
-      runAction(async () => {
-        const info = await projectApi.rotateRoutineWebhook(routine.name);
-        setInstallInfo(info);
-        loadStatus();
-      }),
-    [loadStatus, routine.name, runAction]
-  );
-
-  const handleToggleEnabled = useCallback(
-    () =>
-      runAction(async () => {
-        if (!status) return;
-        const next = await projectApi.setRoutineWebhookEnabled(
-          routine.name,
-          !status.enabled
-        );
-        setStatus(next);
-      }),
-    [routine.name, runAction, status]
-  );
+  const handleToggleEnabled = useCallback(() => {
+    if (!routine) return;
+    void runAction(async () => {
+      if (!status) return;
+      const next = await projectApi.setRoutineWebhookEnabled(
+        routine.name,
+        !status.enabled
+      );
+      setStatus(next);
+    });
+  }, [routine, runAction, status]);
 
   const handleReplay = useCallback(
-    (deliveryId: string) =>
-      runAction(async () => {
+    (deliveryId: string) => {
+      void runAction(async () => {
         await projectApi.replayRoutineWebhookDelivery(deliveryId);
         Message.success(
           t("webhooks.replayQueued", { defaultValue: "Delivery replayed" })
         );
         loadDeliveries();
-      }),
+      });
+    },
     [loadDeliveries, runAction, t]
   );
 
@@ -145,9 +164,19 @@ const WebhookRow: React.FC<WebhookRowProps> = ({ routine }) => {
     [t]
   );
 
-  const Chevron = expanded ? ArrowDown01Icon : ArrowRight01Icon;
-  const paused = Boolean(status?.pausedAt);
+  if (!routine) {
+    return (
+      <DetailPaneLayout testId="routine-webhook-detail-pane">
+        <DetailPanePlaceholder
+          variant="empty"
+          title={t("common:teamInbox.empty.selectTitle")}
+          subtitle={t("common:teamInbox.empty.selectSubtitle")}
+        />
+      </DetailPaneLayout>
+    );
+  }
 
+  const paused = Boolean(status?.pausedAt);
   const statusChip = !status ? null : !status.installed ? (
     <span className="text-[11px] text-text-4">
       {t("webhooks.notInstalled", { defaultValue: "Not installed" })}
@@ -168,201 +197,195 @@ const WebhookRow: React.FC<WebhookRowProps> = ({ routine }) => {
       {t("webhooks.disabled", { defaultValue: "Disabled" })}
     </span>
   );
+  const copyLabel = t("webhooks.copy", { defaultValue: "Copy" });
 
   return (
-    <div className="border-b border-border-1">
-      <button
-        type="button"
-        onClick={() => setExpanded((previous) => !previous)}
-        data-testid={`routine-webhook-row-${routine.name}`}
-        className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-fill-1"
+    <DetailPaneLayout
+      testId="routine-webhook-detail-pane"
+      header={{
+        title: routine.name,
+        subtitle: `rev ${routine.revision}`,
+        icon: Link01Icon,
+        actions: statusChip,
+      }}
+      onClose={onClose}
+      closeTestId="routine-webhook-detail-close"
+    >
+      <div
+        className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-4"
+        data-testid={`routine-webhook-detail-${routine.name}`}
       >
-        <HugeiconsIcon
-          icon={Chevron}
-          size={14}
-          strokeWidth={1.75}
-          className="shrink-0 text-text-3"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-medium text-text-1">
-            {routine.name}
-            <span className="ml-1 text-[11px] text-text-3">
-              rev {routine.revision}
-            </span>
-          </div>
-          {status?.secretHint ? (
-            <div className="truncate text-[11px] text-text-3">
-              {t("webhooks.secretHint", { defaultValue: "Secret" })} ·{" "}
-              {status.secretHint}
-            </div>
-          ) : null}
-        </div>
-        {statusChip}
-      </button>
-      {expanded && (
-        <div className="flex flex-col gap-3 px-11 pb-3">
-          <div className="flex flex-wrap items-center gap-2">
-            {status?.installed ? (
-              <>
-                <Button
-                  variant="secondary"
-                  size="small"
-                  onClick={handleToggleEnabled}
-                  disabled={busy || !status}
-                  data-testid={`routine-webhook-toggle-${routine.name}`}
-                >
-                  {status?.enabled
-                    ? t("webhooks.disable", { defaultValue: "Disable" })
-                    : t("webhooks.enable", { defaultValue: "Enable" })}
-                </Button>
-                <Button
-                  variant="tertiary"
-                  size="small"
-                  onClick={handleRotate}
-                  disabled={busy}
-                  data-testid={`routine-webhook-rotate-${routine.name}`}
-                >
-                  {t("webhooks.rotate", { defaultValue: "Rotate secret" })}
-                </Button>
-              </>
-            ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          {status?.installed ? (
+            <>
               <Button
-                variant="primary"
+                variant="secondary"
                 size="small"
-                onClick={handleInstall}
-                disabled={busy}
-                data-testid={`routine-webhook-install-${routine.name}`}
+                onClick={handleToggleEnabled}
+                disabled={busy || !status}
+                data-testid={`routine-webhook-toggle-${routine.name}`}
               >
-                {t("webhooks.install", { defaultValue: "Install webhook" })}
+                {status.enabled
+                  ? t("webhooks.disable", { defaultValue: "Disable" })
+                  : t("webhooks.enable", { defaultValue: "Enable" })}
               </Button>
-            )}
-            <Button
-              variant="tertiary"
-              size="small"
-              iconOnly
-              icon={
-                <HugeiconsIcon
-                  icon={Refresh04Icon}
-                  data-icon="refresh-cw"
-                  size={13}
-                  strokeWidth={1.75}
-                />
-              }
-              onClick={() => {
-                loadStatus();
-                loadDeliveries();
-              }}
-              data-testid={`routine-webhook-refresh-${routine.name}`}
-            />
-          </div>
-
-          {installInfo ? (
-            <div
-              className="flex flex-col gap-1.5 rounded-md bg-fill-1 px-3 py-2.5"
-              data-testid={`routine-webhook-install-info-${routine.name}`}
-            >
-              <p className="text-[11px] text-text-3">
-                {t("webhooks.secretShownOnce", {
-                  defaultValue:
-                    "The secret is shown once — store it in your provider now.",
-                })}
-              </p>
-              <div className="flex items-center gap-2">
-                <code className="min-w-0 flex-1 truncate text-[11px] text-text-2">
-                  {installInfo.urlPath}
-                </code>
-                <Button
-                  variant="tertiary"
-                  size="mini"
-                  iconOnly
-                  icon={
-                    <HugeiconsIcon
-                      icon={Copy01Icon}
-                      data-icon="copy"
-                      size={12}
-                    />
-                  }
-                  onClick={() => handleCopy(installInfo.urlPath)}
-                  data-testid={`routine-webhook-copy-url-${routine.name}`}
-                />
-              </div>
-              <div className="flex items-center gap-2">
-                <code className="min-w-0 flex-1 truncate text-[11px] text-text-2">
-                  {installInfo.secret}
-                </code>
-                <Button
-                  variant="tertiary"
-                  size="mini"
-                  iconOnly
-                  icon={
-                    <HugeiconsIcon
-                      icon={Copy01Icon}
-                      data-icon="copy"
-                      size={12}
-                    />
-                  }
-                  onClick={() => handleCopy(installInfo.secret)}
-                  data-testid={`routine-webhook-copy-secret-${routine.name}`}
-                />
-              </div>
-            </div>
-          ) : null}
-
-          {deliveries === null ? (
-            <div className="text-[12px] text-text-3">…</div>
-          ) : deliveries.length === 0 ? (
-            <div className="text-[12px] text-text-3">
-              {t("webhooks.noDeliveries", {
-                defaultValue: "No deliveries yet",
-              })}
-            </div>
+              <Button
+                variant="tertiary"
+                size="small"
+                onClick={handleRotate}
+                disabled={busy}
+                data-testid={`routine-webhook-rotate-${routine.name}`}
+              >
+                {t("webhooks.rotate", { defaultValue: "Rotate secret" })}
+              </Button>
+            </>
           ) : (
-            <ul className="flex flex-col gap-1">
-              {deliveries.map((delivery) => (
-                <li
-                  key={delivery.id}
-                  className="flex items-center gap-2 rounded px-1 py-1 text-[12px]"
-                  data-testid={`routine-webhook-delivery-${delivery.id}`}
-                >
-                  <span
-                    className={`shrink-0 font-medium ${
-                      DELIVERY_STATUS_TONE[delivery.status] ?? "text-text-2"
-                    }`}
-                  >
-                    {delivery.status}
-                  </span>
-                  <span className="min-w-0 flex-1 truncate text-text-2">
-                    {delivery.provider}/{delivery.eventKind}
-                    {delivery.reason ? ` · ${delivery.reason}` : ""}
-                  </span>
-                  <span className="shrink-0 text-[11px] text-text-3">
-                    {new Date(delivery.createdAt).toLocaleString()}
-                  </span>
-                  <Button
-                    variant="tertiary"
-                    size="mini"
-                    onClick={() => handleReplay(delivery.id)}
-                    disabled={busy}
-                    data-testid={`routine-webhook-replay-${delivery.id}`}
-                  >
-                    {t("webhooks.replay", { defaultValue: "Replay" })}
-                  </Button>
-                </li>
-              ))}
-            </ul>
+            <Button
+              variant="primary"
+              size="small"
+              onClick={handleInstall}
+              disabled={busy}
+              data-testid={`routine-webhook-install-${routine.name}`}
+            >
+              {t("webhooks.install", { defaultValue: "Install webhook" })}
+            </Button>
           )}
+          <WorkManagementRefreshButton
+            label={t("common:actions.refresh", { defaultValue: "Refresh" })}
+            loading={busy}
+            onRefresh={() => {
+              loadStatus();
+              loadDeliveries();
+            }}
+            dataTestId={`routine-webhook-refresh-${routine.name}`}
+          />
         </div>
-      )}
-    </div>
+
+        {status?.secretHint ? (
+          <div className="text-[11px] text-text-3">
+            {t("webhooks.secretHint", { defaultValue: "Secret" })} ·{" "}
+            {status.secretHint}
+          </div>
+        ) : null}
+
+        {installInfo ? (
+          <div
+            className="flex flex-col gap-1.5 rounded-md bg-fill-1 px-3 py-2.5"
+            data-testid={`routine-webhook-install-info-${routine.name}`}
+          >
+            <p className="text-[11px] text-text-3">
+              {t("webhooks.secretShownOnce", {
+                defaultValue:
+                  "The secret is shown once — store it in your provider now.",
+              })}
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="min-w-0 flex-1 truncate text-[11px] text-text-2">
+                {installInfo.urlPath}
+              </code>
+              <Button
+                variant="tertiary"
+                size="mini"
+                iconOnly
+                aria-label={copyLabel}
+                icon={
+                  <HugeiconsIcon icon={Copy01Icon} data-icon="copy" size={12} />
+                }
+                onClick={() => handleCopy(installInfo.urlPath)}
+                data-testid={`routine-webhook-copy-url-${routine.name}`}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="min-w-0 flex-1 truncate text-[11px] text-text-2">
+                {installInfo.secret}
+              </code>
+              <Button
+                variant="tertiary"
+                size="mini"
+                iconOnly
+                aria-label={copyLabel}
+                icon={
+                  <HugeiconsIcon icon={Copy01Icon} data-icon="copy" size={12} />
+                }
+                onClick={() => handleCopy(installInfo.secret)}
+                data-testid={`routine-webhook-copy-secret-${routine.name}`}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {deliveries === null ? (
+          <Placeholder variant="loading" />
+        ) : deliveries.length === 0 ? (
+          <Placeholder
+            variant="empty"
+            title={t("webhooks.noDeliveries", {
+              defaultValue: "No deliveries yet",
+            })}
+          />
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {deliveries.map((delivery) => (
+              <li
+                key={delivery.id}
+                className="flex items-center gap-2 rounded px-1 py-1 text-[12px]"
+                data-testid={`routine-webhook-delivery-${delivery.id}`}
+              >
+                <span
+                  className={`shrink-0 font-medium ${
+                    DELIVERY_STATUS_TONE[delivery.status] ?? "text-text-2"
+                  }`}
+                >
+                  {delivery.status}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-text-2">
+                  {delivery.provider}/{delivery.eventKind}
+                  {delivery.reason ? ` · ${delivery.reason}` : ""}
+                </span>
+                <span className="shrink-0 text-[11px] text-text-3">
+                  {new Date(delivery.createdAt).toLocaleString()}
+                </span>
+                <Button
+                  variant="tertiary"
+                  size="mini"
+                  onClick={() => handleReplay(delivery.id)}
+                  disabled={busy}
+                  data-testid={`routine-webhook-replay-${delivery.id}`}
+                >
+                  {t("webhooks.replay", { defaultValue: "Replay" })}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </DetailPaneLayout>
   );
 };
 
-const RoutineWebhooksPanel: React.FC = () => {
+interface RoutineWebhooksPanelProps {
+  query?: string;
+  listHeader?: ReactNode;
+  fullHeader?: ReactNode;
+  listFullscreen?: boolean;
+  onSelectDetail?: () => void;
+}
+
+const RoutineWebhooksPanel: React.FC<RoutineWebhooksPanelProps> = ({
+  query = "",
+  listHeader,
+  fullHeader,
+  listFullscreen = false,
+  onSelectDetail,
+}) => {
   const { t } = useTranslation("sessions");
   const [routines, setRoutines] = useState<PortableRoutineSummary[] | null>(
     null
   );
   const [error, setError] = useState<string | null>(null);
+  const [selectedRoutineId, setSelectedRoutineId] = useState<string | null>(
+    null
+  );
 
   const load = useCallback(() => {
     projectApi
@@ -384,29 +407,93 @@ const RoutineWebhooksPanel: React.FC = () => {
     return () => window.removeEventListener("focus", load);
   }, [load]);
 
+  const visibleRoutines = useMemo(
+    () => (routines ? searchPortableRoutines(routines, query) : []),
+    [query, routines]
+  );
+  const selectedRoutine =
+    visibleRoutines.find(
+      (routine) => routine.routineId === selectedRoutineId
+    ) ?? null;
+  const entries = useMemo<CompactListPanelEntry[]>(
+    () =>
+      visibleRoutines.map((routine) => ({
+        key: routine.routineId,
+        title: routine.name,
+        titlePrefix: `rev ${routine.revision}`,
+        time: new Date(routine.updatedAt).toLocaleString(),
+        metadata: <span className="truncate">{routine.routineId}</span>,
+        preview: routine.specHash,
+        leading: (
+          <HugeiconsIcon
+            icon={Link01Icon}
+            data-icon="link"
+            size={14}
+            strokeWidth={1.8}
+            aria-hidden="true"
+          />
+        ),
+        leadingClassName: routine.enabled ? "text-success-6" : "text-text-3",
+        ariaLabel: `${routine.name}, rev ${routine.revision}`,
+        dataAttributes: {
+          "data-testid": "routine-webhook-row",
+          "data-routine-id": routine.routineId,
+        },
+        onSelect: () => {
+          setSelectedRoutineId(routine.routineId);
+          onSelectDetail?.();
+        },
+      })),
+    [onSelectDetail, visibleRoutines]
+  );
+
+  const emptyContent = error ? (
+    <Placeholder
+      variant="error"
+      placement="sidebar"
+      title={error}
+      fillParentHeight
+    />
+  ) : routines && routines.length === 0 ? (
+    <Placeholder
+      variant="empty"
+      placement="sidebar"
+      title={t("webhooks.empty", {
+        defaultValue: "No routines yet — apply one from the CLI first",
+      })}
+      fillParentHeight
+    />
+  ) : (
+    <Placeholder variant="no-results" placement="sidebar" fillParentHeight />
+  );
+  const routineList = (
+    <CompactListPanel
+      ariaLabel={t("webhooks.title", { defaultValue: "Webhooks" })}
+      entries={entries}
+      selectedEntryKey={selectedRoutine?.routineId ?? null}
+      loading={routines === null && !error}
+      emptyContent={emptyContent}
+      testId="routine-webhooks-compact-list"
+    />
+  );
+
   return (
-    <div
-      className="min-h-0 flex-1 overflow-y-auto"
-      data-testid="routine-webhooks-panel"
-    >
-      {error ? (
-        <Placeholder variant="error" title={error} fillParentHeight />
-      ) : routines === null ? (
-        <Placeholder variant="loading" fillParentHeight />
-      ) : routines.length === 0 ? (
-        <Placeholder
-          variant="empty"
-          title={t("webhooks.empty", {
-            defaultValue: "No routines yet — apply one from the CLI first",
-          })}
-          fillParentHeight
+    <InboxListDetailLayout
+      testId="routine-webhooks-list-detail-layout"
+      defaultSplit
+      listFullscreen={listFullscreen}
+      listHeader={listHeader}
+      fullHeader={fullHeader}
+      listContent={routineList}
+      fullContent={routineList}
+      detailContent={
+        <WebhookDetailPane
+          key={selectedRoutine?.routineId ?? "empty"}
+          routine={selectedRoutine}
+          onClose={() => setSelectedRoutineId(null)}
         />
-      ) : (
-        routines.map((routine) => (
-          <WebhookRow key={routine.routineId} routine={routine} />
-        ))
-      )}
-    </div>
+      }
+    />
   );
 };
 

--- a/src/modules/MainApp/WorkManagement/WorkManagementDatasetSwitch.test.ts
+++ b/src/modules/MainApp/WorkManagement/WorkManagementDatasetSwitch.test.ts
@@ -22,6 +22,7 @@ describe("WorkManagementDatasetSwitch", () => {
     [WORK_MANAGEMENT_DATASET.WORK_ITEMS, 'data-icon="list-todo"'],
     [WORK_MANAGEMENT_DATASET.GITHUB_ISSUES, 'data-icon="circle-dot"'],
     [WORK_MANAGEMENT_DATASET.REVIEWS, 'data-icon="git-pull-request"'],
+    [WORK_MANAGEMENT_DATASET.RUNS, 'data-icon="play-circle"'],
   ])("renders one simple select for %s", (activeDataset, activeIcon) => {
     const markup = renderToStaticMarkup(
       createElement(WorkManagementDatasetSwitch, {
@@ -52,6 +53,7 @@ describe("WorkManagementDatasetSwitch", () => {
       WORK_MANAGEMENT_DATASET.INBOX,
       WORK_MANAGEMENT_DATASET.PROJECTS,
       WORK_MANAGEMENT_DATASET.WORK_ITEMS,
+      WORK_MANAGEMENT_DATASET.RUNS,
     ]);
   });
 

--- a/src/modules/MainApp/WorkManagement/WorkManagementDatasetSwitch.tsx
+++ b/src/modules/MainApp/WorkManagement/WorkManagementDatasetSwitch.tsx
@@ -9,6 +9,7 @@ import {
   HugeiconsIcon,
   InboxIcon,
   ListTodoIcon,
+  PlayCircleIcon,
 } from "@src/icons";
 
 import {
@@ -29,6 +30,7 @@ export const WORK_MANAGEMENT_DATASET_MENU_ORDER = [
   WORK_MANAGEMENT_DATASET.INBOX,
   WORK_MANAGEMENT_DATASET.PROJECTS,
   WORK_MANAGEMENT_DATASET.WORK_ITEMS,
+  WORK_MANAGEMENT_DATASET.RUNS,
 ] as const satisfies readonly WorkManagementDataset[];
 
 export function WorkManagementDatasetSwitch({
@@ -42,12 +44,14 @@ export function WorkManagementDatasetSwitch({
   const inboxLabel = t("navigation:labels.inbox");
   const issuesLabel = t("sessions:kanban.sidebar.githubIssues");
   const reviewsLabel = t("sessions:kanban.sidebar.githubPrs");
+  const runsLabel = t("sessions:kanban.sidebar.runs");
   const activeDatasetLabel: Record<WorkManagementDataset, string> = {
     [WORK_MANAGEMENT_DATASET.INBOX]: inboxLabel,
     [WORK_MANAGEMENT_DATASET.PROJECTS]: projectsLabel,
     [WORK_MANAGEMENT_DATASET.WORK_ITEMS]: workItemsLabel,
     [WORK_MANAGEMENT_DATASET.GITHUB_ISSUES]: issuesLabel,
     [WORK_MANAGEMENT_DATASET.REVIEWS]: reviewsLabel,
+    [WORK_MANAGEMENT_DATASET.RUNS]: runsLabel,
   };
   const options = useMemo<SelectOption[]>(() => {
     const optionsByDataset: Record<WorkManagementDataset, SelectOption> = {
@@ -126,6 +130,21 @@ export function WorkManagementDatasetSwitch({
         ),
         dataTestId: "work-dataset-reviews",
       },
+      [WORK_MANAGEMENT_DATASET.RUNS]: {
+        value: WORK_MANAGEMENT_DATASET.RUNS,
+        label: runsLabel,
+        triggerLabel: compact ? "" : runsLabel,
+        icon: (
+          <HugeiconsIcon
+            icon={PlayCircleIcon}
+            data-icon="play-circle"
+            size={14}
+            strokeWidth={1.9}
+            aria-hidden="true"
+          />
+        ),
+        dataTestId: "work-dataset-runs",
+      },
     };
 
     return WORK_MANAGEMENT_DATASET_MENU_ORDER.map(
@@ -137,6 +156,7 @@ export function WorkManagementDatasetSwitch({
     issuesLabel,
     projectsLabel,
     reviewsLabel,
+    runsLabel,
     workItemsLabel,
   ]);
 

--- a/src/modules/MainApp/WorkManagement/index.tsx
+++ b/src/modules/MainApp/WorkManagement/index.tsx
@@ -106,6 +106,12 @@ const WorkManagementPage: React.FC<WorkManagementPageProps> = ({
         });
         return;
       }
+      if (dataset === WORK_MANAGEMENT_DATASET.RUNS) {
+        setActiveWorkManagementSection({
+          section: WORK_MANAGEMENT_SECTION.RUNS,
+        });
+        return;
+      }
       setActiveWorkManagementSection({
         section:
           dataset === WORK_MANAGEMENT_DATASET.GITHUB_ISSUES

--- a/src/modules/MainApp/WorkManagement/workManagementDataset.test.ts
+++ b/src/modules/MainApp/WorkManagement/workManagementDataset.test.ts
@@ -42,5 +42,11 @@ describe("resolveWorkManagementDataset", () => {
         projectsView: WORK_MANAGEMENT_PROJECTS_VIEW.PROJECTS,
       })
     ).toBe(WORK_MANAGEMENT_DATASET.REVIEWS);
+    expect(
+      resolveWorkManagementDataset({
+        section: WORK_MANAGEMENT_SECTION.RUNS,
+        projectsView: WORK_MANAGEMENT_PROJECTS_VIEW.PROJECTS,
+      })
+    ).toBe(WORK_MANAGEMENT_DATASET.RUNS);
   });
 });

--- a/src/modules/MainApp/WorkManagement/workManagementDataset.ts
+++ b/src/modules/MainApp/WorkManagement/workManagementDataset.ts
@@ -11,6 +11,7 @@ export const WORK_MANAGEMENT_DATASET = {
   INBOX: "inbox",
   GITHUB_ISSUES: "github-issues",
   REVIEWS: "reviews",
+  RUNS: "runs",
 } as const;
 
 export type WorkManagementDataset =
@@ -35,6 +36,9 @@ export function resolveWorkManagementDataset({
   }
   if (section === WORK_MANAGEMENT_SECTION.GITHUB_PRS) {
     return WORK_MANAGEMENT_DATASET.REVIEWS;
+  }
+  if (section === WORK_MANAGEMENT_SECTION.RUNS) {
+    return WORK_MANAGEMENT_DATASET.RUNS;
   }
   if (
     section === WORK_MANAGEMENT_SECTION.PROJECTS &&


### PR DESCRIPTION
## Problem

Routine Runs and Webhooks use bespoke full-width expandable rows while Inbox, Pull Requests, and Issues use the shared Work Management master-detail layout. This duplicates header and row structure, makes navigation inconsistent, and leaves detail content mixed into the list instead of a stable right pane.

## Solution

Make Runs a first-class Work Management dataset and move both Routine tabs onto the existing shared layout primitives:

- `InboxListDetailLayout` owns split and fullscreen presentation
- `CompactListPanel` owns keyboard-accessible left navigation
- `DetailPaneLayout` owns selected Run and Webhook details
- `SplitListHeader`, the shared search input, refresh action, and fullscreen action retain the established compact/full header behavior
- Run status/work items and Webhook status/deliveries load only after selection
- Focus refresh listeners are scoped to the active Routine tab and cleaned up on switch/unmount

Existing Webhook install, enable/disable, rotate, copy, replay, and refresh operations remain available in the selected detail pane.

## Potential risks

The row density, selection flow, and location of Run/Webhook actions change visibly. A regression could affect selection restoration after filtering, fullscreen-to-detail transitions, or detail loading/error presentation. Structural and search behavior are covered by tests, but no live desktop screenshot or manual theme/viewport pass was performed because local desktop UI control is disabled for this task.

There are no backend, schema, persistence, dependency, IPC, or wire-format changes. Rollback is a normal revert of the single commit.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/modules/MainApp/WorkManagement` — passed: 19 files, 83 tests
- `pnpm run typecheck:fast` — passed
- Targeted ESLint over all changed TypeScript/TSX files with zero warnings — passed
- `pnpm run check:test-placement` — passed across 508 directories
- `pnpm run check:circular` — passed across 6,590 modules
- `git diff --check origin/develop...HEAD` — passed
- Commit hooks ran normally; lint-staged and staged-file TypeScript checks passed
- Manual desktop visual verification and screenshots — not run; UI-control permission was not granted

## Audit

Frontend UI audit: **0 fix**, **11 keep with reason**, **0 abstract**. The report is included at `docs/frontend-ui-audit-2026-09-07/RoutineRunsSurface.md`.

Performance verdict: **pass**. Lists remain bounded (Runs: 200; deliveries: 50), detail loading is selection-driven, no polling was added, and only the active tab owns a focus listener.