### PR TITLE
perf(agent-station): release diagnostic replay payload ownership

### DIFF
--- a/src/engines/Simulator/apps/core/__tests__/fullEventHydrationRegistry.test.ts
+++ b/src/engines/Simulator/apps/core/__tests__/fullEventHydrationRegistry.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import {
+  clearHydratedEvents,
+  getHydratedEventStats,
+  hydrateFullEventWindow,
+} from "../fullEventHydrationRegistry";
+
+const event = (id: string) =>
+  ({ id, result: { text: "x".repeat(1000) } }) as unknown as SessionEvent;
+afterEach(() => {
+  clearHydratedEvents();
+  vi.unstubAllGlobals();
+});
+describe("replay diagnostic ownership", () => {
+  it("does not own payloads after weak references expire", () => {
+    let alive = true;
+    vi.stubGlobal(
+      "WeakRef",
+      class {
+        constructor(private value: SessionEvent) {}
+        deref() {
+          return alive ? this.value : undefined;
+        }
+      }
+    );
+    const events = [event("one")];
+    expect(hydrateFullEventWindow(events)).toEqual(events);
+    expect(getHydratedEventStats().entries).toBe(1);
+    alive = false;
+    expect(getHydratedEventStats()).toEqual({ entries: 0, bytes: 0 });
+    expect(events[0].result).toBeDefined();
+  });
+  it("bounds diagnostic metadata and deduplicates repeated event identities", () => {
+    const events = Array.from({ length: 700 }, (_, i) => event(String(i)));
+    hydrateFullEventWindow(events);
+    expect(getHydratedEventStats().entries).toBe(600);
+    hydrateFullEventWindow(events.slice(-20));
+    expect(getHydratedEventStats().entries).toBe(600);
+    clearHydratedEvents();
+    expect(events).toHaveLength(700);
+  });
+  it("keeps replay usable on runtimes without WeakRef", () => {
+    vi.stubGlobal("WeakRef", undefined);
+    const events = [event("one")];
+    expect(hydrateFullEventWindow(events)).toEqual(events);
+    expect(getHydratedEventStats().entries).toBe(0);
+  });
+});

--- a/src/engines/Simulator/apps/core/fullEventHydrationRegistry.ts
+++ b/src/engines/Simulator/apps/core/fullEventHydrationRegistry.ts
@@ -1,14 +1,18 @@
+/// <reference lib="es2021.weakref" />
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { estimateRuntimeValueBytes } from "@src/hooks/perf/runtimeMemoryStats";
 import { registerCache } from "@src/util/memory/cacheRegistry";
 
 const MAX_HYDRATED_EVENTS = 600;
 
-const hydratedEvents = new Map<string, SessionEvent>();
+const hydratedEvents = new Map<string, WeakRef<SessionEvent>>();
 
 function touch(event: SessionEvent): void {
   hydratedEvents.delete(event.id);
-  hydratedEvents.set(event.id, event);
+  // Diagnostics must never extend the lifetime of a replay payload.
+  if (typeof WeakRef !== "undefined") {
+    hydratedEvents.set(event.id, new WeakRef(event));
+  }
 }
 
 function prune(): void {
@@ -35,8 +39,10 @@ export function clearHydratedEvents(): void {
 
 export function getHydratedEventStats(): { entries: number; bytes: number } {
   let bytes = 0;
-  for (const event of hydratedEvents.values()) {
-    bytes += estimateRuntimeValueBytes(event);
+  for (const [id, reference] of hydratedEvents) {
+    const event = reference.deref();
+    if (event) bytes += estimateRuntimeValueBytes(event);
+    else hydratedEvents.delete(id);
   }
   return { entries: hydratedEvents.size, bytes };
 }


### PR DESCRIPTION
## Problem

Agent Station memory diagnostics held strong references to up to 600 replay events after the active view released them. A diagnostic registry therefore prolonged payload lifetimes.

## Solution

Keep only WeakRef entries in the bounded diagnostics registry and prune dead entries when estimating memory. Replay consumers keep their own event arrays; active history is unchanged. Runtimes without WeakRef skip optional tracking.

## Potential risks

Garbage collection timing makes the diagnostic estimate opportunistic. No persistence, wire, or dependency changes. Actual process RSS and CPU were not measured; the change removes ownership rather than guaranteeing a numerical reduction.

## Verification

- `pnpm test src/engines/Simulator/apps/core/__tests__/fullEventHydrationRegistry.test.ts` — 3 passed (weak-reference expiry, 600-entry bound, unsupported runtime).
- `GOMAXPROCS=2 pnpm run typecheck:fast` — passed after rebasing onto current develop.
- `git diff --name-only origin/develop...HEAD -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0` — passed. Normal pre-commit hooks also passed.
- `git diff --check` and final scoped diff inspection — passed. No visible UI change; screenshots would not demonstrate GC ownership.
