### PR TITLE
fix(agent-station): scope replay loads and expose retry states

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/SubagentHistoryLifecycle.md
+++ b/docs/frontend-ui-audit-2026-09-07/SubagentHistoryLifecycle.md
@@ -1,0 +1,20 @@
+# Subagent history lifecycle UI audit
+
+| Line                                                                 | Element             | Verdict          | Reason                                                                | Suggested change                                                |
+| -------------------------------------------------------------------- | ------------------- | ---------------- | --------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `src/engines/Simulator/components/GridCell/SubagentChatPane.tsx:150` | Empty history state | fix              | Loading and failures previously looked like an idle child             | Applied: distinct loading status and design-system retry Button |
+| `src/engines/Simulator/components/GridCell/SubagentChatPane.tsx:180` | History retry       | keep with reason | Keeps existing content during retry and exposes the owning load state | None                                                            |
+| `src/engines/Simulator/components/GridCell/IndependentGridCell.tsx`  | Cell chrome         | keep with reason | Passes load state without changing layout or unrelated controls       | None                                                            |
+
+Verdict totals: **1 fix**, **2 keep with reason**, **0 abstract**.
+
+| Area               | Verdict | Evidence                                                            | Change or reason kept                                                            | Verification                         |
+| ------------------ | ------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------ |
+| Background work    | fix     | Effect owns subscription and request generation                     | Hidden views unsubscribe; explicit retry coalesces in-flight work                | Mounted hidden/retry test            |
+| Memory             | fix     | Event map pruned to current roster; existing 360-event cap retained | Old completions stop before fetching a snapshot                                  | Mounted parent-switch test           |
+| Scope/isolation    | fix     | Every continuation checks disposed owner                            | Previous parent cannot repopulate local state                                    | Deferred cache completion regression |
+| Rendering/hot path | fix     | Load status identity changes only with status                       | Stable unchanged status props; streamed updates buffered during initial baseline | Source review and tests              |
+
+Architecture review: ownership, async state machine, initialization parity, and cleanup; no wire or persistence changes. This change retains existing full-history loading semantics. Cursor-centered disk paging is a separate change.
+
+Performance verdict: blocked for real-app CPU/RSS and visual verification because computer control is not authorized. Automated tests cover owning hook lifecycle and rendered loading/error/empty actions. No numerical performance claim.

--- a/src/engines/Simulator/apps/backgroundTasks/BackgroundTasksApp.tsx
+++ b/src/engines/Simulator/apps/backgroundTasks/BackgroundTasksApp.tsx
@@ -49,7 +49,8 @@ const BackgroundTasksApp: React.FC<BackgroundTasksAppProps> = ({
   onClose,
   onMinimize,
 }) => {
-  const subagentEventsMap = useMultiSessionSimulatorEvents(activeSessions);
+  const { eventsMap: subagentEventsMap, loadState } =
+    useMultiSessionSimulatorEvents(activeSessions);
 
   const childEntries = useMemo(() => {
     return activeSessions.map((sub) => ({
@@ -108,6 +109,7 @@ const BackgroundTasksApp: React.FC<BackgroundTasksAppProps> = ({
               specs={[]}
               sessionType={entry.sessionType}
               threadId={entry.sessionId}
+              historyLoad={loadState(entry.sessionId)}
               independentReplay
               externalCursorMs={mainCursorMs}
               isSessionLive={entry.isSessionLive}

--- a/src/engines/Simulator/components/GridCell/IndependentGridCell.tsx
+++ b/src/engines/Simulator/components/GridCell/IndependentGridCell.tsx
@@ -40,6 +40,7 @@ import { SubagentChatPane } from "./SubagentChatPane";
 import { SubagentPinnedPreviewPopover } from "./SubagentPinnedPreviewPopover";
 
 const IndependentGridCellComponent: React.FC<GridCellProps> = ({
+  historyLoad,
   index,
   color: _color,
   title,
@@ -255,6 +256,7 @@ const IndependentGridCellComponent: React.FC<GridCellProps> = ({
             {threadId ? (
               <SubagentChatPane
                 sessionId={threadId}
+                historyLoad={historyLoad}
                 cursorMs={cursorMsForPane}
                 isSessionLive={isSessionLive}
               />

--- a/src/engines/Simulator/components/GridCell/SubagentChatPane.loading.test.ts
+++ b/src/engines/Simulator/components/GridCell/SubagentChatPane.loading.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { SubagentChatPane } from "./SubagentChatPane";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? key,
+  }),
+}));
+vi.mock(
+  "@src/engines/SessionCore/derived/sessionScopedChatEvents",
+  async () => {
+    const { atom } = await import("jotai");
+    const empty = atom([]);
+    return { chatEventsForSessionAtomFamily: () => empty };
+  }
+);
+vi.mock("@src/engines/ChatPanel/ChatHistory", () => ({ default: () => null }));
+vi.mock("./SubagentPromptToggle", () => ({ SubagentPromptToggle: () => null }));
+it("distinguishes loading, retryable failure and confirmed empty history", () => {
+  const env = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  const host = document.createElement("div");
+  const root = createRoot(host);
+  const retry = vi.fn();
+  const render = (status: "loading" | "ready" | "error") =>
+    act(() =>
+      root.render(
+        createElement(SubagentChatPane, {
+          sessionId: "child",
+          historyLoad: { status, retry },
+        })
+      )
+    );
+  try {
+    render("loading");
+    expect(host.textContent).toContain("Loading history");
+    render("error");
+    expect(host.textContent).toContain("Couldn’t load history");
+    act(() => host.querySelector("button")?.click());
+    expect(retry).toHaveBeenCalledOnce();
+    render("ready");
+    expect(host.textContent).toContain("Waiting for activity");
+  } finally {
+    act(() => root.unmount());
+    delete env.IS_REACT_ACT_ENVIRONMENT;
+  }
+});

--- a/src/engines/Simulator/components/GridCell/SubagentChatPane.tsx
+++ b/src/engines/Simulator/components/GridCell/SubagentChatPane.tsx
@@ -79,6 +79,7 @@ import { setAllBlocksCollapsedAtom } from "@src/store/ui/collapseStateAtom";
 import { SubagentPromptToggle } from "./SubagentPromptToggle";
 
 interface SubagentChatPaneProps {
+  historyLoad?: import("../../hooks/useMultiSessionSimulatorEvents").SubagentHistoryLoad;
   /** Subagent session id — passed to ChatSessionContext so the chat events
    *  atom routes to `chatEventsForSessionAtomFamily(sessionId)`. */
   sessionId: string;
@@ -94,6 +95,7 @@ interface SubagentChatPaneProps {
 
 const SubagentChatPaneComponent: React.FC<SubagentChatPaneProps> = ({
   sessionId,
+  historyLoad,
   cursorMs = null,
   isSessionLive = false,
 }) => {
@@ -141,11 +143,23 @@ const SubagentChatPaneComponent: React.FC<SubagentChatPaneProps> = ({
   if (isEmpty) {
     return (
       <div className="flex h-full w-full items-center justify-center bg-chat-pane px-4 text-center">
-        <span className="text-[12px] text-text-3">
-          {t("simulator.subagentPane.waitingForActivity", {
-            defaultValue: "Waiting for activity…",
-          })}
-        </span>
+        {historyLoad?.status === "error" ? (
+          <Button variant="tertiary" size="small" onClick={historyLoad.retry}>
+            {t("simulator.subagentPane.retryHistory", {
+              defaultValue: "Couldn’t load history — Retry",
+            })}
+          </Button>
+        ) : (
+          <span role="status" className="text-[12px] text-text-3">
+            {historyLoad?.status === "loading"
+              ? t("simulator.subagentPane.loadingHistory", {
+                  defaultValue: "Loading history…",
+                })
+              : t("simulator.subagentPane.waitingForActivity", {
+                  defaultValue: "Waiting for activity…",
+                })}
+          </span>
+        )}
       </div>
     );
   }
@@ -165,6 +179,13 @@ const SubagentChatPaneComponent: React.FC<SubagentChatPaneProps> = ({
   // owns its own popover state — see `SubagentPromptToggle`.
   const paginationTrailingSlot = (
     <>
+      {historyLoad?.status === "error" && (
+        <Button variant="tertiary" size="small" onClick={historyLoad.retry}>
+          {t("simulator.subagentPane.retryHistory", {
+            defaultValue: "Couldn’t load history — Retry",
+          })}
+        </Button>
+      )}
       <SubagentPromptToggle sessionId={sessionId} />
       <Button
         htmlType="button"

--- a/src/engines/Simulator/components/SubagentPipCard.tsx
+++ b/src/engines/Simulator/components/SubagentPipCard.tsx
@@ -140,7 +140,8 @@ const SubagentPipCard: React.FC<SubagentPipCardProps> = ({
     () => activeSessions.slice(pageStartIndex, pageStartIndex + pageSize),
     [activeSessions, pageSize, pageStartIndex]
   );
-  const subagentEventsMap = useMultiSessionSimulatorEvents(visibleSessions);
+  const { eventsMap: subagentEventsMap, loadState } =
+    useMultiSessionSimulatorEvents(visibleSessions);
 
   // "Monitoring N" prefers clips still running at the cursor, but completed
   // imported/live child clips still count when they are the visible monitor
@@ -623,6 +624,7 @@ const SubagentPipCard: React.FC<SubagentPipCardProps> = ({
                       specs={[]}
                       sessionType={entry.sessionType}
                       threadId={entry.sessionId}
+                      historyLoad={loadState(entry.sessionId)}
                       externalCursorMs={liveFollow ? null : mainCursorMs}
                       isHighlighted={isHighlighted}
                       isExpanded={isExpanded}

--- a/src/engines/Simulator/hooks/__tests__/useMultiSessionSimulatorEvents.test.ts
+++ b/src/engines/Simulator/hooks/__tests__/useMultiSessionSimulatorEvents.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { useMultiSessionSimulatorEvents } from "../useMultiSessionSimulatorEvents";
+import type { SubagentSession } from "../useSubagentSessions";
+
+const proxy = vi.hoisted(() => ({
+  getSnapshot: vi.fn(),
+  loadFromCache: vi.fn(),
+  subscribeSession: vi.fn(),
+  getLatestSessionSnapshot: vi.fn(),
+}));
+vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
+  eventStoreProxy: proxy,
+  isStreamingSnapshot: (snapshot: { streaming?: boolean }) =>
+    snapshot.streaming === true,
+}));
+beforeEach(() => {
+  proxy.subscribeSession.mockImplementation(() => vi.fn());
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: false,
+  });
+});
+afterEach(() => vi.resetAllMocks());
+it("rejects late loads after a parent switch before allocating a full snapshot", async () => {
+  const env = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  let resolveOld: (n: number) => void = () => {};
+  proxy.loadFromCache
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        })
+    )
+    .mockResolvedValue(0);
+  proxy.getSnapshot.mockResolvedValue({ sortedSimulatorEvents: [] });
+  let result: ReturnType<typeof useMultiSessionSimulatorEvents> | undefined;
+  function Harness({ id }: { id: string }) {
+    const value = useMultiSessionSimulatorEvents([
+      { sessionId: id } as SubagentSession,
+    ]);
+    useEffect(() => {
+      result = value;
+    }, [value]);
+    return null;
+  }
+  const root = createRoot(document.createElement("div"));
+  try {
+    await act(async () => root.render(createElement(Harness, { id: "old" })));
+    await act(async () => root.render(createElement(Harness, { id: "new" })));
+    await act(async () => resolveOld(1000));
+    expect(proxy.getSnapshot.mock.calls).toEqual([["new"]]);
+    expect([...result!.eventsMap.keys()]).toEqual(["new"]);
+    expect(result!.loadState("new").status).toBe("ready");
+  } finally {
+    act(() => root.unmount());
+    delete env.IS_REACT_ACT_ENVIRONMENT;
+  }
+});
+it("exposes failed versus empty history and retries once on request", async () => {
+  const env = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  proxy.loadFromCache
+    .mockRejectedValueOnce(new Error("offline"))
+    .mockResolvedValue(0);
+  proxy.getSnapshot.mockResolvedValue({ sortedSimulatorEvents: [] });
+  let result: ReturnType<typeof useMultiSessionSimulatorEvents> | undefined;
+  function Harness() {
+    const value = useMultiSessionSimulatorEvents([
+      { sessionId: "child" } as SubagentSession,
+    ]);
+    useEffect(() => {
+      result = value;
+    }, [value]);
+    return null;
+  }
+  const root = createRoot(document.createElement("div"));
+  try {
+    await act(async () => root.render(createElement(Harness)));
+    expect(result!.loadState("child").status).toBe("error");
+    await act(async () => {
+      result!.loadState("child").retry();
+      result!.loadState("child").retry();
+    });
+    expect(proxy.loadFromCache).toHaveBeenCalledTimes(2);
+    expect(result!.loadState("child").status).toBe("ready");
+    await act(async () => {
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await act(async () => result!.loadState("child").retry());
+    expect(proxy.loadFromCache).toHaveBeenCalledTimes(2);
+  } finally {
+    act(() => root.unmount());
+    delete env.IS_REACT_ACT_ENVIRONMENT;
+  }
+});
+
+it("keeps stream updates that arrive while a baseline request is in flight", async () => {
+  const env = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  let finish: (snapshot: unknown) => void = () => {};
+  proxy.loadFromCache.mockResolvedValue(1);
+  proxy.getSnapshot.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        finish = resolve;
+      })
+  );
+  let result: ReturnType<typeof useMultiSessionSimulatorEvents> | undefined;
+  function Harness() {
+    const value = useMultiSessionSimulatorEvents([
+      { sessionId: "child" } as SubagentSession,
+    ]);
+    useEffect(() => {
+      result = value;
+    }, [value]);
+    return null;
+  }
+  const root = createRoot(document.createElement("div"));
+  try {
+    await act(async () => root.render(createElement(Harness)));
+    const receive = proxy.subscribeSession.mock.calls[0][1];
+    const event = {
+      id: "event",
+      createdAt: "2026-09-07T00:00:00Z",
+      displayText: "old",
+    };
+    await act(async () =>
+      receive({
+        streaming: true,
+        simulatorEventUpserts: [{ ...event, displayText: "new" }],
+      })
+    );
+    await act(async () => finish({ sortedSimulatorEvents: [event] }));
+    expect(result!.eventsMap.get("child")?.[0].displayText).toBe("new");
+    expect(proxy.getSnapshot).toHaveBeenCalledOnce();
+  } finally {
+    act(() => root.unmount());
+    delete env.IS_REACT_ACT_ENVIRONMENT;
+  }
+});

--- a/src/engines/Simulator/hooks/useMultiSessionSimulatorEvents.ts
+++ b/src/engines/Simulator/hooks/useMultiSessionSimulatorEvents.ts
@@ -6,7 +6,13 @@
  * for grid cells. This intentionally keeps only the latest window per child
  * session so large subagent histories do not stay duplicated in React state.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { type SessionEvent } from "@src/engines/SessionCore";
 import {
@@ -106,153 +112,163 @@ function extractSimulatorEvents(
   );
 }
 
+export interface SubagentHistoryLoad {
+  status: "loading" | "ready" | "error";
+  retry: () => void;
+}
+
+const INITIAL_LOAD_STATE: SubagentHistoryLoad = {
+  status: "loading",
+  retry: () => {},
+};
+
+function subscribeVisibility(listener: () => void) {
+  document.addEventListener("visibilitychange", listener);
+  return () => document.removeEventListener("visibilitychange", listener);
+}
+const isVisible = () => !document.hidden;
+
 export function useMultiSessionSimulatorEvents(
   subagentSessions: SubagentSession[]
-): SessionEventsMap {
+) {
   const [eventsMap, setEventsMap] = useState<SessionEventsMap>(EMPTY_MAP);
-  const loadedRef = useRef<Set<string>>(new Set());
-  const mapKeysRef = useRef<Set<string>>(new Set());
-  const lastEventsPerSessionRef = useRef<Map<string, SessionEvent[]>>(
+  const [statuses, setStatuses] = useState<Map<string, SubagentHistoryLoad>>(
     new Map()
   );
-  // Sessions that have received at least one DerivedSnapshot (full baseline).
-  const derivedSeenRef = useRef<Set<string>>(new Set());
-  // Sessions with an in-flight/completed full-snapshot hydration request,
-  // so repeated StreamingSnapshots don't trigger a getSnapshot stampede.
-  const hydrationRequestedRef = useRef<Set<string>>(new Set());
-
-  const applySnapshot = useCallback((sessionId: string, snapshot: Snapshot) => {
-    if (!isStreamingSnapshot(snapshot)) {
-      derivedSeenRef.current.add(sessionId);
-    }
-    const previousEvents = lastEventsPerSessionRef.current.get(sessionId) ?? [];
-    const events = extractSimulatorEvents(snapshot, previousEvents);
-    lastEventsPerSessionRef.current.set(sessionId, events);
-    mapKeysRef.current.add(sessionId);
-    setEventsMap((prev) => {
-      const next = new Map(prev);
-      next.set(sessionId, events);
-      return next;
-    });
-  }, []);
-
-  const handleSnapshot = useCallback(
-    (sessionId: string, snapshot: Snapshot) => {
-      if (
-        isStreamingSnapshot(snapshot) &&
-        !derivedSeenRef.current.has(sessionId) &&
-        !hydrationRequestedRef.current.has(sessionId)
-      ) {
-        // StreamingSnapshot before any DerivedSnapshot baseline: the
-        // streaming payload only carries a capped upsert window, so the grid
-        // would show a truncated history. Pull the full derived snapshot
-        // once; the per-session Set prevents duplicate fetches.
-        hydrationRequestedRef.current.add(sessionId);
-        void eventStoreProxy
-          .getSnapshot(sessionId)
-          .then((full) => {
-            if (full && !derivedSeenRef.current.has(sessionId)) {
-              applySnapshot(sessionId, full as Snapshot);
-            }
-          })
-          .catch((err) => {
-            hydrationRequestedRef.current.delete(sessionId);
-            log.warn(
-              "[multiSessionSimulator] full snapshot hydration failed",
-              sessionId,
-              err
-            );
-          });
-      }
-
-      applySnapshot(sessionId, snapshot);
-    },
-    [applySnapshot]
+  const eventsRef = useRef<SessionEventsMap>(new Map());
+  const retryRef = useRef<(id: string) => void>(() => {});
+  const retry = useCallback((id: string) => retryRef.current(id), []);
+  const visible = useSyncExternalStore(
+    subscribeVisibility,
+    isVisible,
+    () => true
+  );
+  const idsKey = JSON.stringify(
+    [...new Set(subagentSessions.map((sub) => sub.sessionId))].sort()
   );
 
   useEffect(() => {
-    if (subagentSessions.length === 0) {
-      loadedRef.current.clear();
-      lastEventsPerSessionRef.current.clear();
-      derivedSeenRef.current.clear();
-      hydrationRequestedRef.current.clear();
-      if (mapKeysRef.current.size > 0) {
-        mapKeysRef.current.clear();
-        queueMicrotask(() => setEventsMap(EMPTY_MAP));
-      }
-      return;
-    }
-
-    const sessionIds = new Set(subagentSessions.map((sub) => sub.sessionId));
+    const ids = JSON.parse(idsKey) as string[];
+    const membership = new Set(ids);
+    let disposed = false;
     const unsubs: Array<() => void> = [];
-
-    for (const sub of subagentSessions) {
-      const sid = sub.sessionId;
-
-      const unsub = eventStoreProxy.subscribeSession(sid, (snapshot) => {
-        handleSnapshot(sid, snapshot);
-      });
-      unsubs.push(unsub);
-
-      if (!loadedRef.current.has(sid)) {
-        loadedRef.current.add(sid);
-
-        const liveSnap = eventStoreProxy.getLatestSessionSnapshot(sid);
-        if (liveSnap) {
-          queueMicrotask(() => handleSnapshot(sid, liveSnap));
-        } else {
-          eventStoreProxy
-            .loadFromCache(sid)
-            .then(async (loadedCount) => {
-              if (loadedCount === 0) return;
-              const snap = await eventStoreProxy.getSnapshot(sid);
-              if (snap && sessionIds.has(sid)) {
-                handleSnapshot(sid, snap as Snapshot);
-              }
-            })
-            .catch((err) => {
-              // Allow a retry on the next effect run — without this delete the
-              // session would be permanently stuck with no events after a
-              // transient cache failure.
-              loadedRef.current.delete(sid);
-              log.warn("[multiSessionSimulator] cache load failed", sid, err);
-            });
-        }
-      }
-    }
-
-    const staleKeys: string[] = [];
-    for (const key of mapKeysRef.current) {
-      if (!sessionIds.has(key)) staleKeys.push(key);
-    }
-    if (staleKeys.length > 0) {
-      for (const key of staleKeys) {
-        mapKeysRef.current.delete(key);
-        lastEventsPerSessionRef.current.delete(key);
-      }
-      queueMicrotask(() => {
-        setEventsMap((prev) => {
-          const next = new Map(prev);
-          for (const key of staleKeys) next.delete(key);
-          return next;
-        });
-      });
-    }
-
-    for (const sid of loadedRef.current) {
-      if (!sessionIds.has(sid)) {
-        loadedRef.current.delete(sid);
-        lastEventsPerSessionRef.current.delete(sid);
-        derivedSeenRef.current.delete(sid);
-        hydrationRequestedRef.current.delete(sid);
-      }
-    }
-
-    return () => {
-      for (const unsub of unsubs) unsub();
+    const pending = new Set<string>();
+    const baseline = new Set<string>();
+    const failed = new Set<string>();
+    const fullReceivedDuringLoad = new Set<string>();
+    const duringLoad = new Map<string, SessionEvent[]>();
+    eventsRef.current = new Map(
+      [...eventsRef.current].filter(([id]) => membership.has(id))
+    );
+    const publish = () => {
+      if (!disposed) setEventsMap(new Map(eventsRef.current));
     };
-  }, [subagentSessions, handleSnapshot]);
-
-  if (subagentSessions.length === 0) return EMPTY_MAP;
-  return eventsMap;
+    const setStatus = (id: string, status: SubagentHistoryLoad["status"]) => {
+      if (disposed) return;
+      setStatuses((previous) => {
+        if (
+          previous.get(id)?.status === status &&
+          [...previous.keys()].every((key) => membership.has(key))
+        )
+          return previous;
+        return new Map(
+          [...previous].filter(([key]) => membership.has(key))
+        ).set(id, { status, retry: () => retry(id) });
+      });
+    };
+    const apply = (id: string, snapshot: Snapshot) => {
+      if (disposed) return;
+      if (!isStreamingSnapshot(snapshot)) baseline.add(id);
+      eventsRef.current.set(
+        id,
+        extractSimulatorEvents(snapshot, eventsRef.current.get(id) ?? [])
+      );
+      publish();
+    };
+    const load = async (id: string, fromCache: boolean) => {
+      if (disposed || !visible || pending.has(id)) return;
+      pending.add(id);
+      failed.delete(id);
+      duringLoad.set(id, []);
+      fullReceivedDuringLoad.delete(id);
+      setStatus(id, "loading");
+      try {
+        if (fromCache) await eventStoreProxy.loadFromCache(id);
+        if (disposed) return;
+        const snapshot = await eventStoreProxy.getSnapshot(id);
+        if (disposed) return;
+        if (!fullReceivedDuringLoad.has(id)) apply(id, snapshot);
+        const buffered = duringLoad.get(id) ?? [];
+        if (buffered.length) {
+          eventsRef.current.set(
+            id,
+            mergeEventUpserts(eventsRef.current.get(id) ?? [], buffered)
+          );
+          publish();
+        }
+        setStatus(id, "ready");
+      } catch (error) {
+        if (!disposed) {
+          failed.add(id);
+          setStatus(id, "error");
+          log.warn("Subagent history load failed", id, error);
+        }
+      } finally {
+        pending.delete(id);
+        duringLoad.delete(id);
+        fullReceivedDuringLoad.delete(id);
+      }
+    };
+    const onSnapshot = (id: string, snapshot: Snapshot) => {
+      if (disposed) return;
+      if (!isStreamingSnapshot(snapshot) && pending.has(id))
+        fullReceivedDuringLoad.add(id);
+      if (isStreamingSnapshot(snapshot) && pending.has(id)) {
+        duringLoad.set(
+          id,
+          mergeEventUpserts(
+            duringLoad.get(id) ?? [],
+            snapshot.simulatorEventUpserts ?? []
+          )
+        );
+      }
+      apply(id, snapshot);
+      if (baseline.has(id)) setStatus(id, "ready");
+      else if (!pending.has(id) && !failed.has(id)) void load(id, false);
+    };
+    retryRef.current = (id) => {
+      if (membership.has(id)) void load(id, true);
+    };
+    queueMicrotask(() => {
+      if (disposed) return;
+      publish();
+      setStatuses(
+        (previous) =>
+          new Map([...previous].filter(([id]) => membership.has(id)))
+      );
+      if (!visible) return;
+      for (const id of ids) {
+        unsubs.push(
+          eventStoreProxy.subscribeSession(id, (snapshot) =>
+            onSnapshot(id, snapshot)
+          )
+        );
+        const latest = eventStoreProxy.getLatestSessionSnapshot(id);
+        if (latest) onSnapshot(id, latest);
+        else void load(id, true);
+      }
+    });
+    return () => {
+      disposed = true;
+      unsubs.forEach((unsubscribe) => unsubscribe());
+    };
+  }, [idsKey, visible, retry]);
+  const membership = new Set(subagentSessions.map((sub) => sub.sessionId));
+  return {
+    eventsMap: [...eventsMap.keys()].every((id) => membership.has(id))
+      ? eventsMap
+      : new Map([...eventsMap].filter(([id]) => membership.has(id))),
+    loadState: (id: string): SubagentHistoryLoad =>
+      statuses.get(id) ?? INITIAL_LOAD_STATE,
+  };
 }

--- a/src/engines/Simulator/types/gridTypes.ts
+++ b/src/engines/Simulator/types/gridTypes.ts
@@ -22,6 +22,7 @@ export interface TaskThread {
 // ============================================
 
 export interface GridCellProps {
+  historyLoad?: import("../hooks/useMultiSessionSimulatorEvents").SubagentHistoryLoad;
   index: number;
   color: string;
   title: string;


### PR DESCRIPTION
## Problem

An old child history request could complete after a page or parent change and repopulate retired local state. Initial failures appeared as “Waiting for activity” and retries were unreliable.

## Solution

Scope subscriptions and continuations to the active effect, stop subscriptions while the document is hidden, and stop retired cache completions before requesting a full snapshot. Coalesce in-flight retries, preserve stream upserts that arrive during baseline hydration, and expose loading/error/ready states with an explicit retry action. Keep existing content during failed reloads.

## Potential risks

The underlying cache request cannot be cancelled after dispatch; its result is prevented from causing retired local work. Existing full-history hydration and the 360-event local window are unchanged. Full transcript paging is outside this PR. Native visibility transitions and visual loading/error layouts were not exercised because computer control is not authorized. No persistence or IPC changes.

## Verification

- `pnpm test src/engines/Simulator/hooks/__tests__/useMultiSessionSimulatorEvents.test.ts src/engines/Simulator/components/GridCell/SubagentChatPane.loading.test.ts` — 4 passed (retired request, retry/hidden behavior, concurrent stream update, rendered states).
- `GOMAXPROCS=2 pnpm run typecheck:fast` — passed after develop integration.
- `git diff --name-only origin/develop...HEAD -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0` — passed. Normal pre-commit hooks also passed.
- `git diff --check` and final diff inspection — passed. UI audit: 1 fix applied, 2 keep with reason, 0 abstract. Native screenshots and process CPU/RSS measurements were not run.
