### PR TITLE
perf(sidebar): pause RAM diagnostics while hidden

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/useRamMonitorMetrics.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/useRamMonitorMetrics.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRamMonitorMetrics } from "./useRamMonitorMetrics";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  refresh: vi.fn(),
+  collect: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ warn: vi.fn() }),
+}));
+vi.mock("@src/hooks/perf", () => ({
+  useRuntimeRamStats: () => ({ refresh: mocks.refresh, rows: [] }),
+  useAppMemorySnapshot: () => ({}),
+  collectWebViewRuntimeDiagnostics: mocks.collect,
+  getLoadedScriptSourceStats: () => ({}),
+}));
+vi.mock("@src/util/memory/cacheRegistry", () => ({
+  listRegisteredCaches: () => [],
+}));
+vi.mock(
+  "@src/engines/TerminalCore/components/TerminalInteractive/bufferCache",
+  () => ({
+    getTerminalBufferCacheStats: () => ({ bytes: 0, entries: 0 }),
+  })
+);
+
+let root: Root;
+let host: HTMLDivElement;
+let visible = true;
+function Probe({ open }: { open: boolean }) {
+  useRamMonitorMetrics(open);
+  return null;
+}
+async function render(open = true) {
+  await act(async () => root.render(createElement(Probe, { open })));
+}
+async function visibility(next: boolean) {
+  await act(async () => {
+    visible = next;
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+const calls = (command: string) =>
+  mocks.invoke.mock.calls.filter(([name]) => name === command).length;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  visible = true;
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => (visible ? "visible" : "hidden"),
+  });
+  mocks.invoke.mockResolvedValue([]);
+  host = document.createElement("div");
+  document.body.append(host);
+  root = createRoot(host);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  host.remove();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("sidebar RAM polling lifecycle", () => {
+  it("stops all work while hidden and refreshes once on return", async () => {
+    await render();
+    expect(mocks.refresh).toHaveBeenCalledTimes(1);
+    await visibility(false);
+    expect(vi.getTimerCount()).toBe(0);
+    await advance(120_000);
+    expect(mocks.refresh).toHaveBeenCalledTimes(1);
+    await visibility(true);
+    expect(mocks.refresh).toHaveBeenCalledTimes(2);
+    expect(calls("get_pty_memory_usage")).toBe(2);
+    await render(false);
+    expect(vi.getTimerCount()).toBe(0);
+    await visibility(false);
+    await visibility(true);
+    expect(mocks.refresh).toHaveBeenCalledTimes(2);
+  });
+  it("does no work on hidden mount and avoids duplicate minute-boundary refreshes", async () => {
+    visible = false;
+    await render();
+    expect(mocks.invoke).not.toHaveBeenCalled();
+    await visibility(true);
+    await advance(60_000);
+    expect(calls("get_memory_breakdown")).toBe(5);
+    expect(calls("get_pty_memory_usage")).toBe(2);
+    expect(mocks.refresh).toHaveBeenCalledTimes(5);
+  });
+  it("discards stale completions and coalesces a visibility return while IPC is pending", async () => {
+    let resolve!: (value: unknown) => void;
+    mocks.invoke.mockImplementation((name) =>
+      name === "get_memory_breakdown"
+        ? new Promise((done) => {
+            resolve = done;
+          })
+        : Promise.resolve([])
+    );
+    await render();
+    await visibility(false);
+    await visibility(true);
+    expect(calls("get_memory_breakdown")).toBe(1);
+    await act(async () => resolve([]));
+    expect(mocks.refresh).not.toHaveBeenCalled();
+    expect(calls("get_memory_breakdown")).toBe(2);
+    await render(false);
+    await act(async () => resolve([]));
+    expect(mocks.collect).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/useRamMonitorMetrics.ts
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/useRamMonitorMetrics.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { getTerminalBufferCacheStats } from "@src/engines/TerminalCore/components/TerminalInteractive/bufferCache";
 import { createLogger } from "@src/hooks/logger";
@@ -9,6 +9,7 @@ import {
   useAppMemorySnapshot,
   useRuntimeRamStats,
 } from "@src/hooks/perf";
+import { startVisibilityAwarePoller } from "@src/shared/scheduling/visibilityAwarePoller";
 import { listRegisteredCaches } from "@src/util/memory/cacheRegistry";
 
 import {
@@ -22,7 +23,6 @@ const logger = createLogger("SidebarRamMonitor");
 
 export function useRamMonitorMetrics(isOpen: boolean) {
   const [snapshot, setSnapshot] = useState<MetricsSnapshot>(EMPTY_SNAPSHOT);
-  const lastExpensiveFetchAtRef = useRef(0);
   const {
     rows: runtimeRows,
     fpsSample,
@@ -32,106 +32,93 @@ export function useRamMonitorMetrics(isOpen: boolean) {
   } = useRuntimeRamStats(false);
   const appMemoryState = useAppMemorySnapshot(isOpen);
 
-  const fetchExpensiveMetrics = useCallback(async (force = false) => {
-    if (document.visibilityState !== "visible") return;
-
-    const now = Date.now();
-    if (
-      !force &&
-      now - lastExpensiveFetchAtRef.current < EXPENSIVE_METRICS_POLL_INTERVAL_MS
-    ) {
-      return;
-    }
-    lastExpensiveFetchAtRef.current = now;
-
-    try {
-      const ptyMemory = await invoke<PtyMemoryInfo[]>(
-        "get_pty_memory_usage"
-      ).catch(() => []);
-
-      setSnapshot((previousSnapshot) => ({
-        ...previousSnapshot,
-        ptyMemory,
-        lastUpdatedAt: Date.now(),
-        errorMessage: null,
-      }));
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      logger.warn("failed to fetch expensive sidebar RAM metrics", error);
-      setSnapshot((previousSnapshot) => ({
-        ...previousSnapshot,
-        errorMessage,
-      }));
-    }
-  }, []);
-
-  const fetchCheapMetrics = useCallback(async () => {
-    if (document.visibilityState !== "visible") return;
-
-    try {
-      const memoryBreakdown = await invoke<MemoryBreakdown>(
-        "get_memory_breakdown"
-      );
-      const terminalBufferStats = getTerminalBufferCacheStats();
-      const webViewDiagnostics = collectWebViewRuntimeDiagnostics();
-      const scriptSources = getLoadedScriptSourceStats();
-
-      setSnapshot((previousSnapshot) => ({
-        ...previousSnapshot,
-        memoryBreakdown,
-        webViewDiagnostics,
-        scriptSources,
-        terminalBufferBytes: terminalBufferStats.bytes,
-        terminalBufferEntries: terminalBufferStats.entries,
-        cacheRegistry: listRegisteredCaches(),
-        lastUpdatedAt: Date.now(),
-        errorMessage: null,
-      }));
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      logger.warn("failed to fetch sidebar RAM metrics", error);
-      setSnapshot((previousSnapshot) => ({
-        ...previousSnapshot,
-        errorMessage,
-      }));
-    }
-  }, []);
-
-  const refreshAll = useCallback(
-    (forceExpensive = false) => {
-      refreshRuntimeStats();
-      void fetchCheapMetrics();
-      void fetchExpensiveMetrics(forceExpensive);
-    },
-    [fetchCheapMetrics, fetchExpensiveMetrics, refreshRuntimeStats]
-  );
-
   useEffect(() => {
     if (!isOpen) return;
+    let disposed = false;
+    let generation = 0;
+    // In-flight IPC cannot be cancelled, but its result must not publish after
+    // hiding, closing, or a subsequent visibility lifecycle.
+    const invalidate = () => {
+      generation += 1;
+    };
+    document.addEventListener("visibilitychange", invalidate);
+    const isCurrent = (started: number) =>
+      !disposed &&
+      generation === started &&
+      document.visibilityState === "visible";
 
-    const frameId = window.requestAnimationFrame(() => refreshAll(true));
-    const cheapIntervalId = window.setInterval(
-      refreshAll,
+    const fetchCheapMetrics = async () => {
+      const started = generation;
+      try {
+        const memoryBreakdown = await invoke<MemoryBreakdown>(
+          "get_memory_breakdown"
+        );
+        if (!isCurrent(started)) return;
+        refreshRuntimeStats();
+        const terminalBufferStats = getTerminalBufferCacheStats();
+        const webViewDiagnostics = collectWebViewRuntimeDiagnostics();
+        const scriptSources = getLoadedScriptSourceStats();
+        const cacheRegistry = listRegisteredCaches();
+        setSnapshot((previousSnapshot) => ({
+          ...previousSnapshot,
+          memoryBreakdown,
+          webViewDiagnostics,
+          scriptSources,
+          terminalBufferBytes: terminalBufferStats.bytes,
+          terminalBufferEntries: terminalBufferStats.entries,
+          cacheRegistry,
+          lastUpdatedAt: Date.now(),
+          errorMessage: null,
+        }));
+      } catch (error) {
+        if (!isCurrent(started)) return;
+        logger.warn("failed to fetch sidebar RAM metrics", error);
+        setSnapshot((previous) => ({
+          ...previous,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        }));
+      }
+    };
+    const fetchExpensiveMetrics = async () => {
+      const started = generation;
+      try {
+        const ptyMemory = await invoke<PtyMemoryInfo[]>(
+          "get_pty_memory_usage"
+        ).catch(() => []);
+        if (!isCurrent(started)) return;
+        setSnapshot((previous) => ({
+          ...previous,
+          ptyMemory,
+          lastUpdatedAt: Date.now(),
+          errorMessage: null,
+        }));
+      } catch (error) {
+        if (!isCurrent(started)) return;
+        logger.warn("failed to fetch expensive sidebar RAM metrics", error);
+        setSnapshot((previous) => ({
+          ...previous,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        }));
+      }
+    };
+
+    const stopCheap = startVisibilityAwarePoller(
+      document,
+      fetchCheapMetrics,
       CHEAP_METRICS_POLL_INTERVAL_MS
     );
-    const expensiveIntervalId = window.setInterval(
-      () => refreshAll(true),
+    const stopExpensive = startVisibilityAwarePoller(
+      document,
+      fetchExpensiveMetrics,
       EXPENSIVE_METRICS_POLL_INTERVAL_MS
     );
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") refreshAll(true);
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
-      window.cancelAnimationFrame(frameId);
-      window.clearInterval(cheapIntervalId);
-      window.clearInterval(expensiveIntervalId);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      disposed = true;
+      stopCheap();
+      stopExpensive();
+      document.removeEventListener("visibilitychange", invalidate);
     };
-  }, [isOpen, refreshAll]);
+  }, [isOpen, refreshRuntimeStats]);
 
   return {
     snapshot,


### PR DESCRIPTION
## Problem

An open sidebar RAM popover keeps two interval timers running while the document is hidden. Both timers call the full refresh routine, duplicating cheap diagnostics and FPS sampling at minute boundaries. Runtime refresh happens before the old visibility guards.

## Solution

Reuse the shared visibility-aware scheduler with separate 15-second cheap and 60-second expensive refresh loops. Each loop stops while hidden, refreshes once on visibility return, and waits for its request to settle before rearming. Reject IPC completions from an earlier visibility lifecycle or a closed popover before collecting runtime diagnostics or publishing results. Preserve existing PTY-error fallback behavior.

## Potential risks

Native IPC already in flight cannot be cancelled; stale completions are discarded. Refresh cadence is now measured after request settlement, so slow requests reduce update frequency. Existing runtime-memory subscriptions and already-started FPS samples are outside this timer fix. No dependency, persistence, schema, or IPC contract changes. Revert this commit to restore the prior scheduler.

Real Tauri visibility behavior, CPU/RSS measurements, and rendered interaction were not exercised because desktop computer control is explicit opt-in. Screenshots would not demonstrate this scheduling-only change; there is no layout or copy change.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/useRamMonitorMetrics.test.ts src/shared/scheduling/visibilityAwarePoller.test.ts` — 6 tests passed: hidden mount, visible cadence, no duplicate minute refresh, pause/resume, close cleanup, stale completion rejection, and pending-request catch-up.
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/useRamMonitorMetrics*.ts --max-warnings 0` — passed.
- `GOMAXPROCS=2 pnpm run typecheck:fast` — passed (initial competing runs were stopped and retried with bounded concurrency).
- `pnpm run check:test-placement` — passed.
- `git diff --check` — passed.

## Performance review

| Area | Verdict | Evidence | Decision | Verification |
| --- | --- | --- | --- | --- |
| Background work | fix | two visibility-aware owned loops | stop hidden; refresh on return; no overlapping ticks | hook and scheduler tests |
| Scope/lifecycle | fix | effect disposal and visibility generation | discard late IPC results | deferred-promise test |
| Rendering/hot path | fix | runtime refresh belongs only to cheap loop | no timer-driven hidden traversal or duplicate minute refresh | refresh call counts |

Architecture layers 1–7 and 9 reviewed for compilation, ownership, naming, defaults, boundaries, and open/hidden/closed initialization. Layers 8 and 10 skipped: no wire or resolver changes. Performance verdict: blocked for real Tauri CPU/RSS measurement; automated lifecycle assertions pass.
