### PR TITLE
feat(workstation): land local document application menu

### DIFF
--- a/docs/architecture-audit-2026-09-07/DocumentOpenMenu.md
+++ b/docs/architecture-audit-2026-09-07/DocumentOpenMenu.md
@@ -1,0 +1,22 @@
+# Document application opening architecture review
+
+Scope: document preview header → DocumentOpenMenu → Tauri commands → system_services::document_apps → NSWorkspace / OS opener.
+
+Acceptance: no eager OS query, no polling, bounded cache and concurrent requests, exact local file associations, source-side local path validation, shared header integration, no document writes or persistence changes.
+
+| Layer                     | Result                                                                                                                                                                   |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1 Compilation             | Frontend typecheck and targeted lint passed in the isolated PR worktree; Rust Clippy and 3 tests passed, including native macOS PDF handler discovery                    |
+| 2 Ownership/deduplication | One header action for the preview branches; one query cache owns repeated/concurrent discovery                                                                           |
+| 3 Naming                  | DocumentApplication means an installed OS file handler, distinct from app-level workstations                                                                             |
+| 4 Semantic overload       | File path and application bundle path are separate named fields                                                                                                          |
+| 5 Defaults                | Default-app opening always available; named handler discovery is macOS-only; other platforms return an empty list and use the OS default opener                          |
+| 6 Boundaries              | Native discovery and file validation remain in the existing OS services crate; no upper-layer imports                                                                    |
+| 7 Readability             | No startup registration hook, watcher or timer; ordinary menu expansion owns loading                                                                                     |
+| 8 Wire                    | Serialization test asserts path/name/isDefault; paths passed as structured IPC/process arguments, never interpolated into shell code; no icons or document contents sent |
+| 9 Entry points            | Both commands registered in handler_list.inc; both validate an existing absolute file on a blocking worker; UI forwards selectedFile, not the breadcrumb path            |
+| 10 Resolution             | Default and compatible applications both come from NSWorkspace for the same exact file URL; cache keys are full paths rather than just extensions                        |
+
+No schema, dependency, lockfile, migration, or account data changes. No network/provider/session initialization paths apply. System association changes become visible on the next menu expansion after the 60-second cache TTL. Removed applications fail at launch validation; the error is shown without an automatic retry loop. Unsaved document edits must be saved/discarded first. External editor changes use the existing preview reload behavior.
+
+Verification commands and remaining runtime limitations are recorded in `docs/org2-performance-guard-2026-09-07/DocumentOpenMenu.md`.

--- a/docs/frontend-ui-audit-2026-09-07/DocumentOpenMenu.md
+++ b/docs/frontend-ui-audit-2026-09-07/DocumentOpenMenu.md
@@ -1,0 +1,13 @@
+# DocumentOpenMenu UI audit
+
+Paths below are relative to `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/`.
+
+| Line                            | Element          | Verdict          | Reason                                                                                                                               | Suggested change |
+| ------------------------------- | ---------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `DocumentOpenMenu/index.tsx:47` | Application menu | keep with reason | Uses shared Dropdown options, placement and keyboard behavior; loading and failure are disabled menu rows                            | None             |
+| `DocumentOpenMenu/index.tsx:97` | Open in trigger  | keep with reason | Uses Button mini sizing and theme styles, with accessible name and expanded state; no new size/color literals                        | None             |
+| `views/BinaryView.tsx:88`       | Header placement | keep with reason | One shared slot covers the document preview branches, including preview error/unsupported content; no per-format toolbar duplication | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+D1–D5 reviewed. No cross-file design-system sweep candidate. Browser/web mode hides the local launcher. Unsaved spreadsheet edits disable launch. Actual desktop layout/theme/keyboard checks were not run: user preferences disallow desktop control without explicit opt-in. The component tests verify demand loading, stale completion, platform fallback and dirty state using a mocked Dropdown, not the real popup's rendering.

--- a/docs/org2-performance-guard-2026-09-07/DocumentOpenMenu.md
+++ b/docs/org2-performance-guard-2026-09-07/DocumentOpenMenu.md
@@ -1,0 +1,22 @@
+# DocumentOpenMenu performance guard
+
+| Area               | Verdict | Evidence                                                                                                      | Change or reason kept                                                                                                            | Verification                                        |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Background work    | keep    | OS lookup starts only on menu expansion on macOS; no timer, scan, watcher, network call or startup effect     | NSWorkspace queries and launch/file validation use spawn_blocking; closing cancels UI delivery, bounded native lookup may finish | Demand/TTL tests and real native PDF discovery test |
+| Memory             | keep    | Module cache retains at most 32 file keys including pending requests; native result capped at 64 apps per key | Completed entries evict by recency, lazy 60s TTL, failures evict, saturation rejects without creating more work                  | Completed and pending capacity tests                |
+| Scope/isolation    | keep    | Cache key is exact local path in this webview; only OS handler metadata, no file contents or cloud/user data  | Different files preserve per-file associations; keyed component remount and effect cancellation reject late UI completion        | File-switch test, exact-path forwarding test        |
+| Rendering/hot path | keep    | State belongs to menu, no global React subscription                                                           | Startup/file switching does not query handlers; state resets in expansion event                                                  | Component mount, platform and dirty-state tests     |
+
+Lifecycle: app start/idle/hidden/focus return creates no scheduled work; active expansion performs one bounded lookup; close/unmount prevents result delivery; repeat expansion uses the shared cache. Native in-flight work finishes without UI delivery after close. No network, authentication, sync, provider or session lifecycle applies. Cache lifetime ends with the webview and is capacity bounded throughout. No automatic external-file reload was added.
+
+Verification:
+
+- `pnpm test src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu`: 8 tests passed
+- `pnpm typecheck`: passed in the isolated PR worktree based on current origin/develop
+- `pnpm exec eslint src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/views/BinaryView.tsx --max-warnings 0`: passed
+- `cargo test --manifest-path src-tauri/Cargo.toml -p system_services document_apps --lib`: 3 tests passed, including native macOS PDF handler discovery without launching an app
+- `cargo clippy --manifest-path src-tauri/Cargo.toml -p system_services --lib -- -D warnings`: passed
+- `git diff --check`: passed in the isolated PR worktree
+- Actual Tauri UI layout, external app launch, visible/hidden CPU/RSS measurements, and Windows/Linux execution: not run; desktop control has not been authorized and only this macOS environment is available
+
+Performance verdict: blocked — code-level demand, bounds and stale-result invariants are tested, but actual desktop visible/hidden/post-close CPU/RSS and launch interaction have not been measured. No runtime performance improvement is claimed.

--- a/src-tauri/crates/system-services/src/document_apps.rs
+++ b/src-tauri/crates/system-services/src/document_apps.rs
@@ -1,0 +1,156 @@
+//! On-demand OS document handlers. No scanning, timers, or retained file contents.
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentApplication {
+    pub path: String,
+    pub name: String,
+    pub is_default: bool,
+}
+
+fn validate_document(path: &str) -> Result<(), String> {
+    let path = Path::new(path);
+    if !path.is_absolute() || !path.is_file() {
+        return Err("Expected an existing absolute local file path".into());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn applications(path: &str) -> Vec<DocumentApplication> {
+    use objc2_app_kit::NSWorkspace;
+    use objc2_foundation::{NSFileManager, NSString, NSURL};
+    objc2::rc::autoreleasepool(|_| {
+        let workspace = NSWorkspace::sharedWorkspace();
+        let url = NSURL::fileURLWithPath(&NSString::from_str(path));
+        let default_path = workspace
+            .URLForApplicationToOpenURL(&url)
+            .and_then(|url| url.path());
+        let manager = NSFileManager::defaultManager();
+        let mut apps = Vec::new();
+        for url in workspace.URLsForApplicationsToOpenURL(&url).iter() {
+            let Some(path) = url.path() else { continue };
+            let app_path = path.to_string();
+            if apps
+                .iter()
+                .any(|app: &DocumentApplication| app.path == app_path)
+            {
+                continue;
+            }
+            apps.push(DocumentApplication {
+                is_default: default_path
+                    .as_ref()
+                    .is_some_and(|default| **default == *path),
+                name: manager.displayNameAtPath(&path).to_string(),
+                path: app_path,
+            });
+        }
+        apps.sort_by(|a, b| {
+            b.is_default
+                .cmp(&a.is_default)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        apps.truncate(64);
+        apps
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn applications(_path: &str) -> Vec<DocumentApplication> {
+    Vec::new()
+}
+
+#[tauri::command]
+pub async fn document_applications(path: String) -> Result<Vec<DocumentApplication>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        validate_document(&path)?;
+        Ok(applications(&path))
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+pub async fn document_open(path: String, application: Option<String>) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        validate_document(&path)?;
+        if let Some(application) = application {
+            #[cfg(target_os = "macos")]
+            {
+                let app_path = Path::new(&application);
+                if !app_path.is_absolute()
+                    || !app_path.is_dir()
+                    || app_path.extension().is_none_or(|ext| ext != "app")
+                {
+                    return Err("Expected an installed application bundle".into());
+                }
+                let status = std::process::Command::new("/usr/bin/open")
+                    .arg("-a")
+                    .arg(application)
+                    .arg("--")
+                    .arg(path)
+                    .status()
+                    .map_err(|error| error.to_string())?;
+                if !status.success() {
+                    return Err("The application could not open this file".into());
+                }
+                Ok(())
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = application;
+                Err("Application selection is only supported on macOS".into())
+            }
+        } else {
+            open::that(path).map_err(|error| error.to_string())
+        }
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_urls_relative_paths_and_directories() {
+        for path in ["https://example.com/file.pdf", "file.pdf", "/"] {
+            assert!(validate_document(path).is_err());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn discovers_native_pdf_handlers_without_launching_apps() {
+        let path =
+            std::env::temp_dir().join(format!("orgii-document-apps-{}.pdf", std::process::id()));
+        std::fs::write(&path, b"%PDF-1.4\n%%EOF\n").unwrap();
+        let result = applications(path.to_str().unwrap());
+        std::fs::remove_file(path).unwrap();
+        assert!(
+            !result.is_empty(),
+            "macOS should have a registered PDF handler"
+        );
+        assert!(result.len() <= 64);
+        assert!(result
+            .iter()
+            .all(|app| Path::new(&app.path).is_absolute() && !app.name.is_empty()));
+        assert!(result.iter().filter(|app| app.is_default).count() <= 1);
+    }
+
+    #[test]
+    fn application_wire_contract() {
+        let app = DocumentApplication {
+            path: "/Applications/Preview.app".into(),
+            name: "Preview".into(),
+            is_default: true,
+        };
+        assert_eq!(
+            serde_json::to_value(app).unwrap(),
+            serde_json::json!({"path":"/Applications/Preview.app", "name":"Preview", "isDefault":true})
+        );
+    }
+}

--- a/src-tauri/crates/system-services/src/lib.rs
+++ b/src-tauri/crates/system-services/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod app_menu;
 pub mod dependencies;
 pub mod dock_menu;
+pub mod document_apps;
 pub mod network;
 pub mod notifications;
 pub mod power;

--- a/src-tauri/src/commands/handler_list.inc
+++ b/src-tauri/src/commands/handler_list.inc
@@ -152,6 +152,8 @@ integrations::github::detect::detect_github_credentials,
 integrations::github::profile::github_fetch_profile,
 project_management::sync::git_credentials::git_credential_for_remote,
 // Platform commands
+system_services::document_apps::document_applications,
+system_services::document_apps::document_open,
 system_services::notifications::send_notification,
 system_services::notifications::check_notification_permission,
 system_services::notifications::request_notification_permission,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -2633,5 +2633,14 @@
       "previewFailed": "Couldn't read cookies from that browser",
       "importFailed": "Couldn't import the selected cookies"
     }
+  },
+  "documentOpen": {
+    "label": "Open in…",
+    "defaultApp": "Default application",
+    "appDefault": "{{name}} (default)",
+    "loading": "Loading applications…",
+    "loadFailed": "Applications unavailable — reopen to retry",
+    "openFailed": "Could not open the document",
+    "saveFirst": "Save or discard changes before opening in another application"
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -2495,5 +2495,14 @@
   "notifications": {
     "taskCancelledToast": "「{{name}}」已取消",
     "taskCompletedToast": "「{{name}}」已完成。開啟工作階段以檢視結果。"
+  },
+  "documentOpen": {
+    "label": "開啟方式…",
+    "defaultApp": "預設應用程式",
+    "appDefault": "{{name}}（預設）",
+    "loading": "正在載入應用程式…",
+    "loadFailed": "無法載入應用程式，請重新展開重試",
+    "openFailed": "無法開啟文件",
+    "saveFirst": "請先儲存或捨棄修改，再使用其他應用程式開啟"
   }
 }

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -2562,5 +2562,14 @@
       "previewFailed": "无法从该浏览器读取 Cookie",
       "importFailed": "无法导入所选 Cookie"
     }
+  },
+  "documentOpen": {
+    "label": "打开方式…",
+    "defaultApp": "默认应用",
+    "appDefault": "{{name}}（默认）",
+    "loading": "正在加载应用…",
+    "loadFailed": "无法加载应用，请重新展开重试",
+    "openFailed": "无法打开文档",
+    "saveFirst": "请先保存或放弃修改，再使用其他应用打开"
   }
 }

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu/DocumentOpenMenu.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu/DocumentOpenMenu.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import DocumentOpenMenu from "./index";
+
+const mocks = vi.hoisted(() => ({ load: vi.fn(), open: vi.fn(), mac: true }));
+vi.mock("./documentApplications", () => ({
+  loadDocumentApplications: mocks.load,
+  openDocument: mocks.open,
+}));
+vi.mock("@src/util/platform/tauri", () => ({
+  isMacOS: () => mocks.mac,
+  isTauriDesktop: () => true,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/components/Message", () => ({ default: { error: vi.fn() } }));
+vi.mock("@src/components/Button", () => ({
+  default: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    React.createElement("button", props),
+}));
+vi.mock("@src/components/Dropdown", () => ({
+  default: ({
+    children,
+    onVisibleChange,
+    popupVisible,
+    options,
+    onSelect,
+    disabled,
+  }: {
+    children: React.ReactElement;
+    onVisibleChange: (v: boolean) => void;
+    popupVisible: boolean;
+    options: { value: string; label: string; disabled?: boolean }[];
+    onSelect: (v: string) => void;
+    disabled: boolean;
+  }) =>
+    React.createElement(
+      "div",
+      null,
+      React.cloneElement(
+        children as React.ReactElement<Record<string, unknown>>,
+        {
+          "data-trigger": true,
+          disabled,
+          onClick: () => onVisibleChange(!popupVisible),
+        }
+      ),
+      ...(popupVisible
+        ? options.map((option) =>
+            React.createElement(
+              "button",
+              {
+                key: option.value,
+                disabled: option.disabled,
+                onClick: () => onSelect(option.value),
+              },
+              option.label
+            )
+          )
+        : [])
+    ),
+}));
+let root: Root;
+let container: HTMLDivElement;
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  mocks.load.mockReset();
+  mocks.open.mockReset();
+  mocks.mac = true;
+  mocks.open.mockResolvedValue(undefined);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+async function render(filePath = "/a.pdf", dirty = false) {
+  await act(async () =>
+    root.render(
+      React.createElement(DocumentOpenMenu, {
+        filePath,
+        hasUnsavedChanges: dirty,
+      })
+    )
+  );
+}
+async function toggle() {
+  await act(async () =>
+    container.querySelector<HTMLButtonElement>("[data-trigger]")!.click()
+  );
+}
+
+it("loads only on expansion and discards a late result after file switch", async () => {
+  let resolve!: (apps: unknown[]) => void;
+  mocks.load.mockImplementation(
+    () =>
+      new Promise((done) => {
+        resolve = done;
+      })
+  );
+  await render();
+  expect(mocks.load).not.toHaveBeenCalled();
+  await toggle();
+  expect(mocks.load).toHaveBeenCalledWith("/a.pdf");
+  await render("/b.pdf");
+  await act(async () =>
+    resolve([{ path: "/Old.app", name: "Old app", isDefault: false }])
+  );
+  expect(container.textContent).not.toContain("Old app");
+  expect(mocks.load).toHaveBeenCalledTimes(1);
+});
+
+it("does not detect applications on other platforms and opens the exact current file", async () => {
+  mocks.mac = false;
+  await render("/b.xlsx");
+  await toggle();
+  expect(mocks.load).not.toHaveBeenCalled();
+  const button = [...container.querySelectorAll("button")].find(
+    (item) => item.textContent === "documentOpen.defaultApp"
+  )!;
+  await act(async () => button.click());
+  expect(mocks.open).toHaveBeenCalledWith("/b.xlsx", undefined);
+});
+
+it("prevents opening unsaved spreadsheet contents", async () => {
+  await render("/b.xlsx", true);
+  await toggle();
+  expect(mocks.load).not.toHaveBeenCalled();
+  expect(mocks.open).not.toHaveBeenCalled();
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu/documentApplications.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu/documentApplications.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
+beforeEach(() => {
+  vi.resetModules();
+  invoke.mockReset();
+  vi.useFakeTimers();
+});
+afterEach(() => vi.useRealTimers());
+
+async function service() {
+  return import("./documentApplications");
+}
+
+describe("document application discovery", () => {
+  it("does no eager or timed discovery and single-flights exact files", async () => {
+    const api = await service();
+    expect(invoke).not.toHaveBeenCalled();
+    let resolve!: (apps: []) => void;
+    invoke.mockImplementation(
+      () =>
+        new Promise<[]>((done) => {
+          resolve = done;
+        })
+    );
+    const first = api.loadDocumentApplications("/file.pdf");
+    expect(api.loadDocumentApplications("/file.pdf")).toBe(first);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    resolve([]);
+    await first;
+    await api.loadDocumentApplications("/file.pdf");
+    vi.advanceTimersByTime(60_001);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    invoke.mockResolvedValue([]);
+    await api.loadDocumentApplications("/file.pdf");
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds completed entries and keeps separate file associations", async () => {
+    const api = await service();
+    invoke.mockResolvedValue([]);
+    for (let i = 0; i < 33; i++)
+      await api.loadDocumentApplications(`/file-${i}.pdf`);
+    await api.loadDocumentApplications("/file-32.pdf");
+    expect(invoke).toHaveBeenCalledTimes(33);
+    await api.loadDocumentApplications("/file-0.pdf");
+    expect(invoke).toHaveBeenCalledTimes(34);
+  });
+
+  it("bounds pending requests without evicting their single-flight entries", async () => {
+    const api = await service();
+    invoke.mockImplementation(() => new Promise(() => {}));
+    const first = api.loadDocumentApplications("/file-0.pdf");
+    for (let i = 1; i < 32; i++)
+      void api.loadDocumentApplications(`/file-${i}.pdf`);
+    await expect(api.loadDocumentApplications("/overflow.pdf")).rejects.toThrow(
+      "busy"
+    );
+    expect(api.loadDocumentApplications("/file-0.pdf")).toBe(first);
+    expect(invoke).toHaveBeenCalledTimes(32);
+  });
+
+  it("allows explicit retry after failure and passes paths as data", async () => {
+    const api = await service();
+    invoke.mockRejectedValueOnce(new Error("failed"));
+    await expect(api.loadDocumentApplications("/file.pdf")).rejects.toThrow(
+      "failed"
+    );
+    invoke.mockResolvedValue([]);
+    await api.loadDocumentApplications("/file.pdf");
+    await api.openDocument("/a 'quoted'.pdf", "/Applications/Preview.app");
+    expect(invoke).toHaveBeenLastCalledWith("document_open", {
+      path: "/a 'quoted'.pdf",
+      application: "/Applications/Preview.app",
+    });
+  });
+
+  it("covers modern and legacy documents without detecting unrelated files", async () => {
+    const api = await service();
+    for (const ext of [
+      "PDF",
+      "doc",
+      "docx",
+      "xls",
+      "xlsx",
+      "ppt",
+      "pptx",
+      "pages",
+      "odt",
+    ])
+      expect(api.isExternalDocument(`/file.${ext}`)).toBe(true);
+    for (const path of ["/file.ts", "/pdf", "/file.pdf.ts"])
+      expect(api.isExternalDocument(path)).toBe(false);
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu/documentApplications.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu/documentApplications.ts
@@ -1,0 +1,69 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface DocumentApplication {
+  path: string;
+  name: string;
+  isDefault: boolean;
+}
+
+// Exact file keys preserve per-document default-app associations. At most 32
+// entries (including in-flight requests); expiry is checked only on demand.
+const entries = new Map<
+  string,
+  {
+    promise: Promise<DocumentApplication[]>;
+    expiresAt: number;
+    pending: boolean;
+  }
+>();
+const TTL_MS = 60_000;
+const MAX_ENTRIES = 32;
+
+export function loadDocumentApplications(
+  path: string
+): Promise<DocumentApplication[]> {
+  const existing = entries.get(path);
+  if (existing && (existing.pending || existing.expiresAt > Date.now())) {
+    entries.delete(path);
+    entries.set(path, existing);
+    return existing.promise;
+  }
+  entries.delete(path);
+  if (entries.size >= MAX_ENTRIES) {
+    const oldest = [...entries].find(([, entry]) => !entry.pending);
+    if (!oldest)
+      return Promise.reject(new Error("Application discovery is busy"));
+    entries.delete(oldest[0]);
+  }
+  const entry = {
+    promise: invoke<DocumentApplication[]>("document_applications", { path }),
+    expiresAt: 0,
+    pending: true,
+  };
+  entries.set(path, entry);
+  entry.promise = entry.promise.then(
+    (apps) => {
+      entry.pending = false;
+      entry.expiresAt = Date.now() + TTL_MS;
+      return apps;
+    },
+    (error: unknown) => {
+      entries.delete(path);
+      throw error;
+    }
+  );
+  return entry.promise;
+}
+
+export function openDocument(
+  path: string,
+  application?: string
+): Promise<void> {
+  return invoke("document_open", { path, application: application ?? null });
+}
+
+export function isExternalDocument(path: string): boolean {
+  return /\.(pdf|docx?|xlsx?|pptx?|pages|numbers|key|odt|ods|odp|rtf)$/i.test(
+    path
+  );
+}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/DocumentOpenMenu/index.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import Button from "@src/components/Button";
+import Dropdown from "@src/components/Dropdown";
+import Message from "@src/components/Message";
+import { isMacOS, isTauriDesktop } from "@src/util/platform/tauri";
+
+import {
+  type DocumentApplication,
+  loadDocumentApplications,
+  openDocument,
+} from "./documentApplications";
+
+interface Props {
+  filePath: string;
+  hasUnsavedChanges: boolean;
+}
+
+function DocumentOpenMenuContent({ filePath, hasUnsavedChanges }: Props) {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+  const [apps, setApps] = useState<DocumentApplication[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [opening, setOpening] = useState(false);
+
+  useEffect(() => {
+    if (!visible || !isMacOS()) return;
+    let cancelled = false;
+    void loadDocumentApplications(filePath)
+      .then((result) => {
+        if (!cancelled) setApps(result);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [filePath, visible]);
+
+  return (
+    <Dropdown
+      popupVisible={visible}
+      onVisibleChange={(nextVisible) => {
+        if (nextVisible) {
+          setLoading(isMacOS());
+          setFailed(false);
+          setApps([]);
+        }
+        setVisible(nextVisible);
+      }}
+      options={[
+        { value: "default", label: t("documentOpen.defaultApp") },
+        ...apps.map((app) => ({
+          value: app.path,
+          label: app.isDefault
+            ? t("documentOpen.appDefault", { name: app.name })
+            : app.name,
+        })),
+        ...(loading
+          ? [
+              {
+                value: "loading",
+                label: t("documentOpen.loading"),
+                disabled: true,
+              },
+            ]
+          : []),
+        ...(failed
+          ? [
+              {
+                value: "failed",
+                label: t("documentOpen.loadFailed"),
+                disabled: true,
+              },
+            ]
+          : []),
+      ]}
+      onSelect={(value) => {
+        if (hasUnsavedChanges || opening) return;
+        setVisible(false);
+        setOpening(true);
+        void openDocument(
+          filePath,
+          value === "default" ? undefined : String(value)
+        )
+          .catch(() => Message.error(t("documentOpen.openFailed")))
+          .finally(() => setOpening(false));
+      }}
+      disabled={hasUnsavedChanges || opening}
+    >
+      <Button
+        size="mini"
+        disabled={hasUnsavedChanges || opening}
+        title={
+          hasUnsavedChanges
+            ? t("documentOpen.saveFirst")
+            : t("documentOpen.label")
+        }
+        aria-label={t("documentOpen.label")}
+        aria-haspopup="menu"
+        aria-expanded={visible}
+      >
+        {t("documentOpen.label")}
+      </Button>
+    </Dropdown>
+  );
+}
+
+export default function DocumentOpenMenu(props: Props) {
+  if (!isTauriDesktop()) return null;
+  return <DocumentOpenMenuContent key={props.filePath} {...props} />;
+}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/views/BinaryView.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/views/BinaryView.tsx
@@ -20,6 +20,8 @@ import {
   PdfPreview,
   VideoPreview,
 } from "../../FilePreviewContent";
+import DocumentOpenMenu from "../DocumentOpenMenu";
+import { isExternalDocument } from "../DocumentOpenMenu/documentApplications";
 import type { BinaryViewProps } from "../types";
 
 const LazyDbPreviewView = React.lazy(
@@ -83,7 +85,17 @@ export const BinaryView: React.FC<BinaryViewProps> = ({
     onReload,
     loading: false,
     hasUnsavedChanges: hasPreviewUnsavedChanges,
-    beforeMoreMenuSlot: <TabBarBottomPanelToggle />,
+    beforeMoreMenuSlot: (
+      <>
+        {isExternalDocument(selectedFile) && (
+          <DocumentOpenMenu
+            filePath={selectedFile}
+            hasUnsavedChanges={hasPreviewUnsavedChanges}
+          />
+        )}
+        <TabBarBottomPanelToggle />
+      </>
+    ),
     isMarkdownFile: false,
     isPreviewMode: true,
     onTogglePreview: undefined,


### PR DESCRIPTION
## Problem

PR #1375 was merged into its prerequisite branch after #1376 had already merged into develop, leaving the document application menu absent from develop.

## Solution

Apply the previously reviewed document application menu to current develop. The resulting tree is identical to #1375's tested head, including the prerequisite timestamp test fixes already present on develop. This adds on-demand macOS application discovery and local document opening without polling.

## Potential risks

The feature retains #1375's limitations: named application selection is macOS-only; OS associations are cached for 60 seconds; actual desktop launch, visual evidence, Windows/Linux execution, and CPU/RSS measurements remain unverified. Two additive Tauri commands require frontend/backend deployment together. There are no persistence, schema or dependency changes. Revert this commit to roll back without data recovery.

Direct push was rejected because develop requires pull requests. This PR uses the normal protected-branch workflow.

## Verification

- Commit hooks: lint-staged, TypeScript check and scoped system_services Clippy passed.
- `git diff e6e904cd19cb7266fec0aefca60c3dd6e20ee260 HEAD --stat`: empty; exact tree parity with the previously tested PR head.
- `git diff --cached --check`: passed before commit.
- Identical #1375 tree: frontend CI passed 11,686 tests across 1,575 files, typecheck and lint. Local targeted tests passed 80 tests; native document discovery tests passed 3 tests.
- No new desktop interaction tests were performed; user preferences prohibit desktop control without explicit opt-in.
