### PR TITLE
fix(workstation): match dragged tab icons and labels

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/SortableTab.md
+++ b/docs/frontend-ui-audit-2026-09-07/SortableTab.md
@@ -1,0 +1,8 @@
+# SortableTab UI audit
+
+| Line                                                                         | Element                 | Verdict          | Reason                                                                                            | Suggested change |
+| ---------------------------------------------------------------------------- | ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/WorkStation/shared/TabBar/components/SortableTab/index.tsx:127` | Interactive tab surface | keep with reason | Retains TabPillSurface, sortable keyboard attributes, selection semantics, and existing tooltips. | None.            |
+| `src/modules/WorkStation/shared/TabBar/components/SortableTab/index.tsx:154` | Visible content         | keep with reason | Delegates presentation only; close controls and drag ownership stay with the regular tab.         | None.            |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-07/TabBar.md
+++ b/docs/frontend-ui-audit-2026-09-07/TabBar.md
@@ -1,0 +1,8 @@
+# TabBar UI audit
+
+| Line                                                  | Element            | Verdict          | Reason                                                                                                           | Suggested change |
+| ----------------------------------------------------- | ------------------ | ---------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/WorkStation/shared/TabBar/index.tsx:469` | Drag preview shell | keep with reason | Uses the shared drag surface styling and the regular tab’s 240px width cap; the visual duplicate is aria-hidden. | None.            |
+| `src/modules/WorkStation/shared/TabBar/index.tsx:473` | Icon and label     | keep with reason | Uses WorkstationTabContent with the same tab, selection state, and Git status as the strip.                      | None.            |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-07/WorkstationTabContent.md
+++ b/docs/frontend-ui-audit-2026-09-07/WorkstationTabContent.md
@@ -1,0 +1,8 @@
+# WorkstationTabContent UI audit
+
+| Line                                                                            | Element                      | Verdict          | Reason                                                                                                                                                                  | Suggested change |
+| ------------------------------------------------------------------------------- | ---------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/WorkStation/shared/TabBar/components/WorkstationTabContent.tsx:67` | Shared content renderer      | keep with reason | Reuses WorkstationTabIcon and TabLabelRowScrim; introduces no interactive control or duplicate sortable registration.                                                   | None.            |
+| `src/modules/WorkStation/shared/TabBar/components/WorkstationTabContent.tsx:84` | Typography and status colors | keep with reason | Preserves existing 13px labels, 11px status markers, and semantic Git colors. Available workstation typography presets add different font weights or serve other roles. | None.            |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.

--- a/src/modules/WorkStation/shared/TabBar/components/SortableTab/__tests__/index.test.ts
+++ b/src/modules/WorkStation/shared/TabBar/components/SortableTab/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { WorkStationTab } from "@src/store/workstation/tabs/types";
 
 import { SortableTab, resolveWorkstationTabIntegrationIcon } from "..";
+import { WorkstationTabContent } from "../../WorkstationTabContent";
 
 vi.mock("@src/components/IntegrationIcon", () => ({
   default: ({ type, size }: { type: string; size: number }) =>
@@ -87,5 +88,46 @@ describe("resolveWorkstationTabIntegrationIcon", () => {
     expect(markup).toMatch(
       /<svg[^>]*class="[^"]*text-text-1[^"]*"[^>]*data-icon="layout-grid"/
     );
+  });
+});
+
+describe("Workstation tab drag content", () => {
+  it("renders a tool glyph and localized label instead of the stored title", () => {
+    const markup = renderToStaticMarkup(
+      createElement(WorkstationTabContent, {
+        tab: {
+          ...tab("start"),
+          title: "Stale stored title",
+          icon: "LayoutGrid",
+        },
+        isActive: true,
+      })
+    );
+
+    expect(markup).toContain('data-icon="layout-grid"');
+    expect(markup).toContain("navigation:routes.launchpad");
+    expect(markup).not.toContain("Stale stored title");
+  });
+
+  it("preserves timeline revisions and the comparison glyph", () => {
+    const markup = renderToStaticMarkup(
+      createElement(WorkstationTabContent, {
+        tab: {
+          ...tab("git-diff", {
+            isTimeline: true,
+            shortSha: "abc123",
+            headShortSha: "def456",
+          }),
+          title: "index.ts",
+        },
+        isActive: false,
+      })
+    );
+
+    expect(markup).toContain("index.ts (abc123)");
+    expect(markup).toContain("(def456)");
+    expect(markup).toContain('data-icon="move-horizontal"');
+    expect(markup).toContain('data-icon="lock"');
+    expect(markup).not.toContain("Working Tree");
   });
 });

--- a/src/modules/WorkStation/shared/TabBar/components/SortableTab/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/components/SortableTab/index.tsx
@@ -9,36 +9,20 @@ import React, { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip";
-import { TabLabelRowScrim } from "@src/components/TabPill/TabLabelRowScrim";
 import { TabPillCloseButton } from "@src/components/TabPill/TabPillCloseButton";
 import { TabPillSurface } from "@src/components/TabPill/TabPillSurface";
-import {
-  getStatusColor,
-  getStatusColorForFile,
-  getStatusLetterForFile,
-} from "@src/config/gitStatus";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
-import {
-  HugeiconsIcon,
-  LockIcon as Lock,
-  MoveLeftIcon as MoveHorizontal,
-} from "@src/icons";
 import { CODE_EDITOR_TOUR_TARGETS } from "@src/scaffold/Tutorials/codeEditorTourConfig";
 import type { GitFileInfo } from "@src/store/git";
-import {
-  isPlaceholderBrowserSessionTitle,
-  translatePlaceholderBrowserSessionTitle,
-} from "@src/store/workstation/browser/tabs";
-import {
-  CODE_EDITOR_MAIN_TERMINAL_TAB_ID,
-  resolveProjectManagerTabTitle,
-} from "@src/store/workstation/tabs";
 
 import type { WorkStationTab } from "../../types";
 import {
+  WorkstationTabContent,
+  getWorkstationTabDisplayTitle,
+} from "../WorkstationTabContent";
+import {
   WORKSTATION_TAB_ICONS,
-  WorkstationTabIcon,
   resolveWorkstationTabIntegrationIcon,
 } from "../WorkstationTabIcon";
 
@@ -58,17 +42,6 @@ interface SortableTabProps {
   gitInfo?: GitFileInfo | null;
   /** Icon only (e.g. narrow tab strip); title still in native tooltip via getTabTitle(). */
   hideLabel?: boolean;
-}
-
-// ============================================
-// Helper Functions
-// ============================================
-
-/**
- * Get color class for git status letter - uses centralized VSCode styling
- */
-function getGitStatusColor(statusLetter: string): string {
-  return getStatusColor(statusLetter);
 }
 
 // ============================================
@@ -106,40 +79,6 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
       zIndex: isDragging ? 100 : undefined,
     };
 
-    const getDisplayTitle = () => {
-      if (
-        tab.type === "browser-session" &&
-        isPlaceholderBrowserSessionTitle(tab.title)
-      ) {
-        return translatePlaceholderBrowserSessionTitle(tab.title, t);
-      }
-      if (
-        tab.type === "project-dashboard" ||
-        tab.type === "project-work-items" ||
-        tab.type === "project-linear-projects" ||
-        tab.type === "project-linear-work-items"
-      ) {
-        return resolveProjectManagerTabTitle(tab, t);
-      }
-      // Localized titles for the singleton tool tabs.
-      switch (tab.type) {
-        case "start":
-          return t("navigation:routes.launchpad");
-        case "search-sessions":
-          return t("navigation:workstation.plusMenu.searchSessions");
-        case "explorer":
-          return t("common:labels.files");
-        case "source-control":
-          return t("common:actions.review");
-        case "terminal":
-          if (tab.id === CODE_EDITOR_MAIN_TERMINAL_TAB_ID) {
-            return t("common:tabs.terminal");
-          }
-          break;
-      }
-      return tab.title;
-    };
-
     const getTabTitle = () => {
       const filePath = tab.data.filePath as string | undefined;
       const sessionName = tab.data.sessionName as string | undefined;
@@ -162,7 +101,7 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
           return prTitle ? `#${tab.data.prNumber} ${prTitle}` : tab.title;
         }
         default:
-          return getDisplayTitle();
+          return getWorkstationTabDisplayTitle(tab, t);
       }
     };
 
@@ -175,7 +114,7 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
             ? "open_source_control_tab"
             : null;
     const shortcut = shortcutId ? getShortcutKeys(shortcutId) : "";
-    const shortcutTooltipLabel = getDisplayTitle();
+    const shortcutTooltipLabel = getWorkstationTabDisplayTitle(tab, t);
 
     const hasUnsaved = !!tab.hasUnsavedChanges;
     const showCloseSlot = isTabHovered || hasUnsaved;
@@ -183,17 +122,6 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
     const showLabelRightScrim = isTabHovered || hasUnsaved;
     const closeButtonLayoutClass =
       "-translate-y-1/2 absolute right-1 top-1/2 z-10 h-5 w-5";
-
-    const titleTextClass = (base: string) =>
-      `${base} ${
-        tab.type === "git-diff" && tab.data.gitStatusLetter === "D"
-          ? "text-danger-6 line-through"
-          : tab.type === "file" && gitInfo
-            ? getStatusColorForFile(gitInfo.status, gitInfo.staged)
-            : isActive
-              ? "text-text-1"
-              : "text-text-2"
-      }`;
 
     const tabPill = (
       <TabPillSurface
@@ -223,65 +151,13 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
         onMouseLeave={() => setIsTabHovered(false)}
         title={shortcut ? undefined : getTabTitle()}
       >
-        {/* Keep icon in-flow so width only comes from the label column; close stays overlay-only. */}
-        <div className="flex shrink-0 items-center justify-center">
-          <WorkstationTabIcon tab={tab} isActive={isActive} />
-        </div>
-
-        {!hideLabel && tab.type === "git-diff" && tab.data.isTimeline ? (
-          <div
-            className={`relative flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-[13px] ${
-              isActive ? "text-text-1" : "text-text-2"
-            }`}
-          >
-            <span className="min-w-0 flex-1 truncate">
-              {tab.title} ({String(tab.data.shortSha)})
-            </span>
-            <HugeiconsIcon
-              icon={MoveHorizontal}
-              data-icon="move-horizontal"
-              size={12}
-              className="shrink-0"
-            />
-            <span className="shrink-0">
-              ({String(tab.data.headShortSha || "HEAD")})
-            </span>
-            <HugeiconsIcon
-              icon={Lock}
-              data-icon="lock"
-              size={11}
-              className="shrink-0"
-            />
-            <TabLabelRowScrim visible={showLabelRightScrim} />
-          </div>
-        ) : !hideLabel ? (
-          <div className="relative flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-            <span
-              className={titleTextClass(
-                "min-w-0 flex-1 overflow-hidden text-[13px] text-ellipsis whitespace-nowrap"
-              )}
-            >
-              {tab.type === "git-diff"
-                ? `${tab.title} (Working Tree)`
-                : getDisplayTitle()}
-            </span>
-            {tab.type === "git-diff" && !!tab.data.gitStatusLetter && (
-              <span
-                className={`shrink-0 text-[11px] font-bold ${getGitStatusColor(tab.data.gitStatusLetter as string)}`}
-              >
-                {String(tab.data.gitStatusLetter)}
-              </span>
-            )}
-            {tab.type === "file" && gitInfo && (
-              <span
-                className={`shrink-0 text-[11px] font-bold ${getStatusColorForFile(gitInfo.status, gitInfo.staged)}`}
-              >
-                {getStatusLetterForFile(gitInfo.status, gitInfo.staged)}
-              </span>
-            )}
-            <TabLabelRowScrim visible={showLabelRightScrim} />
-          </div>
-        ) : null}
+        <WorkstationTabContent
+          tab={tab}
+          isActive={isActive}
+          gitInfo={gitInfo}
+          hideLabel={hideLabel}
+          showLabelRightScrim={showLabelRightScrim}
+        />
 
         <TabPillCloseButton
           data-action="editor.tab.close"

--- a/src/modules/WorkStation/shared/TabBar/components/WorkstationTabContent.tsx
+++ b/src/modules/WorkStation/shared/TabBar/components/WorkstationTabContent.tsx
@@ -1,0 +1,155 @@
+import type { TFunction } from "i18next";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import { TabLabelRowScrim } from "@src/components/TabPill/TabLabelRowScrim";
+import {
+  getStatusColor,
+  getStatusColorForFile,
+  getStatusLetterForFile,
+} from "@src/config/gitStatus";
+import {
+  HugeiconsIcon,
+  LockIcon as Lock,
+  MoveLeftIcon as MoveHorizontal,
+} from "@src/icons";
+import type { GitFileInfo } from "@src/store/git";
+import {
+  isPlaceholderBrowserSessionTitle,
+  translatePlaceholderBrowserSessionTitle,
+} from "@src/store/workstation/browser/tabs";
+import {
+  CODE_EDITOR_MAIN_TERMINAL_TAB_ID,
+  resolveProjectManagerTabTitle,
+} from "@src/store/workstation/tabs";
+
+import type { WorkStationTab } from "../types";
+import { WorkstationTabIcon } from "./WorkstationTabIcon";
+
+export function getWorkstationTabDisplayTitle(
+  tab: WorkStationTab,
+  t: TFunction
+) {
+  if (
+    tab.type === "browser-session" &&
+    isPlaceholderBrowserSessionTitle(tab.title)
+  ) {
+    return translatePlaceholderBrowserSessionTitle(tab.title, t);
+  }
+  if (
+    tab.type === "project-dashboard" ||
+    tab.type === "project-work-items" ||
+    tab.type === "project-linear-projects" ||
+    tab.type === "project-linear-work-items"
+  ) {
+    return resolveProjectManagerTabTitle(tab, t);
+  }
+  // Localized titles for the singleton tool tabs.
+  switch (tab.type) {
+    case "start":
+      return t("navigation:routes.launchpad");
+    case "search-sessions":
+      return t("navigation:workstation.plusMenu.searchSessions");
+    case "explorer":
+      return t("common:labels.files");
+    case "source-control":
+      return t("common:actions.review");
+    case "terminal":
+      if (tab.id === CODE_EDITOR_MAIN_TERMINAL_TAB_ID) {
+        return t("common:tabs.terminal");
+      }
+      break;
+  }
+  return tab.title;
+}
+
+/** Shared visible content for the tab strip and its drag preview. */
+export function WorkstationTabContent({
+  tab,
+  isActive,
+  gitInfo = null,
+  hideLabel = false,
+  showLabelRightScrim = false,
+}: {
+  tab: WorkStationTab;
+  isActive: boolean;
+  gitInfo?: GitFileInfo | null;
+  hideLabel?: boolean;
+  showLabelRightScrim?: boolean;
+}) {
+  const { t } = useTranslation();
+  const titleTextClass = (base: string) =>
+    `${base} ${
+      tab.type === "git-diff" && tab.data.gitStatusLetter === "D"
+        ? "text-danger-6 line-through"
+        : tab.type === "file" && gitInfo
+          ? getStatusColorForFile(gitInfo.status, gitInfo.staged)
+          : isActive
+            ? "text-text-1"
+            : "text-text-2"
+    }`;
+
+  return (
+    <>
+      {/* Keep icon in-flow so width only comes from the label column; close stays overlay-only. */}
+      <div className="flex shrink-0 items-center justify-center">
+        <WorkstationTabIcon tab={tab} isActive={isActive} />
+      </div>
+
+      {!hideLabel && tab.type === "git-diff" && tab.data.isTimeline ? (
+        <div
+          className={`relative flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-[13px] ${
+            isActive ? "text-text-1" : "text-text-2"
+          }`}
+        >
+          <span className="min-w-0 flex-1 truncate">
+            {tab.title} ({String(tab.data.shortSha)})
+          </span>
+          <HugeiconsIcon
+            icon={MoveHorizontal}
+            data-icon="move-horizontal"
+            size={12}
+            className="shrink-0"
+          />
+          <span className="shrink-0">
+            ({String(tab.data.headShortSha || "HEAD")})
+          </span>
+          <HugeiconsIcon
+            icon={Lock}
+            data-icon="lock"
+            size={11}
+            className="shrink-0"
+          />
+          <TabLabelRowScrim visible={showLabelRightScrim} />
+        </div>
+      ) : !hideLabel ? (
+        <div className="relative flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+          <span
+            className={titleTextClass(
+              "min-w-0 flex-1 overflow-hidden text-[13px] text-ellipsis whitespace-nowrap"
+            )}
+          >
+            {tab.type === "git-diff"
+              ? `${tab.title} (Working Tree)`
+              : getWorkstationTabDisplayTitle(tab, t)}
+          </span>
+          {tab.type === "git-diff" && !!tab.data.gitStatusLetter && (
+            <span
+              className={`shrink-0 text-[11px] font-bold ${getStatusColor(tab.data.gitStatusLetter as string)}`}
+            >
+              {String(tab.data.gitStatusLetter)}
+            </span>
+          )}
+          {tab.type === "file" && gitInfo && (
+            <span
+              className={`shrink-0 text-[11px] font-bold ${getStatusColorForFile(gitInfo.status, gitInfo.staged)}`}
+            >
+              {getStatusLetterForFile(gitInfo.status, gitInfo.staged)}
+            </span>
+          )}
+          <TabLabelRowScrim visible={showLabelRightScrim} />
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/modules/WorkStation/shared/TabBar/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/index.tsx
@@ -38,7 +38,6 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import { useActionSystemOptional } from "@src/ActionSystem";
-import FileTypeIcon from "@src/components/FileTypeIcon";
 import { TAB_PILL_DRAG_OVERLAY_CLASS } from "@src/components/TabPill/TabPillSurface";
 import { TAB_PAIR_SEPARATOR_SLOT_CLASS } from "@src/components/TabPill/config";
 import { NoDragRegion } from "@src/components/WindowChrome";
@@ -73,6 +72,7 @@ import { tabScrollRevealAtom } from "@src/store/workstation/tabs";
 
 import TabContextMenu from "./TabContextMenu";
 import { SortableTab, TabBarControls } from "./components";
+import { WorkstationTabContent } from "./components/WorkstationTabContent";
 import { TAB_BAR_HEIGHT, TAB_STRIP_SECTION_RULE_CLASS } from "./config";
 import {
   useAutoScrollToActive,
@@ -466,16 +466,15 @@ export const TabBar: React.FC<TabBarProps> = memo(
                     <DragOverlay dropAnimation={null}>
                       {draggingTab && (
                         <div
-                          className={TAB_PILL_DRAG_OVERLAY_CLASS}
+                          className={`${TAB_PILL_DRAG_OVERLAY_CLASS} max-w-[240px]`}
+                          aria-hidden
                           style={{ zIndex: 9999 }}
                         >
-                          <FileTypeIcon
-                            fileName={draggingTab.title}
-                            size="small"
+                          <WorkstationTabContent
+                            tab={draggingTab}
+                            isActive={draggingTab.id === activeTabId}
+                            gitInfo={tabGitInfoMap.get(draggingTab.id)}
                           />
-                          <span className="max-w-[150px] overflow-hidden text-[13px] text-ellipsis whitespace-nowrap">
-                            {draggingTab.title}
-                          </span>
                         </div>
                       )}
                     </DragOverlay>,


### PR DESCRIPTION
## Problem

Dragging a My Station tab displayed a generic file icon and the raw saved title. The tab strip uses type-specific icons and translated labels, so tool, browser, project and diff tabs could change identity while being dragged. This is a presentation mismatch; persisted tab data is unchanged.

## Solution

Share `WorkstationTabContent` between the regular tab and its drag preview. Both now use the same icon, localized label, revision comparison and Git status rendering. Keep sortable registration, tooltips and close controls in the regular tab. Match the regular 240px width cap and hide the visual duplicate from assistive technology.

## Potential risks

The shared tab content extraction affects the regular strip as well as the overlay. Native pointer/keyboard dragging, overflow truncation, themes, browser favicon loading and session icons have not been visually verified; desktop control was not authorized. Automated rendering tests cover tool identity and revision labels but do not replace those runtime checks. No dependencies, persistence formats, migrations or public APIs change; reverting this commit restores the previous rendering.

## Verification

Run in an isolated worktree based on the latest `origin/develop`:

- `pnpm test src/modules/WorkStation/shared/TabBar/components/SortableTab/__tests__` — 9 tests passed across 2 files.
- `pnpm typecheck:fast` — passed with no errors.
- `pnpm exec eslint src/modules/WorkStation/shared/TabBar/index.tsx src/modules/WorkStation/shared/TabBar/components/SortableTab/index.tsx src/modules/WorkStation/shared/TabBar/components/WorkstationTabContent.tsx src/modules/WorkStation/shared/TabBar/components/SortableTab/__tests__/index.test.ts --max-warnings 0` — passed.
- `pnpm exec prettier --check src/modules/WorkStation/shared/TabBar/index.tsx src/modules/WorkStation/shared/TabBar/components/SortableTab/index.tsx src/modules/WorkStation/shared/TabBar/components/WorkstationTabContent.tsx src/modules/WorkStation/shared/TabBar/components/SortableTab/__tests__/index.test.ts` — passed.
- `git diff --cached --check` and `git diff origin/develop...HEAD --check` — passed; final diff reviewed for unrelated changes, secrets and generated artifacts.
- Commit hooks ran successfully: lint-staged (Oxlint, ESLint, Prettier) and TypeScript check. Rust checks were skipped because no Rust files changed.
- Native screenshots/recordings and rendered E2E tests were not run; desktop control is opt-in and was not authorized. Full application test suite was not run for this scoped rendering change.

## Audit

Frontend UI audit reports included: 0 fix, 6 keep with reason, 0 abstract. Existing semantic colors, typography and tab primitives are retained.
