### PR TITLE
test(time): align relative label expectations with sentence case

### DIFF
--- a/src/features/KanbanBoard/components/TaskCard/taskCardTime.test.ts
+++ b/src/features/KanbanBoard/components/TaskCard/taskCardTime.test.ts
@@ -7,7 +7,7 @@ const NOW = Date.parse("2026-07-22T12:00:00.000Z");
 describe("formatTaskCardLastUpdated", () => {
   it("shows a localized current-time label for updates less than five minutes old", () => {
     expect(formatTaskCardLastUpdated("2026-07-22T11:55:01.000Z", NOW)).toBe(
-      "now"
+      "Now"
     );
   });
 

--- a/src/features/SessionCreator/components/__tests__/worktreeBranchSource.test.ts
+++ b/src/features/SessionCreator/components/__tests__/worktreeBranchSource.test.ts
@@ -336,22 +336,17 @@ describe("formatBranchTimestamp", () => {
 
   it("formats a recent commit with the shared 'short' relative style", () => {
     // `formatRelativeTime("short")` is Intl-backed, so the exact strings
-    // ("1 hr. ago", "yesterday") belong to the runtime's ICU data. Derive the
-    // expectations the same way rather than pinning one ICU's spelling.
+    // ("1 hr. ago") belong to the runtime's ICU data. The standalone
+    // yesterday label is sentence-cased by the shared formatter.
     const short = (value: number, unit: Intl.RelativeTimeFormatUnit) =>
       new Intl.RelativeTimeFormat("en", { style: "short" }).format(value, unit);
-    const shortAuto = (value: number, unit: Intl.RelativeTimeFormatUnit) =>
-      new Intl.RelativeTimeFormat("en", {
-        style: "short",
-        numeric: "auto",
-      }).format(value, unit);
 
     expect(
       formatBranchTimestamp(option({ lastCommitDate: "2026-07-11T11:00:00Z" }))
     ).toBe(short(-1, "hour"));
     expect(
       formatBranchTimestamp(option({ lastCommitDate: "2026-07-10T12:00:00Z" }))
-    ).toBe(shortAuto(-1, "day"));
+    ).toBe("Yesterday");
     expect(
       formatBranchTimestamp(option({ lastCommitDate: "2026-07-09T12:00:00Z" }))
     ).toBe(short(-2, "day"));

--- a/src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts
@@ -141,9 +141,9 @@ describe("TeamInboxRow", () => {
     );
     expect(secondaryText).toHaveLength(1);
     // `formatRelativeTime("nano")` renders the localized immediate label
-    // ("now"), not the old hand-rolled "Now".
+    // ("Now"), not the old hand-rolled "Now".
     const time = Array.from(container.querySelectorAll("span")).find(
-      (element) => element.textContent === "now"
+      (element) => element.textContent === "Now"
     );
     expect(time?.className).toContain("text-text-3");
     expect(time?.className).not.toContain("text-text-2");

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/__tests__/workstationIssueHelpers.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/__tests__/workstationIssueHelpers.test.ts
@@ -242,12 +242,12 @@ describe("formatTimeAgo", () => {
     return d.toISOString();
   }
 
-  it('returns "today" for the current date', () => {
-    expect(formatTimeAgo(new Date().toISOString())).toBe("today");
+  it('returns "Today" for the current date', () => {
+    expect(formatTimeAgo(new Date().toISOString())).toBe("Today");
   });
 
-  it('returns "yesterday" for 1 day ago', () => {
-    expect(formatTimeAgo(daysAgo(1))).toBe("yesterday");
+  it('returns "Yesterday" for 1 day ago', () => {
+    expect(formatTimeAgo(daysAgo(1))).toBe("Yesterday");
   });
 
   it("returns N days ago for 2-29 days", () => {

--- a/src/util/data/formatters/dateLocalDisplay.test.ts
+++ b/src/util/data/formatters/dateLocalDisplay.test.ts
@@ -63,7 +63,7 @@ describe("local date display helpers", () => {
     vi.setSystemTime(new Date(2026, 1, 25, 14, 30, 0));
 
     expect(formatRelativeElapsedShort(new Date(2026, 1, 25, 14, 29, 30))).toBe(
-      "now"
+      "Now"
     );
     expect(formatRelativeElapsedShort(new Date(2026, 1, 25, 14, 25, 0))).toBe(
       "5m ago"


### PR DESCRIPTION
## Problem

The full frontend suite on develop and PR #1375 has six failures across five test files. The shared relative-time formatter now deliberately sentence-cases standalone labels, but consumer assertions and a TeamInbox timestamp selector still expect lowercase now/today/yesterday.

## Solution

Update the affected test expectations and timestamp selector to Now/Today/Yesterday. Preserve the Intl-derived numeric-duration expectations and every existing layout assertion. This is a test-only prerequisite for #1375; production formatting and UI behavior are unchanged.

## Potential risks

Only stale test expectations change. Assertions remain exact, with no case-insensitive matching, skipped tests, or weakened CI gates. No API, persistence, dependency, platform or lifecycle changes apply. Reverting this commit restores the failing expectations and does not affect user data.

## Verification

- Before repair, targeted execution reproduced all six CI failures: 6 failed, 66 passed.
- After repair, `pnpm test src/util/data/formatters/dateLocalDisplay.test.ts src/features/KanbanBoard/components/TaskCard/taskCardTime.test.ts src/features/SessionCreator/components/__tests__/worktreeBranchSource.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/__tests__/workstationIssueHelpers.test.ts`: 72 tests passed across 5 files.
- `git diff --cached --check`: passed.
- No screenshots or Rust checks are needed for assertion-only changes. The full frontend CI suite will rerun on the PR.
