### PR TITLE
refactor(component-deps): isolate remaining shared helper owners

### DIFF
--- a/docs/architecture-audit-2026-09-07/ComponentDependenciesFollowup.md
+++ b/docs/architecture-audit-2026-09-07/ComponentDependenciesFollowup.md
@@ -1,0 +1,31 @@
+# Component dependency follow-up
+
+Acceptance: all six remaining helper-only seams have dedicated owners, callers use them directly, the existing UI and Git provider lifecycle stay unchanged, and focused boundary/behavior tests, TypeScript and scoped lint pass. This sweep does not introduce lazy loading, new caches or polling.
+
+| Boundary                 | Former owner                                | New owner                                       | Invariant                                                                       |
+| ------------------------ | ------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------- |
+| Panel header tokens      | PanelHeader renderer                        | PanelHeader/tokens.ts                           | Same token values; token-only callers do not import header UI                   |
+| Workstation trail tokens | WorkstationTrailSurface renderer            | blocks/workstationTrailTokens.ts                | Same width/rail classes; layout calculations do not import trail UI             |
+| Email classifier         | EmailMessageBubble renderer and broad utils | Communication/emailBubbleEvent.ts               | Same tool names and strict transcript marker check; no tool registry dependency |
+| Submission data          | SubmissionsContent renderer                 | SessionReplay/submissionsData.ts                | Same artifact normalization, first-seen ordering and deduplication              |
+| Markdown tabs            | MarkdownEditor renderer                     | MarkdownEditor/useMarkdownEditorTabs.ts         | Same translated labels and memo dependency; wizard hook avoids editor UI        |
+| Git status reads         | GitStatusProvider and provider barrel       | GitStatusContext/context.ts and useGitStatus.ts | One context singleton; readers avoid provider/watcher imports                   |
+
+## Ten-layer review
+
+1. Compilation: full TypeScript and scoped lint verification recorded in the PR.
+2. Ownership/dead code: definitions moved, not copied; equivalent helper-only callers migrated. Intentional provider/component APIs retain their render exports.
+3. Naming: existing exported names and meanings retained; new filenames identify the shared owner.
+4. Semantic overload: no domain term changes; UI renderers, data projection and context reads now have distinct owners.
+5. Defaults: email markers, artifact fallback/dedupe, tab order/labels and missing-provider error preserved.
+6. Cross-domain leakage: leaf modules do not import their former renderer/provider. This is the central repaired invariant.
+7. Discoverability: imports name token, classifier, projection or read-hook owners directly.
+8. Wire/serialization: intentionally no payload, schema, persistence or IPC changes; no live payload dump needed.
+9. Init parity: both deferred placeholder and active Git provider use the same context; scheduling/watcher bodies unchanged. Other leaves have no initialization side effects.
+10. Resolver symmetry: submission field precedence moved intact, with focused derivation tests. No resolver policy changes.
+
+## React performance and lifecycle
+
+Applicable: heavy dependency boundaries and context ownership. No Next.js/RSC/SWR changes apply. Static graph tests demonstrate source isolation only; tree shaking and legitimate render consumers can retain emitted code. No bundle-byte, startup-time, memory or frame-time improvement is claimed. The Git lifecycle review and deferred mount tests cover context identity and scheduled handoff/cleanup; native WebView profiling is unverified.
+
+UI consistency findings are in the scoped frontend audit reports. JSX and styling values are unchanged. Rollback is a normal revert; there is no data migration or dependency/configuration change.

--- a/docs/architecture-audit-2026-09-07/GitStatusReaders.md
+++ b/docs/architecture-audit-2026-09-07/GitStatusReaders.md
@@ -1,0 +1,40 @@
+# Git status reader dependencies
+
+The Git status read hook previously lived in an index that re-exported the deferred provider, and the context singleton lived in the active provider. A reader therefore had a static path to provider-owned repository fetching, event listeners, watcher registration, and store dependencies.
+
+The context and read hook now have leaf modules. All 11 production hook consumers import the read hook directly; provider entry points retain their existing exports. Both providers import the same context singleton. The provider bodies, state, fetch ownership, deferred timing, and cleanup remain unchanged.
+
+## Architecture coverage
+
+| Layer                  | Evidence and verdict                                                                                 |
+| ---------------------- | ---------------------------------------------------------------------------------------------------- |
+| 1 Compilation          | `pnpm typecheck:fast` and focused lint validate moved imports and types                              |
+| 2 Deduplication        | One context initializer and one read hook; production readers use the new leaf                       |
+| 3 Naming               | Existing public names retained                                                                       |
+| 4 Semantic overloading | Repository status context remains separate from the file-tree-local context of the same name         |
+| 5 Defaults             | Null context still throws the same missing-provider error; deferred placeholder unchanged            |
+| 6 Boundaries           | Read hook reaches only context.ts and React at runtime, verified by static import graph              |
+| 7 Discoverability      | context.ts owns identity, useGitStatus.ts owns reads, provider owns effects                          |
+| 8 Wire protocol        | Not applicable: no IPC payload or serializer changes                                                 |
+| 9 Init parity          | Active and deferred providers share the singleton; deferred handoff covered by a rendered JSdom test |
+| 10 Resolver symmetry   | Not applicable: no resolver or priority-chain changes                                                |
+
+## React and lifecycle review
+
+| Area               | Verdict | Evidence                                                                                                               | Change or reason kept                                    | Verification                                                                            |
+| ------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Background work    | keep    | Existing provider owns Git listeners, fetches and watchers; deferred provider owns one idle callback or fallback timer | No effect body or resource owner changed                 | JSdom fallback handoff and idle cancellation tests; source diff review                  |
+| Memory             | keep    | One module-level React context                                                                                         | No additional cache, state container or retained history | Read-hook identity assertion                                                            |
+| Scope/isolation    | keep    | Existing provider still selects the current repository and supplies its value                                          | No repository or authentication key changes              | Exact context value and action identity assertions                                      |
+| Rendering/hot path | fix     | Hook-only imports no longer traverse the provider barrel                                                               | Direct leaf imports across all 11 callers                | Static import graph excludes providers, hooks and application stores from the read hook |
+
+Lifecycle matrix: clean load sees the same loading placeholder; fallback activation hands readers the active value; closing before idle activation cancels its callback. Visible/hidden, online/offline, identity switching, repository changes and shutdown inside the active provider retain unchanged implementation. No new background work was introduced. Native WebView CPU/RSS, startup timing and production bundle bytes were not measured; this is a verified dependency boundary change, not a measured runtime speedup.
+
+Performance verdict: pass for the changed import boundary and unchanged resource ownership; no runtime performance improvement claimed.
+
+## Verification
+
+- `pnpm test src/contexts/git/GitStatusContext/useGitStatus.test.ts src/contexts/git/GitStatusContext/DeferredGitStatusProvider.test.ts src/contexts/git/GitStatusContext/hooks/__tests__/useGitStatusFetch.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/SourceControlTab.initialization.test.ts` — 9 tests in 4 files passed
+- `pnpm typecheck:fast` — passed
+- Scoped `pnpm exec eslint` on GitStatusContext source/tests and all migrated readers — passed
+- No visual changes; no native UI control performed

--- a/docs/frontend-ui-audit-2026-09-07/CommunicationAndSubmissionsLeaves.md
+++ b/docs/frontend-ui-audit-2026-09-07/CommunicationAndSubmissionsLeaves.md
@@ -1,0 +1,12 @@
+# Communication and submissions dependency leaves UI audit
+
+Scope: renderer imports and extracted pure classification/derivation only. Rendered markup, handlers, styles, labels, and PR status behavior are unchanged. No visual evidence is needed for moving data functions; native WebView behavior was not exercised.
+
+| Line                                                                                               | Element                | Verdict          | Reason                                                                                                                                     | Suggested change |
+| -------------------------------------------------------------------------------------------------- | ---------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `src/modules/WorkStation/Chat/Communication/EmailMessageBubble.tsx:240`                            | Message bubble shell   | keep with reason | Existing ChatBubbleLayout, ChatBubbleAvatar, and ChatBubbleHeader remain the shared scaffold; classification is now imported independently | None             |
+| `src/modules/WorkStation/Diff/SessionReplay/SubmissionsContent.tsx:165`                            | Commit rows            | keep with reason | Existing GitCommitRow owns row navigation and rendering; moving derivation preserves its props and click path                              | None             |
+| `src/modules/WorkStation/Diff/SessionReplay/SubmissionsContent.tsx:180`                            | Empty states           | keep with reason | Existing Placeholder controls localized empty rendering; the data leaf preserves empty arrays                                              | None             |
+| `src/modules/WorkStation/Diff/SessionReplay/__tests__/SubmissionsContent.prStatusBadge.test.ts:14` | PR badge data contract | keep with reason | The type now comes from the data leaf while the same renderer and status badge tests cover unresolved and resolved states                  | None             |
+
+Verdict totals: **0 fix**, **4 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-07/GitStatusReaders.md
+++ b/docs/frontend-ui-audit-2026-09-07/GitStatusReaders.md
@@ -1,0 +1,10 @@
+# Git status readers UI audit
+
+| Line                                                                                          | Element                                           | Verdict          | Reason                                                                                                                       | Suggested change |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/contexts/git/GitStatusContext/DeferredGitStatusProvider.tsx:60`                          | Context provider wrapper                          | keep with reason | Supplies the same placeholder and child subtree with unchanged deferred mount behavior; not a visual primitive               | None             |
+| `src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.tsx:20` | Git status consumer import and equivalent readers | keep with reason | Changes only the hook import across readers; existing markup, tokens, sizes, labels and accessibility behavior remain intact | None             |
+
+D1–D5 checked against the changed lines: no visual primitive, class, color, size, interaction or repeated visual structure changed. Screenshots would not demonstrate the import boundary.
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.

--- a/docs/frontend-ui-audit-2026-09-07/LayoutTokens.md
+++ b/docs/frontend-ui-audit-2026-09-07/LayoutTokens.md
@@ -1,0 +1,12 @@
+# Layout token consumers UI audit
+
+| Line                                                               | Element                                                 | Verdict          | Reason                                                                                                                                                                     | Suggested change |
+| ------------------------------------------------------------------ | ------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/shared/layouts/blocks/PanelHeader/index.tsx:49`       | Header button and sizing tokens                         | keep with reason | The renderer and token-only callers share the exact existing token object from a leaf module; button semantics, theme classes, spacing, and context behavior are preserved | None             |
+| `src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx:15` | Trail surface, icon-button, and responsive width tokens | keep with reason | Extraction preserves existing theme classes and the separate trail/terminal width custom properties; renderer and layout calculations continue sharing one owner           | None             |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+Scope includes import-only changes in Calendar and Gantt toolbars, channel header, MoveToOrgDialog, DetailHeaderClose, FileHeader, BuilderTypeDetailPanel, BuilderTypesPanel, PageBreadcrumb, and PropertiesRailFrame. Their JSX, styling values, focus behavior, and accessibility attributes are unchanged. Component-plus-token consumers retain the existing component exports; all token-only consumers import the leaf modules. No visual redesign or new design-system sweep is proposed.
+
+Verification: 22 tests passed across `layoutTokenBoundaries.test.ts`, `WorkstationTrailSurface.test.ts`, `trailWidth.test.ts`, `PropertiesRailFrame.test.ts`, and `GitHubDetailSkeleton/index.test.ts`. These cover renderer markup, responsive widths, and the absence of renderer/React imports from the token and pure-layout boundaries. Native WebView screenshots and performance measurements were not taken; this change makes no measured startup or bundle-size claim.

--- a/docs/frontend-ui-audit-2026-09-07/MarkdownEditorTabs.md
+++ b/docs/frontend-ui-audit-2026-09-07/MarkdownEditorTabs.md
@@ -1,0 +1,12 @@
+# MarkdownEditor tab hook UI audit
+
+Scope: extracting the shared tab-label hook and migrating its editor, Agent wizard and Policy form consumers. D1–D5 reviewed at the changed boundary; no markup, tokens, accessibility behavior or rendering structure changes.
+
+| Line                                                                                 | Element               | Verdict          | Reason                                                                                                                   | Suggested change |
+| ------------------------------------------------------------------------------------ | --------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `src/modules/shared/components/MarkdownEditor/index.tsx:17`                          | Shared tab-label hook | keep with reason | The editor continues to render the same TabPill control and translated labels; only ownership moves to a React/i18n leaf | None             |
+| `src/scaffold/WizardSystem/variants/Policy/PolicyRuleWizard/MarkdownRuleForm.tsx:13` | Policy editor imports | keep with reason | This form actually renders MarkdownEditor and keeps that import; its tab labels now share the same leaf as Agent wizard  | None             |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+No visual evidence is needed for an import-only change with identical JSX. Native visual verification was not performed. The dependency regression establishes the hook's source boundary, not emitted bundle savings.

--- a/src/contexts/git/GitStatusContext/DeferredGitStatusProvider.test.ts
+++ b/src/contexts/git/GitStatusContext/DeferredGitStatusProvider.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DeferredGitStatusProvider } from "./DeferredGitStatusProvider";
+import {
+  DEFERRED_MOUNT_FALLBACK_MS,
+  DEFERRED_MOUNT_TIMEOUT_MS,
+} from "./constants";
+import { useGitStatus } from "./useGitStatus";
+
+vi.mock("./GitStatusProvider", async () => {
+  const { GitStatusContext } = await import("./context");
+  return {
+    GitStatusProvider: ({ children }: { children: React.ReactNode }) =>
+      createElement(
+        GitStatusContext.Provider,
+        {
+          value: {
+            currentGitStatus: null,
+            scopedGitStatus: null,
+            gitSuggestedAction: null,
+            loading: false,
+            error: "active provider",
+            hasActiveRepo: true,
+            forceRefresh: async () => {},
+          },
+        },
+        children
+      ),
+  };
+});
+
+function Reader() {
+  const value = useGitStatus();
+  return createElement("span", null, value.loading ? "loading" : value.error);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("deferred Git status context handoff", () => {
+  it("keeps readers on the shared context when the fallback mounts the provider", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const host = document.createElement("div");
+    const root = createRoot(host);
+    await act(async () =>
+      root.render(
+        createElement(DeferredGitStatusProvider, null, createElement(Reader))
+      )
+    );
+    expect(host.textContent).toBe("loading");
+    await act(async () => vi.advanceTimersByTime(DEFERRED_MOUNT_FALLBACK_MS));
+    expect(host.textContent).toBe("active provider");
+    await act(async () => root.unmount());
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels pending idle mount when closed before readiness", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const request = vi.fn(() => 42);
+    const cancel = vi.fn();
+    vi.stubGlobal("requestIdleCallback", request);
+    vi.stubGlobal("cancelIdleCallback", cancel);
+    const root = createRoot(document.createElement("div"));
+    await act(async () =>
+      root.render(
+        createElement(DeferredGitStatusProvider, null, createElement(Reader))
+      )
+    );
+    expect(request).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: DEFERRED_MOUNT_TIMEOUT_MS,
+    });
+    await act(async () => root.unmount());
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledWith(42);
+  });
+});

--- a/src/contexts/git/GitStatusContext/DeferredGitStatusProvider.tsx
+++ b/src/contexts/git/GitStatusContext/DeferredGitStatusProvider.tsx
@@ -11,11 +11,12 @@
  */
 import React, { useEffect, useState } from "react";
 
-import { GitStatusContext, GitStatusProvider } from "./GitStatusProvider";
+import { GitStatusProvider } from "./GitStatusProvider";
 import {
   DEFERRED_MOUNT_FALLBACK_MS,
   DEFERRED_MOUNT_TIMEOUT_MS,
 } from "./constants";
+import { GitStatusContext } from "./context";
 import type { GitStatusContextValue } from "./types";
 
 /**

--- a/src/contexts/git/GitStatusContext/GitStatusProvider.tsx
+++ b/src/contexts/git/GitStatusContext/GitStatusProvider.tsx
@@ -20,7 +20,6 @@ import {
 } from "@/src/store/git";
 import { useAtomValue, useSetAtom } from "jotai";
 import React, {
-  createContext,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -45,6 +44,7 @@ import type {
 } from "@src/types/session/steps";
 
 import { REPO_SWITCH_DEBOUNCE_MS } from "./constants";
+import { GitStatusContext } from "./context";
 import { useGitEventListeners } from "./hooks/useGitEventListeners";
 import { useGitStatusFetch } from "./hooks/useGitStatusFetch";
 import { useWatcherRegistration } from "./hooks/useWatcherRegistration";
@@ -54,13 +54,7 @@ import type {
   StartupState,
 } from "./types";
 
-// ============================================
-// Context
-// ============================================
-
-export const GitStatusContext = createContext<GitStatusContextValue | null>(
-  null
-);
+export { GitStatusContext } from "./context";
 
 // ============================================
 // Provider

--- a/src/contexts/git/GitStatusContext/context.ts
+++ b/src/contexts/git/GitStatusContext/context.ts
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+
+import type { GitStatusContextValue } from "./types";
+
+/** Shared by deferred and active providers without importing their lifecycle. */
+export const GitStatusContext = createContext<GitStatusContextValue | null>(
+  null
+);

--- a/src/contexts/git/GitStatusContext/index.tsx
+++ b/src/contexts/git/GitStatusContext/index.tsx
@@ -12,27 +12,7 @@
  * - Call forceRefresh() after mutations (save, stage, commit)
  * - NEVER create their own event listeners
  */
-import { useContext } from "react";
-
-import { DeferredGitStatusProvider } from "./DeferredGitStatusProvider";
-import { GitStatusContext } from "./GitStatusProvider";
-import type { GitStatusContextValue } from "./types";
-
-// ============================================
-// Hook
-// ============================================
-
-export function useGitStatus(): GitStatusContextValue {
-  const context = useContext(GitStatusContext);
-  if (!context) {
-    throw new Error("useGitStatus must be used within GitStatusProvider");
-  }
-  return context;
-}
-
-// ============================================
-// Exports
-// ============================================
-
-export { DeferredGitStatusProvider, GitStatusContext };
-export type { GitStatusContextValue };
+export { DeferredGitStatusProvider } from "./DeferredGitStatusProvider";
+export { GitStatusContext } from "./context";
+export { useGitStatus } from "./useGitStatus";
+export type { GitStatusContextValue } from "./types";

--- a/src/contexts/git/GitStatusContext/useGitStatus.test.ts
+++ b/src/contexts/git/GitStatusContext/useGitStatus.test.ts
@@ -1,0 +1,67 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  reachableFilesMatching,
+  walkStaticImports,
+} from "@src/test/staticImportGraph";
+
+import { GitStatusContext } from "./context";
+import type { GitStatusContextValue } from "./types";
+import { useGitStatus } from "./useGitStatus";
+
+describe("useGitStatus read boundary", () => {
+  it("reads the exact provider value and refresh action", () => {
+    const value: GitStatusContextValue = {
+      currentGitStatus: null,
+      scopedGitStatus: null,
+      gitSuggestedAction: null,
+      loading: false,
+      error: "repository unavailable",
+      forceRefresh: async () => {},
+      hasActiveRepo: true,
+    };
+    function Reader() {
+      const observed = useGitStatus();
+      expect(observed).toBe(value);
+      expect(observed.forceRefresh).toBe(value.forceRefresh);
+      return createElement("span", null, observed.error);
+    }
+    expect(
+      renderToStaticMarkup(
+        createElement(
+          GitStatusContext.Provider,
+          { value },
+          createElement(Reader)
+        )
+      )
+    ).toBe("<span>repository unavailable</span>");
+  });
+
+  it("preserves the missing-provider error", () => {
+    function Reader() {
+      useGitStatus();
+      return null;
+    }
+    expect(() => renderToStaticMarkup(createElement(Reader))).toThrow(
+      "useGitStatus must be used within GitStatusProvider"
+    );
+  });
+
+  it("does not bring provider lifecycle or application state into a reader", () => {
+    const graph = walkStaticImports([
+      "contexts/git/GitStatusContext/useGitStatus.ts",
+    ]);
+    expect(
+      reachableFilesMatching(
+        graph,
+        /GitStatusProvider|DeferredGitStatusProvider|\/hooks\/|^store\//
+      )
+    ).toEqual([]);
+    expect([...graph.packages]).toEqual(["react"]);
+    expect(reachableFilesMatching(graph, /context\.ts$/)).toEqual([
+      "contexts/git/GitStatusContext/context.ts",
+    ]);
+  });
+});

--- a/src/contexts/git/GitStatusContext/useGitStatus.ts
+++ b/src/contexts/git/GitStatusContext/useGitStatus.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { GitStatusContext } from "./context";
+import type { GitStatusContextValue } from "./types";
+
+/** Read current repository state without importing its provider implementation. */
+export function useGitStatus(): GitStatusContextValue {
+  const context = useContext(GitStatusContext);
+  if (!context) {
+    throw new Error("useGitStatus must be used within GitStatusProvider");
+  }
+  return context;
+}

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
@@ -1,7 +1,7 @@
 import {
   FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS,
   WORKSTATION_TRAIL_WIDTH,
-} from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
+} from "@src/modules/shared/layouts/blocks/workstationTrailTokens";
 import type { ChatPanelTab } from "@src/store/chatPanel/chatPanelTabsAtom";
 
 /**

--- a/src/features/CalendarView/components/Toolbar/index.tsx
+++ b/src/features/CalendarView/components/Toolbar/index.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import Button from "@src/components/Button";
 import TabPill from "@src/components/TabPill";
 import { ArrowLeft01Icon, ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
-import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks";
+import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 
 import {
   MONTH_NAMES_SHORT,

--- a/src/features/DiscussionChannels/ChannelPanelView/ChannelPanelHeader.tsx
+++ b/src/features/DiscussionChannels/ChannelPanelView/ChannelPanelHeader.tsx
@@ -19,7 +19,7 @@ import {
   Settings02Icon,
   UserMultipleIcon,
 } from "@src/icons";
-import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks";
+import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 
 export interface ChannelPanelHeaderProps {
   name: string;

--- a/src/features/GanttChart/components/Toolbar/index.tsx
+++ b/src/features/GanttChart/components/Toolbar/index.tsx
@@ -16,7 +16,7 @@ import {
   ZoomInAreaIcon,
   ZoomOutAreaIcon,
 } from "@src/icons";
-import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks";
+import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 
 import { VIEW_SCOPE_OPTIONS } from "../../config";
 import type { ZoomLevel } from "../../hooks/useGanttZoom";

--- a/src/features/TeamCollaboration/components/MoveToOrgDialog/index.tsx
+++ b/src/features/TeamCollaboration/components/MoveToOrgDialog/index.tsx
@@ -22,7 +22,7 @@ import Message from "@src/components/Message";
 import Tooltip from "@src/components/Tooltip";
 import { createLogger } from "@src/hooks/logger";
 import { HugeiconsIcon, InformationCircleIcon } from "@src/icons";
-import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader";
+import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 import { DEFAULT_SESSION_ORG_ID } from "@src/store/session";
 import type { Session } from "@src/store/session/sessionAtom/types";
 

--- a/src/hooks/git/useGitAutoFetch.ts
+++ b/src/hooks/git/useGitAutoFetch.ts
@@ -13,7 +13,7 @@ import { useAtomValue } from "jotai";
 import { useEffect, useRef } from "react";
 
 import { gitApi } from "@src/api/http/git";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { createLogger } from "@src/hooks/logger";
 import { selectedRepoAtom, selectedRepoIdAtom } from "@src/store/repo";
 import {

--- a/src/hooks/git/useGitOperations.ts
+++ b/src/hooks/git/useGitOperations.ts
@@ -19,7 +19,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { useActionSystemOptional } from "@src/ActionSystem";
 import type { GitErrorType } from "@src/api/http/git/streaming";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { GitOperationsService } from "@src/services/git/GitOperationsService";
 import type { GitPullStrategy } from "@src/store/ui/editorSettingsAtom";
 

--- a/src/modules/MainApp/Integrations/shared/DetailHeaderClose.tsx
+++ b/src/modules/MainApp/Integrations/shared/DetailHeaderClose.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
+import { COLLAPSIBLE_SECTION_TOKENS } from "@src/config/detailPanelTokens";
 import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
 import {
   ArrowDown02Icon,
@@ -11,10 +12,7 @@ import {
   HugeiconsIcon,
   Refresh04Icon,
 } from "@src/icons";
-import {
-  COLLAPSIBLE_SECTION_TOKENS,
-  PANEL_HEADER_TOKENS,
-} from "@src/modules/shared/layouts/blocks";
+import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 
 interface DetailHeaderCloseProps {
   onClick: () => void;

--- a/src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesRailFrame.test.ts
+++ b/src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesRailFrame.test.ts
@@ -2,7 +2,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { WORKSTATION_TRAIL_RAIL_PADDING_CLASS } from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
+import { WORKSTATION_TRAIL_RAIL_PADDING_CLASS } from "@src/modules/shared/layouts/blocks/workstationTrailTokens";
 
 import PropertiesRailFrame from "./PropertiesRailFrame";
 

--- a/src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesRailFrame.tsx
+++ b/src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesRailFrame.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import {
   WORKSTATION_TRAIL_RAIL_PADDING_CLASS,
   WORKSTATION_TRAIL_WIDTH,
-} from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
+} from "@src/modules/shared/layouts/blocks/workstationTrailTokens";
 import { classNames } from "@src/util/ui/classNames";
 
 interface PropertiesRailFrameProps {

--- a/src/modules/WorkStation/Chat/Communication/EmailMessageBubble.tsx
+++ b/src/modules/WorkStation/Chat/Communication/EmailMessageBubble.tsx
@@ -46,23 +46,11 @@ import {
 import { truncate } from "@src/util/string/truncate";
 
 import { useCommunicationAgentIdentity } from "./communicationAgentIdentity";
+import { isAgentOrgInboxTranscriptEvent } from "./emailBubbleEvent";
 import type { MessageEntry } from "./types";
-import { extractMessageContent, isAgentOrgInboxTranscriptEvent } from "./utils";
+import { extractMessageContent } from "./utils";
 
 const SUBJECT_MAX_CHARS = 80;
-
-export const EMAIL_BUBBLE_TOOLS = [
-  "org_send_message",
-  "send_message",
-  "send_to_inbox",
-] as const;
-
-export function isEmailBubbleEvent(event: SessionEvent): boolean {
-  return (
-    isAgentOrgInboxTranscriptEvent(event) ||
-    (EMAIL_BUBBLE_TOOLS as readonly string[]).includes(event.functionName)
-  );
-}
 
 /**
  * Normalized view model fed to the bubble UI. All fields except `body` are

--- a/src/modules/WorkStation/Chat/Communication/MessageViewer.tsx
+++ b/src/modules/WorkStation/Chat/Communication/MessageViewer.tsx
@@ -22,7 +22,6 @@ import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApprova
 import { HugeiconsIcon, UnfoldMoreIcon } from "@src/icons";
 import type { SessionReplayPlaceholderMode } from "@src/modules/WorkStation/shared";
 
-import { isEmailBubbleEvent } from "./EmailMessageBubble";
 import { EmptyState } from "./EmptyState";
 import {
   BubbleWrapper,
@@ -44,6 +43,7 @@ import {
 } from "./MessageViewer/planDocViewModel";
 import { PlanDocPanel } from "./PlanDocPanel";
 import { TodoKanban } from "./TodoKanban";
+import { isEmailBubbleEvent } from "./emailBubbleEvent";
 import type { MessageEntry, MessageViewMode } from "./types";
 
 function minuteBucket(timestamp: string): number {

--- a/src/modules/WorkStation/Chat/Communication/MessageViewer/MessageBubbleRenderer.tsx
+++ b/src/modules/WorkStation/Chat/Communication/MessageViewer/MessageBubbleRenderer.tsx
@@ -10,8 +10,9 @@ import {
   isOrgTaskEvent,
 } from "../AgentEventBubbles";
 import { ChatBubble, TodoBubble, UnloadedTurnBubble } from "../ChatBubble";
-import { EmailMessageBubble, isEmailBubbleEvent } from "../EmailMessageBubble";
+import { EmailMessageBubble } from "../EmailMessageBubble";
 import { ThinkBubble } from "../ThinkBubble";
+import { isEmailBubbleEvent } from "../emailBubbleEvent";
 import type { MessageEntry, MessageViewMode } from "../types";
 import {
   renderInteractionWidget,

--- a/src/modules/WorkStation/Chat/Communication/__tests__/emailBubbleEvent.test.ts
+++ b/src/modules/WorkStation/Chat/Communication/__tests__/emailBubbleEvent.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { walkStaticImports } from "@src/test/staticImportGraph";
+
+import { isEmailBubbleEvent } from "../emailBubbleEvent";
+
+function minimalSessionEvent(
+  overrides: Partial<SessionEvent> = {}
+): SessionEvent {
+  return {
+    chunk_id: null,
+    id: "evt-1",
+    sessionId: "sess-1",
+    createdAt: "2026-03-29T12:00:00.000Z",
+    functionName: "assistant",
+    uiCanonical: "",
+    actionType: "tool_call",
+    args: {},
+    result: {},
+    source: "assistant",
+    displayText: "",
+    displayStatus: "completed",
+    displayVariant: "tool_call",
+    activityStatus: "agent",
+    ...overrides,
+  };
+}
+
+describe("email bubble classification", () => {
+  it.each(["org_send_message", "send_message", "send_to_inbox"])(
+    "recognizes %s",
+    (functionName) => {
+      expect(isEmailBubbleEvent(minimalSessionEvent({ functionName }))).toBe(
+        true
+      );
+    }
+  );
+  it("recognizes inbox transcripts from args and result without a tool name", () => {
+    expect(
+      isEmailBubbleEvent(
+        minimalSessionEvent({ args: { agentOrgInboxTranscript: true } })
+      )
+    ).toBe(true);
+    expect(
+      isEmailBubbleEvent(
+        minimalSessionEvent({ result: { agentOrgInboxTranscript: true } })
+      )
+    ).toBe(true);
+    expect(
+      isEmailBubbleEvent(
+        minimalSessionEvent({ args: { agentOrgInboxTranscript: "true" } })
+      )
+    ).toBe(false);
+    expect(isEmailBubbleEvent(minimalSessionEvent())).toBe(false);
+  });
+  it("classifies without loading React, the renderer, or tool registry", () => {
+    const graph = walkStaticImports([
+      "modules/WorkStation/Chat/Communication/emailBubbleEvent.ts",
+    ]);
+    expect(graph.files.size).toBe(1);
+    expect(graph.packages.size).toBe(0);
+  });
+});

--- a/src/modules/WorkStation/Chat/Communication/config.ts
+++ b/src/modules/WorkStation/Chat/Communication/config.ts
@@ -23,7 +23,7 @@ import { isSyntheticUserInputEvent } from "@src/engines/SessionCore/sync/utils/a
 import { defineSimulatorAppConfig } from "@src/engines/Simulator/apps/core/configFactory";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 
-import { isEmailBubbleEvent } from "./EmailMessageBubble";
+import { isEmailBubbleEvent } from "./emailBubbleEvent";
 import type { MessageEntry, SimulatorMessagesState } from "./types";
 import {
   convertToMessageEntry,

--- a/src/modules/WorkStation/Chat/Communication/emailBubbleEvent.ts
+++ b/src/modules/WorkStation/Chat/Communication/emailBubbleEvent.ts
@@ -1,0 +1,21 @@
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+export function isAgentOrgInboxTranscriptEvent(event: SessionEvent): boolean {
+  return Boolean(
+    event.args?.agentOrgInboxTranscript === true ||
+    event.result?.agentOrgInboxTranscript === true
+  );
+}
+
+export const EMAIL_BUBBLE_TOOLS = [
+  "org_send_message",
+  "send_message",
+  "send_to_inbox",
+] as const;
+
+export function isEmailBubbleEvent(event: SessionEvent): boolean {
+  return (
+    isAgentOrgInboxTranscriptEvent(event) ||
+    (EMAIL_BUBBLE_TOOLS as readonly string[]).includes(event.functionName)
+  );
+}

--- a/src/modules/WorkStation/Chat/Communication/utils.ts
+++ b/src/modules/WorkStation/Chat/Communication/utils.ts
@@ -11,22 +11,18 @@ import { ASK_QUESTION_FUNCTIONS } from "@src/engines/ChatPanel/InputArea/AskQues
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { getAppSubtool } from "@src/engines/SessionCore/rendering/registry/initToolRegistry";
 
+import { isAgentOrgInboxTranscriptEvent } from "./emailBubbleEvent";
 import type {
   CommunicationUnloadedTurnMeta,
   MessageEntry,
   MessageViewMode,
 } from "./types";
 
+export { isAgentOrgInboxTranscriptEvent } from "./emailBubbleEvent";
+
 // ============================================
 // Event Type Checking (all delegate to Rust)
 // ============================================
-
-export function isAgentOrgInboxTranscriptEvent(event: SessionEvent): boolean {
-  return Boolean(
-    event.args?.agentOrgInboxTranscript === true ||
-    event.result?.agentOrgInboxTranscript === true
-  );
-}
 
 /** Rust AppSubtool: subtool === "message" means chat/conversation */
 export function isChatEvent(eventFunction: string): boolean {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from "react-i18next";
 
 import { Message } from "@src/components/Message";
 import { Placeholder } from "@src/components/Placeholder";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import {
   CodeMirrorConflictEditor,
   CodeMirrorDiff,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
@@ -33,7 +33,7 @@ import { useTranslation } from "react-i18next";
 
 import { useActionSystem } from "@src/ActionSystem";
 import { Placeholder } from "@src/components/Placeholder";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { useSourceControlAttention } from "@src/hooks/git/useSourceControlAttention";
 import { useWorkStationTabShortcutBridge } from "@src/hooks/tabHost/useWorkStationTabShortcutBridge";
 import { usePublishWorkstationTabHeader } from "@src/hooks/tabHost/useWorkstationTabHeader";

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/index.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/index.ts
@@ -12,7 +12,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { DetachedHeadDialog } from "@src/components/GitDialogs";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { useCommitForm } from "@src/modules/WorkStation/CodeEditor/hooks/sourceControl/useCommitForm";
 import { useFileSelection } from "@src/modules/WorkStation/CodeEditor/hooks/sourceControl/useFileSelection";

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.tsx
@@ -17,7 +17,7 @@ import type { GitWorktreeEntry } from "@src/api/http/git/types";
 import AnyIcon from "@src/components/AnyIcon";
 import { Placeholder } from "@src/components/Placeholder";
 import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { useRepoGitInitialization } from "@src/hooks/git";
 import type { PrimarySidebarTab } from "@src/modules/WorkStation/shared/PrimarySidebarLayout";
 import { workspaceFoldersAtom } from "@src/store/ui/workspaceFoldersAtom";

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/SourceControlTab.initialization.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/SourceControlTab.initialization.test.ts
@@ -27,7 +27,7 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock("@src/contexts/git", () => ({
+vi.mock("@src/contexts/git/GitStatusContext/useGitStatus", () => ({
   useGitStatus: () => ({
     currentGitStatus: { exists: true },
     forceRefresh: vi.fn(),

--- a/src/modules/WorkStation/CodeEditor/hooks/sourceControl/useGitFiles.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/sourceControl/useGitFiles.ts
@@ -21,7 +21,7 @@ import {
   useState,
 } from "react";
 
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import type { GitFile } from "@src/types/git/types";
 import type { GitRepositoryStatus } from "@src/types/session/steps";
 

--- a/src/modules/WorkStation/CodeEditor/hooks/useCodeEditorHandlers.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/useCodeEditorHandlers.ts
@@ -12,7 +12,7 @@ import { useCallback } from "react";
 
 import { getGitFileContent } from "@src/api/http/git/diff";
 import Message from "@src/components/Message";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { createLogger } from "@src/hooks/logger";
 import {
   type PanelState,

--- a/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
+++ b/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GitWorktreeEntry } from "@src/api/http/git/types";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { useRepoGitInitialization } from "@src/hooks/git";
 import {
   sourceControlFilterModeAtom,

--- a/src/modules/WorkStation/Diff/SessionReplay/SubmissionsContent.tsx
+++ b/src/modules/WorkStation/Diff/SessionReplay/SubmissionsContent.tsx
@@ -1,11 +1,9 @@
 import React, { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { GitCommitInfo } from "@src/api/http/git/types";
 import { Placeholder } from "@src/components/Placeholder";
 import PrStatusBadge from "@src/components/PrStatusBadge";
 import { HEADER_BUTTON, TYPOGRAPHY } from "@src/config/workstation/tokens";
-import type { ExtractedGitArtifactData } from "@src/engines/SessionCore/core/types";
 import {
   HugeiconsIcon,
   SquareArrowUpRight02Icon,
@@ -15,50 +13,11 @@ import GitCommitRow from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrima
 import { truncateBranchLabel } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/prCardHelpers";
 import { PR_STATUS_UNKNOWN } from "@src/shared/pr/prStatus";
 
-export type SubmissionArtifactOrigin = "created" | "mentioned";
-
-export type SubmissionArtifact = ExtractedGitArtifactData & {
-  repoId?: string;
-  repoPath?: string;
-  origin?: SubmissionArtifactOrigin;
-  /** Event ID where this artifact was extracted from (for replay navigation). */
-  eventId?: string;
-};
-
-export type SubmissionCommit = Pick<
-  GitCommitInfo,
-  "sha" | "short_sha" | "summary"
-> & {
-  author?: GitCommitInfo["author"] | null;
-  repoId?: string;
-  repoPath?: string;
-  origin?: SubmissionArtifactOrigin;
-  /** Event ID where this commit was first mentioned (extracted from text/shell, not orgtrack-linked). */
-  mentionedEventId?: string;
-};
-
-export interface PullRequestSubmission {
-  key: string;
-  url?: string;
-  repoFullName?: string;
-  prNumber?: number;
-  prTitle?: string;
-  sourceBranch?: string;
-  targetBranch?: string;
-  origin?: SubmissionArtifactOrigin;
-  /** Normalized PR status (`open` / `merged` / `closed` / `draft`), or
-   * `unknown` when the GitHub read failed. Injected by the parent after a
-   * batch GitHub fetch; absent while the first read is in flight, or for rows
-   * missing repoFullName-or-prNumber, which can never be read. Those render as
-   * `unknown` too — never as `open`, which would assert a state nothing
-   * verified. */
-  statusKey?: string;
-}
-
-export interface SubmissionsData {
-  commits: SubmissionCommit[];
-  pullRequests: PullRequestSubmission[];
-}
+import type {
+  PullRequestSubmission,
+  SubmissionArtifactOrigin,
+  SubmissionCommit,
+} from "./submissionsData";
 
 interface SubmissionCommitsContentProps {
   commits: SubmissionCommit[];
@@ -70,79 +29,6 @@ interface SubmissionCommitsContentProps {
 interface SubmissionPullRequestsContentProps {
   pullRequests: PullRequestSubmission[];
   emptyLabel: string;
-}
-
-function extractCommitSha(artifact: SubmissionArtifact): string {
-  if (artifact.sha) return artifact.sha.trim();
-  const match = artifact.url?.match(
-    /github\.com\/[^/]+\/[^/]+\/commit\/([a-f0-9]{7,40})/i
-  );
-  return match?.[1] ?? "";
-}
-
-function commitFromArtifact(
-  artifact: SubmissionArtifact
-): SubmissionCommit | null {
-  const sha = extractCommitSha(artifact);
-  const shortSha = artifact.shortSha ?? sha.slice(0, 7);
-  if (!sha && !shortSha) return null;
-  return {
-    sha: sha || shortSha,
-    short_sha: shortSha || sha.slice(0, 7),
-    summary: artifact.subject ?? shortSha ?? sha,
-    author: null,
-    repoId: artifact.repoId,
-    repoPath: artifact.repoPath,
-    origin: artifact.origin,
-    mentionedEventId: artifact.eventId,
-  };
-}
-
-function getSubmissionDedupeKey(artifact: SubmissionArtifact): string | null {
-  if (artifact.url) return `${artifact.kind}:url:${artifact.url}`;
-  if (artifact.kind === "commit" && artifact.sha)
-    return `commit:sha:${artifact.sha}`;
-  if (
-    artifact.kind === "pullRequest" &&
-    artifact.repoFullName &&
-    artifact.prNumber
-  ) {
-    return `pullRequest:${artifact.repoFullName}#${artifact.prNumber}`;
-  }
-  return null;
-}
-
-export function deriveSubmissionsData(
-  artifacts: readonly SubmissionArtifact[]
-): SubmissionsData {
-  const seenKeys = new Set<string>();
-  const commits: SubmissionCommit[] = [];
-  const pullRequests: PullRequestSubmission[] = [];
-
-  for (const artifact of artifacts) {
-    const key = getSubmissionDedupeKey(artifact);
-    if (!key || seenKeys.has(key)) continue;
-    seenKeys.add(key);
-
-    if (artifact.kind === "commit") {
-      const commit = commitFromArtifact(artifact);
-      if (commit) commits.push(commit);
-      continue;
-    }
-
-    pullRequests.push({
-      key,
-      url: artifact.url,
-      repoFullName: artifact.repoFullName,
-      prNumber: artifact.prNumber,
-      prTitle: artifact.prTitle,
-      sourceBranch: artifact.sourceBranch,
-      targetBranch: artifact.targetBranch,
-      origin: artifact.origin,
-    });
-  }
-
-  return { commits, pullRequests };
 }
 
 function SubmissionArtifactLabel({

--- a/src/modules/WorkStation/Diff/SessionReplay/__tests__/SubmissionsContent.prStatusBadge.test.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/__tests__/SubmissionsContent.prStatusBadge.test.ts
@@ -10,10 +10,8 @@ import { describe, expect, it } from "vitest";
 
 import { getPrStatusVariant } from "@src/shared/pr/prStatus";
 
-import {
-  type PullRequestSubmission,
-  SubmissionPullRequestsContent,
-} from "../SubmissionsContent";
+import { SubmissionPullRequestsContent } from "../SubmissionsContent";
+import type { PullRequestSubmission } from "../submissionsData";
 
 const NEUTRAL = getPrStatusVariant("unknown");
 const OPEN = getPrStatusVariant("open");

--- a/src/modules/WorkStation/Diff/SessionReplay/__tests__/submissionsData.test.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/__tests__/submissionsData.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { walkStaticImports } from "@src/test/staticImportGraph";
+
+import { deriveSubmissionsData } from "../submissionsData";
+
+describe("submissions data", () => {
+  it("preserves commit navigation metadata, infers URL SHAs, and deduplicates first occurrence", () => {
+    const result = deriveSubmissionsData([
+      {
+        kind: "commit",
+        url: "https://github.com/acme/repo/commit/abcdef123456",
+        subject: "First",
+        repoId: "repo",
+        repoPath: "/repo",
+        origin: "mentioned",
+        eventId: "event",
+      },
+      {
+        kind: "commit",
+        url: "https://github.com/acme/repo/commit/abcdef123456",
+        subject: "Duplicate",
+      },
+      { kind: "commit" },
+    ]);
+    expect(result.commits).toEqual([
+      {
+        sha: "abcdef123456",
+        short_sha: "abcdef1",
+        summary: "First",
+        author: null,
+        repoId: "repo",
+        repoPath: "/repo",
+        origin: "mentioned",
+        mentionedEventId: "event",
+      },
+    ]);
+    expect(result.pullRequests).toEqual([]);
+  });
+  it("preserves PR references and leaves unread statuses unresolved", () => {
+    const result = deriveSubmissionsData([
+      {
+        kind: "pullRequest",
+        repoFullName: "acme/repo",
+        prNumber: 42,
+        prTitle: "First",
+        sourceBranch: "feature",
+        targetBranch: "develop",
+        origin: "created",
+      },
+      {
+        kind: "pullRequest",
+        repoFullName: "acme/repo",
+        prNumber: 42,
+        prTitle: "Duplicate",
+      },
+    ]);
+    expect(result.pullRequests).toEqual([
+      {
+        key: "pullRequest:acme/repo#42",
+        repoFullName: "acme/repo",
+        prNumber: 42,
+        prTitle: "First",
+        sourceBranch: "feature",
+        targetBranch: "develop",
+        origin: "created",
+      },
+    ]);
+    expect(result.pullRequests[0]).not.toHaveProperty("statusKey");
+  });
+  it("derives data without loading renderers or runtime dependencies", () => {
+    const graph = walkStaticImports([
+      "modules/WorkStation/Diff/SessionReplay/submissionsData.ts",
+    ]);
+    expect(graph.files.size).toBe(1);
+    expect(graph.packages.size).toBe(0);
+  });
+});

--- a/src/modules/WorkStation/Diff/SessionReplay/diffSessionReplay.useCommitNavigation.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/diffSessionReplay.useCommitNavigation.ts
@@ -25,8 +25,8 @@ import type { Repo } from "@src/store/repo/types";
 import type { SimulatorDiffCommitNavigationRequest } from "@src/store/ui/simulatorAtom";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 
-import type { SubmissionCommit } from "./SubmissionsContent";
 import { getRepoContextKey } from "./diffSessionReplay.repoContext";
+import type { SubmissionCommit } from "./submissionsData";
 import type { DiffReplayTab } from "./types";
 import type { SubmissionRepoContext } from "./useSubmissionsData";
 

--- a/src/modules/WorkStation/Diff/SessionReplay/diffSessionReplay.useSidebarTab.tsx
+++ b/src/modules/WorkStation/Diff/SessionReplay/diffSessionReplay.useSidebarTab.tsx
@@ -26,11 +26,13 @@ import {
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 
 import {
-  type PullRequestSubmission,
-  type SubmissionCommit,
   SubmissionCommitsContent,
   SubmissionPullRequestsContent,
 } from "./SubmissionsContent";
+import type {
+  PullRequestSubmission,
+  SubmissionCommit,
+} from "./submissionsData";
 import type { DiffReplayTab } from "./types";
 
 export interface UseDiffSidebarTabParams {

--- a/src/modules/WorkStation/Diff/SessionReplay/submissionsArtifacts.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/submissionsArtifacts.ts
@@ -18,7 +18,7 @@ import { getGitArtifactsFromEvent } from "@src/shared/git/sessionGitArtifacts";
 import type {
   SubmissionArtifact,
   SubmissionArtifactOrigin,
-} from "./SubmissionsContent";
+} from "./submissionsData";
 
 export interface SubmissionRepoContext {
   repoId?: string;

--- a/src/modules/WorkStation/Diff/SessionReplay/submissionsData.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/submissionsData.ts
@@ -1,0 +1,120 @@
+import type { GitCommitInfo } from "@src/api/http/git/types";
+import type { ExtractedGitArtifactData } from "@src/engines/SessionCore/core/types";
+
+export type SubmissionArtifactOrigin = "created" | "mentioned";
+
+export type SubmissionArtifact = ExtractedGitArtifactData & {
+  repoId?: string;
+  repoPath?: string;
+  origin?: SubmissionArtifactOrigin;
+  /** Event ID where this artifact was extracted from (for replay navigation). */
+  eventId?: string;
+};
+
+export type SubmissionCommit = Pick<
+  GitCommitInfo,
+  "sha" | "short_sha" | "summary"
+> & {
+  author?: GitCommitInfo["author"] | null;
+  repoId?: string;
+  repoPath?: string;
+  origin?: SubmissionArtifactOrigin;
+  /** Event ID where this commit was first mentioned (extracted from text/shell, not orgtrack-linked). */
+  mentionedEventId?: string;
+};
+
+export interface PullRequestSubmission {
+  key: string;
+  url?: string;
+  repoFullName?: string;
+  prNumber?: number;
+  prTitle?: string;
+  sourceBranch?: string;
+  targetBranch?: string;
+  origin?: SubmissionArtifactOrigin;
+  /** Normalized PR status (`open` / `merged` / `closed` / `draft`), or
+   * `unknown` when the GitHub read failed. Injected by the parent after a
+   * batch GitHub fetch; absent while the first read is in flight, or for rows
+   * missing repoFullName-or-prNumber, which can never be read. Those render as
+   * `unknown` too — never as `open`, which would assert a state nothing
+   * verified. */
+  statusKey?: string;
+}
+
+export interface SubmissionsData {
+  commits: SubmissionCommit[];
+  pullRequests: PullRequestSubmission[];
+}
+
+function extractCommitSha(artifact: SubmissionArtifact): string {
+  if (artifact.sha) return artifact.sha.trim();
+  const match = artifact.url?.match(
+    /github\.com\/[^/]+\/[^/]+\/commit\/([a-f0-9]{7,40})/i
+  );
+  return match?.[1] ?? "";
+}
+
+function commitFromArtifact(
+  artifact: SubmissionArtifact
+): SubmissionCommit | null {
+  const sha = extractCommitSha(artifact);
+  const shortSha = artifact.shortSha ?? sha.slice(0, 7);
+  if (!sha && !shortSha) return null;
+  return {
+    sha: sha || shortSha,
+    short_sha: shortSha || sha.slice(0, 7),
+    summary: artifact.subject ?? shortSha ?? sha,
+    author: null,
+    repoId: artifact.repoId,
+    repoPath: artifact.repoPath,
+    origin: artifact.origin,
+    mentionedEventId: artifact.eventId,
+  };
+}
+
+function getSubmissionDedupeKey(artifact: SubmissionArtifact): string | null {
+  if (artifact.url) return `${artifact.kind}:url:${artifact.url}`;
+  if (artifact.kind === "commit" && artifact.sha)
+    return `commit:sha:${artifact.sha}`;
+  if (
+    artifact.kind === "pullRequest" &&
+    artifact.repoFullName &&
+    artifact.prNumber
+  ) {
+    return `pullRequest:${artifact.repoFullName}#${artifact.prNumber}`;
+  }
+  return null;
+}
+
+export function deriveSubmissionsData(
+  artifacts: readonly SubmissionArtifact[]
+): SubmissionsData {
+  const seenKeys = new Set<string>();
+  const commits: SubmissionCommit[] = [];
+  const pullRequests: PullRequestSubmission[] = [];
+
+  for (const artifact of artifacts) {
+    const key = getSubmissionDedupeKey(artifact);
+    if (!key || seenKeys.has(key)) continue;
+    seenKeys.add(key);
+
+    if (artifact.kind === "commit") {
+      const commit = commitFromArtifact(artifact);
+      if (commit) commits.push(commit);
+      continue;
+    }
+
+    pullRequests.push({
+      key,
+      url: artifact.url,
+      repoFullName: artifact.repoFullName,
+      prNumber: artifact.prNumber,
+      prTitle: artifact.prTitle,
+      sourceBranch: artifact.sourceBranch,
+      targetBranch: artifact.targetBranch,
+      origin: artifact.origin,
+    });
+  }
+
+  return { commits, pullRequests };
+}

--- a/src/modules/WorkStation/Diff/SessionReplay/useSubmissionsData.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/useSubmissionsData.ts
@@ -37,15 +37,15 @@ import { PR_STATUS_UNKNOWN, normalizePrStatus } from "@src/shared/pr/prStatus";
 import type { Repo } from "@src/store/repo/types";
 
 import {
+  type SubmissionRepoContext,
+  collectSubmissionArtifacts,
+} from "./submissionsArtifacts";
+import {
   type PullRequestSubmission,
   type SubmissionCommit,
   type SubmissionsData,
   deriveSubmissionsData,
-} from "./SubmissionsContent";
-import {
-  type SubmissionRepoContext,
-  collectSubmissionArtifacts,
-} from "./submissionsArtifacts";
+} from "./submissionsData";
 
 export type { SubmissionRepoContext } from "./submissionsArtifacts";
 

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
@@ -24,7 +24,7 @@ import type { GitWorktreeEntry } from "@src/api/http/git/types";
 import AnyIcon from "@src/components/AnyIcon";
 import { Placeholder } from "@src/components/Placeholder";
 import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { sessionIdAtom } from "@src/engines/SessionCore";
 import { useFileReviewBatchActions } from "@src/hooks/fileReview";
 import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";

--- a/src/modules/WorkStation/shared/StatusBar/utils/useEditorStatusBarGit.ts
+++ b/src/modules/WorkStation/shared/StatusBar/utils/useEditorStatusBarGit.ts
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 
 import { PushRejectedDialog } from "@src/components/GitDialogs";
 import Message from "@src/components/Message";
-import { useGitStatus } from "@src/contexts/git";
+import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { showGitErrorAndHandle } from "@src/hooks/git/gitErrorDialog";
 import {
   type GitOperationResult,

--- a/src/modules/shared/components/FileHeader/index.tsx
+++ b/src/modules/shared/components/FileHeader/index.tsx
@@ -27,7 +27,7 @@ import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import type { WorkstationTabHeaderHost } from "@src/hooks/tabHost/useWorkstationTabHeader";
 import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
 import { Cancel01Icon, FileSymlinkIcon, HugeiconsIcon } from "@src/icons";
-import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader";
+import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 import type { DiffViewMode } from "@src/types/git/types";
 import { copyText } from "@src/util/data/clipboard";
 

--- a/src/modules/shared/components/GitHubDetailSkeleton/index.test.ts
+++ b/src/modules/shared/components/GitHubDetailSkeleton/index.test.ts
@@ -2,7 +2,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { WORKSTATION_TRAIL_WIDTH } from "@src/modules/shared/layouts/blocks/WorkstationTrailSurface";
+import { WORKSTATION_TRAIL_WIDTH } from "@src/modules/shared/layouts/blocks/workstationTrailTokens";
 
 import GitHubDetailSkeleton from ".";
 

--- a/src/modules/shared/components/MarkdownEditor/index.tsx
+++ b/src/modules/shared/components/MarkdownEditor/index.tsx
@@ -15,6 +15,7 @@ import Markdown from "@src/components/MarkDown";
 import TabPill from "@src/components/TabPill";
 
 import "./index.scss";
+import { useMarkdownEditorTabs } from "./useMarkdownEditorTabs";
 
 // Lazy: MarkdownEditor is mounted by the Settings/Integrations wizards and
 // the AgentOrgs configuration surfaces; loading CodeMirror only when the
@@ -66,20 +67,6 @@ function isImageFile(file: File): boolean {
 
 function editorHeight(value: number | string): string {
   return typeof value === "number" ? `${value}px` : value;
-}
-
-export function useMarkdownEditorTabs() {
-  const { t } = useTranslation();
-  return useMemo(
-    () => [
-      { key: "edit", label: t("common:actions.edit") },
-      {
-        key: "preview",
-        label: t("common:common.preview"),
-      },
-    ],
-    [t]
-  );
 }
 
 const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>(

--- a/src/modules/shared/components/MarkdownEditor/useMarkdownEditorTabs.test.ts
+++ b/src/modules/shared/components/MarkdownEditor/useMarkdownEditorTabs.test.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { SRC_ROOT, walkStaticImports } from "@src/test/staticImportGraph";
+
+describe("markdown tab hook dependency boundary", () => {
+  it("does not load the editor or preview renderer to obtain tab labels", () => {
+    const graph = walkStaticImports([
+      "modules/shared/components/MarkdownEditor/useMarkdownEditorTabs.ts",
+    ]);
+    expect(
+      [...graph.files].map((file) => path.relative(SRC_ROOT, file))
+    ).toEqual([
+      "modules/shared/components/MarkdownEditor/useMarkdownEditorTabs.ts",
+    ]);
+    expect([...graph.packages].sort()).toEqual(["react", "react-i18next"]);
+  });
+});

--- a/src/modules/shared/components/MarkdownEditor/useMarkdownEditorTabs.ts
+++ b/src/modules/shared/components/MarkdownEditor/useMarkdownEditorTabs.ts
@@ -1,0 +1,16 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+export function useMarkdownEditorTabs() {
+  const { t } = useTranslation();
+  return useMemo(
+    () => [
+      { key: "edit", label: t("common:actions.edit") },
+      {
+        key: "preview",
+        label: t("common:common.preview"),
+      },
+    ],
+    [t]
+  );
+}

--- a/src/modules/shared/dataSource/BuilderTypeDetailPanel.tsx
+++ b/src/modules/shared/dataSource/BuilderTypeDetailPanel.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import { ArrowLeft01Icon, ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
-import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks";
+import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 import Modal from "@src/scaffold/ModalSystem";
 
 import BuilderTypeAvatar from "./BuilderTypeAvatar";

--- a/src/modules/shared/dataSource/BuilderTypesPanel.tsx
+++ b/src/modules/shared/dataSource/BuilderTypesPanel.tsx
@@ -2,16 +2,16 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
-import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
+import {
+  DETAIL_PANEL_TOKENS,
+  STAT_GRID_TOKENS,
+} from "@src/config/detailPanelTokens";
 import { ArrowLeft02Icon, HugeiconsIcon } from "@src/icons";
 import {
   SECTION_GAP_CLASSES,
   SECTION_SUBHEADING_CLASSES,
 } from "@src/modules/shared/layouts/SectionLayout";
-import {
-  PANEL_HEADER_TOKENS,
-  STAT_GRID_TOKENS,
-} from "@src/modules/shared/layouts/blocks";
+import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 
 import BuilderTypeAvatar from "./BuilderTypeAvatar";
 import BuilderTypeDetailModal from "./BuilderTypeDetailPanel";

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 
-import { WORKSTATION_TRAIL_WIDTH } from "../blocks/WorkstationTrailSurface";
+import { WORKSTATION_TRAIL_WIDTH } from "../blocks/workstationTrailTokens";
 
 export const WORKSTATION_TRAIL_WIDTH_VARIABLE = "--workstation-trail-width";
 export const WORKSTATION_TRAIL_TRACK_WIDTH_VARIABLE =

--- a/src/modules/shared/layouts/blocks/PageBreadcrumb/index.tsx
+++ b/src/modules/shared/layouts/blocks/PageBreadcrumb/index.tsx
@@ -23,7 +23,7 @@ import {
 import { hoverSidebarOpenAtom } from "@src/store/ui/hoverSidebarAtom";
 import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
 
-import { PANEL_HEADER_TOKENS } from "../PanelHeader";
+import { PANEL_HEADER_TOKENS } from "../PanelHeader/tokens";
 
 // ============================================
 // Component

--- a/src/modules/shared/layouts/blocks/PanelHeader/index.tsx
+++ b/src/modules/shared/layouts/blocks/PanelHeader/index.tsx
@@ -46,6 +46,8 @@ import {
   Search01Icon,
 } from "@src/icons";
 
+import { PANEL_HEADER_TOKENS } from "./tokens";
+
 /**
  * Surface background context for nested PanelHeader instances.
  *
@@ -63,73 +65,7 @@ const PanelHeaderSurfaceContext = createContext<PanelHeaderSurface | null>(
   null
 );
 
-// ============================================
-// Tokens
-// ============================================
-
-/** Standard sizes and button props for PanelHeader elements */
-export const PANEL_HEADER_TOKENS = {
-  /**
-   * Header row layout for custom panel headers (when not using PanelHeader component).
-   * Matches the 40px row used by PanelHeader: flex, px-3 (no border — add `border-b border-border-2` if needed).
-   */
-  row: "flex h-10 shrink-0 items-center gap-2 px-3",
-
-  /** Icon size for title icons (breadcrumb, title prefix) */
-  iconSize: 14,
-  /** Icon size inside action buttons (slightly larger for tap target) */
-  buttonIconSize: 16,
-  /** Stroke width for glyph icons in panel header buttons */
-  iconStrokeWidth: 1.75,
-  /** Font size for title text */
-  fontSize: 13,
-  /** Header height */
-  height: 40,
-  /** TabPill size for header-level pill toggles — always small in 40px headers */
-  tabPillSize: "small" as const,
-
-  /**
-   * Standard props for ALL icon-only action buttons in 40px headers.
-   * 24×24 circle, 16px icon, hover shows fill-2 background.
-   * Spread on `<Button>`, add `icon`, `onClick`, `title`.
-   */
-  actionButton: {
-    variant: "tertiary" as const,
-    size: "mini" as const,
-    shape: "circle" as const,
-    iconOnly: true as const,
-    className: "hover:bg-fill-2!",
-  },
-
-  /**
-   * Pill-shaped action button (32×24) for dropdown triggers.
-   * Use instead of actionButton when the control opens a dropdown (e.g. Add + chevron).
-   */
-  actionButtonPill: {
-    variant: "tertiary" as const,
-    size: "mini" as const,
-    shape: "round" as const,
-    iconOnly: true as const,
-    className: "hover:bg-fill-2! h-6! w-9! min-w-9!",
-  },
-
-  /**
-   * Props for danger action buttons (delete, close).
-   * 24×24 circle, 16px icon, hover shows danger-1 background with danger-6 text.
-   */
-  dangerButton: {
-    variant: "tertiary" as const,
-    size: "mini" as const,
-    shape: "circle" as const,
-    iconOnly: true as const,
-    className: "hover:bg-danger-1! hover:text-danger-6!",
-  },
-
-  /**
-   * Vertical rule between header controls (same as FileHeader tab | actions separator).
-   */
-  verticalSeparator: "h-4 w-px shrink-0 bg-border-2",
-} as const;
+export { PANEL_HEADER_TOKENS } from "./tokens";
 
 // ============================================
 // PanelRefreshButton — guaranteed min-spin refresh for panel headers

--- a/src/modules/shared/layouts/blocks/PanelHeader/tokens.ts
+++ b/src/modules/shared/layouts/blocks/PanelHeader/tokens.ts
@@ -1,0 +1,63 @@
+/** Standard sizes and button props for PanelHeader elements */
+export const PANEL_HEADER_TOKENS = {
+  /**
+   * Header row layout for custom panel headers (when not using PanelHeader component).
+   * Matches the 40px row used by PanelHeader: flex, px-3 (no border — add `border-b border-border-2` if needed).
+   */
+  row: "flex h-10 shrink-0 items-center gap-2 px-3",
+
+  /** Icon size for title icons (breadcrumb, title prefix) */
+  iconSize: 14,
+  /** Icon size inside action buttons (slightly larger for tap target) */
+  buttonIconSize: 16,
+  /** Stroke width for glyph icons in panel header buttons */
+  iconStrokeWidth: 1.75,
+  /** Font size for title text */
+  fontSize: 13,
+  /** Header height */
+  height: 40,
+  /** TabPill size for header-level pill toggles — always small in 40px headers */
+  tabPillSize: "small" as const,
+
+  /**
+   * Standard props for ALL icon-only action buttons in 40px headers.
+   * 24×24 circle, 16px icon, hover shows fill-2 background.
+   * Spread on `<Button>`, add `icon`, `onClick`, `title`.
+   */
+  actionButton: {
+    variant: "tertiary" as const,
+    size: "mini" as const,
+    shape: "circle" as const,
+    iconOnly: true as const,
+    className: "hover:bg-fill-2!",
+  },
+
+  /**
+   * Pill-shaped action button (32×24) for dropdown triggers.
+   * Use instead of actionButton when the control opens a dropdown (e.g. Add + chevron).
+   */
+  actionButtonPill: {
+    variant: "tertiary" as const,
+    size: "mini" as const,
+    shape: "round" as const,
+    iconOnly: true as const,
+    className: "hover:bg-fill-2! h-6! w-9! min-w-9!",
+  },
+
+  /**
+   * Props for danger action buttons (delete, close).
+   * 24×24 circle, 16px icon, hover shows danger-1 background with danger-6 text.
+   */
+  dangerButton: {
+    variant: "tertiary" as const,
+    size: "mini" as const,
+    shape: "circle" as const,
+    iconOnly: true as const,
+    className: "hover:bg-danger-1! hover:text-danger-6!",
+  },
+
+  /**
+   * Vertical rule between header controls (same as FileHeader tab | actions separator).
+   */
+  verticalSeparator: "h-4 w-px shrink-0 bg-border-2",
+} as const;

--- a/src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx
+++ b/src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx
@@ -6,41 +6,29 @@ import {
   createElement,
 } from "react";
 
-import { DROPDOWN_PANEL } from "@src/components/Dropdown/tokens";
 import {
-  BUTTON_SIZE,
-  EDITOR_TAB_CANVAS_BG_CLASS,
   TAB_BAR_TRAILING_CLUSTER_CLASS,
   WORKSTATION_TRAIL_CONTENT,
 } from "@src/config/workstation/tokens";
 import { ArrowDown01Icon, ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
 
+import {
+  WORKSTATION_TRAIL_ICON_BUTTON_CLASS,
+  WORKSTATION_TRAIL_SURFACE_CLASS,
+} from "./workstationTrailTokens";
+
+export {
+  WORKSTATION_TRAIL_SURFACE_CLASS,
+  WORKSTATION_TRAIL_WIDTH,
+  WORKSTATION_TRAIL_RAIL_PADDING_CLASS,
+  FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS,
+  WORKSTATION_TRAIL_ICON_BUTTON_CLASS,
+} from "./workstationTrailTokens";
+
 export interface WorkstationTrailSurfaceProps extends HTMLAttributes<HTMLElement> {
   as?: "aside" | "div";
   children?: ReactNode;
 }
-
-export const WORKSTATION_TRAIL_SURFACE_CLASS = `max-h-full w-full flex-col overflow-hidden rounded-xl border border-border-1 p-1 ${DROPDOWN_PANEL.shadowSoftClass} ${EDITOR_TAB_CANVAS_BG_CLASS}`;
-export const WORKSTATION_TRAIL_WIDTH = {
-  expandedPx: 256,
-  /**
-   * Expanded focused-chat column. Its width comes from the
-   * `--workstation-trail-track-width` custom property the trail sets inline
-   * (see `FocusedChatWorkstationRail/trailWidth.ts`) — the column has to
-   * contain both the trail surface and the wider docked terminal. The
-   * container query keeps it at zero below 1100px, where the compact
-   * dropdown takes over.
-   */
-  resizableResponsiveClass:
-    "@[1100px]/focusedchat:w-(--workstation-trail-track-width)",
-  /** Trail surface's own width inside that column. */
-  surfaceResponsiveClass: "@[1100px]/focusedchat:w-(--workstation-trail-width)",
-  collapsedResponsiveClass: "@[1100px]/focusedchat:w-11",
-} as const;
-export const WORKSTATION_TRAIL_RAIL_PADDING_CLASS = "px-1 pb-1 pt-2";
-export const FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS =
-  "@[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2";
-export const WORKSTATION_TRAIL_ICON_BUTTON_CLASS = `flex ${BUTTON_SIZE.sm} shrink-0 items-center justify-center rounded-lg text-text-1 transition-colors hover:bg-fill-2`;
 
 export interface WorkstationTrailHeaderProps {
   actions?: ReactNode;

--- a/src/modules/shared/layouts/blocks/layoutTokenBoundaries.test.ts
+++ b/src/modules/shared/layouts/blocks/layoutTokenBoundaries.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  reachableFilesMatching,
+  walkStaticImports,
+} from "@src/test/staticImportGraph";
+
+describe("layout token dependency boundaries", () => {
+  it.each([
+    "modules/shared/layouts/blocks/PanelHeader/tokens.ts",
+    "modules/shared/layouts/blocks/workstationTrailTokens.ts",
+    "modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.ts",
+    "engines/ChatPanel/focusedChatWorkstationLayout.ts",
+  ])("keeps %s independent of layout renderers", (entry) => {
+    const graph = walkStaticImports([entry]);
+    expect(
+      reachableFilesMatching(
+        graph,
+        /(?:PanelHeader\/index|WorkstationTrailSurface)\.tsx$/
+      )
+    ).toEqual([]);
+    expect(graph.packages.has("react")).toBe(false);
+    expect(graph.packages.has("@hugeicons/core-free-icons")).toBe(false);
+  });
+});

--- a/src/modules/shared/layouts/blocks/workstationTrailTokens.ts
+++ b/src/modules/shared/layouts/blocks/workstationTrailTokens.ts
@@ -1,0 +1,27 @@
+import { DROPDOWN_PANEL } from "@src/components/Dropdown/tokens";
+import {
+  BUTTON_SIZE,
+  EDITOR_TAB_CANVAS_BG_CLASS,
+} from "@src/config/workstation/tokens";
+
+export const WORKSTATION_TRAIL_SURFACE_CLASS = `max-h-full w-full flex-col overflow-hidden rounded-xl border border-border-1 p-1 ${DROPDOWN_PANEL.shadowSoftClass} ${EDITOR_TAB_CANVAS_BG_CLASS}`;
+export const WORKSTATION_TRAIL_WIDTH = {
+  expandedPx: 256,
+  /**
+   * Expanded focused-chat column. Its width comes from the
+   * `--workstation-trail-track-width` custom property the trail sets inline
+   * (see `FocusedChatWorkstationRail/trailWidth.ts`) — the column has to
+   * contain both the trail surface and the wider docked terminal. The
+   * container query keeps it at zero below 1100px, where the compact
+   * dropdown takes over.
+   */
+  resizableResponsiveClass:
+    "@[1100px]/focusedchat:w-(--workstation-trail-track-width)",
+  /** Trail surface's own width inside that column. */
+  surfaceResponsiveClass: "@[1100px]/focusedchat:w-(--workstation-trail-width)",
+  collapsedResponsiveClass: "@[1100px]/focusedchat:w-11",
+} as const;
+export const WORKSTATION_TRAIL_RAIL_PADDING_CLASS = "px-1 pb-1 pt-2";
+export const FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS =
+  "@[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2";
+export const WORKSTATION_TRAIL_ICON_BUTTON_CLASS = `flex ${BUTTON_SIZE.sm} shrink-0 items-center justify-center rounded-lg text-text-1 transition-colors hover:bg-fill-2`;

--- a/src/scaffold/WizardSystem/variants/Agent/useAgentWizard.ts
+++ b/src/scaffold/WizardSystem/variants/Agent/useAgentWizard.ts
@@ -10,7 +10,7 @@ import type {
   CapabilitySet,
   SubAgentRef,
 } from "@src/modules/MainApp/AgentOrgs/types";
-import { useMarkdownEditorTabs } from "@src/modules/shared/components/MarkdownEditor";
+import { useMarkdownEditorTabs } from "@src/modules/shared/components/MarkdownEditor/useMarkdownEditorTabs";
 
 interface UseAgentWizardReturn {
   // Navigation

--- a/src/scaffold/WizardSystem/variants/Policy/PolicyRuleWizard/MarkdownRuleForm.tsx
+++ b/src/scaffold/WizardSystem/variants/Policy/PolicyRuleWizard/MarkdownRuleForm.tsx
@@ -10,9 +10,8 @@ import Select from "@src/components/Select";
 import TabPill from "@src/components/TabPill";
 import type { CursorRepo, PolicySource } from "@src/hooks/policies";
 import type { AgentDefinition } from "@src/modules/MainApp/AgentOrgs/types";
-import MarkdownEditor, {
-  useMarkdownEditorTabs,
-} from "@src/modules/shared/components/MarkdownEditor";
+import MarkdownEditor from "@src/modules/shared/components/MarkdownEditor";
+import { useMarkdownEditorTabs } from "@src/modules/shared/components/MarkdownEditor/useMarkdownEditorTabs";
 import {
   SectionContainer,
   SectionRow,


### PR DESCRIPTION
## Problem

Six remaining small consumers obtain tokens, classification, derived submission data, tab labels or Git status reads from modules that also own rendering or provider effects. For example, focused-chat width calculations import WorkstationTrailSurface, and useGitStatus imports bring repository watcher/fetch ownership through a provider barrel.

## Solution

Extract dedicated owners for PanelHeader tokens, workstation-trail tokens, email event classification, submission derivation/types, Markdown editor tab labels, and the Git status context/read hook. Migrate equivalent helper-only callers, including all eleven Git status readers. Keep the existing component/provider entry points where rendering is actually required.

Token values, rendered JSX, translated tab labels, email classification, submission ordering/deduplication, the single context identity, and deferred provider timing are unchanged. This completes the remaining six findings from the component-dependency audit as one dependency-direction sweep; asynchronous loader changes are in separate PRs.

## Potential risks

An import migration could accidentally duplicate context identity or alter classification/data projection. Focused tests cover the exact context value/action, missing-provider error, deferred handoff/cancellation, transcript markers, commit navigation metadata, first-occurrence deduplication, and unresolved PR status. Source graph checks keep the new leaves independent of their former renderers/providers. Existing Git watcher/fetch effect bodies remain unchanged.

No dependency, lockfile, configuration, persistence, schema or IPC changes are required. Internal hook/data imports move together; intentional component/provider APIs retain their exports. Rollback is a normal revert with no data recovery or migration. JSX and styles are unchanged, so screenshots would not demonstrate this boundary change. Native WebView behavior, CPU/RSS and actual startup or emitted bundle savings were not measured; no runtime performance improvement is claimed.

## Verification

- `pnpm test "src/modules/shared/layouts/blocks/layoutTokenBoundaries.test.ts" "src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts" "src/modules/shared/layouts/FocusedChatWorkstationRail/trailWidth.test.ts" "src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesRailFrame.test.ts" "src/modules/shared/components/GitHubDetailSkeleton/index.test.ts" "src/modules/WorkStation/Chat/Communication/__tests__/emailBubbleEvent.test.ts" "src/modules/WorkStation/Chat/Communication/__tests__/utils.test.ts" "src/modules/WorkStation/Diff/SessionReplay/__tests__/submissionsData.test.ts" "src/modules/WorkStation/Diff/SessionReplay/__tests__/SubmissionsContent.prStatusBadge.test.ts" "src/modules/WorkStation/Diff/SessionReplay/__tests__/useSubmissionsData.prStatus.test.ts" "src/contexts/git/GitStatusContext/useGitStatus.test.ts" "src/contexts/git/GitStatusContext/DeferredGitStatusProvider.test.ts" "src/contexts/git/GitStatusContext/hooks/__tests__/useGitStatusFetch.test.ts" "src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/SourceControlTab.initialization.test.ts" "src/modules/shared/components/MarkdownEditor/useMarkdownEditorTabs.test.ts"` — 15 files, 78 tests passed
- `pnpm typecheck:fast` — full-project TypeScript check passed
- Scoped `pnpm exec eslint --max-warnings 0` over all 58 changed source/test files — passed
- `pnpm check:circular` — no cycles across 6,581 modules
- `pnpm check:test-placement` — consistent across 512 directories
- `git diff --cached --check` and `git diff origin/develop...HEAD --check` — passed
- Normal commit hooks passed: lint-staged (oxlint, ESLint, Prettier), TypeScript gate and commitlint; Rust check skipped because no Rust files changed
- Inspected final source/test/report scope for unrelated changes, secrets, private paths, debug logs, generated files and configuration churn; none included
- Existing Vite CJS deprecation and missing-i18next test-fixture warnings remain; they did not fail the suites
- Full production build and native UI/profiling were not run for this import-only follow-up; no Rust code changed

## Audit

Architecture covers all ten layers, with wire/persistence changes inapplicable. The lifecycle verdict passes for the changed import boundary and unchanged resource ownership. UI audits: 0 fix, 10 keep with reason, 0 abstract.
