### PR TITLE
fix(agent-station): isolate child chat collapse controls

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/SubagentCollapseScope.md
+++ b/docs/frontend-ui-audit-2026-09-07/SubagentCollapseScope.md
@@ -1,0 +1,19 @@
+# Subagent collapse scope UI audit
+
+| Line                                                                   | Element         | Verdict          | Reason                                                                                                                         | Suggested change |
+| ---------------------------------------------------------------------- | --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `src/engines/Simulator/components/GridCell/SubagentChatPane.tsx:219`   | Collapse button | keep with reason | Existing design-system Button retains its translated title and accessible label; its command now belongs to this child session | None             |
+| `src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx:66` | Turn control    | keep with reason | Context changes state ownership without changing chrome or keyboard behavior                                                   | None             |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+Architecture: reviewed state ownership, consumers, initialization parity, identity, and cleanup (layers 1–5 and 8–10); skipped wire protocol and backend layers because neither changes. Existing parent consumers receive the original default atoms.
+
+| Area               | Verdict | Evidence                                                                    | Change or reason kept                                                                 | Verification                                          |
+| ------------------ | ------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Background work    | keep    | No new timer or subscription                                                | Jotai owns mounted subscriptions                                                      | Mounted hook regression                               |
+| Memory             | fix     | Session scope registry capped at 200; both override maps capped at 200 each | Only atoms and scalar overrides retained; least recently used dormant state may reset | Source review                                         |
+| Scope/isolation    | fix     | Child context provider                                                      | Parent and siblings use different commands/maps                                       | Mounted real block hooks and turn override assertions |
+| Rendering/hot path | keep    | Existing Jotai subscriptions                                                | Only scope changes                                                                    | Targeted test                                         |
+
+Performance verdict: blocked for real-app CPU/RSS and repeated-open measurements: computer control was not authorized. Structural scope isolation is covered by automated tests; no numerical runtime savings claimed. No visual changes requiring screenshots.

--- a/src/engines/ChatPanel/ChatCollapseScope.test.ts
+++ b/src/engines/ChatPanel/ChatCollapseScope.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it } from "vitest";
+
+import {
+  collapseAllCommandAtom,
+  setAllBlocksCollapsedAtom,
+} from "@src/store/ui/collapseStateAtom";
+
+import {
+  ChatCollapseScope,
+  getSubagentCollapseScope,
+} from "./ChatCollapseScope";
+import { useEventBlockHeader } from "./blocks/primitives/useEventBlockHeader";
+
+it("isolates real block consumers in two subagent panes from each other and the parent", () => {
+  const environment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  environment.IS_REACT_ACT_ENVIRONMENT = true;
+  const store = createStore();
+  const a = getSubagentCollapseScope("collapse-test-a");
+  const b = getSubagentCollapseScope("collapse-test-b");
+  const host = document.createElement("div");
+  const root = createRoot(host);
+  function Block({ name }: { name: string }) {
+    const state = useEventBlockHeader({
+      eventId: "same-event-id",
+      collapseAllValue: true,
+    });
+    return createElement(
+      "span",
+      { "data-name": name },
+      String(state.isCollapsed)
+    );
+  }
+  const content = () =>
+    createElement(
+      Provider,
+      { store },
+      createElement(Block, { name: "parent" }),
+      createElement(
+        ChatCollapseScope.Provider,
+        { value: a },
+        createElement(Block, { name: "a" })
+      ),
+      createElement(
+        ChatCollapseScope.Provider,
+        { value: b },
+        createElement(Block, { name: "b" })
+      )
+    );
+  try {
+    act(() => root.render(content()));
+    act(() => store.set(a.setAllBlocksCollapsedAtom, true));
+    expect(host.textContent).toBe("falsetruefalse");
+    expect(store.get(collapseAllCommandAtom).epoch).toBe(0);
+    act(() => store.set(setAllBlocksCollapsedAtom, true));
+    expect(host.textContent).toBe("truetruefalse");
+    store.set(b.setTurnCollapseOverrideAtom, {
+      turnId: "turn",
+      collapsed: false,
+    });
+    act(() => store.set(a.setAllBlocksCollapsedAtom, false));
+    expect(host.textContent).toBe("truefalsefalse");
+    expect(store.get(b.turnCollapseOverrideAtom).get("turn")).toBe(false);
+    expect(getSubagentCollapseScope("collapse-test-a")).toBe(a);
+  } finally {
+    act(() => root.unmount());
+    delete environment.IS_REACT_ACT_ENVIRONMENT;
+  }
+});
+
+it("bounds dormant session scopes while retaining recently revisited state", () => {
+  const oldest = getSubagentCollapseScope("oldest");
+  const recent = getSubagentCollapseScope("recent");
+  for (let i = 0; i < 205; i++) {
+    getSubagentCollapseScope(`bounded-${i}`);
+    expect(getSubagentCollapseScope("recent")).toBe(recent);
+  }
+  expect(getSubagentCollapseScope("oldest")).not.toBe(oldest);
+});

--- a/src/engines/ChatPanel/ChatCollapseScope.ts
+++ b/src/engines/ChatPanel/ChatCollapseScope.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react";
+
+import * as defaults from "@src/store/ui/collapseStateAtom";
+
+export const ChatCollapseScope =
+  createContext<ReturnType<typeof defaults.createCollapseState>>(defaults);
+export const useChatCollapseState = () => useContext(ChatCollapseScope);
+
+// Small UI state survives page switches without retaining any event bodies.
+const scopes = new Map<
+  string,
+  ReturnType<typeof defaults.createCollapseState>
+>();
+export function getSubagentCollapseScope(sessionId: string) {
+  const scope = scopes.get(sessionId) ?? defaults.createCollapseState();
+  scopes.delete(sessionId);
+  scopes.set(sessionId, scope);
+  while (scopes.size > 200) {
+    const oldest = scopes.keys().next().value;
+    if (oldest === undefined) break;
+    scopes.delete(oldest);
+  }
+  return scope;
+}

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatHistoryProjectionModel.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatHistoryProjectionModel.ts
@@ -2,6 +2,7 @@ import { useAtomValue } from "jotai";
 import { useEffect, useMemo, useRef } from "react";
 
 import type { CursorIdeTurnSummary } from "@src/api/tauri/externalHistory";
+import { useChatCollapseState } from "@src/engines/ChatPanel/ChatCollapseScope";
 import type { SessionLoadStatus } from "@src/engines/SessionCore";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { addressRunActiveAtom } from "@src/features/Org2Cloud/addressCommentsRun";
@@ -9,10 +10,6 @@ import {
   estimateRuntimeValueBytes,
   registerChatRenderedTreeMemoryEntry,
 } from "@src/hooks/perf/runtimeMemoryStats";
-import {
-  collapseAllCommandAtom,
-  turnCollapseOverrideAtom,
-} from "@src/store/ui/collapseStateAtom";
 import { selectedExecutionThreadAtom } from "@src/store/ui/sessionPaginationAtom";
 import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
 
@@ -68,6 +65,8 @@ export function useChatHistoryProjectionModel({
   sessionLoadStatus,
   turnPaginationEnabled,
 }: UseChatHistoryProjectionModelOptions) {
+  const { collapseAllCommandAtom, turnCollapseOverrideAtom } =
+    useChatCollapseState();
   const memoryStatsKeyRef = useRef(Symbol("chat-rendered-tree-memory"));
   const memoryStatsSourceRef = useRef<{
     activeId: string | null;

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatSearch.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatSearch.ts
@@ -14,16 +14,13 @@ import {
   useState,
 } from "react";
 
+import { useChatCollapseState } from "@src/engines/ChatPanel/ChatCollapseScope";
 import { useEventNavigation } from "@src/engines/SessionCore";
 import { useDebouncedCallback } from "@src/hooks/perf";
 import {
   chatFindInChatOpenAtomFamily,
   chatSearchSyncAtomFamily,
 } from "@src/store/ui/chatPanelAtom";
-import {
-  setCollapseStateAtom,
-  setTurnCollapseOverrideAtom,
-} from "@src/store/ui/collapseStateAtom";
 
 import type { OptimizedChatItem } from "../chatItemPipeline/types";
 import type { ChatHistoryListHandle } from "../components/ChatHistoryList";
@@ -185,6 +182,8 @@ export function useChatSearch(
   const pendingScrollNeedsLayoutRef = useRef(false);
 
   const { navigateToEvent } = useEventNavigation();
+  const { setTurnCollapseOverrideAtom, setCollapseStateAtom } =
+    useChatCollapseState();
   const setTurnCollapseOverride = useSetAtom(setTurnCollapseOverrideAtom);
   const setCollapseState = useSetAtom(setCollapseStateAtom);
 

--- a/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx
+++ b/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx
@@ -34,6 +34,7 @@ import React, { memo, useCallback, useContext, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
+import { useChatCollapseState } from "@src/engines/ChatPanel/ChatCollapseScope";
 import { getTurnTimingLabels } from "@src/engines/ChatPanel/ChatHistory/utils/turnTimingFormatting";
 import EventNavigateIcon from "@src/engines/ChatPanel/blocks/primitives/EventNavigateIcon";
 import { InSimulatorReplayContext } from "@src/engines/ChatPanel/blocks/primitives/inSimulatorReplayContext";
@@ -45,11 +46,6 @@ import {
   Loading03Icon,
   UnfoldMoreIcon,
 } from "@src/icons";
-import {
-  collapseAllCommandAtom,
-  setTurnCollapseOverrideAtom,
-  turnCollapseOverrideAtom,
-} from "@src/store/ui/collapseStateAtom";
 
 const log = createLogger("TurnCollapsePinBar");
 
@@ -87,6 +83,11 @@ const TurnCollapsePinBar: React.FC<TurnCollapsePinBarProps> = memo(
     turnCollapseInteractionAtRef,
     onExpand,
   }) => {
+    const {
+      collapseAllCommandAtom,
+      setTurnCollapseOverrideAtom,
+      turnCollapseOverrideAtom,
+    } = useChatCollapseState();
     const { t } = useTranslation("sessions");
     const inSimulatorReplay = useContext(InSimulatorReplayContext);
     const { replayEventById, canReplay } = useChatEventReplay();

--- a/src/engines/ChatPanel/blocks/primitives/useEventBlockHeader.ts
+++ b/src/engines/ChatPanel/blocks/primitives/useEventBlockHeader.ts
@@ -10,11 +10,7 @@
 import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useContext, useEffect, useState } from "react";
 
-import {
-  collapseAllCommandAtom,
-  collapseStateAtom,
-  setCollapseStateAtom,
-} from "@src/store/ui/collapseStateAtom";
+import { useChatCollapseState } from "@src/engines/ChatPanel/ChatCollapseScope";
 
 import { NestedBlockContext } from "./nestedBlockContext";
 
@@ -75,6 +71,8 @@ export function useEventBlockHeader(
     preserveDefaultOnExpand = false,
   } = options;
 
+  const { collapseAllCommandAtom, collapseStateAtom, setCollapseStateAtom } =
+    useChatCollapseState();
   const isNested = useContext(NestedBlockContext);
 
   const collapseMap = useAtomValue(collapseStateAtom);

--- a/src/engines/Simulator/components/GridCell/SubagentChatPane.tsx
+++ b/src/engines/Simulator/components/GridCell/SubagentChatPane.tsx
@@ -45,8 +45,7 @@
  * A trailing `(i)` Info button injected into `TurnPaginationControls`
  * (via `paginationTrailingSlot`) opens a popover showing the original
  * task prompt — see `SubagentPromptToggle`. A collapse-all button
- * next to it calls the same global atom the main ChatPanel header
- * uses. Todo progress stays on the parent composer and the cell's scoped
+ * next to it updates this session’s collapse scope. Todo progress stays on the parent composer and the cell's scoped
  * title-row preview rather than appearing inside this chat history.
  *
  * "New event" divider
@@ -68,13 +67,16 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import { ChatProvider } from "@src/contexts/workspace/ChatContext";
+import {
+  ChatCollapseScope,
+  getSubagentCollapseScope,
+} from "@src/engines/ChatPanel/ChatCollapseScope";
 import ChatHistory from "@src/engines/ChatPanel/ChatHistory";
 import { ChatHistoryOverrideContext } from "@src/engines/ChatPanel/ChatHistoryOverrideContext";
 import { ChatSessionContext } from "@src/engines/ChatPanel/ChatSessionContext";
 import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
 import { findIndexAtTime } from "@src/engines/Simulator/utils/findIndexAtTime";
 import { HugeiconsIcon, ListChevronsDownUpIcon } from "@src/icons";
-import { setAllBlocksCollapsedAtom } from "@src/store/ui/collapseStateAtom";
 
 import { SubagentPromptToggle } from "./SubagentPromptToggle";
 
@@ -102,7 +104,13 @@ const SubagentChatPaneComponent: React.FC<SubagentChatPaneProps> = ({
   // ChatHistory re-reads via `useChatHistory()` and picks up our override.
   const allEvents = useAtomValue(chatEventsForSessionAtomFamily(sessionId));
 
-  const setAllBlocksCollapsed = useSetAtom(setAllBlocksCollapsedAtom);
+  const collapseScope = useMemo(
+    () => getSubagentCollapseScope(sessionId),
+    [sessionId]
+  );
+  const setAllBlocksCollapsed = useSetAtom(
+    collapseScope.setAllBlocksCollapsedAtom
+  );
   const handleCollapseAll = useCallback(() => {
     setAllBlocksCollapsed(true);
   }, [setAllBlocksCollapsed]);
@@ -201,25 +209,27 @@ const SubagentChatPaneComponent: React.FC<SubagentChatPaneProps> = ({
   };
 
   return (
-    <ChatSessionContext.Provider value={sessionId}>
-      <ChatHistoryOverrideContext.Provider value={slicedEvents}>
-        <ChatProvider>
-          <div className="relative flex h-full w-full flex-col overflow-hidden">
-            <div className="relative min-h-0 flex-1 overflow-hidden">
-              <ChatHistory
-                surfaceBgClass="bg-chat-pane"
-                turnPaginationEnabled
-                disableTailCollapse
-                hideGroupUserMessage
-                paginationTrailingSlot={paginationTrailingSlot}
-                newEventDividerLabel={newEventDividerLabel}
-                planningIndicatorScope={planningIndicatorScope}
-              />
+    <ChatCollapseScope.Provider value={collapseScope}>
+      <ChatSessionContext.Provider value={sessionId}>
+        <ChatHistoryOverrideContext.Provider value={slicedEvents}>
+          <ChatProvider>
+            <div className="relative flex h-full w-full flex-col overflow-hidden">
+              <div className="relative min-h-0 flex-1 overflow-hidden">
+                <ChatHistory
+                  surfaceBgClass="bg-chat-pane"
+                  turnPaginationEnabled
+                  disableTailCollapse
+                  hideGroupUserMessage
+                  paginationTrailingSlot={paginationTrailingSlot}
+                  newEventDividerLabel={newEventDividerLabel}
+                  planningIndicatorScope={planningIndicatorScope}
+                />
+              </div>
             </div>
-          </div>
-        </ChatProvider>
-      </ChatHistoryOverrideContext.Provider>
-    </ChatSessionContext.Provider>
+          </ChatProvider>
+        </ChatHistoryOverrideContext.Provider>
+      </ChatSessionContext.Provider>
+    </ChatCollapseScope.Provider>
   );
 };
 

--- a/src/store/ui/collapseStateAtom.ts
+++ b/src/store/ui/collapseStateAtom.ts
@@ -8,81 +8,101 @@ type CollapseAllCommand = {
   collapsed: boolean;
 };
 
-/**
- * Global collapse state for chat blocks.
- * Maps eventId -> collapsed (boolean) so user toggles persist
- * across scroll-out/scroll-in re-mounts.
- */
-export const collapseStateAtom = atom<Map<string, boolean>>(new Map());
+export function createCollapseState() {
+  /**
+   * Global collapse state for chat blocks.
+   * Maps eventId -> collapsed (boolean) so user toggles persist
+   * across scroll-out/scroll-in re-mounts.
+   */
+  const collapseStateAtom = atom<Map<string, boolean>>(new Map());
 
-export const setCollapseStateAtom = atom(
-  null,
-  (
-    get,
-    set,
-    { eventId, collapsed }: { eventId: string; collapsed: boolean }
-  ) => {
-    const current = new Map(get(collapseStateAtom));
-    if (current.size >= MAX_COLLAPSE_ENTRIES && !current.has(eventId)) {
-      const firstKey = current.keys().next().value;
-      if (firstKey) current.delete(firstKey);
-    }
-    current.set(eventId, collapsed);
-    set(collapseStateAtom, current);
-  }
-);
-
-/** Global command for "collapse all" / "expand all" in chat panels. */
-export const collapseAllCommandAtom = atom<CollapseAllCommand>({
-  epoch: 0,
-  collapsed: false,
-});
-
-export const setAllBlocksCollapsedAtom = atom(
-  null,
-  (get, set, collapsed: boolean) => {
-    const current = get(collapseAllCommandAtom);
-    set(collapseAllCommandAtom, {
-      epoch: current.epoch + 1,
-      collapsed,
-    });
-    set(collapseStateAtom, new Map());
-    set(turnCollapseOverrideAtom, new Map());
-  }
-);
-
-// ============================================
-// Per-turn collapse state ("Worked for xxx" summary)
-// ============================================
-
-/**
- * Per-turn collapse override map keyed by `turnId` (the user-message event
- * id at the head of a chat group). Completed turns are collapsed by default;
- * this map only records explicit user overrides via the pin-bar chevron.
- *
- *   undefined  -> default behaviour (completed = collapsed, active = expanded)
- *   true       -> user forced this turn collapsed
- *   false      -> user forced this turn expanded
- */
-export const turnCollapseOverrideAtom = atom<Map<string, boolean>>(new Map());
-
-export const setTurnCollapseOverrideAtom = atom(
-  null,
-  (
-    get,
-    set,
-    { turnId, collapsed }: { turnId: string; collapsed: boolean | undefined }
-  ) => {
-    const current = new Map(get(turnCollapseOverrideAtom));
-    if (collapsed === undefined) {
-      current.delete(turnId);
-    } else {
-      if (current.size >= MAX_TURN_OVERRIDE_ENTRIES && !current.has(turnId)) {
+  const setCollapseStateAtom = atom(
+    null,
+    (
+      get,
+      set,
+      { eventId, collapsed }: { eventId: string; collapsed: boolean }
+    ) => {
+      const current = new Map(get(collapseStateAtom));
+      if (current.size >= MAX_COLLAPSE_ENTRIES && !current.has(eventId)) {
         const firstKey = current.keys().next().value;
         if (firstKey) current.delete(firstKey);
       }
-      current.set(turnId, collapsed);
+      current.set(eventId, collapsed);
+      set(collapseStateAtom, current);
     }
-    set(turnCollapseOverrideAtom, current);
-  }
-);
+  );
+
+  /** Global command for "collapse all" / "expand all" in chat panels. */
+  const collapseAllCommandAtom = atom<CollapseAllCommand>({
+    epoch: 0,
+    collapsed: false,
+  });
+
+  const setAllBlocksCollapsedAtom = atom(
+    null,
+    (get, set, collapsed: boolean) => {
+      const current = get(collapseAllCommandAtom);
+      set(collapseAllCommandAtom, {
+        epoch: current.epoch + 1,
+        collapsed,
+      });
+      set(collapseStateAtom, new Map());
+      set(turnCollapseOverrideAtom, new Map());
+    }
+  );
+
+  // ============================================
+  // Per-turn collapse state ("Worked for xxx" summary)
+  // ============================================
+
+  /**
+   * Per-turn collapse override map keyed by `turnId` (the user-message event
+   * id at the head of a chat group). Completed turns are collapsed by default;
+   * this map only records explicit user overrides via the pin-bar chevron.
+   *
+   *   undefined  -> default behaviour (completed = collapsed, active = expanded)
+   *   true       -> user forced this turn collapsed
+   *   false      -> user forced this turn expanded
+   */
+  const turnCollapseOverrideAtom = atom<Map<string, boolean>>(new Map());
+
+  const setTurnCollapseOverrideAtom = atom(
+    null,
+    (
+      get,
+      set,
+      { turnId, collapsed }: { turnId: string; collapsed: boolean | undefined }
+    ) => {
+      const current = new Map(get(turnCollapseOverrideAtom));
+      if (collapsed === undefined) {
+        current.delete(turnId);
+      } else {
+        if (current.size >= MAX_TURN_OVERRIDE_ENTRIES && !current.has(turnId)) {
+          const firstKey = current.keys().next().value;
+          if (firstKey) current.delete(firstKey);
+        }
+        current.set(turnId, collapsed);
+      }
+      set(turnCollapseOverrideAtom, current);
+    }
+  );
+
+  return {
+    collapseStateAtom,
+    setCollapseStateAtom,
+    collapseAllCommandAtom,
+    setAllBlocksCollapsedAtom,
+    turnCollapseOverrideAtom,
+    setTurnCollapseOverrideAtom,
+  };
+}
+
+export const {
+  collapseStateAtom,
+  setCollapseStateAtom,
+  collapseAllCommandAtom,
+  setAllBlocksCollapsedAtom,
+  turnCollapseOverrideAtom,
+  setTurnCollapseOverrideAtom,
+} = createCollapseState();


### PR DESCRIPTION
## Problem

A child chat’s collapse-all button wrote the parent’s global collapse command, affecting sibling cells and the main chat.

## Solution

Create a session-scoped set of collapse atoms and provide it through React context to block headers, turn projection, pin controls, and search expansion. Default context preserves existing parent behavior. The small per-session UI registry is capped at 200 scopes and contains no replay payloads.

## Potential risks

Least recently used collapse state may reset after visiting more than 200 child sessions. Nested consumers must inherit the scope; the mounted regression exercises real block hooks. No persistence or IPC changes. Real-app visual interaction was not run because computer control is not authorized.

## Verification

- `pnpm test src/engines/ChatPanel/ChatCollapseScope.test.ts` — 2 passed (two children plus parent isolation, bounded dormant scopes).
- `GOMAXPROCS=2 pnpm run typecheck:fast` — passed after develop integration.
- `git diff --name-only origin/develop...HEAD -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0` — passed. Normal pre-commit hooks also passed.
- `git diff --check` and final diff inspection — passed. UI audit: 0 fix, 2 keep with reason, 0 abstract. Chrome is unchanged; screenshots would not show command isolation.
