### PR TITLE
fix(launchpad): adapt card layout and default to collapsed

### DIFF
--- a/src/features/SessionCreator/components/LaunchpadActionGrid.tsx
+++ b/src/features/SessionCreator/components/LaunchpadActionGrid.tsx
@@ -166,7 +166,7 @@ export function LaunchpadActionGrid({
   layoutActionCount,
   presentation = "pill",
 }: LaunchpadActionGridProps): React.ReactNode {
-  const [isStandardCollapsed, setIsStandardCollapsed] = useState(false);
+  const [isStandardCollapsed, setIsStandardCollapsed] = useState(true);
   const [isCompactExpanded, setIsCompactExpanded] = useState(false);
   const contentId = useId();
   const isCardGrid = presentation === "card";
@@ -180,7 +180,7 @@ export function LaunchpadActionGrid({
   const cardWidthClass =
     cardWidthClassName ??
     (actionCount >= 4
-      ? "max-w-[320px]"
+      ? "max-w-[320px] @[640px]/focusedchat:max-w-[640px]"
       : actionCount === 3
         ? "max-w-[480px]"
         : "max-w-[320px]");

--- a/src/features/SessionCreator/components/__tests__/LaunchpadActionGrid.test.ts
+++ b/src/features/SessionCreator/components/__tests__/LaunchpadActionGrid.test.ts
@@ -51,7 +51,7 @@ describe("LaunchpadActionGrid", () => {
     Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
   });
 
-  it("collapses and restores a card grid with tertiary controls", () => {
+  it("starts collapsed and expands, collapses, and restores cards with tertiary controls", () => {
     act(() => {
       root.render(
         createElement(
@@ -70,6 +70,20 @@ describe("LaunchpadActionGrid", () => {
         )
       );
     });
+
+    const initialExpandButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="launchpad-action-grid-expand"]'
+    );
+    expect(initialExpandButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      container.querySelector<HTMLElement>(".launchpad-action-grid-content")
+        ?.hidden
+    ).toBe(true);
+    act(() => initialExpandButton?.click());
+    expect(
+      container.querySelector<HTMLElement>(".launchpad-action-grid-content")
+        ?.hidden
+    ).toBe(false);
 
     const collapseButton = container.querySelector<HTMLButtonElement>(
       '[data-testid="launchpad-action-grid-collapse"]'
@@ -118,7 +132,7 @@ describe("LaunchpadActionGrid", () => {
     ).not.toBeNull();
   });
 
-  it("keeps the narrow four-action card grid compact", () => {
+  it("allows four columns in wide panes and keeps narrow panes compact", () => {
     act(() => {
       root.render(
         createElement(
@@ -136,6 +150,10 @@ describe("LaunchpadActionGrid", () => {
       ".launchpad-action-grid-content"
     );
     expect(grid?.parentElement?.className).toContain("max-w-[320px]");
+    expect(grid?.parentElement?.className).toContain(
+      "@[640px]/focusedchat:max-w-[640px]"
+    );
+    expect(grid?.className).toContain("@[560px]/startactions:grid-cols-4");
   });
 
   it("pins compositor layers so hover repaints cannot re-round icon pixels", () => {
@@ -155,6 +173,14 @@ describe("LaunchpadActionGrid", () => {
         )
       );
     });
+
+    act(() =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="launchpad-action-grid-expand"]'
+        )
+        ?.click()
+    );
 
     // The launchpad block is positioned on a fractional device pixel, so a
     // compositor layer that is created and destroyed on hover re-rounds every


### PR DESCRIPTION
## Problem

The start-page launchpad is capped at 320px even in wide panes. Its four-column container breakpoint requires 560px, so the cards remain 2×2 and the shared heading wraps despite available space. Collapsible cards also start expanded on wide panes.

## Solution

Allow the four-action group to grow to 640px when the focused chat pane is at least 640px wide. This gives the heading room to stay on one line and enables the existing four-column layout. Narrow panes retain the compact grid. Initialize collapsible card groups as collapsed, preserving the existing expand/collapse controls and pill presentation.

Update the component regression tests for the default collapsed state, disclosure interactions, and responsive width classes.

## Potential risks

The default applies to all collapsible card consumers of the shared component. Actual wrapping varies with translated text and pane width; extremely narrow groups retain the existing single-column fallback. Browser container-query rendering, theme appearance, and resizing have not been visually verified. There are no dependency, persistence, API, or background-work changes; rollback is a revert of this commit.

## Verification

Run on the branch based on the latest fetched `origin/develop`:

- `pnpm test src/features/SessionCreator/components/__tests__/LaunchpadActionGrid.test.ts src/features/SessionCreator/variants/ChatPanel/SessionCreatorAgentHero.test.ts src/engines/ChatPanel/ChatPanelStartPage.test.ts` — 20 tests passed across 3 files.
- `pnpm exec eslint src/features/SessionCreator/components/LaunchpadActionGrid.tsx src/features/SessionCreator/components/__tests__/LaunchpadActionGrid.test.ts --max-warnings 0` — passed.
- `git diff --check` — passed.
- Commit hooks — lint-staged (oxlint, ESLint, Prettier) and the TypeScript check passed; Rust checks skipped because no Rust files changed.
- Reviewed the two-file diff for scope, secrets, private paths, generated artifacts, and unrelated changes.

No rendered screenshots or live-app checks were produced because desktop UI control requires explicit opt-in. The responsive regression test checks emitted classes, not browser layout. Full-suite tests were not run for this localized UI fix.
