### PR TITLE
fix(sidebar): complete cloud session search and filter controls

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/CloudMemberFilterDropdown.md
+++ b/docs/frontend-ui-audit-2026-09-07/CloudMemberFilterDropdown.md
@@ -1,0 +1,26 @@
+# CloudMemberFilterDropdown UI audit
+
+| Line                                              | Element              | Verdict          | Reason                                                                                                                                                         | Suggested change |
+| ------------------------------------------------- | -------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| cloudSessionsSection.MemberFilterDropdown.tsx:182 | Dropdown options API | keep with reason | Shared showSearch/filterOption provides input, keyboard navigation, selection and empty state; custom labels retain presence details                           | None             |
+| cloudSessionsSection.MemberFilterDropdown.tsx:190 | Menu height          | keep with reason | Uses DROPDOWN_PANEL.maxHeight (256px), flex layout and the shared min-h-0 scrolling options container                                                          | None             |
+| cloudSessionsSection.MemberFilterDropdown.tsx:175 | Positioned anchor    | keep with reason | Header button lives outside this hook; existing click coordinates anchor the shared dropdown; the outer fixed stacking context uses the shared overlay z-index | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+## Lifecycle review
+
+| Area               | Verdict | Evidence                                                                                                                  | Change or reason kept                                        | Verification                                          |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------- |
+| Background work    | keep    | Dropdown mounts only while memberMenu exists; shared focus timeout and outside-click/resize listeners clean up on unmount | Removed custom Escape listener; no polling or requests added | Dismissal/reopen tests and shared Dropdown tests pass |
+| Memory             | keep    | Query and filtered options belong to mounted Dropdown                                                                     | Closing unmounts query state; reopening starts empty         | Search/reset test with 40 roster members              |
+| Scope/isolation    | keep    | Existing org-scoped roster, presence and hidden-row inputs retained                                                       | No new data source, cache or persistence format              | Typecheck; no cloud transport changes                 |
+| Rendering/hot path | keep    | Option labels built only while open; shared search filters current options                                                | No recurring work while closed                               | Targeted rendered DOM tests; no runtime speed claim   |
+
+Performance verdict: blocked for desktop measurement; user instructions disallow computer control. Automated behavior checks pass. Actual desktop viewport layout, visible/hidden CPU and RSS were not measured. Network/provider/multi-instance scenarios are outside this local menu change.
+
+## Verification
+
+- Targeted member-filter, cloud header, org selector, NavigationSidebar and shared Dropdown suites: 17 tests passed
+- Scoped ESLint and pnpm run typecheck:fast: passed
+- Visual desktop validation: not run under the user's computer-control preference

--- a/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
@@ -173,7 +173,7 @@ const SidebarOrgSelector: React.FC<SidebarOrgSelectorProps> = React.memo(
               selectorClassName={`h-8 px-2! [&_.select-arrow]:text-text-2! ${
                 menuOpen
                   ? "[&_.select-arrow]:opacity-100 bg-sidebar-selected!"
-                  : "[&_.select-arrow]:opacity-0 hover:[&_.select-arrow]:opacity-100 hover:bg-sidebar-selected!"
+                  : "[&_.select-arrow]:opacity-0 group-hover/sidebar:[&_.select-arrow]:opacity-100 hover:[&_.select-arrow]:opacity-100 hover:bg-sidebar-selected!"
               } [&_.select-suffix]:ml-2 [&_.select-value]:flex-initial! [&_.select-value]:gap-3 [&_.select-value]:text-[13px] [&_.select-value]:font-semibold`}
               dataTestId="sidebar-org-selector"
             />

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import type { TFunction } from "i18next";
+import { Provider, createStore } from "jotai";
+import React, { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { DROPDOWN_PANEL } from "@src/components/Dropdown/tokens";
+
+import { useCloudMemberFilterDropdown } from "./cloudSessionsSection.MemberFilterDropdown";
+import type { MemberFilterMenuState } from "./cloudSessionsSection.types";
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+const onFilterChange = vi.fn();
+const env = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function Harness() {
+  const [memberMenu, setMemberMenu] = useState<MemberFilterMenuState | null>({
+    top: 20,
+    left: 20,
+  });
+  const menu = useCloudMemberFilterDropdown({
+    orgId: "org-1",
+    filter: { kind: "all" },
+    memberMenu,
+    setMemberMenu,
+    rows: [],
+    rosterMembers: Array.from({ length: 40 }, (_, index) => ({
+      userId: String(index),
+      displayName: index === 0 ? "Harry" : `Member ${index}`,
+      role: "member",
+      status: "active",
+    })),
+    hiddenRemoteSessionIds: new Set(["org-1|hidden"]),
+    setHiddenRemoteSessionIds: vi.fn(),
+    presenceMap: {},
+    onFilterChange,
+    t: ((key: string) => key) as TFunction,
+  });
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(
+      "button",
+      {
+        onClick: () => setMemberMenu({ top: 20, left: 20 }),
+        "data-testid": "reopen",
+      },
+      "Open"
+    ),
+    menu
+  );
+}
+
+beforeEach(async () => {
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  onFilterChange.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(
+      React.createElement(
+        Provider,
+        { store: createStore() },
+        React.createElement(Harness)
+      )
+    );
+  });
+  await act(async () => {
+    vi.advanceTimersByTime(20);
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+  delete env.IS_REACT_ACT_ENVIRONMENT;
+});
+
+it("searches roster names, caps height, selects and resets after reopening", async () => {
+  const input = document.querySelector("input")!;
+  expect(document.activeElement).toBe(input);
+  const portalRoot = document.querySelector<HTMLElement>(
+    '[data-testid="sidebar-cloud-member-filter"]'
+  )!;
+  expect(portalRoot.parentElement).toBe(document.body);
+  expect(portalRoot.classList.contains(DROPDOWN_PANEL.zIndexClass)).toBe(true);
+  expect(
+    document.querySelector<HTMLElement>(".animate-dropdown-in")?.style.maxHeight
+  ).toBe(`${DROPDOWN_PANEL.maxHeight}px`);
+  expect(document.querySelector('[role="listbox"]')?.className).toContain(
+    "overflow-y-auto"
+  );
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value"
+    )!.set!.call(input, " HARRY ");
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  expect(
+    document.querySelectorAll('[role="listbox"] [role="option"]')
+  ).toHaveLength(1);
+  expect(document.body.textContent).toContain("cloud.sidebar.showHidden");
+  await act(async () => {
+    document
+      .querySelector<HTMLElement>(
+        '[data-testid="sidebar-cloud-filter-member-0"]'
+      )!
+      .click();
+  });
+  expect(onFilterChange).toHaveBeenCalledWith({
+    kind: "member",
+    ownerUserId: "0",
+  });
+  expect(document.querySelector("input")).toBeNull();
+  await act(async () => {
+    container.querySelector<HTMLElement>('[data-testid="reopen"]')!.click();
+  });
+  expect(document.querySelector<HTMLInputElement>("input")!.value).toBe("");
+  expect(
+    document.querySelectorAll('[role="listbox"] [role="option"]')
+  ).toHaveLength(42);
+  await act(async () => {
+    document
+      .querySelector("input")!
+      .dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      );
+  });
+  expect(document.querySelector("input")).toBeNull();
+});
+
+it("closes on outside click", async () => {
+  await act(async () =>
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }))
+  );
+  expect(document.querySelector("input")).toBeNull();
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.tsx
@@ -3,13 +3,15 @@
  * (`cloudSessionsSection.tsx`): the portal-rendered option list (everyone /
  * directly shared with me / each roster member, with online dot + "viewing"
  * subtitle) plus the "show hidden" reveal row, and the state/handlers that
- * back it (escape-to-close, filter selection, hidden-row count).
+ * back it (filter selection and hidden-row count). Search, keyboard navigation,
+ * dismissal and scrolling use the shared Dropdown options API.
  */
 import type { TFunction } from "i18next";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 
+import Dropdown from "@src/components/Dropdown";
 import DropdownItem from "@src/components/Dropdown/DropdownItem";
 import {
   DROPDOWN_CLASSES,
@@ -65,20 +67,6 @@ export function useCloudMemberFilterDropdown({
     () => setMemberMenu(null),
     [setMemberMenu]
   );
-  // Escape dismisses the member-filter panel. Document-level because the
-  // panel's rows are DropdownItem divs (not focus targets) — keyboard users
-  // must be able to bail without picking an option.
-  useEffect(() => {
-    if (!memberMenu) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.stopPropagation();
-        setMemberMenu(null);
-      }
-    };
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => document.removeEventListener("keydown", onKeyDown, true);
-  }, [memberMenu, setMemberMenu]);
   const handleFilterSelect = useCallback(
     (nextFilter: CloudSessionFilter) => {
       onFilterChange(nextFilter);
@@ -111,132 +99,127 @@ export function useCloudMemberFilterDropdown({
     setMemberMenu(null);
   }, [orgId, setHiddenRemoteSessionIds, setMemberMenu]);
 
-  // Same DropdownMenu look as SessionFilterButton, but anchored to the
-  // section header's action button (rendered by NavigationSidebar), so the
-  // panel is positioned from the click target instead of a local triggerRef.
-  const cloudMemberFilterDropdown = memberMenu
-    ? createPortal(
-        <>
-          <div
-            className="fixed inset-0"
-            style={{ zIndex: DROPDOWN_PANEL.zIndex - 1 }}
-            onMouseDown={closeMemberMenu}
-          />
-          <div
-            className={`${DROPDOWN_CLASSES.panelAnimated} ${DROPDOWN_WIDTHS.sidebarMenuClass} fixed`}
-            style={{ top: memberMenu.top, left: memberMenu.left }}
-            data-testid="sidebar-cloud-member-filter"
-            // Keyboard focus may be parked in another pane (chat composer /
-            // terminal), where the document-level Escape listener never
-            // fires. Own the focus while open and handle Escape locally too.
-            tabIndex={-1}
-            ref={(node) => node?.focus({ preventScroll: true })}
-            onKeyDown={(event) => {
-              if (event.key === "Escape") {
-                event.stopPropagation();
-                closeMemberMenu();
-              }
-            }}
-          >
-            <div
-              className={DROPDOWN_CLASSES.itemsColumnPadded}
-              role="listbox"
-              aria-label={t("cloud.sidebar.sessionFilter")}
-            >
-              <div className={DROPDOWN_CLASSES.sectionLabel}>
-                {t("cloud.sidebar.sessionFilter")}
-              </div>
-              {[
-                {
-                  key: "everyone",
-                  filter: { kind: "all" } as CloudSessionFilter,
-                  displayName: t("cloud.sidebar.everyone"),
-                  userId: null as string | null,
-                },
-                {
-                  key: "directly-shared-with-me",
-                  filter: {
-                    kind: "directlySharedWithMe",
-                  } as CloudSessionFilter,
-                  displayName: t("cloud.sidebar.directlySharedWithMe"),
-                  userId: null as string | null,
-                },
-                ...memberOptions.map((option) => ({
-                  key: `member-${option.userId}`,
-                  filter: {
-                    kind: "member",
-                    ownerUserId: option.userId,
-                  } as CloudSessionFilter,
-                  ...option,
-                })),
-              ].map((option) => {
-                const active =
-                  option.filter.kind === filter.kind &&
-                  (option.filter.kind !== "member" ||
-                    (filter.kind === "member" &&
-                      option.filter.ownerUserId === filter.ownerUserId));
-                const presenceEntry = option.userId
-                  ? (orgId ? presenceMap[orgId] : undefined)?.[option.userId]
-                  : undefined;
-                const viewingRow = presenceEntry?.viewingSessionId
-                  ? rows.find(
-                      (row) =>
-                        row.sourceSessionId === presenceEntry.viewingSessionId
-                    )
-                  : undefined;
-                const viewingTitle = viewingRow
-                  ? viewingRow.title.replace(/^(?:⑂\s*)+/u, "")
-                  : undefined;
-                return (
-                  // DropdownItem carries the option semantics itself
-                  // (role="option" + aria-selected + selected check).
-                  <DropdownItem
-                    key={option.key}
-                    dataTestId={`sidebar-cloud-filter-${option.key}`}
-                    selected={active}
-                    onClick={() => handleFilterSelect(option.filter)}
-                  >
-                    <span className="flex min-w-0 flex-col">
-                      <span className="flex min-w-0 items-center gap-1.5">
-                        {presenceEntry && (
-                          <span
-                            data-testid="member-online-dot"
-                            className="h-1.5 w-1.5 shrink-0 rounded-full bg-success-6"
-                          />
-                        )}
-                        <span className="min-w-0 truncate">
-                          {option.displayName}
-                        </span>
-                      </span>
-                      {viewingTitle && (
-                        <span className="min-w-0 truncate pl-3 text-[10px] text-text-3">
-                          {t("cloud.sidebar.memberViewing", {
-                            title: viewingTitle,
-                          })}
-                        </span>
-                      )}
-                    </span>
-                  </DropdownItem>
-                );
-              })}
-              {hiddenCountForOrg > 0 && (
-                <>
-                  <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
-                  <DropdownItem onClick={handleShowHidden}>
-                    <span className="min-w-0 truncate">
-                      {t("cloud.sidebar.showHidden", {
-                        count: hiddenCountForOrg,
-                      })}
-                    </span>
-                  </DropdownItem>
-                </>
-              )}
-            </div>
-          </div>
-        </>,
-        document.body
-      )
-    : null;
+  if (!memberMenu) return null;
 
-  return cloudMemberFilterDropdown;
+  const filterOptions = [
+    {
+      key: "everyone",
+      filter: { kind: "all" } as CloudSessionFilter,
+      displayName: t("cloud.sidebar.everyone"),
+      userId: null as string | null,
+    },
+    {
+      key: "directly-shared-with-me",
+      filter: {
+        kind: "directlySharedWithMe",
+      } as CloudSessionFilter,
+      displayName: t("cloud.sidebar.directlySharedWithMe"),
+      userId: null as string | null,
+    },
+    ...memberOptions.map((option) => ({
+      key: `member-${option.userId}`,
+      filter: {
+        kind: "member",
+        ownerUserId: option.userId,
+      } as CloudSessionFilter,
+      ...option,
+    })),
+  ];
+  const options = filterOptions.map((option) => {
+    const presenceEntry = option.userId
+      ? (orgId ? presenceMap[orgId] : undefined)?.[option.userId]
+      : undefined;
+    const viewingRow = presenceEntry?.viewingSessionId
+      ? rows.find(
+          (row) => row.sourceSessionId === presenceEntry.viewingSessionId
+        )
+      : undefined;
+    const viewingTitle = viewingRow
+      ? viewingRow.title.replace(/^(?:⑂\s*)+/u, "")
+      : undefined;
+
+    return {
+      value: option.key,
+      triggerLabel: option.displayName,
+      dataTestId: `sidebar-cloud-filter-${option.key}`,
+      label: (
+        <span className="flex min-w-0 flex-col">
+          <span className="flex min-w-0 items-center gap-1.5">
+            {presenceEntry && (
+              <span
+                data-testid="member-online-dot"
+                className="h-1.5 w-1.5 shrink-0 rounded-full bg-success-6"
+              />
+            )}
+            <span className="min-w-0 truncate">{option.displayName}</span>
+          </span>
+          {viewingTitle && (
+            <span className="min-w-0 truncate pl-3 text-[10px] text-text-3">
+              {t("cloud.sidebar.memberViewing", {
+                title: viewingTitle,
+              })}
+            </span>
+          )}
+        </span>
+      ),
+    };
+  });
+  const selectedValue =
+    filter.kind === "member"
+      ? `member-${filter.ownerUserId}`
+      : filter.kind === "directlySharedWithMe"
+        ? "directly-shared-with-me"
+        : "everyone";
+
+  return createPortal(
+    <div
+      // Fixed positioning creates a stacking context; the portal root must
+      // own the overlay layer so its child panel can appear above the app.
+      className={`fixed ${DROPDOWN_PANEL.zIndexClass}`}
+      style={{ top: memberMenu.top, left: memberMenu.left }}
+      data-testid="sidebar-cloud-member-filter"
+    >
+      <Dropdown
+        popupVisible
+        onVisibleChange={(visible) => {
+          if (!visible) closeMemberMenu();
+        }}
+        position="bottom-start"
+        className={`${DROPDOWN_CLASSES.panelAnimated} ${DROPDOWN_WIDTHS.sidebarMenuClass} flex flex-col`}
+        style={{ maxHeight: DROPDOWN_PANEL.maxHeight }}
+        showSearch
+        options={options}
+        value={selectedValue}
+        filterOption={(query, option) =>
+          String(option.triggerLabel)
+            .toLocaleLowerCase()
+            .includes(query.trim().toLocaleLowerCase())
+        }
+        onSelect={(value) => {
+          const option = filterOptions.find((entry) => entry.key === value);
+          if (option) handleFilterSelect(option.filter);
+        }}
+        dropdownRender={(menu) => (
+          <>
+            {menu}
+            {hiddenCountForOrg > 0 && (
+              <div className="shrink-0">
+                <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
+                <DropdownItem onClick={handleShowHidden}>
+                  <span className="min-w-0 truncate">
+                    {t("cloud.sidebar.showHidden", {
+                      count: hiddenCountForOrg,
+                    })}
+                  </span>
+                </DropdownItem>
+              </div>
+            )}
+          </>
+        )}
+      >
+        <span aria-hidden="true" />
+      </Dropdown>
+    </div>,
+    document.body
+  );
 }

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.menuItems.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.menuItems.test.ts
@@ -1,0 +1,45 @@
+import type { TFunction } from "i18next";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { openAgentSessionSearchSpotlight } from "@src/scaffold/GlobalSpotlight/openSpotlight";
+
+import { useCloudTeamSessionMenuItems } from "./cloudSessionsSection.menuItems";
+
+vi.mock("@src/scaffold/GlobalSpotlight/openSpotlight", () => ({
+  openAgentSessionSearchSpotlight: vi.fn(),
+}));
+
+describe("cloud Team Sessions header", () => {
+  it("orders pane-hover actions as search, refresh, filter even with no sessions", () => {
+    const refresh = vi.fn();
+    function Harness() {
+      const items = useCloudTeamSessionMenuItems({
+        orgId: "org-1",
+        threads: [],
+        visibleThreads: [],
+        state: "ready",
+        filter: { kind: "all" },
+        memberMenu: null,
+        setMemberMenu: vi.fn(),
+        refreshSpinClass: undefined,
+        handleRefreshClick: refresh,
+        buildRowItem: vi.fn(),
+        t: ((key: string) => key) as TFunction,
+        tCommon: ((key: string) => key) as TFunction,
+      });
+      const actions = items[0].rowActions!;
+      expect(actions.map((action) => action.dataTestId)).toEqual([
+        "cloud-team-sessions-search",
+        "cloud-team-sessions-refresh",
+        "cloud-team-sessions-filter",
+      ]);
+      expect(actions.every((action) => action.showOnSidebarHover)).toBe(true);
+      expect(actions[0].onClick).toBe(openAgentSessionSearchSpotlight);
+      expect(actions[1].onClick).toBe(refresh);
+      return null;
+    }
+    renderToStaticMarkup(createElement(Harness));
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.menuItems.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.menuItems.tsx
@@ -1,6 +1,6 @@
 /**
  * Assembles the Team Sessions section's `NavigationMenuItem[]` list
- * (`cloudSessionsSection.tsx`): the separator header (refresh + member
+ * (`cloudSessionsSection.tsx`): the separator header (search, refresh + member
  * filter row actions), one row per visible fork thread via `buildRowItem`,
  * the "Load more" pagination row, and the empty/loading/error placeholder
  * row.
@@ -11,7 +11,8 @@ import React, { useMemo } from "react";
 import type { CloudSessionFilter } from "@src/features/Org2Cloud/cloudSessionFilter";
 import type { CloudSessionThread } from "@src/features/Org2Cloud/cloudSessionThreads";
 import type { CloudRemoteSessionsFetchState } from "@src/features/Org2Cloud/org2CloudRemoteSessionsAtom";
-import { FilterMailIcon, Refresh04Icon } from "@src/icons";
+import { FilterMailIcon, Refresh04Icon, Search01Icon } from "@src/icons";
+import { openAgentSessionSearchSpotlight } from "@src/scaffold/GlobalSpotlight/openSpotlight";
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 
 import { separator } from "../useSessionMenuItems/menuItemBuilders";
@@ -62,6 +63,15 @@ export function useCloudTeamSessionMenuItems({
     );
     header.rowActions = [
       {
+        showOnSidebarHover: true,
+        icon: Search01Icon,
+        dataIcon: "search",
+        label: t("sidebar.search.sessions"),
+        dataTestId: "cloud-team-sessions-search",
+        onClick: openAgentSessionSearchSpotlight,
+      },
+      {
+        showOnSidebarHover: true,
         icon: Refresh04Icon,
         dataIcon: "refresh-cw",
         iconClassName: refreshSpinClass,
@@ -70,6 +80,7 @@ export function useCloudTeamSessionMenuItems({
         onClick: handleRefreshClick,
       },
       {
+        showOnSidebarHover: true,
         icon: FilterMailIcon,
         label: t("cloud.sidebar.sessionFilter"),
         active: memberMenu !== null || filter.kind !== "all",

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts
@@ -69,7 +69,7 @@ describe("SidebarOrgSelector", () => {
     expect(markup).toContain("hover:bg-sidebar-selected!");
   });
 
-  it("keeps its chevron hidden until the selector is active", () => {
+  it("keeps its chevron hidden until the sidebar or selector is active", () => {
     const markup = renderToStaticMarkup(
       React.createElement(SidebarOrgSelector, {
         ...baseProps,
@@ -80,7 +80,7 @@ describe("SidebarOrgSelector", () => {
     );
 
     expect(markup).toContain("[&amp;_.select-arrow]:opacity-0");
-    expect(markup).not.toContain(
+    expect(markup).toContain(
       "group-hover/sidebar:[&amp;_.select-arrow]:opacity-100"
     );
     expect(markup).toContain("hover:[&amp;_.select-arrow]:opacity-100");

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts
@@ -139,6 +139,36 @@ describe("NavigationSidebar", () => {
     ).toBeLessThan(markup.indexOf('data-testid="sidebar-sessions-refresh"'));
   });
 
+  it("keeps every header action visible when the filter is active outside sidebar hover", () => {
+    const markup = renderToStaticMarkup(
+      createElement(NavigationSidebar, {
+        items: [],
+        activeKey: "",
+        onChange: vi.fn(),
+        menuItems: [
+          {
+            id: "separator-team",
+            key: "separator-team",
+            label: "Team",
+            rowActions: ["Search", "Refresh", "Filter"].map((label) => ({
+              label,
+              active: label === "Filter",
+              showOnSidebarHover: true,
+              onClick: vi.fn(),
+            })),
+          },
+        ],
+        collapsibleSections: true,
+      })
+    );
+    for (const label of ["Search", "Refresh", "Filter"]) {
+      expect(markup).toContain(
+        `<span class="inline-flex"><button type="button" aria-label="${label}"`
+      );
+    }
+    expect(markup).not.toContain("group-hover/sidebar:inline-flex");
+  });
+
   it("renders the standard loading state without dummy rows", () => {
     const markup = renderToStaticMarkup(
       createElement(NavigationSidebar, {

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -496,7 +496,9 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
                             <span
                               key={action.label}
                               className={
-                                action.active
+                                section.headerActions?.some(
+                                  (headerAction) => headerAction.active
+                                )
                                   ? "inline-flex"
                                   : action.showOnSidebarHover
                                     ? "hidden group-focus-within/section-title:inline-flex group-hover/sidebar:inline-flex"


### PR DESCRIPTION
## Problem

Cloud-organization sidebar controls were incomplete: there was no session search button, header actions disappeared when moving into the filter popup, and long member lists had no search or height limit. The shared-dropdown conversion also needed an overlay layer on its outer fixed wrapper to avoid appearing behind the app.

## Solution

Complete the cloud sidebar controls with search → refresh → filter, pane-hover visibility for team/org controls, and persistent header actions while a control is active. Use the shared Dropdown showSearch/filterOption API for member-name filtering, cap the menu at 256px with scrolling, and remove the redundant title. Preserve member presence details, selection, and the show-hidden action. Apply the shared overlay z-index to the outer portal wrapper.

## Potential risks

The search button opens the existing session search: local session names and copied cloud references are supported; cloud-title search is not added. Popup positioning, themes and tight viewports still need desktop visual review. DOM tests verify the stacking class, height constraint and behavior but cannot establish painted layout. Desktop CPU/RSS measurements were not run because computer control is disabled by the user. No schema, persistence, dependency, wire or API changes are introduced; reverting this commit restores prior controls.

## Verification

Passed on the latest develop base:

- `pnpm test src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.menuItems.test.ts src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts src/components/Dropdown/index.test.ts` — 17 tests passed, including search, selection, reopening/reset, Escape/outside dismissal, action order and active visibility
- `pnpm run typecheck:fast` — passed
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown{.tsx,.test.ts} src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.menuItems{.tsx,.test.ts} src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts src/scaffold/NavigationSidebar/variants/NavigationSidebar{.tsx,.test.ts} --max-warnings 0` — passed
- `git diff --check` — passed
- Inspected the final scoped diff for unrelated changes, secrets, personal paths and generated artifacts
- Desktop screenshots/recordings and visual validation were not run because the user has disabled computer control

## Audit

UI audit: 0 fixes, 3 keeps with reasons, 0 abstractions. Lifecycle review and the desktop measurement limitation are documented in `docs/frontend-ui-audit-2026-09-07/CloudMemberFilterDropdown.md`.
