### PR TITLE
feat(sidebar): add session sorting and manual ordering

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/SessionSidebarOrdering-verification.md
+++ b/docs/frontend-ui-audit-2026-09-07/SessionSidebarOrdering-verification.md
@@ -1,0 +1,61 @@
+# Session sidebar ordering verification
+
+Grouping offers time, workspace, agent, and a flat list. Sorting offers priority (waiting for user, then running/in-progress, then other sessions), last updated, and manual order. Existing defaults remain time grouping and last-updated sorting. A drop selects manual sorting; a drop across regular group boundaries or from pins into another group selects the flat list so the position has an unambiguous meaning. Grouping never rewrites workspace, agent, or timestamps.
+
+Order is a local presentation preference, bounded to 5,000 session identities, including unloaded identities so pagination does not erase order. Loaded sessions without a saved rank fall back to recency. Drag-to-unpin uses `useWorkstationSidebarHandlers.handleTogglePin` → `rpc.sessionAggregate.patch({ patch: { pinned } })`, retaining its existing optimistic update and rollback behavior. No schema or wire change, and no historical data remediation is needed.
+
+The drag integration supports root sessions present in the local session map, including imported histories. Remote-only Team Session rows, subagent children, and live terminal rows are not reorderable through this integration. Manual order applies to the loaded roster, not a backend-wide ordering query. No new provider/sync or dual-machine claim is made.
+
+Dragging an unpinned session over pinned rows is rejected, with no insertion line or state mutation. Existing pinned rows can still be reordered, and dragging out of pins still unpins. Pinning remains available through the existing row action. The top pin drop target and its locale strings were removed.
+
+## Architecture review
+
+| Layer                     | Coverage                                                                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1 Compilation             | Typecheck and changed-file lint recorded below                                                                                                   |
+| 2 Ownership/deduplication | Existing drag source and existing session pin dispatcher reused; no second persistence path                                                      |
+| 3 Naming                  | GroupByMode is grouping; SessionSortMode is ordering; both have production consumers                                                             |
+| 4 Overloaded terms        | Session pins are persisted session flags; pinned workspace groups and pinned navigation shortcuts remain separate                                |
+| 5 Defaults                | Explicit `none` handling in menu construction, loaded-row reveal, and collapsed-section pagination; invalid stored sorting falls back to recency |
+| 6 Boundaries              | Sidebar-only order stays in the connector; no session-domain rank field                                                                          |
+| 7 Discoverability         | Sort and organization are separate menus; the bottom unpin target labels the operation                                                           |
+| 8 Serialization           | Local JSON identities and enum only; existing pin patch unchanged. No new network payload to inspect                                             |
+| 9 Initialization          | Fresh-store hydration tested; no new session creation/init entry point                                                                           |
+| 10 Resolver symmetry      | All sort modes share the existing recency fallback; no new multi-field domain resolver                                                           |
+
+## Lifecycle review
+
+| Area               | Verdict | Evidence                                                                                                        | Change or reason kept                                                                                | Verification                                                          |
+| ------------------ | ------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Background work    | keep    | Connector owns drag listeners, removes every listener on unmount/disable; movement is gated by an active source | No timer, polling, network fetch or worker added; Escape, blur and pointercancel reset feedback      | DOM cancellation/unmount tests; source inspection                     |
+| Memory             | keep    | One per-mounted-hook feedback atom; persisted order capped at 5,000 identities                                  | No retained session payloads; unloaded identities retained for pagination stability                  | Parser bound and persistence tests                                    |
+| Scope/isolation    | keep    | Drop source must belong to current menu and session map; eligible rows carry explicit DOM markers               | Order contains local presentation IDs only and cannot hydrate or reveal another account's data       | Current-roster guards inspected; real account/endpoint switch not run |
+| Rendering/hot path | keep    | Pointer feedback has dedicated subscribers instead of updating connector state                                  | Sorting memoized on session list/order/mode; only feedback components subscribe to pointer positions | Hook render-count regression test                                     |
+
+App idle/hidden: no scheduled work added. Active drag: bounded feedback and hit testing only. Close/disable/cancel: listeners disposed or feedback cleared. Offline: order remains local and pinning retains the existing persistence behavior. Provider transitions, transport and multi-instance measurements are outside this presentation change.
+
+Performance verdict: blocked for real Tauri visible/hidden idle, pointer geometry, and open/close measurements because desktop control was not authorized. Unit/DOM evidence does not establish real-app performance.
+
+## Commands
+
+- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/connectors/__tests__/{sidebarSessionOrder,SessionFilterButton,loadedSessionVisibility,sidebarGroupByAtom}.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/{useSessionSidebarOrdering,sectionPagination}.test.ts src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts`: 45 passed before final feedback subscriber refinement
+- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarOrdering.test.ts`: 4 passed after final feedback refinement, including connector render-count assertion
+- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/{sidebarSessionOrder.ts,sidebarGroupByAtom.ts,types.ts,SessionFilterButton.tsx,useSessionMenuItems/index.tsx,loadedSessionVisibility.ts,__tests__/sidebarSessionOrder.test.ts,__tests__/SessionFilterButton.test.ts,__tests__/loadedSessionVisibility.test.ts,WorkstationSidebarConnector/index.tsx,WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.ts,WorkstationSidebarConnector/sectionPagination.ts,WorkstationSidebarConnector/useSessionSidebarOrdering.tsx,WorkstationSidebarConnector/useSessionSidebarOrdering.test.ts} --fix`: passed (zero errors/warnings); final render-count test separately linted after its update
+- `pnpm exec prettier --check src/scaffold/NavigationSidebar/connectors/{sidebarSessionOrder.ts,__tests__/sidebarSessionOrder.test.ts,WorkstationSidebarConnector/useSessionSidebarOrdering.test.ts,WorkstationSidebarConnector/useSessionSidebarOrdering.tsx}`: passed
+- `node scripts/quality/check-test-placement.mjs`: passed across 508 directories
+- `pnpm typecheck:fast`: initial and final passes succeeded (exit 0)
+- `git diff --check`: passed
+- Rust and provider/sync tests: not run; no Rust, provider, schema or sync changes
+- Real Tauri UI/E2E and screenshots: not run; no computer-control authorization
+
+## Drag-to-pin removal verification
+
+- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarOrdering.test.ts`: 6 passed, covering rejected drag-to-pin, preserved ordering in both pin states, drag-to-unpin, insertion feedback, and cancellation
+- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/{index.tsx,useSessionSidebarOrdering.tsx,useSessionSidebarOrdering.test.ts}`: passed
+- `pnpm typecheck:fast`: passed
+- `git diff --check`: passed
+- No new background resources; prior real-app measurement limitation remains
+
+## Isolated PR verification
+
+The seven-file focused Vitest command above passed all 47 tests on the final sidebar-only branch based on the latest develop. The labels-modal changes are excluded from this branch.

--- a/docs/frontend-ui-audit-2026-09-07/SessionSidebarOrdering.md
+++ b/docs/frontend-ui-audit-2026-09-07/SessionSidebarOrdering.md
@@ -1,0 +1,12 @@
+# Session sidebar ordering UI audit
+
+| Line                                                                                                      | Element                  | Verdict          | Reason                                                                                                                      | Suggested change |
+| --------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx:387`                                   | Sort trigger and submenu | keep with reason | Reuses DropdownItem, DropdownPanel, shared submenu positioning and keyboard/click handling; all 13 locales supplied         | None             |
+| `src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarOrdering.tsx:234` | Unpin drop target        | keep with reason | Non-clickable pointer destination use themed border/text tokens; existing row pin actions remain available without dragging | None             |
+| `src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarOrdering.tsx:256` | Insertion line           | keep with reason | Pointer-transparent, aria-hidden overlay uses theme accent; computed coordinates must track actual row bounds               | None             |
+| `src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx:623`                     | Row wrapper composition  | keep with reason | Preserves existing row wrapper and reference drag source; no duplicate button or navigation handler                         | None             |
+
+Verdict totals: **0 fix**, **4 keep with reason**, **0 abstract**.
+
+Visual verification: DOM integration tests cover insertion-line presence and cleanup. No desktop control, screenshot capture, or real Tauri visual check was performed, per the user's computer-use preference. Theme contrast, actual pointer geometry, scrolling during drag, and narrow-window layout remain unverified in the real app.

--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Zum Lösen hier ablegen",
+      "title": "Chats sortieren nach",
+      "priority": "Priorität",
+      "updated": "Zuletzt aktualisiert",
+      "manual": "Manuelle Reihenfolge"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Verwalten",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent & Team"
     },
     "groupBy": {
+      "none": "Keine Gruppierung",
       "title": "Gruppieren nach",
       "byTime": "Nach Zeit",
       "byAgent": "Nach Agent",

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -99,6 +99,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Drop here to unpin",
+      "title": "Sort chats by",
+      "priority": "Priority",
+      "updated": "Last updated",
+      "manual": "Manual order"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Manage",
@@ -108,6 +115,7 @@
       "agentOrgs": "Agent & Team"
     },
     "groupBy": {
+      "none": "No grouping",
       "title": "Group by",
       "byTime": "By Time",
       "byAgent": "By Agent",

--- a/src/i18n/locales/es/navigation.json
+++ b/src/i18n/locales/es/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Registro de cambios"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Suelta aquí para desfijar",
+      "title": "Ordenar chats por",
+      "priority": "Prioridad",
+      "updated": "Última actualización",
+      "manual": "Orden manual"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Gestionar",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent y equipo"
     },
     "groupBy": {
+      "none": "Sin agrupar",
       "title": "Agrupar por",
       "byTime": "Por tiempo",
       "byAgent": "Por Agent",

--- a/src/i18n/locales/fr/navigation.json
+++ b/src/i18n/locales/fr/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Déposer ici pour désépingler",
+      "title": "Trier les discussions par",
+      "priority": "Priorité",
+      "updated": "Dernière mise à jour",
+      "manual": "Ordre manuel"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Gérer",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent et équipe"
     },
     "groupBy": {
+      "none": "Sans regroupement",
       "title": "Grouper par",
       "byTime": "Par date",
       "byAgent": "Par Agent",

--- a/src/i18n/locales/ja/navigation.json
+++ b/src/i18n/locales/ja/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "ここにドロップしてピン留めを解除",
+      "title": "チャットの並び順",
+      "priority": "優先度",
+      "updated": "最終更新",
+      "manual": "手動順"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "管理",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent & チーム"
     },
     "groupBy": {
+      "none": "グループ化なし",
       "title": "グループ表示",
       "byTime": "時間順",
       "byAgent": "Agent 別",

--- a/src/i18n/locales/ko/navigation.json
+++ b/src/i18n/locales/ko/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "여기에 놓아 고정 해제",
+      "title": "채팅 정렬",
+      "priority": "우선순위",
+      "updated": "최근 업데이트",
+      "manual": "수동 순서"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "관리",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent & 팀"
     },
     "groupBy": {
+      "none": "그룹 없음",
       "title": "그룹",
       "byTime": "시간순",
       "byAgent": "Agent 별",

--- a/src/i18n/locales/pl/navigation.json
+++ b/src/i18n/locales/pl/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Upuść tutaj, aby odpiąć",
+      "title": "Sortuj czaty według",
+      "priority": "Priorytet",
+      "updated": "Ostatnia aktualizacja",
+      "manual": "Kolejność ręczna"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Zarządzaj",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent i zespół"
     },
     "groupBy": {
+      "none": "Bez grupowania",
       "title": "Grupuj według",
       "byTime": "Według czasu",
       "byAgent": "Według Agenta",

--- a/src/i18n/locales/pt/navigation.json
+++ b/src/i18n/locales/pt/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Solte aqui para desafixar",
+      "title": "Ordenar conversas por",
+      "priority": "Prioridade",
+      "updated": "Última atualização",
+      "manual": "Ordem manual"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Gerenciar",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent e equipe"
     },
     "groupBy": {
+      "none": "Sem agrupamento",
       "title": "Agrupar por",
       "byTime": "Por Tempo",
       "byAgent": "Por Agent",

--- a/src/i18n/locales/ru/navigation.json
+++ b/src/i18n/locales/ru/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Журнал изменений"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Перетащите сюда, чтобы открепить",
+      "title": "Сортировать чаты",
+      "priority": "Приоритет",
+      "updated": "Последнее обновление",
+      "manual": "Вручную"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Управление",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent и команда"
     },
     "groupBy": {
+      "none": "Без группировки",
       "title": "Группировка",
       "byTime": "По времени",
       "byAgent": "По Agent",

--- a/src/i18n/locales/tr/navigation.json
+++ b/src/i18n/locales/tr/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Sabitlemeyi kaldırmak için buraya bırakın",
+      "title": "Sohbetleri sırala",
+      "priority": "Öncelik",
+      "updated": "Son güncelleme",
+      "manual": "Manuel sıra"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Yönet",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent ve ekip"
     },
     "groupBy": {
+      "none": "Gruplama yok",
       "title": "Grupla",
       "byTime": "Zamana göre",
       "byAgent": "Agent'a göre",

--- a/src/i18n/locales/vi/navigation.json
+++ b/src/i18n/locales/vi/navigation.json
@@ -69,6 +69,13 @@
     "changelog": "Changelog"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "Thả vào đây để bỏ ghim",
+      "title": "Sắp xếp cuộc trò chuyện",
+      "priority": "Ưu tiên",
+      "updated": "Cập nhật gần nhất",
+      "manual": "Thứ tự thủ công"
+    },
     "tabs": {
       "workstation": "Workstation",
       "manage": "Quản lý",
@@ -78,6 +85,7 @@
       "agentOrgs": "Agent và nhóm"
     },
     "groupBy": {
+      "none": "Không nhóm",
       "title": "Nhóm theo",
       "byTime": "Theo thời gian",
       "byAgent": "Theo Agent",

--- a/src/i18n/locales/zh-Hant/navigation.json
+++ b/src/i18n/locales/zh-Hant/navigation.json
@@ -70,6 +70,13 @@
     "changelog": "更新日誌"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "拖到此處取消置頂",
+      "title": "對話排序",
+      "priority": "優先順序",
+      "updated": "最近更新",
+      "manual": "手動排序"
+    },
     "tabs": {
       "workstation": "工作站",
       "manage": "管理",
@@ -79,6 +86,7 @@
       "agentOrgs": "Agent & 團隊"
     },
     "groupBy": {
+      "none": "不分組",
       "title": "分組",
       "byTime": "按時間",
       "byAgent": "按 Agent",

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -70,6 +70,13 @@
     "changelog": "更新日志"
   },
   "sidebar": {
+    "sort": {
+      "dropToUnpin": "拖到此处取消置顶",
+      "title": "会话排序",
+      "priority": "优先级",
+      "updated": "最近更新",
+      "manual": "手动排序"
+    },
     "tabs": {
       "workstation": "工作站",
       "manage": "管理",
@@ -79,6 +86,7 @@
       "agentOrgs": "Agent & 团队"
     },
     "groupBy": {
+      "none": "不分组",
       "title": "分组",
       "byTime": "按时间",
       "byAgent": "按 Agent",

--- a/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
@@ -1,3 +1,4 @@
+import { useAtom } from "jotai";
 import React, {
   type FC,
   useCallback,
@@ -26,6 +27,7 @@ import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip"
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import {
   ArrowRight01Icon,
+  ArrowUpDownIcon,
   ArrowUpRight01Icon,
   FilterMailIcon,
   FolderInputIcon,
@@ -46,12 +48,16 @@ import HoverAnimatedIcon, {
   triggerIconAnimation,
 } from "../components/HoverAnimatedIcon";
 import {
+  SESSION_SORT_MODES,
+  sidebarSessionSortAtom,
+} from "./sidebarSessionOrder";
+import {
   GROUP_BY_MODES,
   SESSION_GROUP_VISIBLE_COUNTS,
   type SessionGroupVisibleCount,
 } from "./types";
 
-type SessionFilterSubmenu = "groupBy" | "visibleCount";
+type SessionFilterSubmenu = "groupBy" | "visibleCount" | "sort";
 
 interface SessionFilterButtonProps {
   groupByMode: string;
@@ -103,6 +109,8 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
     // Multi-choice settings live one level down, while every other row here
     // acts on the list immediately. Keeping their options out of the first
     // level keeps the actions readable and still shows each current value.
+    const [sortMode, setSortMode] = useAtom(sidebarSessionSortAtom);
+    const sortTriggerRef = useRef<HTMLDivElement | null>(null);
     const groupTriggerRef = useRef<HTMLDivElement | null>(null);
     const visibleCountTriggerRef = useRef<HTMLDivElement | null>(null);
     const submenuPanelRef = useRef<HTMLDivElement | null>(null);
@@ -190,7 +198,9 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
         const trigger =
           submenu === "groupBy"
             ? groupTriggerRef.current
-            : visibleCountTriggerRef.current;
+            : submenu === "sort"
+              ? sortTriggerRef.current
+              : visibleCountTriggerRef.current;
         if (trigger) openSubmenu(submenu, trigger);
       },
       [openSubmenu]
@@ -373,6 +383,33 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                   onClick={() => handleSubmenuTriggerClick("groupBy")}
                 >
                   {t("sidebar.groupBy.title")}
+                </DropdownItem>
+                <DropdownItem
+                  ref={sortTriggerRef}
+                  dataTestId="sidebar-sort-trigger"
+                  icon={
+                    <HugeiconsIcon
+                      icon={ArrowUpDownIcon}
+                      data-icon="arrow-up-down"
+                      size={DROPDOWN_ITEM.iconSize}
+                      strokeWidth={2}
+                    />
+                  }
+                  ariaHasPopup="menu"
+                  ariaExpanded={activeSubmenu === "sort"}
+                  onMouseEnter={() => handleSubmenuTriggerEnter("sort")}
+                  onClick={() => handleSubmenuTriggerClick("sort")}
+                  suffix={
+                    <span className="flex items-center gap-1 text-text-3">
+                      {t(`sidebar.sort.${sortMode}`)}
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        size={DROPDOWN_ITEM.iconSize}
+                      />
+                    </span>
+                  }
+                >
+                  {t("sidebar.sort.title")}
                 </DropdownItem>
                 <DropdownItem
                   ref={visibleCountTriggerRef}
@@ -564,7 +601,9 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
               data-testid={
                 activeSubmenu === "groupBy"
                   ? "sidebar-group-by-submenu"
-                  : "sidebar-show-submenu"
+                  : activeSubmenu === "sort"
+                    ? "sidebar-sort-submenu"
+                    : "sidebar-show-submenu"
               }
               onPointerDown={handleSubmenuPointerDown}
               onMouseDown={handleSubmenuMouseDown}
@@ -581,16 +620,31 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                         {resolveGroupByLabel(mode)}
                       </DropdownItem>
                     ))
-                  : SESSION_GROUP_VISIBLE_COUNTS.map((count) => (
-                      <DropdownItem
-                        key={count}
-                        dataTestId={`sidebar-show-recent-${count}`}
-                        selected={count === groupVisibleCount}
-                        onClick={() => handleGroupVisibleCountSelect(count)}
-                      >
-                        {t(`sidebar.show.recent${count}`)}
-                      </DropdownItem>
-                    ))}
+                  : activeSubmenu === "sort"
+                    ? SESSION_SORT_MODES.map((mode) => (
+                        <DropdownItem
+                          key={mode}
+                          dataTestId={`sidebar-sort-${mode}`}
+                          selected={mode === sortMode}
+                          onClick={() => {
+                            setSortMode(mode);
+                            closeSubmenu();
+                            close();
+                          }}
+                        >
+                          {t(`sidebar.sort.${mode}`)}
+                        </DropdownItem>
+                      ))
+                    : SESSION_GROUP_VISIBLE_COUNTS.map((count) => (
+                        <DropdownItem
+                          key={count}
+                          dataTestId={`sidebar-show-recent-${count}`}
+                          selected={count === groupVisibleCount}
+                          onClick={() => handleGroupVisibleCountSelect(count)}
+                        >
+                          {t(`sidebar.show.recent${count}`)}
+                        </DropdownItem>
+                      ))}
               </div>
             </DropdownPanel>,
             document.body

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -57,6 +57,7 @@ import { useWorkstationSidebarSelectionAndCollapse } from "./sidebarConnector.se
 import { useWorkstationSidebarSessionInteractionHandlers } from "./sidebarConnector.sessionInteractionHandlers";
 import { useSidebarSessionRefreshAction } from "./sidebarSessionRefresh";
 import type { WorkstationSidebarKey } from "./types";
+import { useSessionSidebarOrdering } from "./useSessionSidebarOrdering";
 import { useSessionSidebarRowActions } from "./useSessionSidebarRowActions";
 import { useSidebarGuide } from "./useSidebarGuide";
 import { useSidebarStationNavigation } from "./useSidebarStationNavigation";
@@ -611,6 +612,27 @@ export const WorkstationSidebarConnector: React.FC = () => {
       pinnedMenuItems,
     });
 
+  const ordering = useSessionSidebarOrdering({
+    enabled: !projectsVisible && !channelSidebarVisible,
+    items: sidebarMenuItems,
+    sessionMap,
+    onTogglePin: handleTogglePin,
+  });
+  const wrapOrderedRow = ordering.wrap;
+  const renderOrderedMenuItem = useCallback(
+    (
+      item: Parameters<NonNullable<typeof resolvedRenderMenuItemWrapper>>[0],
+      node: React.ReactElement
+    ) =>
+      wrapOrderedRow(
+        item,
+        resolvedRenderMenuItemWrapper
+          ? resolvedRenderMenuItemWrapper(item, node)
+          : node
+      ),
+    [wrapOrderedRow, resolvedRenderMenuItemWrapper]
+  );
+
   const guide = useSidebarGuide({
     t,
     guideCloudOrg: manageableCloudOrg,
@@ -631,7 +653,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
         selectedKey={resolvedSelectedMenuItemId}
         onMenuItemClick={resolvedMenuItemClick}
         onMenuItemContextMenu={resolvedMenuItemContextMenu}
-        renderMenuItemWrapper={resolvedRenderMenuItemWrapper}
+        renderMenuItemWrapper={renderOrderedMenuItem}
         hostTopBarLeadingContent={sidebarOrgSelector}
         macTopBarFollowingContent={
           <div className="shrink-0 px-3 pt-1">{sidebarOrgSelector}</div>
@@ -647,32 +669,37 @@ export const WorkstationSidebarConnector: React.FC = () => {
         }
         listTopPadding
         bottomContent={
-          <SidebarBottomBar
-            leftContent={
-              <SidebarSettingsMenuButton
-                onSignIn={
-                  cloudSignedInIdentity === null ? handleCloudSignIn : undefined
-                }
-                renderTrigger={({ isOpen, onClick }) => (
-                  <SidebarAccountButton
-                    identity={cloudSignedInIdentity}
-                    avatarUrl={cloudSignedInAvatarUrl}
-                    menuOpen={isOpen}
-                    onClick={onClick}
-                  />
-                )}
-              />
-            }
-            rightActions={
-              <>
-                <SidebarGuideButton
-                  {...guide}
-                  onStartSession={handleGoToNewSession}
+          <>
+            {ordering.unpinDropZone}
+            <SidebarBottomBar
+              leftContent={
+                <SidebarSettingsMenuButton
+                  onSignIn={
+                    cloudSignedInIdentity === null
+                      ? handleCloudSignIn
+                      : undefined
+                  }
+                  renderTrigger={({ isOpen, onClick }) => (
+                    <SidebarAccountButton
+                      identity={cloudSignedInIdentity}
+                      avatarUrl={cloudSignedInAvatarUrl}
+                      menuOpen={isOpen}
+                      onClick={onClick}
+                    />
+                  )}
                 />
-                {sidebarBottomRightActions}
-              </>
-            }
-          />
+              }
+              rightActions={
+                <>
+                  <SidebarGuideButton
+                    {...guide}
+                    onStartSession={handleGoToNewSession}
+                  />
+                  {sidebarBottomRightActions}
+                </>
+              }
+            />
+          </>
         }
         isLoading={isLoading}
         collapsibleSections
@@ -689,6 +716,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
             : undefined
         }
       />
+      {ordering.insertionLine}
       <SidebarDialogs
         cloudChannelsDialogs={cloudChannelsDialogs}
         localChannelsDialogs={localChannelsDialogs}

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sectionPagination.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sectionPagination.ts
@@ -14,6 +14,8 @@ export function getSessionSectionVisibleCountKey(
   if (sectionId === "pinned") return sectionId;
 
   switch (groupByMode) {
+    case "none":
+      return "sessions";
     case "byAgent":
       return sectionId.startsWith("agent-org:")
         ? sectionId

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.ts
@@ -23,9 +23,11 @@ import {
   sidebarIncludeExternalAtom,
 } from "../sidebarGroupByAtom";
 import {
-  buildRepoPathToName,
-  sortSessionsByActivity,
-} from "../workstationSidebarData";
+  sidebarSessionOrderAtom,
+  sidebarSessionSortAtom,
+  sortSidebarSessions,
+} from "../sidebarSessionOrder";
+import { buildRepoPathToName } from "../workstationSidebarData";
 import { resetScopedSectionPagination } from "./sectionPagination";
 import { useChatPanelTuiSidebarSessions } from "./sidebarMenuCollections";
 import { useSidebarSessionRefreshEffects } from "./sidebarSessionRefresh";
@@ -43,9 +45,16 @@ export function useWorkstationSidebarScopeAndPagination({
   useSidebarSessionRefreshEffects();
 
   const chatPanelTuiSessions = useChatPanelTuiSidebarSessions();
+  const sortMode = useAtomValue(sidebarSessionSortAtom);
+  const manualOrder = useAtomValue(sidebarSessionOrderAtom);
   const sortedSessions = useMemo(
-    () => sortSessionsByActivity([...chatPanelTuiSessions, ...sessions]),
-    [chatPanelTuiSessions, sessions]
+    () =>
+      sortSidebarSessions(
+        [...chatPanelTuiSessions, ...sessions],
+        sortMode,
+        manualOrder
+      ),
+    [chatPanelTuiSessions, sessions, sortMode, manualOrder]
   );
   const {
     activeCloudOrgId,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarOrdering.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarOrdering.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
+import type { Session } from "@src/store/session";
+
+import {
+  sidebarSessionOrderAtom,
+  sidebarSessionSortAtom,
+} from "../sidebarSessionOrder";
+import { useSessionSidebarOrdering } from "./useSessionSidebarOrdering";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+function mount(pinnedIds = ["a"]) {
+  const store = createStore();
+  store.set(sidebarSessionOrderAtom, []);
+  store.set(sidebarSessionSortAtom, "updated");
+  const onTogglePin = vi.fn(async () => undefined);
+  const items: NavigationMenuItem[] = ["a", "b"].map((id) => ({
+    id,
+    key: id,
+    label: id,
+  }));
+  const sessionMap = new Map(
+    items.map((item) => [
+      item.id,
+      { session_id: item.id, pinned: pinnedIds.includes(item.id) } as Session,
+    ])
+  );
+  let renderCount = 0;
+  function Harness() {
+    renderCount += 1;
+    const ordering = useSessionSidebarOrdering({
+      enabled: true,
+      items,
+      sessionMap,
+      onTogglePin,
+    });
+    return React.createElement(
+      React.Fragment,
+      null,
+      ordering.unpinDropZone,
+      ...items.map((item) =>
+        React.createElement(
+          React.Fragment,
+          { key: item.id },
+          ordering.wrap(item, React.createElement("span", null, item.label))
+        )
+      ),
+      ordering.insertionLine
+    );
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() =>
+    root.render(
+      React.createElement(Provider, { store }, React.createElement(Harness))
+    )
+  );
+  const start = (id: string) =>
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("tab-drag-start", { detail: { tabId: id } })
+      );
+    });
+  const drop = (id: string) => {
+    const row = container.querySelector<HTMLElement>(
+      `[data-sidebar-order-id="${id}"]`
+    )!;
+    vi.spyOn(row, "getBoundingClientRect").mockReturnValue({
+      top: 50,
+      bottom: 80,
+      left: 0,
+      right: 200,
+      width: 200,
+      height: 30,
+    } as DOMRect);
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: () => row,
+    });
+    const rendersBeforeMove = renderCount;
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent("pointermove", { clientX: 30, clientY: 78 })
+      );
+    });
+    expect(renderCount).toBe(rendersBeforeMove);
+    const line = document.querySelector(
+      '[data-testid="sidebar-session-insertion-line"]'
+    );
+    act(() => {
+      document.dispatchEvent(
+        new CustomEvent("tab-drag-end", {
+          detail: { pointerX: 30, pointerY: 78 },
+        })
+      );
+    });
+    return line;
+  };
+  return {
+    store,
+    onTogglePin,
+    start,
+    drop,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("session sidebar drag integration", () => {
+  it("unpins when moving to a regular row, displays a line and saves the position", () => {
+    const view = mount();
+    try {
+      view.start("a");
+      expect(view.drop("b")).not.toBeNull();
+      expect(view.onTogglePin).toHaveBeenCalledWith("a");
+      expect(view.store.get(sidebarSessionSortAtom)).toBe("manual");
+      expect(view.store.get(sidebarSessionOrderAtom)).toEqual(["b", "a"]);
+      expect(
+        document.querySelector('[data-testid="sidebar-session-insertion-line"]')
+      ).toBeNull();
+    } finally {
+      view.unmount();
+    }
+  });
+  it("rejects dragging an unpinned row into pinned rows", () => {
+    const view = mount();
+    try {
+      view.start("b");
+      expect(view.drop("a")).toBeNull();
+      expect(view.onTogglePin).not.toHaveBeenCalled();
+      expect(view.store.get(sidebarSessionOrderAtom)).toEqual([]);
+      expect(view.store.get(sidebarSessionSortAtom)).toBe("updated");
+      expect(
+        document.querySelector('[data-testid="sidebar-pin-drop-zone"]')
+      ).toBeNull();
+    } finally {
+      view.unmount();
+    }
+  });
+  it.each([[[]], [["a", "b"]]])(
+    "retains reordering within the same pin state (%j)",
+    (pinnedIds) => {
+      const view = mount(pinnedIds);
+      try {
+        view.start("a");
+        expect(view.drop("b")).not.toBeNull();
+        expect(view.store.get(sidebarSessionOrderAtom)).toEqual(["b", "a"]);
+        expect(view.onTogglePin).not.toHaveBeenCalled();
+      } finally {
+        view.unmount();
+      }
+    }
+  );
+  it("supports the bottom unpin zone without a row target", () => {
+    const view = mount();
+    try {
+      for (const [source, zoneId] of [["a", "sidebar-unpin-drop-zone"]]) {
+        view.start(source);
+        const zone = document.querySelector<HTMLElement>(
+          `[data-testid="${zoneId}"]`
+        )!;
+        vi.spyOn(zone, "getBoundingClientRect").mockReturnValue({
+          top: 100,
+          bottom: 140,
+          left: 0,
+          right: 200,
+          width: 200,
+          height: 40,
+        } as DOMRect);
+        act(() => {
+          document.dispatchEvent(
+            new CustomEvent("tab-drag-end", {
+              detail: { pointerX: 20, pointerY: 120 },
+            })
+          );
+        });
+        expect(view.onTogglePin).toHaveBeenCalledWith(source);
+      }
+    } finally {
+      view.unmount();
+    }
+  });
+
+  it("cancels without mutations and removes listeners on unmount", () => {
+    const view = mount();
+    view.start("a");
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    view.drop("b");
+    expect(view.onTogglePin).not.toHaveBeenCalled();
+    expect(view.store.get(sidebarSessionSortAtom)).toBe("updated");
+    view.unmount();
+    view.start("a");
+    expect(
+      document.querySelector('[data-testid="sidebar-unpin-drop-zone"]')
+    ).toBeNull();
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarOrdering.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSessionSidebarOrdering.tsx
@@ -1,0 +1,267 @@
+import { type PrimitiveAtom, atom, useAtomValue, useSetAtom } from "jotai";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+import type { TabDragEventDetail } from "@src/modules/WorkStation/shared/TabBar/tabDragTypes";
+import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
+import type { Session } from "@src/store/session";
+import { isChatPanelTuiSessionId } from "@src/util/ui/terminal/chatPanelTuiSessionId";
+
+import { sidebarGroupByAtom } from "../sidebarGroupByAtom";
+import {
+  reorderSessionIds,
+  sidebarSessionOrderAtom,
+  sidebarSessionSortAtom,
+} from "../sidebarSessionOrder";
+
+interface DropTarget {
+  id: string;
+  after: boolean;
+  pinned: boolean;
+  top: number;
+  left: number;
+  width: number;
+}
+
+export function useSessionSidebarOrdering({
+  enabled,
+  items,
+  sessionMap,
+  onTogglePin,
+}: {
+  enabled: boolean;
+  items: readonly NavigationMenuItem[];
+  sessionMap: ReadonlyMap<string, Session>;
+  onTogglePin: (id: string) => Promise<void>;
+}) {
+  const { t } = useTranslation("navigation");
+  const setOrder = useSetAtom(sidebarSessionOrderAtom);
+  const order = useAtomValue(sidebarSessionOrderAtom);
+  const setSort = useSetAtom(sidebarSessionSortAtom);
+  const setGroup = useSetAtom(sidebarGroupByAtom);
+  const unpinZoneRef = useRef<HTMLDivElement>(null);
+  const [feedbackAtom] = useState(() =>
+    atom<DragFeedback>({ dragging: false, target: null })
+  );
+  const setFeedback = useSetAtom(feedbackAtom);
+  const latest = useRef({ items, sessionMap, order, onTogglePin });
+  useLayoutEffect(() => {
+    latest.current = { items, sessionMap, order, onTogglePin };
+  });
+  const eligible = useCallback((id: string) => {
+    const session = latest.current.sessionMap.get(id);
+    return Boolean(
+      session &&
+      !session.parentSessionId &&
+      !id.includes(":subagent:") &&
+      !isChatPanelTuiSessionId(id)
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let source: string | null = null;
+    const reset = () => {
+      source = null;
+      setFeedback({ dragging: false, target: null });
+    };
+    const hitTest = (x: number, y: number): DropTarget | null => {
+      const zone = unpinZoneRef.current?.getBoundingClientRect();
+      if (
+        zone &&
+        x >= zone.left &&
+        x <= zone.right &&
+        y >= zone.top &&
+        y <= zone.bottom
+      ) {
+        return {
+          id: "",
+          pinned: false,
+          after: true,
+          top: zone.bottom,
+          left: zone.left,
+          width: zone.width,
+        };
+      }
+      const row = document
+        .elementFromPoint(x, y)
+        ?.closest<HTMLElement>("[data-sidebar-order-id]");
+      const id = row?.dataset.sidebarOrderId;
+      if (!row || !id || !eligible(id)) return null;
+      const pinned = Boolean(latest.current.sessionMap.get(id)?.pinned);
+      // Existing pins can be reordered, but dragging an unpinned row cannot pin it.
+      if (pinned && (!source || !latest.current.sessionMap.get(source)?.pinned))
+        return null;
+      const rect = row.getBoundingClientRect();
+      const after = y >= rect.top + rect.height / 2;
+      return {
+        id,
+        after,
+        pinned,
+        top: after ? rect.bottom : rect.top,
+        left: rect.left,
+        width: rect.width,
+      };
+    };
+    const start = (event: Event) => {
+      const id = (event as CustomEvent<TabDragEventDetail>).detail.tabId;
+      if (!eligible(id) || !latest.current.items.some((item) => item.id === id))
+        return;
+      source = id;
+      setFeedback({ dragging: true, target: null });
+    };
+    const move = (event: PointerEvent) => {
+      if (source)
+        setFeedback({
+          dragging: true,
+          target: hitTest(event.clientX, event.clientY),
+        });
+    };
+    const end = (event: Event) => {
+      const id = source;
+      const detail = (event as CustomEvent<TabDragEventDetail>).detail;
+      const drop =
+        id && detail.pointerX !== undefined && detail.pointerY !== undefined
+          ? hitTest(detail.pointerX, detail.pointerY)
+          : null;
+      reset();
+      if (!id || !drop || drop.id === id) return;
+      const current = latest.current;
+      if (!current.sessionMap.has(id)) return;
+      const visibleIds = current.items
+        .filter((item) => eligible(item.id))
+        .map((item) => item.id);
+      const candidates = drop.pinned ? visibleIds : [...visibleIds].reverse();
+      const anchor =
+        drop.id ||
+        candidates.find(
+          (other) =>
+            other !== id &&
+            Boolean(current.sessionMap.get(other)?.pinned) === drop.pinned
+        ) ||
+        candidates.find((other) => other !== id);
+      if (anchor)
+        setOrder(
+          reorderSessionIds(current.order, visibleIds, id, anchor, drop.after)
+        );
+      setSort("manual");
+      // Cross-group placement has no meaning in time/workspace/agent groups.
+      // Flatten only when moving between regular groups; never mutate domain metadata.
+      const sectionOf = (rowId: string) => {
+        let section = "";
+        for (const item of current.items) {
+          if (item.id.startsWith("separator-")) section = item.id;
+          if (item.id === rowId) return section;
+        }
+        return section;
+      };
+      if (!drop.pinned && sectionOf(id) !== sectionOf(drop.id))
+        setGroup("none");
+      if (current.sessionMap.get(id)?.pinned && !drop.pinned)
+        void current.onTogglePin(id);
+    };
+    const key = (event: KeyboardEvent) => {
+      if (event.key === "Escape") reset();
+    };
+    document.addEventListener("tab-drag-start", start);
+    document.addEventListener("tab-drag-end", end);
+    window.addEventListener("pointermove", move, { passive: true });
+    window.addEventListener("pointercancel", reset, true);
+    window.addEventListener("blur", reset);
+    window.addEventListener("keydown", key);
+    return () => {
+      setFeedback({ dragging: false, target: null });
+      document.removeEventListener("tab-drag-start", start);
+      document.removeEventListener("tab-drag-end", end);
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointercancel", reset, true);
+      window.removeEventListener("blur", reset);
+      window.removeEventListener("keydown", key);
+    };
+  }, [enabled, eligible, setGroup, setOrder, setSort, setFeedback]);
+
+  const wrap = useCallback(
+    (item: NavigationMenuItem, node: React.ReactElement) =>
+      enabled &&
+      sessionMap.has(item.id) &&
+      !sessionMap.get(item.id)?.parentSessionId &&
+      !item.id.includes(":subagent:") &&
+      !isChatPanelTuiSessionId(item.id) ? (
+        <div data-sidebar-order-id={item.id}>{node}</div>
+      ) : (
+        node
+      ),
+    [enabled, sessionMap]
+  );
+
+  return {
+    wrap,
+    unpinDropZone: enabled ? (
+      <DropZone
+        feedbackAtom={feedbackAtom}
+        zoneRef={unpinZoneRef}
+        label={t("sidebar.sort.dropToUnpin")}
+        testId="sidebar-unpin-drop-zone"
+      />
+    ) : null,
+    insertionLine: enabled ? (
+      <InsertionLine feedbackAtom={feedbackAtom} />
+    ) : null,
+  };
+}
+
+interface DragFeedback {
+  dragging: boolean;
+  target: DropTarget | null;
+}
+function DropZone({
+  feedbackAtom,
+  zoneRef,
+  label,
+  testId,
+}: {
+  feedbackAtom: PrimitiveAtom<DragFeedback>;
+  zoneRef: React.RefObject<HTMLDivElement | null>;
+  label: string;
+  testId: string;
+}) {
+  const { dragging } = useAtomValue(feedbackAtom);
+  return dragging ? (
+    <div
+      ref={zoneRef}
+      data-testid={testId}
+      className="mx-3 rounded-md border border-dashed border-border-2 px-2 py-3 text-xs text-text-2"
+    >
+      {label}
+    </div>
+  ) : null;
+}
+function InsertionLine({
+  feedbackAtom,
+}: {
+  feedbackAtom: PrimitiveAtom<DragFeedback>;
+}) {
+  const { target } = useAtomValue(feedbackAtom);
+  return target
+    ? createPortal(
+        <div
+          aria-hidden="true"
+          data-testid="sidebar-session-insertion-line"
+          className="pointer-events-none fixed z-50 h-0.5 rounded-full bg-primary-6"
+          style={{
+            top: target.top - 1,
+            left: target.left,
+            width: target.width,
+          }}
+        />,
+        document.body
+      )
+    : null;
+}

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts
@@ -83,6 +83,15 @@ describe("SessionFilterButton", () => {
     });
   });
 
+  it("exposes separate sort modes and persists manual selection", async () => {
+    await act(async () => queryTestId("sidebar-sort-trigger")?.click());
+    expect(queryTestId("sidebar-sort-priority")).not.toBeNull();
+    expect(queryTestId("sidebar-sort-updated")).not.toBeNull();
+    await act(async () => queryTestId("sidebar-sort-manual")?.click());
+    expect(localStorage.getItem("orgii:sidebarSessionSort")).toBe('"manual"');
+    expect(mocks.closeDropdown).toHaveBeenCalled();
+  });
+
   afterEach(() => {
     act(() => root.unmount());
     container.remove();

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/loadedSessionVisibility.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/loadedSessionVisibility.test.ts
@@ -18,6 +18,16 @@ function makeSession(
 }
 
 describe("expandVisibleGroupsForSessions", () => {
+  it("reveals loaded rows in the flat list without changing pinned pagination", () => {
+    const counts = expandVisibleGroupsForSessions(
+      new Map(),
+      [makeSession("a"), makeSession("b", { pinned: true })],
+      "none",
+      5
+    );
+    expect(counts.get("sessions")).toBe(6);
+    expect(counts.get("pinned")).toBe(6);
+  });
   it("uses the configured group default before revealing newly loaded rows", () => {
     const next = expandVisibleGroupsForSessions(
       new Map(),

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/sidebarSessionOrder.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/sidebarSessionOrder.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import type { Session } from "@src/store/session";
+
+import {
+  parseSessionOrder,
+  reorderSessionIds,
+  sidebarSessionOrderAtom,
+  sidebarSessionSortAtom,
+  sortSidebarSessions,
+} from "../sidebarSessionOrder";
+
+const sessions = [
+  { session_id: "old", updated_at: "2026-01-01", status: "waiting_for_user" },
+  { session_id: "new", updated_at: "2026-02-01", status: "idle" },
+  { session_id: "running", updated_at: "2026-01-15", status: "running" },
+] as Session[];
+
+describe("sidebar session ordering", () => {
+  it("separates priority, recency and manual order without mutating sessions", () => {
+    const ids = (mode: "priority" | "updated" | "manual") =>
+      sortSidebarSessions(sessions, mode, ["running", "old"]).map(
+        (s) => s.session_id
+      );
+    expect(ids("priority")).toEqual(["old", "running", "new"]);
+    expect(ids("updated")).toEqual(["new", "running", "old"]);
+    expect(ids("manual")).toEqual(["running", "old", "new"]);
+    expect(sessions[0].session_id).toBe("old");
+  });
+  it("moves in both directions and retains unloaded identities", () => {
+    expect(
+      reorderSessionIds(
+        ["hidden", "a", "b", "c"],
+        ["a", "b", "c"],
+        "a",
+        "c",
+        true
+      )
+    ).toEqual(["hidden", "b", "c", "a"]);
+    expect(reorderSessionIds([], ["a", "b", "c"], "c", "a", false)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+    expect(reorderSessionIds(["a", "b"], ["a", "b"], "a", "a", false)).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+  it("validates and bounds persisted identities", () => {
+    expect(parseSessionOrder([null, "", "a", "a", 4])).toEqual(["a"]);
+    expect(
+      parseSessionOrder(Array.from({ length: 6000 }, (_, i) => String(i)))
+    ).toHaveLength(5000);
+  });
+  it("persists mode and order for a fresh store", () => {
+    const store = createStore();
+    store.set(sidebarSessionSortAtom, "manual");
+    store.set(sidebarSessionOrderAtom, ["b", "a"]);
+    expect(
+      JSON.parse(localStorage.getItem("orgii:sidebarSessionOrder")!)
+    ).toEqual(["b", "a"]);
+    const fresh = createStore();
+    const unsub = fresh.sub(sidebarSessionOrderAtom, () => undefined);
+    expect(fresh.get(sidebarSessionOrderAtom)).toEqual(["b", "a"]);
+    unsub();
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/loadedSessionVisibility.ts
+++ b/src/scaffold/NavigationSidebar/connectors/loadedSessionVisibility.ts
@@ -14,6 +14,7 @@ function visibleGroupIdForSession(
   groupByMode: GroupByMode
 ): string {
   if (session.pinned) return "pinned";
+  if (groupByMode === "none") return "sessions";
   if (groupByMode === "byTime") {
     return `time:${getDateGroup(session)}`;
   }

--- a/src/scaffold/NavigationSidebar/connectors/sidebarGroupByAtom.ts
+++ b/src/scaffold/NavigationSidebar/connectors/sidebarGroupByAtom.ts
@@ -72,7 +72,7 @@ function parseStoredWorkspaceKeys(raw: unknown): string[] {
   );
 }
 
-function createStorage<T>(parseValue: (raw: unknown) => T) {
+export function createStorage<T>(parseValue: (raw: unknown) => T) {
   return {
     getItem(key: string, initialValue: T): T {
       if (typeof window === "undefined") return initialValue;

--- a/src/scaffold/NavigationSidebar/connectors/sidebarSessionOrder.ts
+++ b/src/scaffold/NavigationSidebar/connectors/sidebarSessionOrder.ts
@@ -1,0 +1,88 @@
+import { atomWithStorage } from "jotai/utils";
+
+import type { Session } from "@src/store/session";
+
+import { createStorage } from "./sidebarGroupByAtom";
+import { sortSessionsByActivity } from "./workstationSidebarData";
+
+export const SESSION_SORT_MODES = ["priority", "updated", "manual"] as const;
+export type SessionSortMode = (typeof SESSION_SORT_MODES)[number];
+// Presentation preferences retain at most 5,000 identities, including unloaded rows.
+const MAX_ORDERED_SESSIONS = 5000;
+export function parseSessionOrder(raw: unknown): string[] {
+  return Array.isArray(raw)
+    ? [
+        ...new Set(
+          raw.filter(
+            (id): id is string => typeof id === "string" && id.length > 0
+          )
+        ),
+      ].slice(0, MAX_ORDERED_SESSIONS)
+    : [];
+}
+export const sidebarSessionSortAtom = atomWithStorage<SessionSortMode>(
+  "orgii:sidebarSessionSort",
+  "updated",
+  createStorage((raw) =>
+    SESSION_SORT_MODES.includes(raw as SessionSortMode)
+      ? (raw as SessionSortMode)
+      : "updated"
+  ),
+  { getOnInit: true }
+);
+export const sidebarSessionOrderAtom = atomWithStorage<string[]>(
+  "orgii:sidebarSessionOrder",
+  [],
+  createStorage(parseSessionOrder),
+  { getOnInit: true }
+);
+
+export function reorderSessionIds(
+  order: readonly string[],
+  visibleIds: readonly string[],
+  source: string,
+  target: string,
+  after: boolean
+): string[] {
+  if (
+    source === target ||
+    !visibleIds.includes(source) ||
+    !visibleIds.includes(target)
+  )
+    return [...order];
+  const ids = [...new Set([...order, ...visibleIds])].filter(
+    (id) => id !== source
+  );
+  ids.splice(ids.indexOf(target) + (after ? 1 : 0), 0, source);
+  // Keep the touched identity even when the preference reaches its bound.
+  return parseSessionOrder(
+    ids.length > MAX_ORDERED_SESSIONS
+      ? ids.filter((id) => visibleIds.includes(id)).concat(ids)
+      : ids
+  );
+}
+
+export function sortSidebarSessions(
+  sessions: readonly Session[],
+  mode: SessionSortMode,
+  order: readonly string[]
+): Session[] {
+  const sorted = sortSessionsByActivity(sessions);
+  if (mode === "manual") {
+    const ranks = new Map(order.map((id, index) => [id, index]));
+    sorted.sort(
+      (a, b) =>
+        (ranks.get(a.session_id) ?? Infinity) -
+        (ranks.get(b.session_id) ?? Infinity)
+    );
+  } else if (mode === "priority") {
+    const rank = (session: Session) =>
+      session.status === "waiting_for_user"
+        ? 0
+        : session.status === "running" || session.status === "in_progress"
+          ? 1
+          : 2;
+    sorted.sort((a, b) => rank(a) - rank(b));
+  }
+  return sorted;
+}

--- a/src/scaffold/NavigationSidebar/connectors/types.ts
+++ b/src/scaffold/NavigationSidebar/connectors/types.ts
@@ -1,9 +1,10 @@
-export type GroupByMode = "byTime" | "byAgent" | "byWorkspace";
+export type GroupByMode = "byTime" | "byAgent" | "byWorkspace" | "none";
 
 export const GROUP_BY_MODES: readonly GroupByMode[] = [
   "byTime",
   "byWorkspace",
   "byAgent",
+  "none",
 ];
 
 export const SESSION_GROUP_VISIBLE_COUNTS = [5, 10] as const;

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -580,6 +580,16 @@ export function useSessionMenuItems({
   );
   const baseMenuItems = useMemo<NavigationMenuItem[]>(() => {
     switch (groupByMode) {
+      case "none": {
+        const items: NavigationMenuItem[] = [];
+        const hiddenPinned = appendPinnedSessions(items, false);
+        items.push(
+          separator("sessions", tCommon("sessions:chat.history", "Sessions"))
+        );
+        const hidden = appendGroupSessions(items, "sessions", unpinnedSessions);
+        if (!hidden && !hiddenPinned) appendTrailingLoadMoreItems(items);
+        return items;
+      }
       case "byAgent":
         return byAgentMenuItems;
       case "byWorkspace":
@@ -588,7 +598,17 @@ export function useSessionMenuItems({
       default:
         return byTimeMenuItems;
     }
-  }, [groupByMode, byTimeMenuItems, byAgentMenuItems, byWorkspaceMenuItems]);
+  }, [
+    groupByMode,
+    byTimeMenuItems,
+    byAgentMenuItems,
+    byWorkspaceMenuItems,
+    appendPinnedSessions,
+    appendGroupSessions,
+    appendTrailingLoadMoreItems,
+    unpinnedSessions,
+    tCommon,
+  ]);
 
   const menuItems = useMemo<NavigationMenuItem[]>(
     () =>


### PR DESCRIPTION
## Problem

The session sidebar only orders sessions by activity. Users cannot keep a manual order, see a drop insertion line, or unpin a session by dragging it back into the regular list.

## Solution

Add separate Priority, Last updated, and Manual order options with a sorting icon, plus a No grouping option. Persist manual ordering locally. Reuse existing reference dragging for insertion feedback and the existing session pin dispatcher for drag-to-unpin. Preserve reordering within pinned rows; dragging an unpinned row into pins is rejected. Cross-group placement selects the flat list without changing workspace or agent metadata. Translate the new options in all 13 locales.

## Potential risks

Ordering covers loaded local/imported root sessions; remote-only Team Session rows, subagent children, and live terminal rows are not drag-reorderable. Manual order is a local preference capped at 5,000 identities, with recency fallback for unranked sessions. The new localStorage keys are additive, need no migration, and may be removed to reset preferences; reverting this PR restores the prior UI. No schema, dependency or wire changes. Real Tauri pointer geometry, scrolling, theme/narrow-window layout, and idle performance are unverified because desktop control was not authorized. Pin/unpin persistence retains its existing optimistic rollback behavior.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/connectors/__tests__/{sidebarSessionOrder,SessionFilterButton,loadedSessionVisibility,sidebarGroupByAtom}.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/{useSessionSidebarOrdering,sectionPagination}.test.ts src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts`: 47 tests passed in the isolated PR worktree
- Normal pre-commit hooks: lint-staged, TypeScript gate, and repository commit statistics (results recorded in commit output/trailer)
- `git diff --check`: passed
- UI audit: 0 fix, 4 keep with reason, 0 abstract; lifecycle/architecture evidence in the included report
- Real-app UI/E2E, screenshots, and CPU/RSS measurements not run: desktop control was not authorized. No runtime performance improvement is claimed
