### PR TITLE
style(settings): remove workspace defaults heading

### DIFF
--- a/src/modules/MainApp/Settings/sections/EditorSection/components/WorkspaceDefaultPathSection.tsx
+++ b/src/modules/MainApp/Settings/sections/EditorSection/components/WorkspaceDefaultPathSection.tsx
@@ -81,7 +81,7 @@ const WorkspaceDefaultPathSection: React.FC = () => {
   }, [setCustomDefaultRepoPath, t]);
 
   return (
-    <SectionContainer title={t("editor.workspaceDefaults")}>
+    <SectionContainer>
       <SectionRow
         label={t("editor.defaultRepoFolder")}
         description={t("editor.defaultRepoFolderDesc")}


### PR DESCRIPTION
## Problem

Editor settings display an extra “Workspace defaults” heading above the default repository folder controls. The requested layout omits that heading.

## Solution

Remove the title prop from WorkspaceDefaultPathSection's SectionContainer in every locale. Keep the folder selector, custom path controls, and resolved-path row unchanged.

## Potential risks

This is a one-line presentation change with no settings, persistence, routing, or lifecycle changes. The grouping heading disappears, while the individual controls retain their labels. Desktop visual verification was not run because the user has not opted into computer control. The reference screenshot contains a personal path and is not published. Reverting the line restores the heading.

## Verification

- `pnpm exec eslint src/modules/MainApp/Settings/sections/EditorSection/components/WorkspaceDefaultPathSection.tsx --max-warnings 0` — passed on the isolated PR checkout.
- `pnpm typecheck:fast` — passed on the isolated PR checkout.
- `git diff --check` — passed.
- Inspected the diff: only the SectionContainer title prop is removed. No new test was added for this reversible presentation-only change; desktop screenshots were not captured.
