### PR TITLE
fix(spotlight): always discover directories used in other apps

### DIFF
--- a/docs/org2-performance-guard-2026-09-07/ExternalAppDiscovery.md
+++ b/docs/org2-performance-guard-2026-09-07/ExternalAppDiscovery.md
@@ -1,0 +1,14 @@
+# External app discovery lifecycle review
+
+The source of recent directories remains the eight existing Tauri recent-path APIs. Both picker entry points previously disabled discovery when more than five repositories were saved. This PR removes that presentation gate without changing provider parsing, IPC contracts, persisted data, normalization, or the 12-result display cap. The “Used in other apps” locale text is already in the base branch.
+
+| Area               | Verdict | Evidence                                                                     | Change or reason kept                                                               | Verification                                   |
+| ------------------ | ------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Background work    | fix     | One pending provider batch shared by concurrent pickers                      | Load only for enabled visible pickers; no polling; search filters loaded results    | Hook and picker regression tests               |
+| Memory             | keep    | One in-flight promise cleared on settle; each source requested with limit 12 | No app-lifetime result cache; mounted hooks retain results                          | Source inspection and duplicate filtering test |
+| Scope/isolation    | keep    | Current webview/backend local history                                        | Closed-consumer guard prevents stale completion writes; no account cache            | Late completion and reopen test                |
+| Rendering/hot path | keep    | Query changes only recompute bounded results                                 | No per-keypress scans; partial failures are logged and do not hide successful peers | Search and partial-failure tests               |
+
+Native IPC already in progress can finish after closing; it cannot be cancelled by this hook. No retries or recurring timers are added. Provider raw transitions, parsing, cloud transport, and secondary-instance identity mechanisms are unchanged and are not claimed as tested.
+
+Performance verdict: blocked — live native CPU/RSS measurements were not performed; desktop control requires explicit opt-in. Automated lifecycle checks are reported in the PR.

--- a/src/scaffold/GlobalSpotlight/hooks/data/useExternalRecentPaths.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/data/useExternalRecentPaths.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useExternalRecentPaths } from "./useExternalRecentPaths";
+
+const mocks = vi.hoisted(() => ({
+  sources: Array.from({ length: 8 }, () => vi.fn()),
+}));
+vi.mock("@src/api/tauri/externalHistory", () => ({
+  codexAppRecentPaths: mocks.sources[0],
+  claudeCodeRecentPaths: mocks.sources[1],
+  cursorCliRecentPaths: mocks.sources[2],
+  opencodeRecentPaths: mocks.sources[3],
+  windsurfRecentPaths: mocks.sources[4],
+  warpRecentPaths: mocks.sources[5],
+  zcodeRecentPaths: mocks.sources[6],
+  qoderRecentPaths: mocks.sources[7],
+}));
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ warn: vi.fn() }),
+}));
+const existing = Array.from({ length: 10 }, (_, index) => `/saved/${index}`);
+function Probe({
+  enabled = true,
+  query = "",
+}: {
+  enabled?: boolean;
+  query?: string;
+}) {
+  const { recentPathRepos } = useExternalRecentPaths({
+    enabled,
+    existingRepoPaths: existing,
+    searchQuery: query,
+  });
+  return createElement(
+    "div",
+    null,
+    recentPathRepos.map((repo) => repo.fs_uri).join(",")
+  );
+}
+const record = (path: string) => ({
+  path,
+  lastUsedAt: "2026-09-07",
+  sessionCount: 1,
+});
+
+describe("external-app discovery lifecycle", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    mocks.sources.forEach((source) => source.mockReset().mockResolvedValue([]));
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+  it("loads with many saved repos, deduplicates paths, and filters without rescanning", async () => {
+    mocks.sources[0].mockResolvedValue([
+      record("/external"),
+      record("/saved/0"),
+    ]);
+    mocks.sources[1].mockResolvedValue([record("file:///external/")]);
+    await act(async () => root.render(createElement(Probe)));
+    expect(container.textContent).toBe("/external");
+    await act(async () =>
+      root.render(createElement(Probe, { query: "missing" }))
+    );
+    expect(container.textContent).toBe("");
+    mocks.sources.forEach((source) => expect(source).toHaveBeenCalledTimes(1));
+  });
+  it("shares a pending batch and retains successful apps when another fails", async () => {
+    mocks.sources[0].mockRejectedValue(new Error("unavailable"));
+    mocks.sources[1].mockResolvedValue([record("/available")]);
+    await act(async () =>
+      root.render(
+        createElement("div", null, createElement(Probe), createElement(Probe))
+      )
+    );
+    expect(container.textContent).toBe("/available/available");
+    mocks.sources.forEach((source) => expect(source).toHaveBeenCalledTimes(1));
+  });
+  it("does no work while closed or hidden and loads on visibility return", async () => {
+    await act(async () =>
+      root.render(createElement(Probe, { enabled: false }))
+    );
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    await act(async () => root.render(createElement(Probe)));
+    mocks.sources.forEach((source) => expect(source).not.toHaveBeenCalled());
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    await act(async () =>
+      document.dispatchEvent(new Event("visibilitychange"))
+    );
+    mocks.sources.forEach((source) => expect(source).toHaveBeenCalledTimes(1));
+  });
+  it("discards a late result after closing and revalidates on reopen", async () => {
+    let resolve!: (value: ReturnType<typeof record>[]) => void;
+    mocks.sources[0].mockReturnValueOnce(
+      new Promise((done) => {
+        resolve = done;
+      })
+    );
+    await act(async () => root.render(createElement(Probe)));
+    await act(async () =>
+      root.render(createElement(Probe, { enabled: false }))
+    );
+    await act(async () => resolve([record("/late")]));
+    expect(container.textContent).toBe("");
+    mocks.sources[0].mockResolvedValue([record("/fresh")]);
+    await act(async () => root.render(createElement(Probe)));
+    expect(container.textContent).toBe("/fresh");
+  });
+});

--- a/src/scaffold/GlobalSpotlight/hooks/data/useExternalRecentPaths.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/data/useExternalRecentPaths.ts
@@ -10,12 +10,12 @@ import {
   windsurfRecentPaths,
   zcodeRecentPaths,
 } from "@src/api/tauri/externalHistory";
+import { createLogger } from "@src/hooks/logger";
 import type { RepoItem } from "@src/scaffold/GlobalSpotlight/types";
 import { REPO_KIND } from "@src/store/repo";
 
 import { getWorkingDirectoryPathDisplayName } from "../../palettes/WorkingDirectoryPalette/workingDirectoryPathImport";
 
-export const EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD = 5;
 const EXTERNAL_RECENT_PATH_LIMIT = 12;
 
 interface RecentPathRecord {
@@ -71,6 +71,41 @@ function mergeRecentPaths(paths: RecentPathRecord[]): RecentPathRecord[] {
   );
 }
 
+// One bounded in-flight batch per webview, shared by simultaneously open pickers.
+// Results live only in mounted consumers; reopening revalidates app history.
+let inFlight: Promise<RecentPathRecord[]> | undefined;
+const log = createLogger("ExternalRecentPaths");
+const recentPathSources = {
+  codexAppRecentPaths,
+  claudeCodeRecentPaths,
+  cursorCliRecentPaths,
+  opencodeRecentPaths,
+  windsurfRecentPaths,
+  warpRecentPaths,
+  zcodeRecentPaths,
+  qoderRecentPaths,
+};
+
+function loadExternalRecentPaths(): Promise<RecentPathRecord[]> {
+  if (inFlight) return inFlight;
+  const sources = Object.entries(recentPathSources);
+  inFlight = Promise.allSettled(
+    sources.map(([, load]) => load({ limit: EXTERNAL_RECENT_PATH_LIMIT }))
+  )
+    .then((results) => {
+      const paths: RecentPathRecord[] = [];
+      results.forEach((result, index) => {
+        if (result.status === "fulfilled") paths.push(...result.value);
+        else log.warn(`Failed to load ${sources[index][0]}`, result.reason);
+      });
+      return mergeRecentPaths(paths);
+    })
+    .finally(() => {
+      inFlight = undefined;
+    });
+  return inFlight;
+}
+
 export function useExternalRecentPaths({
   enabled,
   existingRepoPaths,
@@ -83,45 +118,18 @@ export function useExternalRecentPaths({
 
     let cancelled = false;
 
-    Promise.all([
-      codexAppRecentPaths({ limit: EXTERNAL_RECENT_PATH_LIMIT }),
-      claudeCodeRecentPaths({ limit: EXTERNAL_RECENT_PATH_LIMIT }),
-      cursorCliRecentPaths({ limit: EXTERNAL_RECENT_PATH_LIMIT }),
-      opencodeRecentPaths({ limit: EXTERNAL_RECENT_PATH_LIMIT }),
-      windsurfRecentPaths({ limit: EXTERNAL_RECENT_PATH_LIMIT }),
-      warpRecentPaths({ limit: EXTERNAL_RECENT_PATH_LIMIT }),
-      zcodeRecentPaths({ limit: EXTERNAL_RECENT_PATH_LIMIT }),
-      qoderRecentPaths({ limit: EXTERNAL_RECENT_PATH_LIMIT }),
-    ]).then(
-      ([
-        codexPaths,
-        claudePaths,
-        cursorCliPaths,
-        opencodePaths,
-        windsurfPaths,
-        warpPaths,
-        zcodePaths,
-        qoderPaths,
-      ]) => {
-        if (!cancelled) {
-          setPaths(
-            mergeRecentPaths([
-              ...codexPaths,
-              ...claudePaths,
-              ...cursorCliPaths,
-              ...opencodePaths,
-              ...windsurfPaths,
-              ...warpPaths,
-              ...zcodePaths,
-              ...qoderPaths,
-            ])
-          );
-        }
-      }
-    );
+    const load = () => {
+      if (document.visibilityState === "hidden") return;
+      void loadExternalRecentPaths().then((recentPaths) => {
+        if (!cancelled) setPaths(recentPaths);
+      });
+    };
+    load();
+    document.addEventListener("visibilitychange", load);
 
     return () => {
       cancelled = true;
+      document.removeEventListener("visibilitychange", load);
     };
   }, [enabled]);
 

--- a/src/scaffold/GlobalSpotlight/hooks/index.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/index.ts
@@ -19,10 +19,7 @@ export { useAddWorkingDirectoryFlow } from "./forms/useAddWorkingDirectoryFlow";
 export type { AddWorkingDirectoryModalStage } from "./forms/useAddWorkingDirectoryFlow";
 
 // Shared data hooks (used by palettes and main Spotlight)
-export {
-  EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD,
-  useExternalRecentPaths,
-} from "./data/useExternalRecentPaths";
+export { useExternalRecentPaths } from "./data/useExternalRecentPaths";
 export { useSharedRepoList } from "./data/useSharedRepoList";
 export { useWorkspaceSwitch } from "./data/useWorkspaceSwitch";
 export type { WorkspaceSwitchEntry } from "./data/useWorkspaceSwitch";

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts
@@ -16,6 +16,8 @@ import { REPO_KIND } from "@src/store/repo";
 
 import { WorkingDirectoryDropdown } from "./WorkingDirectoryDropdown";
 
+const discovery = vi.hoisted(() => ({ enabled: vi.fn() }));
+
 const EXTERNAL_RECENT_PATH = "/Users/tester/Documents/GitHub/business-plan";
 
 vi.mock("react-i18next", () => ({
@@ -27,24 +29,30 @@ vi.mock("@src/api/tauri/repo", () => ({
 }));
 
 vi.mock("@src/scaffold/GlobalSpotlight/hooks", () => ({
-  EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD: 5,
   useSharedRepoList: () => ({
-    repos: [],
+    repos: Array.from({ length: 10 }, (_, index) => ({
+      id: `saved-${index}`,
+      name: `Saved ${index}`,
+      fs_uri: `/saved/${index}`,
+    })),
     filteredRepos: [],
     repoLoading: false,
     refreshReposForce: vi.fn(),
   }),
-  useExternalRecentPaths: () => ({
-    recentPathRepos: [
-      {
-        id: `external-recent:${EXTERNAL_RECENT_PATH}`,
-        name: "business-plan",
-        description: EXTERNAL_RECENT_PATH,
-        fs_uri: EXTERNAL_RECENT_PATH,
-        kind: REPO_KIND.FOLDER,
-      },
-    ],
-  }),
+  useExternalRecentPaths: (options: { enabled: boolean }) => {
+    discovery.enabled(options.enabled);
+    return {
+      recentPathRepos: [
+        {
+          id: `external-recent:${EXTERNAL_RECENT_PATH}`,
+          name: "business-plan",
+          description: EXTERNAL_RECENT_PATH,
+          fs_uri: EXTERNAL_RECENT_PATH,
+          kind: REPO_KIND.FOLDER,
+        },
+      ],
+    };
+  },
   useWorkspaceSwitch: () => ({
     workspaces: [],
     activateWorkspace: vi.fn(),
@@ -120,6 +128,13 @@ describe("WorkingDirectoryDropdown rows", () => {
 
   afterAll(() => {
     Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("loads external apps even with more than five saved repositories", () => {
+    discovery.enabled.mockClear();
+    renderDropdown();
+    expect(discovery.enabled).toHaveBeenLastCalledWith(true);
+    expect(externalRecentRow()).not.toBeNull();
   });
 
   it("keeps the path off the row instead of rendering it as a second line", () => {

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.tsx
@@ -48,7 +48,6 @@ import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import { ICONS } from "../../config";
 import {
-  EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD,
   type WorkspaceSwitchEntry,
   useExternalRecentPaths,
   useSharedRepoList,
@@ -309,7 +308,7 @@ export const WorkingDirectoryDropdown: React.FC<
   );
 
   const { recentPathRepos: externalRecentRepos } = useExternalRecentPaths({
-    enabled: isOpen && repos.length <= EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD,
+    enabled: isOpen,
     existingRepoPaths,
     searchQuery,
   });

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx
@@ -34,7 +34,6 @@ import {
 import { ICONS } from "../../config";
 import {
   type AddWorkingDirectoryModalStage,
-  EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD,
   useAddWorkingDirectoryFlow,
   useExternalRecentPaths,
   useSharedRepoList,
@@ -205,10 +204,7 @@ export const WorkingDirectoryPalette: React.FC<
   );
 
   const { recentPathRepos: externalRecentRepos } = useExternalRecentPaths({
-    enabled:
-      isOpen &&
-      !isManageMode &&
-      repos.length <= EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD,
+    enabled: isOpen && !isManageMode,
     existingRepoPaths,
     searchQuery,
   });


### PR DESCRIPTION
## Problem

The working-directory Spotlight and compact picker stop loading directories used by external apps once more than five repositories are saved. Concurrent open pickers can also issue duplicate discovery batches, and one failed provider currently discards the whole batch.

## Solution

Remove the saved-repository-count gate from both entry points. Share one pending recent-path batch per webview, defer discovery while hidden, filter search against loaded results, and discard closed-consumer completions. Log individual provider failures while preserving successful results. Keep normalization, saved-path exclusion, recency ordering, and the 12-result limit.

The “Used in other apps” translations are already present in develop and are not duplicated here.

## Potential risks

Opening a picker with a large saved list now invokes the existing external-history discovery APIs. Calls already in progress cannot be cancelled when the picker closes, but no polling or retry loop is added. No schema, persistence, IPC, provider-parser, or authentication changes are included. Revert this PR to restore the previous loading policy. Native CPU/RSS and real provider-history transitions were not measured.

## Verification

- `pnpm test -- src/scaffold/GlobalSpotlight/hooks/data/useExternalRecentPaths.test.ts src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts` — 8 tests passed, covering the large-list gate, shared requests, filtering, partial failures, visibility, late results, and reopen.
- `pnpm run typecheck:fast` — passed.
- Normal pre-commit hooks run changed-file ESLint/Prettier and staged TypeScript checks.
- `git diff --cached --check` — passed; inspected the isolated diff for unrelated edits, private paths, secrets and generated files.
- Live Tauri screenshots and runtime measurements were not run because desktop control requires explicit opt-in. The existing section's appearance is unchanged; this PR changes when its data loads.
