### PR TITLE
perf(file-tree): prune collapsed folders on expiry

### DIFF
--- a/src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/__tests__/helpers.test.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/__tests__/helpers.test.ts
@@ -5,7 +5,7 @@ import {
   collectExpandedPaths,
   countTreeNodes,
   findNodeInTree,
-  pruneCollapsedSubtree,
+  pruneCollapsedSubtrees,
   updateTreeChildren,
   updateTreeExpansion,
 } from "@src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/helpers";
@@ -141,7 +141,7 @@ describe("findNodeInTree", () => {
   });
 });
 
-describe("pruneCollapsedSubtree", () => {
+describe("pruneCollapsedSubtrees", () => {
   function browsedTree(): FileNode[] {
     return [
       dir("/repo/src", "src", {
@@ -172,7 +172,7 @@ describe("pruneCollapsedSubtree", () => {
   }
 
   it("drops a collapsed directory's children and remembers expanded descendants", () => {
-    const next = pruneCollapsedSubtree(browsedTree(), "/repo/src");
+    const next = pruneCollapsedSubtrees(browsedTree(), new Set(["/repo/src"]));
     const src = next[0];
     expect(src?.children).toBeUndefined();
     expect(src?.expanded).toBe(false);
@@ -191,22 +191,29 @@ describe("pruneCollapsedSubtree", () => {
         children: [file("/repo/lib/z.ts", "z.ts")],
       }),
     ];
-    const next = pruneCollapsedSubtree(tree, "/repo/lib");
+    const next = pruneCollapsedSubtrees(tree, new Set(["/repo/lib"]));
     expect(next[0]?.children).toBeUndefined();
     expect(next[0]).not.toHaveProperty("retainedExpandedPaths");
   });
 
   it("never prunes an expanded directory, a file, or an unloaded directory", () => {
     const tree = browsedTree();
-    expect(pruneCollapsedSubtree(tree, "/repo/docs")[1]?.children).toHaveLength(
-      1
+    expect(
+      pruneCollapsedSubtrees(tree, new Set(["/repo/docs"]))[1]?.children
+    ).toHaveLength(1);
+    expect(
+      pruneCollapsedSubtrees(tree, new Set(["/repo/src/index.ts"]))
+    ).toEqual(tree);
+    expect(pruneCollapsedSubtrees(tree, new Set(["/repo/src/b"]))).toEqual(
+      tree
     );
-    expect(pruneCollapsedSubtree(tree, "/repo/src/index.ts")).toEqual(tree);
-    expect(pruneCollapsedSubtree(tree, "/repo/src/b")).toEqual(tree);
   });
 
   it("prunes nested targets in place", () => {
-    const next = pruneCollapsedSubtree(browsedTree(), "/repo/src/a/closed");
+    const next = pruneCollapsedSubtrees(
+      browsedTree(),
+      new Set(["/repo/src/a/closed"])
+    );
     const closed = findNodeInTree(next, "/repo/src/a/closed");
     expect(closed?.children).toBeUndefined();
     expect(findNodeInTree(next, "/repo/src/a/deep")?.children).toHaveLength(1);
@@ -215,7 +222,7 @@ describe("pruneCollapsedSubtree", () => {
 
 describe("updateTreeChildren after pruning", () => {
   it("clears the remembered expansion once children are reloaded", () => {
-    const pruned = pruneCollapsedSubtree(
+    const pruned = pruneCollapsedSubtrees(
       [
         dir("/repo/src", "src", {
           expanded: false,
@@ -227,7 +234,7 @@ describe("updateTreeChildren after pruning", () => {
           ],
         }),
       ],
-      "/repo/src"
+      new Set(["/repo/src"])
     );
     expect(pruned[0]?.retainedExpandedPaths).toEqual(["/repo/src/a"]);
     const reloaded = updateTreeChildren(pruned, "/repo/src", [
@@ -241,7 +248,7 @@ describe("updateTreeChildren after pruning", () => {
 
 describe("carryRetainedExpansion", () => {
   it("copies remembered expansion onto a rebuilt tree", () => {
-    const old = pruneCollapsedSubtree(
+    const old = pruneCollapsedSubtrees(
       [
         dir("/repo/src", "src", {
           expanded: false,
@@ -253,7 +260,7 @@ describe("carryRetainedExpansion", () => {
           ],
         }),
       ],
-      "/repo/src"
+      new Set(["/repo/src"])
     );
     const rebuilt: FileNode[] = [
       dir("/repo/src", "src", { expanded: false, children: [] }),
@@ -303,5 +310,29 @@ describe("collectExpandedPaths / countTreeNodes", () => {
     ];
     expect(collectExpandedPaths(tree)).toEqual(["/repo/src", "/repo/src/a"]);
     expect(countTreeNodes(tree)).toBe(4);
+  });
+});
+
+describe("batched subtree pruning", () => {
+  it("visits a wide tree once for many collapsed targets", () => {
+    let pathReads = 0;
+    const tree = Array.from({ length: 1000 }, (_, index) => ({
+      name: String(index),
+      get path() {
+        pathReads += 1;
+        return `/repo/${index}`;
+      },
+      type: "directory" as const,
+      expanded: false,
+      children: [file(`/repo/${index}/x`, "x")],
+    }));
+    const next = pruneCollapsedSubtrees(
+      tree,
+      new Set(Array.from({ length: 1000 }, (_, i) => `/repo/${i}`))
+    );
+    expect(next.every((node) => !node.children)).toBe(true);
+    // One membership check and one immutable copy per directory, independent
+    // of the number of selected paths (the former per-path sweep was quadratic).
+    expect(pathReads).toBe(2000);
   });
 });

--- a/src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/__tests__/useFileTree.test.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/__tests__/useFileTree.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { type Atom, Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FileNode } from "@src/store/workstation/codeEditor/file";
+import { fileTreeAtom } from "@src/store/workstation/codeEditor/file";
+
+import {
+  COLLAPSED_SUBTREE_RETENTION_MS,
+  MAX_RETAINED_TREE_NODES,
+} from "../helpers";
+import { useFileTree } from "../useFileTree";
+
+vi.mock("@src/api/realtime/codeEditorWebSocket", () => ({
+  getCodeEditorWebSocket: () => undefined,
+}));
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ error: vi.fn(), debug: vi.fn(), info: vi.fn() }),
+}));
+vi.mock("@src/store/workstation/codeEditor/file", async () => {
+  const { atom } = await import("jotai");
+  return {
+    fileTreeAtom: atom<FileNode[]>([]),
+    fileLoadingTreeAtom: atom(false),
+    fileTreeErrorAtom: atom(null),
+    fileSelectedPathAtom: atom(""),
+  };
+});
+
+let root: Root;
+let host: HTMLDivElement;
+let store: ReturnType<typeof createStore>;
+let api: ReturnType<typeof useFileTree>;
+let visible: boolean;
+const leaf = (path: string): FileNode => ({ name: path, path, type: "file" });
+function folder(path: string, children: FileNode[]): FileNode {
+  return { name: path, path, type: "directory", expanded: true, children };
+}
+function Probe() {
+  const current = useFileTree("/repo", false);
+  useEffect(() => {
+    api = current;
+  });
+  return null;
+}
+const tree = () => store.get(fileTreeAtom as Atom<FileNode[]>);
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+async function visibility(next: boolean) {
+  await act(async () => {
+    visible = next;
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+async function mount(nodes: FileNode[]) {
+  store.set(fileTreeAtom, nodes);
+  await act(async () =>
+    root.render(createElement(Provider, { store }, createElement(Probe)))
+  );
+}
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.useFakeTimers();
+  visible = true;
+  store = createStore();
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => (visible ? "visible" : "hidden"),
+  });
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  host.remove();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("file tree retention lifecycle", () => {
+  it("owns no idle timer and expires a collapsed subtree once, preserving expansion", async () => {
+    await mount([
+      folder("/repo/a", [folder("/repo/a/b", [leaf("/repo/a/b/c")])]),
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
+    await act(async () => api.toggleDirectory("/repo/a"));
+    await advance(COLLAPSED_SUBTREE_RETENTION_MS - 1);
+    expect(tree()[0].children).toHaveLength(1);
+    await advance(1);
+    expect(tree()[0].children).toBeUndefined();
+    expect(tree()[0].retainedExpandedPaths).toEqual(["/repo/a/b"]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it("pauses expiry while hidden and prunes on visibility return", async () => {
+    await mount([folder("/repo/a", [leaf("/repo/a/b")])]);
+    await act(async () => api.toggleDirectory("/repo/a"));
+    await visibility(false);
+    expect(vi.getTimerCount()).toBe(0);
+    await advance(COLLAPSED_SUBTREE_RETENTION_MS * 2);
+    expect(tree()[0].children).toHaveLength(1);
+    await visibility(true);
+    await advance(0);
+    expect(tree()[0].children).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it("cancels expiry on re-expansion and cleans up on unmount", async () => {
+    await mount([folder("/repo/a", [leaf("/repo/a/b")])]);
+    await act(async () => api.toggleDirectory("/repo/a"));
+    await advance(0);
+    await act(async () => api.toggleDirectory("/repo/a"));
+    expect(vi.getTimerCount()).toBe(0);
+    await advance(COLLAPSED_SUBTREE_RETENTION_MS);
+    expect(tree()[0].children).toHaveLength(1);
+    await act(async () => api.toggleDirectory("/repo/a"));
+    await advance(0);
+    await act(async () => root.render(null));
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it("prunes immediately above the node cap using the committed collapse", async () => {
+    await mount([
+      folder(
+        "/repo/a",
+        Array.from({ length: MAX_RETAINED_TREE_NODES }, (_, i) =>
+          leaf(`/repo/a/${i}`)
+        )
+      ),
+    ]);
+    await act(async () => api.toggleDirectory("/repo/a"));
+    await advance(0);
+    expect(tree()[0].children).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it("keeps separate deadlines for multiple collapsed folders", async () => {
+    await mount([
+      folder("/repo/a", [leaf("/repo/a/x")]),
+      folder("/repo/b", [leaf("/repo/b/x")]),
+    ]);
+    await act(async () => api.toggleDirectory("/repo/a"));
+    await advance(30_000);
+    await act(async () => api.toggleDirectory("/repo/b"));
+    await advance(COLLAPSED_SUBTREE_RETENTION_MS - 30_000);
+    expect(tree()[0].children).toBeUndefined();
+    expect(tree()[1].children).toHaveLength(1);
+    await advance(30_000);
+    expect(tree()[1].children).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/helpers.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/helpers.ts
@@ -26,9 +26,6 @@ const log = createLogger("useCodeEditor");
  */
 export const COLLAPSED_SUBTREE_RETENTION_MS = 2 * 60 * 1000;
 
-/** How often the collapsed-subtree pruner looks for expired subtrees. */
-export const COLLAPSED_SUBTREE_SWEEP_MS = 30 * 1000;
-
 /**
  * Above this many loaded nodes every collapsed subtree is pruned at once,
  * without waiting for the retention window, so a huge repository cannot pin
@@ -247,16 +244,17 @@ export function countTreeNodes(nodes: FileNode[]): number {
 }
 
 /**
- * Drop the loaded children of a collapsed directory, remembering which of its
+ * Drop loaded children of the selected collapsed directories in one traversal,
+ * remembering which of their
  * descendants were expanded so the next expansion restores the same view.
  * Expanded directories and files are left untouched.
  */
-export function pruneCollapsedSubtree(
+export function pruneCollapsedSubtrees(
   tree: FileNode[],
-  targetPath: string
+  targetPaths: ReadonlySet<string>
 ): FileNode[] {
   return tree.map((node) => {
-    if (node.path === targetPath) {
+    if (targetPaths.has(node.path)) {
       if (
         node.type !== "directory" ||
         node.expanded ||
@@ -274,7 +272,7 @@ export function pruneCollapsedSubtree(
     if (node.children) {
       return {
         ...node,
-        children: pruneCollapsedSubtree(node.children, targetPath),
+        children: pruneCollapsedSubtrees(node.children, targetPaths),
       };
     }
     return node;

--- a/src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/useFileTree.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/useFileTree.ts
@@ -19,16 +19,14 @@ import {
 
 import {
   COLLAPSED_SUBTREE_RETENTION_MS,
-  COLLAPSED_SUBTREE_SWEEP_MS,
   MAX_RETAINED_TREE_NODES,
   collectExpandedPaths,
-  countTreeNodes,
   ensureGitignoreChecker,
   findNodeInTree,
   loadDirectoryContents,
   loadDirectorySubtree,
   mergeTreeReloadingExpanded,
-  pruneCollapsedSubtree,
+  pruneCollapsedSubtrees,
   updateTreeChildren,
   updateTreeExpansion,
 } from "./helpers";
@@ -82,68 +80,76 @@ export function useFileTree(
   // the next expansion restores the same view from a fresh directory read.
   const collapsedAtRef = useRef<Map<string, number>>(new Map());
 
-  const pruneCollapsedPaths = useCallback(
-    (paths: string[]) => {
-      if (paths.length === 0) return;
-      for (const path of paths) {
-        collapsedAtRef.current.delete(path);
-      }
-      setFileTree((prev) => {
-        let next = prev;
-        for (const path of paths) {
-          next = pruneCollapsedSubtree(next, path);
-        }
-        return next;
-      });
-    },
-    [setFileTree]
-  );
-
-  const sweepCollapsedSubtrees = useCallback(
-    (force: boolean) => {
-      const collapsedAt = collapsedAtRef.current;
-      if (collapsedAt.size === 0) return;
-      const now = Date.now();
-      const expired: string[] = [];
-      for (const [path, at] of collapsedAt) {
-        const node = findNodeInTree(fileTreeRef.current, path);
-        if (!node || node.type !== "directory" || node.expanded) {
-          collapsedAt.delete(path);
-          continue;
-        }
-        if (!node.children || node.children.length === 0) {
-          collapsedAt.delete(path);
-          continue;
-        }
-        if (force || now - at >= COLLAPSED_SUBTREE_RETENTION_MS) {
-          expired.push(path);
-        }
-      }
-      pruneCollapsedPaths(expired);
-    },
-    [pruneCollapsedPaths]
-  );
-
-  const noteCollapsed = useCallback(
-    (paths: string[]) => {
-      const now = Date.now();
-      for (const path of paths) {
-        collapsedAtRef.current.set(path, now);
-      }
-      if (countTreeNodes(fileTreeRef.current) > MAX_RETAINED_TREE_NODES) {
-        sweepCollapsedSubtrees(true);
-      }
-    },
-    [sweepCollapsedSubtrees]
-  );
+  const noteCollapsed = useCallback((paths: string[]) => {
+    const now = Date.now();
+    for (const path of paths) collapsedAtRef.current.set(path, now);
+  }, []);
 
   useEffect(() => {
-    const timer = setInterval(
-      () => sweepCollapsedSubtrees(false),
-      COLLAPSED_SUBTREE_SWEEP_MS
-    );
-    return () => clearInterval(timer);
-  }, [sweepCollapsedSubtrees]);
+    const collapsedAt = collapsedAtRef.current;
+    if (collapsedAt.size === 0) return;
+
+    // Reconcile retained paths and count nodes in one pass over the committed
+    // tree. In particular, a just-collapsed node must not be read from a stale ref.
+    const retained = new Set<string>();
+    let nodeCount = 0;
+    const visit = (nodes: FileNode[]) => {
+      for (const node of nodes) {
+        nodeCount += 1;
+        if (
+          node.type === "directory" &&
+          !node.expanded &&
+          node.children?.length
+        ) {
+          retained.add(node.path);
+        }
+        if (node.children) visit(node.children);
+      }
+    };
+    visit(fileTree);
+    for (const path of collapsedAt.keys()) {
+      if (!retained.has(path)) collapsedAt.delete(path);
+    }
+    if (collapsedAt.size === 0) return;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const clearTimer = () => {
+      if (timer !== undefined) clearTimeout(timer);
+      timer = undefined;
+    };
+    const expire = () => {
+      clearTimer();
+      if (document.visibilityState === "hidden") return;
+      const now = Date.now();
+      const expired = new Set<string>();
+      let nextExpiry = Infinity;
+      for (const [path, at] of collapsedAt) {
+        const deadline = at + COLLAPSED_SUBTREE_RETENTION_MS;
+        if (nodeCount > MAX_RETAINED_TREE_NODES || deadline <= now) {
+          expired.add(path);
+          collapsedAt.delete(path);
+        } else {
+          nextExpiry = Math.min(nextExpiry, deadline);
+        }
+      }
+      if (expired.size > 0) {
+        setFileTree((previous) => pruneCollapsedSubtrees(previous, expired));
+      }
+      if (nextExpiry !== Infinity) timer = setTimeout(expire, nextExpiry - now);
+    };
+    // Defer the first pass so React observes the committed collapse before
+    // applying memory pressure pruning. No recurring timer exists when idle.
+    const schedule = () => {
+      clearTimer();
+      if (document.visibilityState !== "hidden") timer = setTimeout(expire, 0);
+    };
+    schedule();
+    document.addEventListener("visibilitychange", schedule);
+    return () => {
+      clearTimer();
+      document.removeEventListener("visibilitychange", schedule);
+    };
+  }, [fileTree, setFileTree]);
 
   // ============================================
   // Load file tree


### PR DESCRIPTION
## Problem

The single-root file-tree hook wakes every 30 seconds to sweep retained collapsed folders, including while hidden. It searches the tree separately for every recorded path and then traverses it again for each prune. Memory-pressure cleanup also reads the pre-collapse ref and can discard the just-recorded timestamp instead of pruning.

## Solution

Replace the recurring sweep with one timeout for the next retained-folder expiry. Reconcile timestamps and count nodes in one pass over the committed tree; batch expired paths into one pruning traversal. Stop timers while hidden, process overdue retention on visibility return, and clean up on re-expansion or unmount. Keep the two-minute retention period, node-cap pruning, and remembered descendant expansion. Remove the unused sweep interval constant.

## Potential risks

Hidden windows retain expired children until visibility returns, trading deferred memory reclamation for no hidden timer work. The node cap is a pruning threshold for collapsed folders, not a hard bound on expanded folders. Reopening a pruned folder still requires a filesystem read. No on-disk data, dependencies, schema, or IPC contracts change; reverting restores periodic cleanup.

Real Tauri CPU/RSS and interactive rendering were not measured because desktop computer control is explicit opt-in. Screenshots would not demonstrate this retention scheduling change; layout and copy are unchanged. The multi-root hook has no equivalent periodic collapsed-subtree sweep and is outside this change.

## Verification

- `pnpm test src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/__tests__` — 25 tests passed, including hook-level idle timer counts, exact expiry, hidden/resume, re-expansion, unmount, node cap, independent deadlines, and existing expansion restoration helpers.
- A 1,000-directory batch-pruning test asserts 2,000 path reads (membership plus immutable copy), avoiding a traversal per selected path.
- `pnpm exec eslint src/modules/WorkStation/CodeEditor/hooks/useCodeEditor/{helpers.ts,useFileTree.ts,__tests__/helpers.test.ts,__tests__/useFileTree.test.ts} --max-warnings 0` — passed.
- `GOMAXPROCS=2 pnpm run typecheck:fast` — passed (initial competing runs were stopped and retried with bounded concurrency).
- `pnpm run check:test-placement` — passed.
- `git diff --check` — passed.

## Performance review

| Area | Verdict | Evidence | Decision | Verification |
| --- | --- | --- | --- | --- |
| Background work | fix | next-expiry timeout | no idle/hidden timer; visibility catch-up | hook timer assertions |
| Memory | fix | retained collapsed children | preserve retention and prune above node cap using committed tree | expiry/cap tests |
| Rendering/hot path | fix | batch prune set | one traversal for many expired paths | 1,000-directory operation count |

Architecture layers 1–7 and 9 reviewed for compilation, ownership, naming, defaults, boundaries, and collapse/expand/hidden initialization. Layers 8 and 10 skipped: no wire or resolver changes. Performance verdict: blocked for real Tauri CPU/RSS measurement; automated lifecycle and traversal assertions pass.
