### PR TITLE
fix(agent-station): make child plan previews accessible on demand

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/SubagentPlanPreview.md
+++ b/docs/frontend-ui-audit-2026-09-07/SubagentPlanPreview.md
@@ -1,0 +1,19 @@
+# Subagent plan preview UI audit
+
+| Line                                                                             | Element                | Verdict          | Reason                                                                                        | Suggested change                                                                                  |
+| -------------------------------------------------------------------------------- | ---------------------- | ---------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `src/engines/Simulator/components/GridCell/IndependentGridCell.tsx:198`          | Cell expand control    | fix              | Mouse-only visibility prevented keyboard discovery                                            | Applied: persistent design-system Button with accessible name                                     |
+| `src/engines/Simulator/components/GridCell/SubagentPinnedPreviewPopover.tsx:128` | Plan trigger and panel | fix              | Hover-only tooltip blocked scrolling and had no keyboard entry                                | Applied: progress Button, shared dropdown engine, focusable scroll area, Escape with focus return |
+| `src/engines/Simulator/components/GridCell/SubagentPinnedPreviewPopover.tsx:169` | Portal panel           | keep with reason | Existing dropdown engine owns placement, viewport fit, outside click, and open-only listeners | None                                                                                              |
+| `src/engines/Simulator/components/GridCell/SubagentPinnedPreviewPopover.tsx:92`  | Todo subscription      | keep with reason | Derived atom selects only this session's stable todo array; list mounts only while opened     | None                                                                                              |
+
+Verdict totals: **2 fix**, **2 keep with reason**, **0 abstract**.
+
+| Area               | Verdict | Evidence                                                   | Change or reason kept                                 | Verification                   |
+| ------------------ | ------- | ---------------------------------------------------------- | ----------------------------------------------------- | ------------------------------ |
+| Background work    | keep    | Shared dropdown engine                                     | Listeners end at close/unmount                        | Mounted interaction regression |
+| Memory             | fix     | Hidden plan has no list DOM; finished plan unmounts engine | On-demand list and no extra cache                     | 50-row mount/unmount test      |
+| Scope/isolation    | fix     | Session-selected todo atom                                 | Unrelated todo updates retain selected array identity | Source review                  |
+| Rendering/hot path | fix     | Removed mouse-hover state and callbacks from cell header   | Always-discoverable actions                           | Typecheck and targeted test    |
+
+Performance verdict: blocked for real-app CPU/RSS and visual viewport checks because computer control is not authorized. Automated DOM assertions cover list lifetime, keyboard dismissal, focus return, and scrolling semantics. No measured runtime savings claimed.

--- a/src/engines/Simulator/components/GridCell/IndependentGridCell.tsx
+++ b/src/engines/Simulator/components/GridCell/IndependentGridCell.tsx
@@ -18,6 +18,7 @@ import { useAtomValue } from "jotai";
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import Button from "@src/components/Button";
 import ReplayProgressBar from "@src/components/ReplayProgressBar";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
 import { REPLAY_CONFIG } from "@src/config/workspace/replayConfig";
@@ -56,7 +57,6 @@ const IndependentGridCellComponent: React.FC<GridCellProps> = ({
   const { t } = useTranslation("sessions");
   const focusedCellId = useAtomValue(focusedSubagentCellAtom);
   const isFocused = Boolean(threadId && focusedCellId === threadId);
-  const [isHeaderHovered, setIsHeaderHovered] = useState(false);
 
   // Merge tool call/result pairs once per events-array change, not per cursor
   // tick. SubagentEventPane now expects pre-merged events.
@@ -159,11 +159,7 @@ const IndependentGridCellComponent: React.FC<GridCellProps> = ({
     >
       <div className="flex h-full w-full flex-col overflow-hidden">
         {/* ── Header ── */}
-        <div
-          className="group/header relative flex h-9 shrink-0 cursor-default items-center gap-1.5 bg-fill-2 pr-1.5 pl-3 transition-all duration-200"
-          onMouseEnter={() => setIsHeaderHovered(true)}
-          onMouseLeave={() => setIsHeaderHovered(false)}
-        >
+        <div className="group/header relative flex h-9 shrink-0 cursor-default items-center gap-1.5 bg-fill-2 pr-1.5 pl-3 transition-all duration-200">
           {/* Task title (bold) · subtitle (regular) · current app icon. */}
           <div className="flex min-w-0 flex-1 items-center gap-1.5">
             <span
@@ -190,24 +186,21 @@ const IndependentGridCellComponent: React.FC<GridCellProps> = ({
             )}
           </div>
 
-          {/* Right-side action buttons — fade in on header hover.
-              `will-change: opacity` keeps the compositor layer pinned across
-              the transition so icons don't snap to integer pixels when the
-              layer is destroyed at opacity:1. `invisible` + `pointer-events-none`
-              ensure the buttons are truly inert while hidden. */}
-          <div
-            className={`flex items-center gap-1 transition-opacity duration-150 will-change-[opacity] ${
-              isHeaderHovered
-                ? "opacity-100"
-                : "pointer-events-none invisible opacity-0"
-            }`}
-          >
+          {/* Controls remain discoverable for pointer and keyboard users. */}
+          <div className="flex items-center gap-1">
             {/* Expand / collapse */}
             {onExpand && (
-              <button
-                type="button"
+              <Button
+                htmlType="button"
+                variant="tertiary"
+                size="small"
+                iconOnly
                 onClick={onExpand}
-                className={`flex h-6 w-6 shrink-0 items-center justify-center rounded text-text-2 ${SURFACE_TOKENS.iconButtonHover} hover:text-text-1`}
+                aria-label={
+                  isExpanded
+                    ? t("simulator.gridCell.collapse")
+                    : t("simulator.gridCell.expand")
+                }
                 title={
                   isExpanded
                     ? t("simulator.gridCell.collapse")
@@ -229,19 +222,12 @@ const IndependentGridCellComponent: React.FC<GridCellProps> = ({
                     strokeWidth={2}
                   />
                 )}
-              </button>
+              </Button>
             )}
           </div>
 
-          {/* Pinned-content hover popover. Renders the subagent's plan-todo
-              summary (we suppress the in-history pinned bar so the cell's
-              chat viewport stays clean). Anchored to the header so it
-              floats above the chat surface on hover. */}
           {threadId && (
-            <SubagentPinnedPreviewPopover
-              sessionId={threadId}
-              open={isHeaderHovered}
-            />
+            <SubagentPinnedPreviewPopover key={threadId} sessionId={threadId} />
           )}
         </div>
 

--- a/src/engines/Simulator/components/GridCell/SubagentPinnedPreviewPopover.test.ts
+++ b/src/engines/Simulator/components/GridCell/SubagentPinnedPreviewPopover.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { type TodoItem, sessionTodoMapAtom } from "@src/store/ui/todoAtom";
+
+import { SubagentPinnedPreviewPopover } from "./SubagentPinnedPreviewPopover";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+it("mounts plans on demand, supports keyboard dismissal and scrolling, and releases completed plans", async () => {
+  const env = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    }
+  );
+  const store = createStore();
+  const todos: TodoItem[] = Array.from({ length: 50 }, (_, i) => ({
+    id: `todo-${i}`,
+    content: `Task ${i}`,
+    status: "pending" as const,
+  }));
+  todos[0].status = "completed";
+  todos[1].blockedBy = [1];
+  todos[2].blockedBy = [2];
+  store.set(
+    sessionTodoMapAtom,
+    new Map([
+      [
+        "child",
+        { todos, isUpdating: false, isVisible: true, lastUpdatedAt: null },
+      ],
+    ])
+  );
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  try {
+    await act(async () =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(SubagentPinnedPreviewPopover, { sessionId: "child" })
+        )
+      )
+    );
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    const trigger = host.querySelector("button")!;
+    expect(trigger.textContent).toContain("1/50");
+    act(() => trigger.click());
+    const panel = document.querySelector<HTMLElement>('[role="dialog"]')!;
+    expect(panel).not.toBeNull();
+    expect(panel.querySelectorAll("li")).toHaveLength(50);
+    expect(
+      panel.querySelectorAll("li")[1].classList.contains("opacity-50")
+    ).toBe(false);
+    expect(
+      panel.querySelectorAll("li")[2].classList.contains("opacity-50")
+    ).toBe(true);
+    expect(panel.querySelector("ul")?.tabIndex).toBe(0);
+    expect(
+      panel.querySelector("ul")?.classList.contains("overflow-y-auto")
+    ).toBe(true);
+    act(() =>
+      panel.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      )
+    );
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+    act(() => trigger.click());
+    act(() => store.set(sessionTodoMapAtom, new Map()));
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(host.querySelector("button")).toBeNull();
+  } finally {
+    act(() => root.unmount());
+    host.remove();
+    delete env.IS_REACT_ACT_ENVIRONMENT;
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/engines/Simulator/components/GridCell/SubagentPinnedPreviewPopover.tsx
+++ b/src/engines/Simulator/components/GridCell/SubagentPinnedPreviewPopover.tsx
@@ -1,7 +1,7 @@
 /**
  * SubagentPinnedPreviewPopover
  *
- * Hover-revealed popover surfaced from the subagent cell title row. Mirrors
+ * On-demand, keyboard-accessible plan preview in the subagent title row. Mirrors
  * the per-session plan-todo summary but scoped to the subagent's own session —
  * the composer `PlanTodoPill` reads
  * `workstationActiveSessionIdAtom`, which always points at the parent
@@ -11,10 +11,13 @@
  * The pane never renders when the subagent has no todos; this keeps cells
  * without a plan from leaving a hover hot-zone that points at nothing.
  */
-import { useAtomValue } from "jotai";
-import React, { memo, useMemo } from "react";
+import { atom, useAtomValue } from "jotai";
+import React, { memo, useId, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
+import Button from "@src/components/Button";
+import { useDropdownEngine } from "@src/hooks/dropdown";
 import {
   ArrowRight01Icon,
   HugeiconsIcon,
@@ -31,10 +34,6 @@ import {
 
 interface SubagentPinnedPreviewPopoverProps {
   sessionId: string | null | undefined;
-  /** When true, the popover is visible. Driven by the cell's header-hover
-   *  state in `IndependentGridCell` so it stays in lockstep with the
-   *  action buttons' fade-in / fade-out timing. */
-  open: boolean;
 }
 
 const TERMINAL_STATUSES = new Set(["completed", "cancelled"]);
@@ -88,83 +87,139 @@ const TodoStatusIcon: React.FC<{ status: string; blocked?: boolean }> = ({
 
 const SubagentPinnedPreviewPopoverComponent: React.FC<
   SubagentPinnedPreviewPopoverProps
-> = ({ sessionId, open }) => {
-  const { t } = useTranslation("sessions");
-  const todoMap = useAtomValue(sessionTodoMapAtom);
-
-  const todos = useMemo<TodoItem[]>(
-    () => getTodosForSession(todoMap, sessionId ?? null),
-    [todoMap, sessionId]
+> = ({ sessionId }) => {
+  const todosAtom = useMemo(
+    () => atom((get) => getTodosForSession(get(sessionTodoMapAtom), sessionId)),
+    [sessionId]
   );
+  const todos = useAtomValue(todosAtom);
+  if (
+    todos.length === 0 ||
+    todos.every((todo) => TERMINAL_STATUSES.has(todo.status))
+  )
+    return null;
+  return <PlanPreview todos={todos} />;
+};
 
-  if (todos.length === 0) return null;
+function PlanPreview({ todos }: { todos: TodoItem[] }) {
+  const { t } = useTranslation("sessions");
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const panelId = useId();
+  const { isOpen, isPositioned, toggle, close, panelRef, panelPosition } =
+    useDropdownEngine<HTMLButtonElement>({
+      anchorRef: buttonRef,
+      captureKeyboardFocus: true,
+      autoKeyboardNavigation: false,
+    });
 
   const completedCount = todos.filter((todo) =>
-    TERMINAL_STATUSES.has(todo.status.toLowerCase())
+    TERMINAL_STATUSES.has(todo.status)
   ).length;
-
-  // Same "fully done — nothing useful to surface" guard as PlanTodoPill.
-  if (completedCount === todos.length) return null;
-
   const label = getTodoBatchTitle(todos) || t("planner.todoList.title");
 
   return (
-    <div
-      role="tooltip"
-      className={`pointer-events-none absolute top-full right-2 left-2 z-30 mt-1 max-h-[60vh] overflow-hidden rounded-lg border border-border-2 bg-bg-1 shadow-lg transition-opacity duration-150 ${
-        open ? "opacity-100" : "invisible opacity-0"
-      }`}
-    >
-      <div className="flex items-center gap-1.5 border-b border-border-2/60 px-3 py-1.5">
-        <HugeiconsIcon
-          icon={ListTodoIcon}
-          data-icon="list-todo"
-          size={12}
-          strokeWidth={1.75}
-          className="text-text-2"
-        />
-        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-text-1">
-          {label}
-        </span>
-        <span className="shrink-0 rounded bg-fill-2 px-1.5 py-0.5 text-[10px] text-text-2 tabular-nums">
+    <>
+      <Button
+        ref={buttonRef}
+        htmlType="button"
+        variant="tertiary"
+        size="small"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? panelId : undefined}
+        aria-haspopup="dialog"
+        aria-label={`${label}: ${completedCount}/${todos.length}`}
+        title={label}
+        onClick={toggle}
+        icon={
+          <HugeiconsIcon icon={ListTodoIcon} size={12} strokeWidth={1.75} />
+        }
+      >
+        <span className="tabular-nums">
           {completedCount}/{todos.length}
         </span>
-      </div>
-      <ul className="max-h-[40vh] overflow-y-auto px-2 py-1.5">
-        {todos.map((todo, idx) => {
-          const norm = todo.status.toLowerCase();
-          const done = norm === "completed";
-          const blocked =
-            !done &&
-            todo.blockedBy != null &&
-            todo.blockedBy.length > 0 &&
-            todo.blockedBy.some((blockerIdx) => {
-              const blocker = todos[blockerIdx];
-              return (
-                blocker != null && blocker.status.toLowerCase() !== "completed"
-              );
-            });
-          return (
-            <li
-              key={todo.id || idx}
-              className={`flex items-center gap-1.5 py-0.5 ${blocked ? "opacity-50" : ""}`}
-            >
-              <TodoStatusIcon status={todo.status} blocked={blocked} />
-              <span
-                className={`min-w-0 flex-1 truncate text-[12px] ${
-                  done ? "text-text-3 line-through" : "text-text-1"
-                }`}
-                title={todo.content}
-              >
-                {todo.content}
+      </Button>
+      {isOpen &&
+        createPortal(
+          <div
+            ref={panelRef}
+            id={panelId}
+            role="dialog"
+            aria-label={label}
+            tabIndex={-1}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.stopPropagation();
+                close();
+                buttonRef.current?.focus();
+              }
+            }}
+            className="fixed z-50 flex w-80 max-w-[calc(100vw-24px)] flex-col overflow-hidden rounded-lg border border-border-2 bg-bg-1 shadow-lg"
+            style={{
+              top: panelPosition.top,
+              bottom: panelPosition.bottom,
+              left: panelPosition.left,
+              maxHeight: panelPosition.maxHeight,
+              visibility: isPositioned ? "visible" : "hidden",
+            }}
+          >
+            <div className="flex items-center gap-1.5 border-b border-border-2/60 px-3 py-1.5">
+              <HugeiconsIcon
+                icon={ListTodoIcon}
+                data-icon="list-todo"
+                size={12}
+                strokeWidth={1.75}
+                className="text-text-2"
+              />
+              <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-text-1">
+                {label}
               </span>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
+              <span className="shrink-0 rounded bg-fill-2 px-1.5 py-0.5 text-[10px] text-text-2 tabular-nums">
+                {completedCount}/{todos.length}
+              </span>
+            </div>
+            <ul
+              tabIndex={0}
+              aria-label={label}
+              className="min-h-0 overflow-y-auto px-2 py-1.5"
+            >
+              {todos.map((todo, idx) => {
+                const norm = todo.status.toLowerCase();
+                const done = norm === "completed";
+                const blocked =
+                  !done &&
+                  todo.blockedBy != null &&
+                  todo.blockedBy.length > 0 &&
+                  todo.blockedBy.some((blockerIdx) => {
+                    const blocker = todos[blockerIdx - 1];
+                    return (
+                      blocker != null &&
+                      blocker.status.toLowerCase() !== "completed"
+                    );
+                  });
+                return (
+                  <li
+                    key={todo.id || idx}
+                    className={`flex items-center gap-1.5 py-0.5 ${blocked ? "opacity-50" : ""}`}
+                  >
+                    <TodoStatusIcon status={todo.status} blocked={blocked} />
+                    <span
+                      className={`min-w-0 flex-1 truncate text-[12px] ${
+                        done ? "text-text-3 line-through" : "text-text-1"
+                      }`}
+                      title={todo.content}
+                    >
+                      {todo.content}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>,
+          document.body
+        )}
+    </>
   );
-};
+}
 
 export const SubagentPinnedPreviewPopover = memo(
   SubagentPinnedPreviewPopoverComponent


### PR DESCRIPTION
## Problem

Child plan previews opened only on header hover, blocked pointer events despite being scrollable, and retained the entire hidden list. Header expand controls were also undiscoverable from the keyboard.

## Solution

Use a persistent design-system progress button to open the plan with the shared dropdown engine. Mount the list only while open, allow keyboard scrolling, close on Escape with focus return, and unmount a completed/removed plan. Select only this session’s todo array. Keep expand controls visible and labelled. Interpret blockedBy using its documented one-based task indices.

## Potential risks

The header now displays a compact progress button and a persistent expand action. Native viewport/theme and pointer-scroll checks remain unverified because computer control is not authorized; automated DOM checks verify semantics. No persistence, API, or dependency changes.

## Verification

- `pnpm test src/engines/Simulator/components/GridCell/SubagentPinnedPreviewPopover.test.ts` — 1 passed, covering a 50-item plan, closed DOM, opening, scrollability, Escape/focus return, and removal.
- `GOMAXPROCS=2 pnpm run typecheck:fast` — passed after develop integration.
- `git diff --name-only origin/develop...HEAD -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0` — passed. Normal pre-commit hooks also passed.
- `git diff --check` and final diff inspection — passed. UI audit: 2 fix applied, 2 keep with reason, 0 abstract. Native screenshots/recordings were not captured.
