### PR TITLE
fix(spotlight): pin section titles while scrolling

### DIFF
--- a/docs/org2-performance-guard-2026-09-07/SpotlightStickyTitles.md
+++ b/docs/org2-performance-guard-2026-09-07/SpotlightStickyTitles.md
@@ -1,0 +1,14 @@
+# Spotlight sticky section titles
+
+| Area               | Verdict | Evidence                                                      | Change or reason kept                                                             | Verification                                          |
+| ------------------ | ------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Background work    | keep    | Existing virtualizer owns scrolling                           | No new listeners, timers, requests, or polling                                    | Source inspection                                     |
+| Memory             | keep    | Header indices scoped to current items and component lifetime | Memoized indices; virtual window retains at most one additional row               | Range extractor inspection                            |
+| Scope/isolation    | keep    | No shared mutable state or persisted changes                  | Each mounted picker owns its indices; replaced with items and released on unmount | Source inspection                                     |
+| Rendering/hot path | keep    | Binary search selects the current header; CSS pins it         | Existing virtualization and overscan preserved                                    | Two boundary tests pass; four existing row tests pass |
+
+Lifecycle: mounting derives header indices; active scrolling uses the existing virtualizer; idle/hidden states add no autonomous work; changing results replaces indices; unmount releases component-owned data. Network, identity, provider ingestion, and machine topology are unaffected.
+
+Verification: targeted Vitest run (6 tests), `pnpm run typecheck:fast`, targeted ESLint, and `git diff --check` passed. No runtime CPU/RSS measurements or visual scrolling checks were performed: desktop control requires explicit user opt-in. No runtime performance improvement is claimed.
+
+Performance verdict: blocked for real-app scrolling and lifecycle measurement; static boundedness checks pass.

--- a/src/scaffold/GlobalSpotlight/components/SpotlightItemList.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightItemList.tsx
@@ -8,7 +8,13 @@
  *
  * Row rendering is delegated to SpotlightItemRow.
  */
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import { Placeholder } from "@src/components/Placeholder";
@@ -106,6 +112,10 @@ export const SpotlightItemList: React.FC<SpotlightItemListProps> = ({
     };
   }, [items.length, isLoadingInitial, searchQuery]);
 
+  const stickyIndices = useMemo(
+    () => items.flatMap((item, index) => (item.data?.isHeader ? [index] : [])),
+    [items]
+  );
   const useVirtualization = fixedHeight || items.length > 30;
   const getItemKey = useCallback((index: number) => items[index].id, [items]);
   const estimateSize = useCallback(
@@ -117,10 +127,13 @@ export const SpotlightItemList: React.FC<SpotlightItemListProps> = ({
   );
   const {
     containerRef,
+    stickyIndex,
     rows: virtualRows,
     totalSize,
     handleScroll,
   } = usePickerVirtualization({
+    stickyIndices,
+    scrollPadding: stickyIndices.length ? SPOTLIGHT_TOKENS.itemHeight : 0,
     count: items.length,
     getItemKey,
     estimateSize,
@@ -204,24 +217,35 @@ export const SpotlightItemList: React.FC<SpotlightItemListProps> = ({
       <div
         ref={nonVirtualizedContainerRef}
         className="spotlight-scrollable overflow-y-auto"
-        style={{ maxHeight: containerHeight }}
+        style={{
+          maxHeight: containerHeight,
+          scrollPaddingTop: stickyIndices.length
+            ? SPOTLIGHT_TOKENS.itemHeight
+            : 0,
+        }}
         onScroll={handleScroll}
         onMouseMove={handleMouseMove}
         data-keyboard-mode={dataKeyboardMode}
       >
         {items.map((item, idx) => (
-          <SpotlightItemRow
+          <div
             key={item.id}
-            item={item}
-            selectionState={item.data?.selectionState}
-            index={idx}
-            isSelected={selectedIndex === idx}
-            isKeyboardMode={isKeyboardMode}
-            onSelect={onItemSelect}
-            onHover={onItemHover}
-            onHoverEnd={onItemHoverEnd}
-            searchQuery={searchQuery}
-          />
+            className={
+              item.data?.isHeader ? "sticky top-0 z-10 bg-bg-2" : undefined
+            }
+          >
+            <SpotlightItemRow
+              item={item}
+              selectionState={item.data?.selectionState}
+              index={idx}
+              isSelected={selectedIndex === idx}
+              isKeyboardMode={isKeyboardMode}
+              onSelect={onItemSelect}
+              onHover={onItemHover}
+              onHoverEnd={onItemHoverEnd}
+              searchQuery={searchQuery}
+            />
+          </div>
         ))}
 
         {isLoadingMore && (
@@ -264,7 +288,15 @@ export const SpotlightItemList: React.FC<SpotlightItemListProps> = ({
         {virtualRows.map((row) => (
           <div
             key={row.key}
-            style={{ position: "absolute", top: row.start, left: 0, right: 0 }}
+            className={
+              items[row.index].data?.isHeader ? "z-10 bg-bg-2" : undefined
+            }
+            style={{
+              position: row.index === stickyIndex ? "sticky" : "absolute",
+              top: row.index === stickyIndex ? 0 : row.start,
+              left: 0,
+              right: 0,
+            }}
           >
             <SpotlightItemRow
               item={items[row.index]}

--- a/src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { findStickyIndex } from "./usePickerVirtualization";
+
+describe("picker sticky section selection", () => {
+  it("keeps the current section until the next title reaches the viewport", () => {
+    const headers = [0, 12, 45];
+    expect(findStickyIndex(headers, 0)).toBe(0);
+    expect(findStickyIndex(headers, 11)).toBe(0);
+    expect(findStickyIndex(headers, 12)).toBe(12);
+    expect(findStickyIndex(headers, 44)).toBe(12);
+    expect(findStickyIndex(headers, 45)).toBe(45);
+    expect(findStickyIndex(headers, 1000)).toBe(45);
+    expect(findStickyIndex(headers, 3)).toBe(0);
+  });
+
+  it("does not pin a future title or retain one after headers disappear", () => {
+    expect(findStickyIndex([5, 20], 4)).toBe(-1);
+    expect(findStickyIndex([5, 20], 5)).toBe(5);
+    expect(findStickyIndex([], 20)).toBe(-1);
+  });
+});

--- a/src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.ts
@@ -1,7 +1,25 @@
-import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  type Range,
+  defaultRangeExtractor,
+  useVirtualizer,
+} from "@tanstack/react-virtual";
 import { useCallback, useLayoutEffect, useRef } from "react";
 
+const NO_STICKY_INDICES: number[] = [];
+
+export function findStickyIndex(indices: number[], startIndex: number): number {
+  let low = 0;
+  let high = indices.length;
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    if (indices[mid] <= startIndex) low = mid + 1;
+    else high = mid;
+  }
+  return indices[low - 1] ?? -1;
+}
+
 interface Options {
+  stickyIndices?: number[];
   count: number;
   getItemKey: (index: number) => string | number;
   estimateSize: (index: number) => number;
@@ -18,6 +36,7 @@ interface Options {
 
 /** One scrolling owner for branch/PR rows in both picker presentations. */
 export function usePickerVirtualization({
+  stickyIndices = NO_STICKY_INDICES,
   count,
   getItemKey,
   estimateSize,
@@ -32,6 +51,16 @@ export function usePickerVirtualization({
   onLoadMore,
 }: Options) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const rangeExtractor = useCallback(
+    (range: Range) => {
+      const indices = defaultRangeExtractor(range);
+      const stickyIndex = findStickyIndex(stickyIndices, range.startIndex);
+      return stickyIndex >= 0 && stickyIndex < indices[0]
+        ? [stickyIndex, ...indices]
+        : indices;
+    },
+    [stickyIndices]
+  );
   // eslint-disable-next-line react-hooks/incompatible-library -- TanStack's imperative instance stays inside this hook; consumers receive a rendered snapshot.
   const virtualizer = useVirtualizer({
     count,
@@ -39,6 +68,7 @@ export function usePickerVirtualization({
     estimateSize,
     getScrollElement: () => containerRef.current,
     overscan: 5,
+    rangeExtractor,
     enabled: enabled && count > 0,
     initialRect: { width: 0, height: containerHeight },
     gap,
@@ -78,9 +108,15 @@ export function usePickerVirtualization({
     [onScrollExternal, onLoadMore]
   );
 
+  const rows = virtualizer.getVirtualItems();
+
   return {
     containerRef,
-    rows: virtualizer.getVirtualItems(),
+    stickyIndex: findStickyIndex(
+      stickyIndices,
+      virtualizer.range?.startIndex ?? 0
+    ),
+    rows,
     totalSize: virtualizer.getTotalSize(),
     measureElement: virtualizer.measureElement,
     handleScroll,


### PR DESCRIPTION
## Problem

Spotlight section titles scroll out of view, unlike dropdown headings. In long virtualized lists, the current title also unmounts once it leaves the rendered window.

## Solution

Pin section titles at the top of the Spotlight results with an opaque background. Preserve the active title in virtualized lists by retaining at most one extra row, and reserve header space during keyboard scrolling. Add section-boundary tests and a scoped performance guard report.

## Potential risks

CSS sticky positioning, header transitions, and keyboard visibility still need visual verification in the Tauri app, including light/dark themes and constrained heights. No desktop control was used because it requires explicit user opt-in. The shared virtualization hook has an optional sticky configuration; other picker consumers retain the default range behavior. No persistence, dependencies, IPC, or network behavior changes. Reverting the commit restores the previous scrolling behavior.

## Verification

On the isolated branch based on the latest `origin/develop`:

- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.test.ts src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts` — passed, 6 tests
- `pnpm run typecheck:fast` — passed
- `pnpm exec eslint src/scaffold/GlobalSpotlight/components/SpotlightItemList.tsx src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.ts src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.test.ts` — passed
- `git diff --check` — passed
- Inspected the scoped diff for unrelated changes, secrets, private paths, and generated artifacts

Visual scrolling checks, screenshots, full-suite/E2E testing, and runtime CPU/RSS measurements were not performed. The tests cover section selection boundaries and existing row behavior, not browser layout. Performance guard static checks found bounded state and no new background work; runtime verification remains blocked pending real-app checks.
