### PR TITLE
fix(agent-station): preserve selection as child sessions change

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/SubagentSelection.md
+++ b/docs/frontend-ui-audit-2026-09-07/SubagentSelection.md
@@ -1,0 +1,10 @@
+# Subagent selection UI audit
+
+| Line                                                       | Element                 | Verdict          | Reason                                                                                                | Suggested change |
+| ---------------------------------------------------------- | ----------------------- | ---------------- | ----------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/engines/Simulator/components/SubagentPipCard.tsx:139` | Selected child/page     | keep with reason | Stable session identity preserves the expanded child and page anchor across sibling insertion/removal | None             |
+| `src/engines/Simulator/ActivitySimulator.tsx`              | Parent session boundary | keep with reason | React key resets local selection when the parent changes                                              | None             |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+React review: roster reconciliation changes only scalar selection and the ordered ID list. Full event arrays remain limited to visible cells. No timers or new caches. Mounted component regression exercises sibling insertion/reorder and parent identity reset. Layout and styles unchanged; screenshots would not demonstrate the state transition. Real-app CPU/RSS was not measured; computer control was not authorized.

--- a/src/engines/Simulator/ActivitySimulator.tsx
+++ b/src/engines/Simulator/ActivitySimulator.tsx
@@ -269,6 +269,7 @@ const ActivitySimulator: React.FC = memo(() => {
               {hasActiveSubagents ? (
                 /* Split view: main agent (top) + subagent banner (bottom) */
                 <SubagentPipCard
+                  key={sessionId}
                   mainContent={<ActivitySimulatorGrid {...splitGridProps} />}
                   activeSessions={activeSubagents}
                   mainCursorMs={mainCursorMs}

--- a/src/engines/Simulator/components/SubagentPipCard.lifecycle.test.ts
+++ b/src/engines/Simulator/components/SubagentPipCard.lifecycle.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import type { SubagentSession } from "../hooks/useSubagentSessions";
+import { SubagentPipCard } from "./SubagentPipCard";
+
+vi.mock("../hooks/useMultiSessionSimulatorEvents", () => ({
+  useMultiSessionSimulatorEvents: () => new Map(),
+}));
+vi.mock("./GridCell/IndependentGridCell", () => ({
+  IndependentGridCell: ({
+    threadId,
+    onExpand,
+    isExpanded,
+  }: {
+    threadId: string;
+    onExpand: () => void;
+    isExpanded: boolean;
+  }) =>
+    createElement(
+      "button",
+      {
+        "data-cell": threadId,
+        "data-expanded": String(isExpanded),
+        onClick: onExpand,
+      },
+      threadId
+    ),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock(
+  "@src/modules/shared/components/FileHeader/BreadcrumbFileHeader",
+  () => ({ default: () => null })
+);
+vi.mock("@src/engines/ChatPanel/blocks/primitives", () => ({
+  EVENT_LOADING_SHIMMER_TEXT_CLASSES: "",
+}));
+function sessions(ids: string[]): SubagentSession[] {
+  return ids.map((id) => ({
+    key: id,
+    sessionId: id,
+    name: id,
+    description: "",
+    sessionType: "agent",
+    status: "running",
+    isBackground: true,
+    startedAtMs: 0,
+    endedAtMs: null,
+    isTerminal: false,
+  }));
+}
+it("keeps the expanded child through roster updates and resets on a parent key change", () => {
+  const env = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    }
+  );
+  const host = document.createElement("div");
+  const root = createRoot(host);
+  const render = (ids: string[], parent = "parent-a") =>
+    act(() =>
+      root.render(
+        createElement(SubagentPipCard, {
+          key: parent,
+          activeSessions: sessions(ids),
+          mainContent: null,
+        })
+      )
+    );
+  try {
+    render(["a", "b", "c"]);
+    act(() =>
+      host.querySelector<HTMLButtonElement>('[data-cell="b"]')?.click()
+    );
+    expect(
+      host.querySelector('[data-cell="b"]')?.getAttribute("data-expanded")
+    ).toBe("true");
+    render(["new", "a", "c", "b"]);
+    expect(host.querySelectorAll("[data-cell]")).toHaveLength(1);
+    expect(
+      host.querySelector('[data-cell="b"]')?.getAttribute("data-expanded")
+    ).toBe("true");
+    render(["new", "a", "c", "b"], "parent-b");
+    expect(host.querySelectorAll("[data-cell]")).toHaveLength(2);
+    expect(host.querySelector('[data-expanded="true"]')).toBeNull();
+  } finally {
+    act(() => root.unmount());
+    delete env.IS_REACT_ACT_ENVIRONMENT;
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/engines/Simulator/components/SubagentPipCard.lifecycle.test.ts
+++ b/src/engines/Simulator/components/SubagentPipCard.lifecycle.test.ts
@@ -7,7 +7,15 @@ import type { SubagentSession } from "../hooks/useSubagentSessions";
 import { SubagentPipCard } from "./SubagentPipCard";
 
 vi.mock("../hooks/useMultiSessionSimulatorEvents", () => ({
-  useMultiSessionSimulatorEvents: () => new Map(),
+  // Support the independent history-lifecycle PR while this selection regression
+  // stays concerned only with roster/selection behavior.
+  useMultiSessionSimulatorEvents: () => {
+    const events = new Map();
+    return Object.assign(events, {
+      eventsMap: events,
+      loadState: () => ({ status: "ready", retry: () => {} }),
+    });
+  },
 }));
 vi.mock("./GridCell/IndependentGridCell", () => ({
   IndependentGridCell: ({

--- a/src/engines/Simulator/components/SubagentPipCard.state.test.ts
+++ b/src/engines/Simulator/components/SubagentPipCard.state.test.ts
@@ -2,33 +2,57 @@ import { describe, expect, it } from "vitest";
 
 import { advanceSubagentViewState } from "./SubagentPipCard";
 
+const state = {
+  sessionIds: ["a", "b", "c", "d", "e", "f"],
+  pageIndex: 1,
+  gridExpanded: true,
+  expandedSessionId: "e",
+};
 describe("advanceSubagentViewState", () => {
-  it("preserves navigation for the same monitored session set", () => {
-    const state = {
-      sessionKeySignature: "a,b",
-      pageIndex: 2,
-      gridExpanded: true,
-      expandedSessionId: "session-a",
-    };
-    expect(advanceSubagentViewState(state, "a,b")).toBe(state);
+  it("preserves the same roster state", () => {
+    expect(advanceSubagentViewState(state, [...state.sessionIds])).toBe(state);
   });
-
-  it("resets sticky navigation when the monitored session set changes", () => {
-    expect(
-      advanceSubagentViewState(
-        {
-          sessionKeySignature: "a,b",
-          pageIndex: 2,
-          gridExpanded: true,
-          expandedSessionId: "session-a",
-        },
-        "c,d"
-      )
-    ).toEqual({
-      sessionKeySignature: "c,d",
+  it("keeps expansion and anchors the selected cell when siblings arrive or reorder", () => {
+    const next = advanceSubagentViewState(state, [
+      "e",
+      "new",
+      "a",
+      "b",
+      "c",
+      "d",
+      "f",
+    ]);
+    expect(next).toMatchObject({
+      pageIndex: 0,
+      gridExpanded: true,
+      expandedSessionId: "e",
+    });
+  });
+  it("anchors the old page when the expanded cell disappears", () => {
+    const next = advanceSubagentViewState(state, ["a", "b", "f", "c", "d"]);
+    expect(next).toMatchObject({
+      pageIndex: 0,
+      gridExpanded: true,
+      expandedSessionId: null,
+    });
+  });
+  it("clamps removed pages and clears expansion for an unrelated roster", () => {
+    expect(advanceSubagentViewState(state, ["new"])).toMatchObject({
       pageIndex: 0,
       gridExpanded: false,
       expandedSessionId: null,
     });
+    expect(advanceSubagentViewState(state, [])).toMatchObject({
+      pageIndex: 0,
+      gridExpanded: false,
+      expandedSessionId: null,
+    });
+  });
+  it("keeps a surviving first item on the strip page after insertion", () => {
+    const next = advanceSubagentViewState(
+      { ...state, gridExpanded: false, expandedSessionId: null },
+      ["new", "a", "b", "c", "d", "e", "f"]
+    );
+    expect(next.pageIndex).toBe(1);
   });
 });

--- a/src/engines/Simulator/components/SubagentPipCard.tsx
+++ b/src/engines/Simulator/components/SubagentPipCard.tsx
@@ -57,7 +57,7 @@ const SUBAGENT_GRID_PAGE_SIZE = 4;
 const HIGHLIGHT_LEAD_MS = 90_000;
 
 interface SubagentViewState {
-  sessionKeySignature: string;
+  sessionIds: readonly string[];
   pageIndex: number;
   gridExpanded: boolean;
   expandedSessionId: string | null;
@@ -65,14 +65,38 @@ interface SubagentViewState {
 
 export function advanceSubagentViewState(
   previous: SubagentViewState,
-  sessionKeySignature: string
+  sessionIds: readonly string[]
 ): SubagentViewState {
-  if (previous.sessionKeySignature === sessionKeySignature) return previous;
+  if (
+    previous.sessionIds.length === sessionIds.length &&
+    previous.sessionIds.every((id, index) => id === sessionIds[index])
+  )
+    return previous;
+  const pageSize = previous.gridExpanded
+    ? SUBAGENT_GRID_PAGE_SIZE
+    : SUBAGENT_STRIP_PAGE_SIZE;
+  const expandedSessionId =
+    previous.expandedSessionId &&
+    sessionIds.includes(previous.expandedSessionId)
+      ? previous.expandedSessionId
+      : null;
+  const previousPage = previous.sessionIds.slice(
+    previous.pageIndex * pageSize,
+    (previous.pageIndex + 1) * pageSize
+  );
+  const anchor =
+    expandedSessionId ?? previousPage.find((id) => sessionIds.includes(id));
+  const hasSurvivor = previous.sessionIds.some((id) => sessionIds.includes(id));
   return {
-    sessionKeySignature,
-    pageIndex: 0,
-    gridExpanded: false,
-    expandedSessionId: null,
+    sessionIds,
+    pageIndex: anchor
+      ? Math.floor(sessionIds.indexOf(anchor) / pageSize)
+      : Math.min(
+          previous.pageIndex,
+          Math.max(0, Math.ceil(sessionIds.length / pageSize) - 1)
+        ),
+    gridExpanded: hasSurvivor && previous.gridExpanded,
+    expandedSessionId,
   };
 }
 
@@ -108,24 +132,17 @@ const SubagentPipCard: React.FC<SubagentPipCardProps> = ({
   liveFollow = false,
 }) => {
   const { t } = useTranslation("sessions");
-  const sessionKeySignature = useMemo(
-    () =>
-      activeSessions
-        .map((sub) => sub.key)
-        .sort()
-        .join(","),
+  const sessionIds = useMemo(
+    () => activeSessions.map((sub) => sub.sessionId),
     [activeSessions]
   );
   const [viewState, setViewState] = useState<SubagentViewState>(() => ({
-    sessionKeySignature,
+    sessionIds,
     pageIndex: 0,
     gridExpanded: false,
     expandedSessionId: null,
   }));
-  const nextViewState = advanceSubagentViewState(
-    viewState,
-    sessionKeySignature
-  );
+  const nextViewState = advanceSubagentViewState(viewState, sessionIds);
   if (nextViewState !== viewState) {
     setViewState(nextViewState);
   }


### PR DESCRIPTION
## Problem

When a sibling subagent appeared, disappeared, or reordered, Agent Station reset its grid/page/expanded-child selection. Users lost the child they were inspecting.

## Solution

Preserve a surviving expanded session and anchor the page to a surviving session ID. Clamp removed pages and reset local view state on the parent session key. Event hydration remains scoped to the visible page.

## Potential risks

The numeric page can move when ranking changes so that the selected child stays visible. Removing the selected child falls back to a surviving page anchor. No data or wire changes. Native visual interaction was not run; mounted component tests cover the state transition.

## Verification

- `pnpm test src/engines/Simulator/components/SubagentPipCard.state.test.ts src/engines/Simulator/components/SubagentPipCard.lifecycle.test.ts` — 6 passed.
- `GOMAXPROCS=2 pnpm run typecheck:fast` — passed after develop integration.
- `git diff --name-only origin/develop...HEAD -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0` — passed. Normal pre-commit hooks also passed.
- `git diff --check` and final diff inspection — passed. UI audit: 0 fix, 2 keep with reason, 0 abstract. Layout is unchanged; static screenshots would not demonstrate preserved selection.

The selection regression fixture supports the history-state API in #1342. A temporary integration branch containing #1339–#1344 merged without source conflicts; all 18 targeted frontend tests and the full TypeScript check passed together.
