### PR TITLE
fix(notifications): localize toast outcomes and remove leading icons

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/MessageContainer.md
+++ b/docs/frontend-ui-audit-2026-09-07/MessageContainer.md
@@ -1,0 +1,34 @@
+# MessageContainer UI audit
+
+| Line                                              | Element            | Verdict          | Reason                                                                                                   | Suggested change |
+| ------------------------------------------------- | ------------------ | ---------------- | -------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/components/Message/MessageContainer.tsx:26`  | Type border colors | keep with reason | Shared notification primitive uses semantic theme tokens to retain message tone without decorative icons | None             |
+| `src/components/Message/MessageContainer.tsx:128` | Toast shell        | keep with reason | Existing responsive sizing and shadows belong to the shared primitive; icon removal leaves no spacer     | None             |
+| `src/components/Message/MessageContainer.tsx:184` | Dismiss button     | keep with reason | Functional close control retains its localized accessible label; it is not a leading status icon         | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+Reviewed raw HTML, tokens, sizes/colors, accessibility and duplication. No lifecycle changes. Auto-dismiss and action code is unchanged; tests cover lazy rendering, teardown and icon omission. Desktop visual verification was not performed because computer control was not authorized.
+
+## Localization findings
+
+Refresh summary formatting already calls translation keys; missing catalog entries caused English fallback. Added three refresh outcomes across all supported locales, with a colon separator, and filled two missing task-notification messages. No persisted data is involved or requires remediation.
+
+A source scan also found hardcoded messages outside the catalog gaps fixed here:
+
+- `src/engines/ChatPanel/hooks/useInputArea/usePromptPolish.ts:135`: five Chinese prompt-polishing notices, including a formatted error
+- `src/modules/shared/DevTools/ComponentIssueModal/index.tsx:51`: six English copy/payload notices, including dynamic labels
+- `src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx:441`: “Workspace is working!”
+- `src/modules/WorkStation/CodeEditor/hooks/useCodeEditorEvents.ts:312`: unavailable terminal session
+- `src/modules/WorkStation/CodeEditor/hooks/useCodeEditorHandlers.ts:350`: timeline diff failure
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/views/PlanFileActions.tsx:52`: empty plan file
+
+These remain follow-up localization work; this is a scan of direct Message calls and missing toast catalog keys, not a claim that every application string is localized. Backend-supplied warning text in sessionHandlers also needs its own error-code/localization boundary review.
+
+## Verification
+
+- `pnpm exec vitest run --config config/vitest.config.ts src/components/Message/__tests__`: 19 tests passed (13 locale catalog checks and 6 renderer tests). Existing missing-i18next-instance warning appears in the renderer fixture.
+- `pnpm exec eslint src/components/Message/MessageContainer.tsx src/components/Message/__tests__/notificationTranslations.test.ts src/components/Message/__tests__/messageLazyContainer.test.ts`: passed.
+- `node scripts/quality/check-missing-i18n-keys.mjs --namespace integrations --prefix keyVault.toasts`: zero missing keys.
+- `git diff --check`: passed.
+- Full application/runtime and visual checks were not run. Translations have not had native-speaker review.

--- a/src/components/Message/MessageContainer.tsx
+++ b/src/components/Message/MessageContainer.tsx
@@ -8,13 +8,7 @@ import type { FC } from "react";
 import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import AnyIcon from "@src/components/AnyIcon";
-import {
-  Cancel01Icon,
-  CheckmarkCircle01Icon,
-  HugeiconsIcon,
-  InformationCircleIcon,
-} from "@src/icons";
+import { Cancel01Icon, HugeiconsIcon } from "@src/icons";
 
 import {
   DEFAULT_DURATION,
@@ -27,17 +21,9 @@ import {
 // Config
 // ============================================
 
-type IconMessageType = Extract<MessageType, "success" | "info">;
-
-const ICONS: Record<IconMessageType, typeof CheckmarkCircle01Icon> = {
-  success: CheckmarkCircle01Icon,
-  info: InformationCircleIcon,
-};
-
-const TYPE_STYLES: Record<MessageType, { border: string; icon?: string }> = {
+const TYPE_STYLES: Record<MessageType, { border: string }> = {
   success: {
     border: "border-success-6/30",
-    icon: "bg-success-6/15 text-success-6",
   },
   error: {
     border: "border-danger-6/30",
@@ -47,7 +33,6 @@ const TYPE_STYLES: Record<MessageType, { border: string; icon?: string }> = {
   },
   info: {
     border: "border-primary-6/30",
-    icon: "bg-primary-6/15 text-primary-6",
   },
 };
 
@@ -64,7 +49,6 @@ const MessageItem = ({
   closable = true,
   onClose,
   onRemove,
-  icon,
   className = "",
   download,
   cancel,
@@ -95,8 +79,6 @@ const MessageItem = ({
   }, [duration, handleClose]);
 
   const typeStyle = TYPE_STYLES[type];
-  const iconType: IconMessageType | null =
-    type === "success" || type === "info" ? type : null;
   const hasDescription = Boolean(title || download || cancel || action);
   const handleDownload = useCallback(() => {
     const blob =
@@ -145,14 +127,6 @@ const MessageItem = ({
       }}
       className={`pointer-events-auto relative flex w-full cursor-default gap-3 overflow-hidden rounded-xl border bg-bg-2 p-[14px_16px] shadow-[0_2px_4px_rgba(0,0,0,0.04),0_12px_24px_rgba(0,0,0,0.08)] transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-px hover:shadow-[0_4px_8px_rgba(0,0,0,0.06),0_16px_32px_rgba(0,0,0,0.12)] max-[480px]:gap-2.5 max-[480px]:rounded-[10px] max-[480px]:p-[12px_14px] ${hasDescription ? "items-start" : "items-center"} ${typeStyle.border} ${className}`}
     >
-      {iconType && (
-        <div
-          className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg max-[480px]:h-6 max-[480px]:w-6 max-[480px]:rounded-md ${typeStyle.icon}`}
-        >
-          {icon || <AnyIcon icon={ICONS[iconType]} size={18} />}
-        </div>
-      )}
-
       {/* Content */}
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         {title && (

--- a/src/components/Message/__tests__/messageLazyContainer.test.ts
+++ b/src/components/Message/__tests__/messageLazyContainer.test.ts
@@ -96,27 +96,29 @@ describe("Message (lazy toast container)", () => {
     expect(document.querySelector("[data-message-root]")).toBeNull();
   });
 
-  it("omits icons from error and warning toasts", async () => {
-    await act(async () => {
-      Message.error({
-        content: "refresh failed",
-        duration: 0,
-        closable: false,
-        icon: createElement("span", { "data-testid": "error-icon" }),
-      });
-      Message.warning({
-        content: "quota is low",
-        duration: 0,
-        closable: false,
-        icon: createElement("span", { "data-testid": "warning-icon" }),
-      });
-    });
-
-    await waitForToastText("refresh failed");
-    await waitForToastText("quota is low");
-    const root = document.querySelector("[data-message-root]");
-    expect(root?.querySelector("svg")).toBeNull();
-    expect(root?.querySelector('[data-testid="error-icon"]')).toBeNull();
-    expect(root?.querySelector('[data-testid="warning-icon"]')).toBeNull();
-  });
+  it.each(["success", "info", "warning", "error"] as const)(
+    "omits default and custom leading icons from %s toasts",
+    async (type) => {
+      for (const custom of [false, true]) {
+        const content = `${type} ${custom ? "custom" : "default"}`;
+        await act(async () => {
+          Message[type]({
+            content,
+            duration: 0,
+            closable: false,
+            ...(custom
+              ? {
+                  icon: createElement("span", { "data-testid": "custom-icon" }),
+                }
+              : {}),
+          });
+        });
+        await waitForToastText(content);
+        const root = document.querySelector("[data-message-root]");
+        expect(root?.querySelector("svg")).toBeNull();
+        expect(root?.querySelector('[data-testid="custom-icon"]')).toBeNull();
+        act(() => Message.clear());
+      }
+    }
+  );
 });

--- a/src/components/Message/__tests__/notificationTranslations.test.ts
+++ b/src/components/Message/__tests__/notificationTranslations.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const locales = resolve(process.cwd(), "src/i18n/locales");
+const keys = ["refreshedDelta", "refreshedNoChange", "refreshPartial"];
+const placeholders = (value: string) => value.match(/{{\w+}}/g)?.sort() ?? [];
+const read = (locale: string, namespace: string) =>
+  JSON.parse(
+    readFileSync(resolve(locales, locale, `${namespace}.json`), "utf8")
+  );
+
+describe("notification translation catalogs", () => {
+  it.each(readdirSync(locales))(
+    "provides refresh and task messages in %s",
+    (locale) => {
+      const toasts = read(locale, "integrations").keyVault.toasts;
+      const source = read("en", "integrations").keyVault.toasts;
+      for (const key of keys) {
+        expect(toasts[key]).toBeTruthy();
+        expect(placeholders(toasts[key])).toEqual(placeholders(source[key]));
+        if (locale !== "en") expect(toasts[key]).not.toBe(source[key]);
+      }
+      expect(toasts.refreshedNoChange).toMatch(/[:：]/);
+      expect(toasts.refreshedNoChange).not.toMatch(/—|--/);
+      const notifications = read(locale, "common").notifications;
+      for (const key of ["taskCompletedToast", "taskCancelledToast"]) {
+        expect(notifications[key]).toBeTruthy();
+        expect(placeholders(notifications[key])).toEqual(["{{name}}"]);
+        if (locale !== "en") {
+          expect(notifications[key]).not.toBe(
+            read("en", "common").notifications[key]
+          );
+        }
+      }
+    }
+  );
+});

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -2478,5 +2478,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "„{{name}}“ wurde abgebrochen",
+    "taskCompletedToast": "„{{name}}“ abgeschlossen. Öffne die Sitzung, um das Ergebnis zu prüfen."
   }
 }

--- a/src/i18n/locales/de/integrations.json
+++ b/src/i18n/locales/de/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "Die lokalen Anmeldedaten werden entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
     "toasts": {
       "refreshed": "{{name}} erfolgreich aktualisiert",
+      "refreshPartial": "Modelle aktualisiert: +{{added}} / -{{removed}}, aber bei {{failed}} von {{total}} Konten ist ein Fehler aufgetreten",
+      "refreshedNoChange": "Modelle aktualisiert: keine Änderungen",
+      "refreshedDelta": "Modelle aktualisiert: {{added}} hinzugefügt, {{removed}} entfernt",
       "refreshError": "{{name}} konnte nicht aktualisiert werden",
       "localRemoved": "{{name}} entfernt",
       "deleteError": "{{name}} konnte nicht gelöscht werden"

--- a/src/i18n/locales/en/integrations.json
+++ b/src/i18n/locales/en/integrations.json
@@ -24,8 +24,8 @@
     "toasts": {
       "refreshed": "{{name}} refreshed successfully",
       "refreshedDelta": "Models refreshed: +{{added}} added, -{{removed}} removed",
-      "refreshedNoChange": "Models refreshed — no changes",
-      "refreshPartial": "Models refreshed (+{{added}} / -{{removed}}), but {{failed}} of {{total}} accounts failed",
+      "refreshedNoChange": "Models refreshed: no changes",
+      "refreshPartial": "Models refreshed: +{{added}} / -{{removed}}, but {{failed}} of {{total}} accounts failed",
       "refreshError": "Failed to refresh {{name}}: {{error}}",
       "localRemoved": "{{name}} removed",
       "deleteError": "Failed to delete {{name}}"

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -2470,5 +2470,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "«{{name}}» se canceló",
+    "taskCompletedToast": "«{{name}}» completada. Abre la sesión para revisar el resultado."
   }
 }

--- a/src/i18n/locales/es/integrations.json
+++ b/src/i18n/locales/es/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "Esto eliminará la credencial local. Esta acción no se puede deshacer.",
     "toasts": {
       "refreshed": "{{name}} actualizado correctamente",
+      "refreshPartial": "Modelos actualizados: +{{added}} / -{{removed}}, pero fallaron {{failed}} de {{total}} cuentas",
+      "refreshedNoChange": "Modelos actualizados: sin cambios",
+      "refreshedDelta": "Modelos actualizados: {{added}} añadidos, {{removed}} eliminados",
       "refreshError": "Error al actualizar {{name}}",
       "localRemoved": "{{name}} eliminado",
       "deleteError": "Error al eliminar {{name}}"

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -2473,5 +2473,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "« {{name}} » a été annulée",
+    "taskCompletedToast": "« {{name}} » est terminée. Ouvrez la session pour consulter le résultat."
   }
 }

--- a/src/i18n/locales/fr/integrations.json
+++ b/src/i18n/locales/fr/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "Cela supprimera les identifiants locaux. Cette action est irréversible.",
     "toasts": {
       "refreshed": "{{name}} actualisé avec succès",
+      "refreshPartial": "Modèles actualisés : +{{added}} / -{{removed}}, mais {{failed}} comptes sur {{total}} ont échoué",
+      "refreshedNoChange": "Modèles actualisés : aucun changement",
+      "refreshedDelta": "Modèles actualisés : {{added}} ajoutés, {{removed}} supprimés",
       "refreshError": "Échec de l'actualisation de {{name}}",
       "localRemoved": "{{name}} supprimé",
       "deleteError": "Échec de la suppression de {{name}}"

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -2473,5 +2473,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "「{{name}}」はキャンセルされました",
+    "taskCompletedToast": "「{{name}}」が完了しました。セッションを開いて結果を確認してください。"
   }
 }

--- a/src/i18n/locales/ja/integrations.json
+++ b/src/i18n/locales/ja/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "ローカル認証情報が削除されます。この操作は元に戻せません。",
     "toasts": {
       "refreshed": "{{name}} の更新が完了しました",
+      "refreshPartial": "モデルを更新しました：{{added}} 件追加、{{removed}} 件削除。ただし {{total}} アカウント中 {{failed}} 件で失敗しました",
+      "refreshedNoChange": "モデルを更新しました：変更なし",
+      "refreshedDelta": "モデルを更新しました：{{added}} 件追加、{{removed}} 件削除",
       "refreshError": "{{name}} の更新に失敗しました",
       "localRemoved": "{{name}} を削除しました",
       "deleteError": "{{name}} の削除に失敗しました"

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -2471,5 +2471,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "“{{name}}” 취소됨",
+    "taskCompletedToast": "“{{name}}” 완료. 세션을 열어 결과를 확인하세요."
   }
 }

--- a/src/i18n/locales/ko/integrations.json
+++ b/src/i18n/locales/ko/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "로컬 자격 증명이 제거됩니다. 이 작업은 되돌릴 수 없습니다.",
     "toasts": {
       "refreshed": "{{name}} 새로고침 완료",
+      "refreshPartial": "모델 새로고침 완료: {{added}}개 추가, {{removed}}개 제거. 단, {{total}}개 계정 중 {{failed}}개 실패",
+      "refreshedNoChange": "모델 새로고침 완료: 변경 사항 없음",
+      "refreshedDelta": "모델 새로고침 완료: {{added}}개 추가, {{removed}}개 제거",
       "refreshError": "{{name}} 새로고침 실패",
       "localRemoved": "{{name}} 제거됨",
       "deleteError": "{{name}} 삭제 실패"

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -2490,5 +2490,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "Anulowano „{{name}}”",
+    "taskCompletedToast": "Ukończono „{{name}}”. Otwórz sesję, aby sprawdzić wynik."
   }
 }

--- a/src/i18n/locales/pl/integrations.json
+++ b/src/i18n/locales/pl/integrations.json
@@ -21,6 +21,9 @@
     "confirmRemoveMessage": "To usunie lokalnie zapisany klucz. Tej operacji nie można cofnąć.",
     "toasts": {
       "refreshed": "{{name}} odświeżono pomyślnie",
+      "refreshPartial": "Modele odświeżone: +{{added}} / -{{removed}}, ale wystąpił błąd dla {{failed}} z {{total}} kont",
+      "refreshedNoChange": "Modele odświeżone: bez zmian",
+      "refreshedDelta": "Modele odświeżone: dodano {{added}}, usunięto {{removed}}",
       "refreshError": "Nie udało się odświeżyć {{name}}",
       "localRemoved": "{{name}} usunięto",
       "deleteError": "Nie udało się usunąć {{name}}"

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -2470,5 +2470,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "“{{name}}” foi cancelada",
+    "taskCompletedToast": "“{{name}}” concluída. Abra a sessão para conferir o resultado."
   }
 }

--- a/src/i18n/locales/pt/integrations.json
+++ b/src/i18n/locales/pt/integrations.json
@@ -21,6 +21,9 @@
     "confirmRemoveMessage": "Isso removerá a chave salva localmente. Esta ação não pode ser desfeita.",
     "toasts": {
       "refreshed": "{{name}} atualizado com sucesso",
+      "refreshPartial": "Modelos atualizados: +{{added}} / -{{removed}}, mas {{failed}} de {{total}} contas falharam",
+      "refreshedNoChange": "Modelos atualizados: sem alterações",
+      "refreshedDelta": "Modelos atualizados: {{added}} adicionados, {{removed}} removidos",
       "refreshError": "Falha ao atualizar {{name}}",
       "localRemoved": "{{name}} removido",
       "deleteError": "Falha ao excluir {{name}}"

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -2490,5 +2490,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "«{{name}}» отменена",
+    "taskCompletedToast": "«{{name}}» завершена. Откройте сеанс, чтобы просмотреть результат."
   }
 }

--- a/src/i18n/locales/ru/integrations.json
+++ b/src/i18n/locales/ru/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "Локальные учётные данные будут удалены. Это действие нельзя отменить.",
     "toasts": {
       "refreshed": "{{name}} успешно обновлён",
+      "refreshPartial": "Модели обновлены: +{{added}} / -{{removed}}, но произошла ошибка для {{failed}} из {{total}} аккаунтов",
+      "refreshedNoChange": "Модели обновлены: без изменений",
+      "refreshedDelta": "Модели обновлены: добавлено {{added}}, удалено {{removed}}",
       "refreshError": "Не удалось обновить {{name}}",
       "localRemoved": "{{name}} удалён",
       "deleteError": "Не удалось удалить {{name}}"

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -2475,5 +2475,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "“{{name}}” iptal edildi",
+    "taskCompletedToast": "“{{name}}” tamamlandı. Sonucu incelemek için oturumu açın."
   }
 }

--- a/src/i18n/locales/tr/integrations.json
+++ b/src/i18n/locales/tr/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "Yerel kimlik bilgileri kaldırılacak. Bu işlem geri alınamaz.",
     "toasts": {
       "refreshed": "{{name}} başarıyla yenilendi",
+      "refreshPartial": "Modeller yenilendi: +{{added}} / -{{removed}}, ancak {{total}} hesaptan {{failed}} tanesi başarısız oldu",
+      "refreshedNoChange": "Modeller yenilendi: değişiklik yok",
+      "refreshedDelta": "Modeller yenilendi: {{added}} eklendi, {{removed}} kaldırıldı",
       "refreshError": "{{name}} yenilenemedi",
       "localRemoved": "{{name}} kaldırıldı",
       "deleteError": "{{name}} silinemedi"

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -2468,5 +2468,9 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "“{{name}}” đã bị hủy",
+    "taskCompletedToast": "“{{name}}” đã hoàn tất. Mở phiên để xem kết quả."
   }
 }

--- a/src/i18n/locales/vi/integrations.json
+++ b/src/i18n/locales/vi/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "Thông tin xác thực cục bộ sẽ bị xóa. Hành động này không thể hoàn tác.",
     "toasts": {
       "refreshed": "{{name}} đã làm mới thành công",
+      "refreshPartial": "Đã làm mới mô hình: +{{added}} / -{{removed}}, nhưng {{failed}} trên {{total}} tài khoản bị lỗi",
+      "refreshedNoChange": "Đã làm mới mô hình: không có thay đổi",
+      "refreshedDelta": "Đã làm mới mô hình: thêm {{added}}, xóa {{removed}}",
       "refreshError": "Không thể làm mới {{name}}",
       "localRemoved": "{{name}} đã xóa",
       "deleteError": "Không thể xóa {{name}}"

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -2491,5 +2491,9 @@
       "previewFailed": "無法從該瀏覽器讀取 Cookie",
       "importFailed": "無法匯入所選 Cookie"
     }
+  },
+  "notifications": {
+    "taskCancelledToast": "「{{name}}」已取消",
+    "taskCompletedToast": "「{{name}}」已完成。開啟工作階段以檢視結果。"
   }
 }

--- a/src/i18n/locales/zh-Hant/integrations.json
+++ b/src/i18n/locales/zh-Hant/integrations.json
@@ -20,6 +20,9 @@
     "confirmRemoveMessage": "這將移除本地賬戶配置，此操作無法撤銷。",
     "toasts": {
       "refreshed": "{{name}} 刷新成功",
+      "refreshPartial": "模型已重新整理：新增 {{added}} 個，移除 {{removed}} 個，但 {{total}} 個帳戶中有 {{failed}} 個失敗",
+      "refreshedNoChange": "模型已重新整理：無變更",
+      "refreshedDelta": "模型已重新整理：新增 {{added}} 個，移除 {{removed}} 個",
       "refreshError": "{{name}} 重新整理失敗：{{error}}",
       "localRemoved": "{{name}} 已移除",
       "deleteError": "{{name}} 刪除失敗"

--- a/src/i18n/locales/zh/integrations.json
+++ b/src/i18n/locales/zh/integrations.json
@@ -21,6 +21,9 @@
     "confirmRemoveActiveSessions_other": "仍有 {{count}} 个活跃会话在使用此账号，移除后它们的下一轮将失败：",
     "toasts": {
       "refreshed": "{{name}} 刷新成功",
+      "refreshPartial": "模型已刷新：新增 {{added}} 个，移除 {{removed}} 个，但 {{total}} 个账户中有 {{failed}} 个失败",
+      "refreshedNoChange": "模型已刷新：无变化",
+      "refreshedDelta": "模型已刷新：新增 {{added}} 个，移除 {{removed}} 个",
       "refreshError": "{{name}} 刷新失败：{{error}}",
       "localRemoved": "{{name}} 已移除",
       "deleteError": "{{name}} 删除失败"


### PR DESCRIPTION
## Problem

Model refresh outcome notifications fall back to English because three translation keys are missing from non-English catalogs. Task-completed and task-cancelled notifications have the same gap in eleven locales. Success and info toasts still display leading status icons that the user requested removing across all message types.

## Solution

Supply the missing refresh and task outcome translations across supported locales, preserving interpolation placeholders. Use a colon in refresh summaries, including “Models refreshed: no changes”. Remove the shared leading-icon slot, including custom icons, while preserving the dismiss button, actions and semantic border colors. Add catalog coverage and renderer regression tests, plus an audit inventory of additional hardcoded messages for follow-up.

## Potential risks

Translations have not had native-speaker review. Desktop visual verification and screenshots were not produced because the user disallows computer control without explicit opt-in; appearance across themes and narrow viewports remains unverified. The icon config field remains accepted for compatibility but no longer renders a leading icon. No persistence, schema, dependency, wire protocol or lifecycle changes are involved. Other hardcoded messages identified in prompt polishing, developer tools and editor actions remain documented follow-up work; this does not claim application-wide localization completeness.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/components/Message/__tests__`: 19 tests passed, including all 13 locales and all four toast types with default/custom icons. Reran after integrating latest develop. The renderer fixture emits its existing missing-i18next-instance warning.
- `pnpm exec eslint src/components/Message/MessageContainer.tsx src/components/Message/__tests__/notificationTranslations.test.ts src/components/Message/__tests__/messageLazyContainer.test.ts`: passed.
- `node scripts/quality/check-missing-i18n-keys.mjs --namespace integrations --prefix keyVault.toasts`: zero missing keys, also rerun after integration.
- `node scripts/quality/check-test-placement.mjs`: passed.
- `git diff --check`: passed. Scoped diff inspected for unrelated changes, secrets and generated artifacts.
- Commit hooks: staged oxlint, ESLint and Prettier passed; `npx tsgo --noEmit --pretty false` passed for the full project. Rust checks were skipped because no Rust files changed.
- Full application build/runtime and visual checks were not run.

## Audit

Shared toast UI audit: 0 fix, 3 keep with reason, 0 abstract. See `docs/frontend-ui-audit-2026-09-07/MessageContainer.md` for findings and the remaining hardcoded-message inventory.
