### PR TITLE
feat(spotlight): add concise responsive detail panes

### DIFF
--- a/docs/architecture-audit-2026-09-07/SpotlightDetailPane.md
+++ b/docs/architecture-audit-2026-09-07/SpotlightDetailPane.md
@@ -1,0 +1,20 @@
+# Spotlight detail panes architecture audit
+
+Acceptance: one reusable pane, no hover IPC, two-row metadata without timestamps, structured multi-folder chips, row-aligned side positioning and centered placement below the complete footer.
+
+| Layer          | Assessment                                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 1 Compilation  | Typecheck and targeted tests run in the isolated branch; exact results in PR verification                           |
+| 2 Structure    | Shared SpotlightDetailPane serves the generic row renderer and compact repo/workspace/branch/path peers             |
+| 3 Naming       | detailFolders describes typed folder members; anchorSelector identifies the enclosing surface                       |
+| 4 Semantics    | Row bounds determine side-pane vertical alignment; panel bounds determine horizontal clearance and footer placement |
+| 5 Defaults     | Existing session-card placements remain unchanged; right-or-bottom and outer panel classes are opt-in               |
+| 6 Boundaries   | Domain metadata stays in Spotlight; the generic hover primitive owns only geometry and lifecycle                    |
+| 7 Readability  | Pure sidePanePlacement helper owns geometry; structured members replace a primary-path-only preview                 |
+| 8 Wire         | Skipped: no backend, IPC, persistence, or schema change                                                             |
+| 9 Entry parity | Both multi-folder producers supply folder names and paths; shared and compact rows use the same pane                |
+| 10 Resolution  | Explicit metadata builds concise summaries; branch time-bearing descriptions/right labels are not used              |
+
+The previous pane used whole-panel vertical bounds, making its position static. A separate square scroller clipped the rounded inner card shadow. The new outer surface owns clipping and decoration; trigger and panel geometry have separate roles.
+
+No persisted data is modified. Reverting this PR restores prior hover behavior.

--- a/docs/frontend-ui-audit-2026-09-07/SpotlightDetailPane.md
+++ b/docs/frontend-ui-audit-2026-09-07/SpotlightDetailPane.md
@@ -1,0 +1,15 @@
+# Spotlight detail panes UI audit
+
+| Line                          | Element            | Verdict          | Reason                                                                                                                                              | Suggested change |
+| ----------------------------- | ------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `SpotlightDetailPane.tsx:69`  | Hover ownership    | keep with reason | Reuses HoverCardBase singleton and disposal; no per-palette overlay engine                                                                          | None             |
+| `SpotlightDetailPane.tsx:74`  | Surface            | keep with reason | The outer scrolling portal owns the same rounded border, background and shadow as Spotlight, preventing square clipping                             | None             |
+| `SpotlightDetailPane.tsx:84`  | Compact content    | keep with reason | Two visual rows; title and summary truncate; branch commit timestamps are excluded from metadata selection                                          | None             |
+| `SpotlightDetailPane.tsx:105` | Multi-folder chips | keep with reason | Reuses Tag and AnyIcon, receives typed folder members from both picker producers, and keeps full paths in titles                                    | None             |
+| `sidePanePlacement.ts:8`      | Geometry           | keep with reason | Measured panel bounds and viewport padding govern layout; right placement follows the row, below placement centers under the footer with an 8px gap | None             |
+
+Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.
+
+No config-level sweep candidate. Existing picker keyboard activation remains unchanged; focusable triggers also open detail panes. Blank and disabled items have no empty preview. Multi-folder chips occupy one horizontal scrolling row.
+
+Live screenshots and native light/dark/narrow-window inspection were not performed because desktop control requires explicit user opt-in. Automated tests cover row alignment, centered below-footer geometry, rounded surface ownership, concise metadata, structured folders, singleton behavior, Escape, scroll dismissal, resize and unmount.

--- a/docs/org2-performance-guard-2026-09-07/SpotlightDetailPane.md
+++ b/docs/org2-performance-guard-2026-09-07/SpotlightDetailPane.md
@@ -1,0 +1,12 @@
+# Spotlight detail panes lifecycle review
+
+| Area               | Verdict | Evidence                                                                                             | Change or reason kept                                                                     | Verification                             |
+| ------------------ | ------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------- |
+| Background work    | keep    | Existing delayed hover and close timers; one active pane                                             | No polling or hover IPC; hidden opening is suppressed                                     | Hover/unmount interaction tests          |
+| Memory             | keep    | One active owner, anchor reference and geometry; visible row subscriptions                           | Reference cleared on dismissal; no added global result cache                              | Singleton and cleanup tests              |
+| Scope/isolation    | keep    | Already-loaded local row metadata                                                                    | No cloud or provider identity cache                                                       | Source inspection                        |
+| Rendering/hot path | keep    | One observer for active pane, row and panel, plus active-only resize/scroll/key/visibility listeners | All disconnected on close; inactive-trigger unmount does not cancel another owner's close | Resize, scroll, Escape and unmount tests |
+
+Closed or hidden panes perform no repeated work. Multi-folder content reads existing workspace members; it does not scan folders or query Git. Keyboard focus support is opt-in with secondary placement.
+
+Performance verdict: blocked — native visible/hidden CPU/RSS measurements and Tauri visual verification were not run. Desktop control requires explicit opt-in. Unit/interaction results support lifecycle correctness, not a measured runtime improvement.

--- a/src/components/SessionHoverCard/HoverCardBase.tsx
+++ b/src/components/SessionHoverCard/HoverCardBase.tsx
@@ -11,6 +11,7 @@ import { createPortal } from "react-dom";
 
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
+import { getSidePanePlacement } from "./sidePanePlacement";
 import {
   allocateInstanceId,
   cancelPendingClose,
@@ -20,7 +21,10 @@ import {
   useHoverCardState,
 } from "./singletonStore";
 
-export type HoverCardPosition = "bottom-start" | "right-start";
+export type HoverCardPosition =
+  | "bottom-start"
+  | "right-start"
+  | "right-or-bottom";
 
 const DEFAULT_MOUSE_ENTER_DELAY_MS = 500;
 const DEFAULT_MOUSE_LEAVE_DELAY_MS = 100;
@@ -30,6 +34,10 @@ const TRIGGER_GAP_PX = 8;
 const CARD_LEAVE_DELAY_MS = 80;
 
 interface HoverCardBaseProps {
+  panelClassName?: string;
+  /** Optional enclosing panel to clear when placing a secondary pane. */
+  anchorSelector?: string;
+  zIndex?: number;
   cardId?: string | null;
   children: React.ReactElement;
   position?: HoverCardPosition;
@@ -48,6 +56,9 @@ interface HoverCardTriggerProps {
 }
 
 interface HoverCardPortalProps {
+  anchorSelector?: string;
+  panelClassName?: string;
+  zIndex?: number;
   instanceId: number;
   cardId: string;
   position: HoverCardPosition;
@@ -72,6 +83,8 @@ type ElementProps = {
   onMouseEnter?: (event: React.MouseEvent) => void;
   onMouseLeave?: (event: React.MouseEvent) => void;
   onClick?: (event: React.MouseEvent) => void;
+  onFocus?: (event: React.FocusEvent) => void;
+  onBlur?: (event: React.FocusEvent) => void;
   [key: string]: unknown;
 };
 
@@ -91,12 +104,24 @@ function computePortalStyle(
   rect: DOMRect,
   position: HoverCardPosition,
   cardWidth: number,
-  cardHeight: number
+  cardHeight: number,
+  viewport = getViewportSize(),
+  panelRect = rect
 ): React.CSSProperties {
   let top = 0;
   let left = 0;
 
-  const viewport = getViewportSize();
+  if (position === "right-or-bottom") {
+    return {
+      position: "fixed",
+      ...getSidePanePlacement(
+        rect,
+        { width: cardWidth, height: cardHeight },
+        viewport,
+        panelRect
+      ),
+    };
+  }
 
   if (position === "right-start") {
     top = rect.top;
@@ -153,7 +178,6 @@ const HoverCardTrigger: React.FC<HoverCardTriggerProps> = ({
   useEffect(() => {
     return () => {
       clearEnterTimer();
-      cancelPendingClose();
       scheduleClose(instanceId, 0);
     };
   }, [clearEnterTimer, instanceId]);
@@ -165,8 +189,19 @@ const HoverCardTrigger: React.FC<HoverCardTriggerProps> = ({
     const run = () => {
       enterTimerRef.current = null;
       const current = triggerRef.current;
-      if (!current) return;
-      openCard(instanceId, cardId, current.getBoundingClientRect(), position);
+      if (
+        !current ||
+        (position === "right-or-bottom" &&
+          document.visibilityState === "hidden")
+      )
+        return;
+      openCard(
+        instanceId,
+        cardId,
+        current.getBoundingClientRect(),
+        position,
+        current
+      );
     };
     if (mouseEnterDelay <= 0) {
       run();
@@ -203,6 +238,14 @@ const HoverCardTrigger: React.FC<HoverCardTriggerProps> = ({
       handleLeave();
       originalProps.onMouseLeave?.(event);
     },
+    onFocus: (event: React.FocusEvent) => {
+      if (position === "right-or-bottom") openWithDelay();
+      originalProps.onFocus?.(event);
+    },
+    onBlur: (event: React.FocusEvent) => {
+      if (position === "right-or-bottom") handleLeave();
+      originalProps.onBlur?.(event);
+    },
     onClick: (event: React.MouseEvent) => {
       clearEnterTimer();
       dismissHoverCard();
@@ -212,6 +255,9 @@ const HoverCardTrigger: React.FC<HoverCardTriggerProps> = ({
 };
 
 const HoverCardPortal: React.FC<HoverCardPortalProps> = ({
+  anchorSelector,
+  panelClassName,
+  zIndex = 1000,
   instanceId,
   cardId,
   position,
@@ -219,13 +265,29 @@ const HoverCardPortal: React.FC<HoverCardPortalProps> = ({
 }) => {
   const cardRef = useRef<HTMLDivElement | null>(null);
   const [cardSize, setCardSize] = useState({ width: 0, height: 0 });
-  const { triggerRect } = useHoverCardState();
+  const { triggerRect, anchorElement } = useHoverCardState();
+  const [geometry, setGeometry] = useState(() => ({
+    anchorRect: triggerRect,
+    panelRect: triggerRect,
+    viewport: getViewportSize(),
+  }));
 
   useLayoutEffect(() => {
     const node = cardRef.current;
     if (!node) return;
 
+    const panelElement = anchorSelector
+      ? anchorElement?.closest<HTMLElement>(anchorSelector)
+      : null;
     const updateCardSize = () => {
+      if (position === "right-or-bottom" && anchorElement) {
+        // Viewport changes can alter placement even when the anchor is unchanged.
+        setGeometry({
+          anchorRect: anchorElement.getBoundingClientRect(),
+          panelRect: (panelElement ?? anchorElement).getBoundingClientRect(),
+          viewport: getViewportSize(),
+        });
+      }
       const rect = node.getBoundingClientRect();
       setCardSize((current) =>
         current.width === rect.width && current.height === rect.height
@@ -237,23 +299,60 @@ const HoverCardPortal: React.FC<HoverCardPortalProps> = ({
     updateCardSize();
     const observer = new ResizeObserver(updateCardSize);
     observer.observe(node);
-    return () => observer.disconnect();
-  }, [cardId]);
+    if (position === "right-or-bottom" && anchorElement) {
+      observer.observe(anchorElement);
+      if (panelElement && panelElement !== anchorElement)
+        observer.observe(panelElement);
+      window.addEventListener("resize", updateCardSize);
+    }
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateCardSize);
+    };
+  }, [anchorElement, anchorSelector, cardId, position]);
+
+  useEffect(() => {
+    if (position !== "right-or-bottom") return;
+    const dismiss = () => dismissHoverCard();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") dismiss();
+    };
+    const onScroll = (event: Event) => {
+      if (
+        !(event.target instanceof Node) ||
+        !cardRef.current?.contains(event.target)
+      )
+        dismiss();
+    };
+    window.addEventListener("scroll", onScroll, true);
+    document.addEventListener("visibilitychange", dismiss);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("scroll", onScroll, true);
+      document.removeEventListener("visibilitychange", dismiss);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [position]);
 
   if (!triggerRect) return null;
 
   const style = computePortalStyle(
-    triggerRect,
+    position === "right-or-bottom"
+      ? (geometry.anchorRect ?? triggerRect)
+      : triggerRect,
     position,
     cardSize.width,
-    cardSize.height
+    cardSize.height,
+    position === "right-or-bottom" ? geometry.viewport : undefined,
+    geometry.panelRect ?? triggerRect
   );
 
   return createPortal(
     <div
       ref={cardRef}
       data-hover-card="true"
-      style={style}
+      className={panelClassName}
+      style={{ ...style, zIndex }}
       onMouseEnter={cancelPendingClose}
       onMouseLeave={() => scheduleClose(instanceId, CARD_LEAVE_DELAY_MS)}
     >
@@ -302,6 +401,9 @@ export const HoverCardRow: React.FC<HoverCardRowProps> = ({
 );
 
 const HoverCardBase: React.FC<HoverCardBaseProps> = ({
+  panelClassName,
+  anchorSelector,
+  zIndex,
   cardId,
   children,
   position = DEFAULT_POSITION,
@@ -329,6 +431,9 @@ const HoverCardBase: React.FC<HoverCardBaseProps> = ({
       </HoverCardTrigger>
       {isActiveOwner && (
         <HoverCardPortal
+          anchorSelector={anchorSelector}
+          panelClassName={panelClassName}
+          zIndex={zIndex}
           instanceId={instanceId}
           cardId={cardId}
           position={position}

--- a/src/components/SessionHoverCard/sidePanePlacement.test.ts
+++ b/src/components/SessionHoverCard/sidePanePlacement.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { getSidePanePlacement } from "./sidePanePlacement";
+
+const anchor = { left: 100, right: 700, top: 100, bottom: 500 };
+const size = { width: 320, height: 220 };
+
+describe("secondary pane placement", () => {
+  it("clears the parent panel on the right in wide windows", () => {
+    expect(
+      getSidePanePlacement(anchor, size, { width: 1200, height: 800 })
+    ).toMatchObject({ top: 100, left: 708 });
+  });
+  it("centers below the panel when the right side cannot fit", () => {
+    expect(
+      getSidePanePlacement(anchor, size, { width: 800, height: 800 })
+    ).toMatchObject({ top: 508, left: 240, maxHeight: 284 });
+  });
+  it("clears the 36px footer with the same 8px gap while side placement follows the row", () => {
+    const row = { left: 108, right: 692, top: 200, bottom: 232 };
+    const shell = { left: 100, right: 700, bottom: 500 + 8 + 36 };
+    expect(
+      getSidePanePlacement(row, size, { width: 800, height: 900 }, shell)
+    ).toMatchObject({ top: 552, left: 240 });
+    expect(
+      getSidePanePlacement(row, size, { width: 1200, height: 900 }, shell)
+    ).toMatchObject({ top: 200, left: 708 });
+  });
+  it("keeps a scrollable pane visible in very small windows", () => {
+    const result = getSidePanePlacement(anchor, size, {
+      width: 280,
+      height: 640,
+    });
+    expect(result.left).toBe(8);
+    expect(result.maxWidth).toBe(264);
+    expect(result.maxHeight).toBe(124);
+    expect(result.top + result.maxHeight).toBe(632);
+  });
+});

--- a/src/components/SessionHoverCard/sidePanePlacement.ts
+++ b/src/components/SessionHoverCard/sidePanePlacement.ts
@@ -1,0 +1,34 @@
+/** A secondary pane clears its parent panel, then falls below on narrow windows. */
+export function getSidePanePlacement(
+  anchor: Pick<DOMRect, "top" | "right" | "bottom" | "left">,
+  size: { width: number; height: number },
+  viewport: { width: number; height: number },
+  panel: Pick<DOMRect, "right" | "bottom" | "left"> = anchor
+) {
+  const padding = 8;
+  const gap = 8;
+  const fitsRight = panel.right + gap + size.width <= viewport.width - padding;
+  const top = fitsRight
+    ? Math.max(
+        padding,
+        Math.min(anchor.top, viewport.height - size.height - padding)
+      )
+    : panel.bottom + gap;
+  const maxHeight = Math.max(0, viewport.height - top - padding);
+  return {
+    width: "max-content" as const,
+    top,
+    left: fitsRight
+      ? panel.right + gap
+      : Math.max(
+          padding,
+          Math.min(
+            (panel.left + panel.right - size.width) / 2,
+            viewport.width - size.width - padding
+          )
+        ),
+    maxHeight,
+    maxWidth: Math.max(0, viewport.width - padding * 2),
+    overflowY: "auto" as const,
+  };
+}

--- a/src/components/SessionHoverCard/singletonStore.ts
+++ b/src/components/SessionHoverCard/singletonStore.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 
-type HoverCardPosition = "bottom-start" | "right-start";
+import type { HoverCardPosition } from "./HoverCardBase";
 
 const DEFAULT_POSITION: HoverCardPosition = "bottom-start";
 
@@ -16,6 +16,7 @@ export interface HoverCardState {
   activeCardId: string | null;
   /** Anchor rect for the active trigger — drives the portal positioning. */
   triggerRect: DOMRect | null;
+  anchorElement: HTMLElement | null;
   /** Position style for the active trigger. */
   position: HoverCardPosition;
   /** Bumped whenever the state changes; used by `useSyncExternalStore`. */
@@ -26,6 +27,7 @@ const initialState: HoverCardState = {
   activeInstanceId: null,
   activeCardId: null,
   triggerRect: null,
+  anchorElement: null,
   position: DEFAULT_POSITION,
   revision: 0,
 };
@@ -71,6 +73,7 @@ export function dismissHoverCard(): void {
     activeInstanceId: null,
     activeCardId: null,
     triggerRect: null,
+    anchorElement: null,
     position: DEFAULT_POSITION,
     revision: state.revision + 1,
   };
@@ -81,13 +84,15 @@ export function openCard(
   instanceId: number,
   cardId: string,
   triggerRect: DOMRect,
-  position: HoverCardPosition
+  position: HoverCardPosition,
+  anchorElement: HTMLElement | null = null
 ): void {
   cancelPendingClose();
   state = {
     activeInstanceId: instanceId,
     activeCardId: cardId,
     triggerRect,
+    anchorElement,
     position,
     revision: state.revision + 1,
   };
@@ -104,6 +109,7 @@ export function scheduleClose(instanceId: number, delayMs: number): void {
       activeInstanceId: null,
       activeCardId: null,
       triggerRect: null,
+      anchorElement: null,
       position: DEFAULT_POSITION,
       revision: state.revision + 1,
     };

--- a/src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.test.ts
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dismissHoverCard } from "@src/components/SessionHoverCard/singletonStore";
+
+import { SpotlightItemRow } from "./SpotlightItemRow";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("Spotlight row detail panes", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  const select = vi.fn();
+  const pane = () =>
+    document.querySelector<HTMLElement>("[data-spotlight-detail-pane]");
+  const hover = (id: string) => {
+    act(() => {
+      container
+        .querySelector(`[data-spotlight-item-id='${id}']`)!
+        .dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      vi.advanceTimersByTime(500);
+    });
+  };
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      }
+    );
+    select.mockClear();
+    container = document.createElement("div");
+    container.setAttribute("data-spotlight-detail-anchor", "");
+    document.body.append(container);
+    root = createRoot(container);
+    act(() =>
+      root.render(
+        createElement(
+          "div",
+          null,
+          ...[
+            {
+              id: "repo",
+              label: "Repository",
+              type: "repo" as const,
+              data: { fs_uri: "/work/repo", branch: "main" },
+            },
+            {
+              id: "folders",
+              label: "Workspace",
+              type: "repo" as const,
+              data: {
+                detailFolders: [
+                  { name: "client", path: "/work/client" },
+                  { name: "server", path: "/work/server" },
+                ],
+                contextMenuCopy: { path: "/work/client" },
+              },
+            },
+            {
+              id: "branch",
+              label: "feature",
+              type: "branch" as const,
+              desc: "Remote · 19m",
+              data: {
+                isRemote: true,
+                worktreePath: "/work/tree",
+                lastCommitDate: "2026-09-07T20:58:01+08:00",
+                rightLabel: "19m",
+              },
+            },
+          ].map((item, index) =>
+            createElement(SpotlightItemRow, {
+              key: item.id,
+              item,
+              index,
+              isSelected: false,
+              isKeyboardMode: false,
+              onHover: vi.fn(),
+              onSelect: select,
+              searchQuery: "",
+            })
+          )
+        )
+      )
+    );
+  });
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+      dismissHoverCard();
+    });
+    container.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+  it("shows loaded metadata after a delay, with only one pane across rows", () => {
+    expect(pane()).toBeNull();
+    hover("repo");
+    expect(pane()?.textContent).toContain("/work/repo");
+    expect(pane()?.textContent).toContain("main");
+    hover("branch");
+    expect(
+      document.querySelectorAll("[data-spotlight-detail-pane]")
+    ).toHaveLength(1);
+    expect(pane()?.textContent).toContain("/work/tree");
+    expect(pane()?.textContent).toContain("git.remote");
+    expect(pane()?.children).toHaveLength(2);
+    expect(pane()?.textContent).not.toContain("19m");
+    expect(pane()?.textContent).not.toContain("2026-09-07");
+    expect(select).not.toHaveBeenCalled();
+  });
+  it("shows multi-folder names as separate chips instead of the primary path", () => {
+    hover("folders");
+    const chips = pane()?.querySelector("[data-spotlight-folder-chips]");
+    expect(chips?.children).toHaveLength(2);
+    expect(chips?.textContent).toContain("client");
+    expect(chips?.textContent).toContain("server");
+    expect(pane()?.textContent).not.toContain("/work/client");
+    expect(chips?.firstElementChild?.getAttribute("title")).toBe(
+      "/work/client"
+    );
+    expect(pane()?.children).toHaveLength(2);
+  });
+  it("lets the pointer enter the pane without dismissing or selecting the row", () => {
+    hover("repo");
+    act(() => {
+      container
+        .querySelector("[data-spotlight-item-id='repo']")!
+        .dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
+      pane()!.parentElement!.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true })
+      );
+      vi.advanceTimersByTime(150);
+    });
+    expect(pane()).not.toBeNull();
+    act(() => pane()!.click());
+    expect(select).not.toHaveBeenCalled();
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      )
+    );
+    expect(pane()).toBeNull();
+  });
+  it("repositions below on resize and dismisses on list scroll", () => {
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
+      top: 50,
+      bottom: 294,
+      left: 40,
+      right: 700,
+      width: 660,
+      height: 244,
+    } as DOMRect);
+    const row = container.querySelector("[data-spotlight-item-id='repo']")!;
+    vi.spyOn(row, "getBoundingClientRect").mockReturnValue({
+      top: 150,
+      bottom: 182,
+      left: 48,
+      right: 692,
+      width: 644,
+      height: 32,
+    } as DOMRect);
+    vi.stubGlobal("innerWidth", 1200);
+    vi.stubGlobal("innerHeight", 800);
+    hover("repo");
+    expect(pane()?.parentElement?.style.left).toBe("708px");
+    expect(pane()?.parentElement?.style.top).toBe("150px");
+    expect(pane()?.parentElement?.classList.contains("rounded-2xl")).toBe(true);
+    expect(pane()?.classList.contains("shadow-xl")).toBe(false);
+    vi.stubGlobal("innerWidth", 600);
+    act(() => window.dispatchEvent(new Event("resize")));
+    expect(pane()?.parentElement?.style.top).toBe("302px");
+    act(() => container.dispatchEvent(new Event("scroll")));
+    expect(pane()).toBeNull();
+  });
+  it("cancels pending hover when the picker unmounts", () => {
+    act(() =>
+      container
+        .querySelector("[data-spotlight-item-id='repo']")!
+        .dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
+    );
+    act(() => root.render(null));
+    act(() => vi.advanceTimersByTime(1000));
+    expect(pane()).toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import AnyIcon from "@src/components/AnyIcon";
+import HoverCardBase from "@src/components/SessionHoverCard/HoverCardBase";
+import Tag from "@src/components/Tag";
+
+import { ICONS } from "../config";
+import { SPOTLIGHT_CONFIG, SPOTLIGHT_TOKENS } from "../constants";
+import type { SpotlightItem } from "../types";
+
+interface Props {
+  item: SpotlightItem;
+  children: React.ReactElement;
+}
+
+/** Shared across palettes. Details use already-loaded row metadata only. */
+export function SpotlightDetailPane({ item, children }: Props) {
+  const { t } = useTranslation();
+  const data = item.data;
+  if (data?.isHeader || data?.disabled) return children;
+  const isBranch = item.type === "branch" || data?.isRef === true;
+  const isCurrent =
+    data?.isCurrentSelection === true || data?.isCurrent === true;
+  const path = [
+    data?.contextMenuCopy?.path,
+    data?.fs_uri,
+    data?.repoPath,
+    data?.worktreePath,
+    data?.repo_url,
+    item.type === "file" ? data?.rightLabel : undefined,
+  ].find(
+    (value): value is string => typeof value === "string" && !!value.trim()
+  );
+  // Branch descriptions and right labels contain commit times, so the pane
+  // derives its summary from explicit branch metadata instead.
+  const description =
+    !isBranch && !path
+      ? [data?.description, data?.descTitle, item.description, item.desc].find(
+          (value): value is string =>
+            typeof value === "string" && !!value.trim()
+        )
+      : undefined;
+  const summary = [
+    isBranch
+      ? data?.isRemote
+        ? t("git.remote")
+        : t("filters.local")
+      : undefined,
+    isCurrent ? t("selectors.branch.labels.current") : undefined,
+    path,
+    typeof data?.branch === "string" ? data.branch : undefined,
+    description,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const folders = data?.detailFolders;
+  if (!summary && !folders?.length) return children;
+
+  return (
+    <HoverCardBase
+      key={item.id}
+      cardId={`spotlight-detail:${item.id}`}
+      position="right-or-bottom"
+      anchorSelector="[data-spotlight-detail-anchor], [role='menu']"
+      panelClassName="rounded-2xl border border-border-2 bg-bg-2 shadow-xl"
+      zIndex={SPOTLIGHT_CONFIG.containerZIndex + 1}
+      renderContent={() => (
+        <section
+          aria-label={item.label}
+          data-spotlight-detail-pane
+          className={`w-80 max-w-[calc(100vw-16px)] p-4 text-text-1 select-text ${SPOTLIGHT_TOKENS.subFontSize}`}
+        >
+          <div className="flex items-start gap-2 font-medium">
+            {item.icon && (
+              <AnyIcon
+                icon={item.icon}
+                size={SPOTLIGHT_TOKENS.iconSize}
+                className="shrink-0 text-text-2"
+              />
+            )}
+            <span className="min-w-0 truncate">{item.label}</span>
+          </div>
+          {folders?.length ? (
+            <div
+              className="mt-2 flex gap-1.5 overflow-x-auto pb-1"
+              data-spotlight-folder-chips
+            >
+              {folders.map((folder, index) => (
+                <span key={index} className="shrink-0" title={folder.path}>
+                  <Tag
+                    size="small"
+                    icon={<AnyIcon icon={ICONS.folder} size={12} />}
+                  >
+                    <span className="block max-w-48 truncate">
+                      {folder.name}
+                    </span>
+                  </Tag>
+                </span>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-2 truncate text-text-2" title={summary}>
+              {summary}
+            </div>
+          )}
+        </section>
+      )}
+    >
+      {children}
+    </HoverCardBase>
+  );
+}

--- a/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx
@@ -32,6 +32,7 @@ import {
 import { ICONS } from "../config";
 import { SPOTLIGHT_TOKENS } from "../constants";
 import type { SpotlightItem, SpotlightItemData } from "../types";
+import { SpotlightDetailPane } from "./SpotlightDetailPane";
 import { HighlightText } from "./highlightUtils";
 
 // ============ CONSTANTS ============
@@ -352,7 +353,7 @@ export const SpotlightItemRow = memo<SpotlightItemRowProps>(
       );
     }
 
-    return (
+    const row = (
       <div
         data-testid={testId}
         data-spotlight-item-index={index}
@@ -535,6 +536,7 @@ export const SpotlightItemRow = memo<SpotlightItemRowProps>(
         </div>
       </div>
     );
+    return <SpotlightDetailPane item={item}>{row}</SpotlightDetailPane>;
   }
 );
 

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx
@@ -38,6 +38,7 @@ import {
 } from "@src/icons";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
+import { SpotlightDetailPane } from "../../components/SpotlightDetailPane";
 import type { BranchItem } from "../../types";
 import { categorizeBranches } from "../../utils/branchUtils";
 import { BranchDropdownList } from "./BranchDropdownList";
@@ -69,40 +70,49 @@ const BranchRow: React.FC<BranchRowProps> = ({
   keyboardProps,
 }) => {
   return (
-    <button
-      type="button"
-      data-testid={`branch-dropdown-row-${branch.name}`}
-      {...keyboardProps}
-      className={`${DROPDOWN_CLASSES.item} ${
-        isCurrent ? DROPDOWN_CLASSES.itemSelected : DROPDOWN_CLASSES.itemHover
-      } w-full justify-start`}
+    <SpotlightDetailPane
+      item={{
+        id: branch.name,
+        label: branch.name,
+        type: "branch",
+        data: { ...branch, isCurrentSelection: isCurrent },
+      }}
     >
-      <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-        {isCurrent ? (
-          <HugeiconsIcon
-            icon={Tick01Icon}
-            data-icon="check"
-            size={DROPDOWN_ITEM.iconSize}
-            className="text-primary-6"
-          />
-        ) : branch.worktreePath ? (
-          <HugeiconsIcon
-            icon={FolderClosedIcon}
-            data-icon="folder"
-            size={DROPDOWN_ITEM.iconSize}
-            className="text-text-2"
-          />
-        ) : (
-          <HugeiconsIcon
-            icon={WorkflowCircle05Icon}
-            data-icon="git-branch"
-            size={DROPDOWN_ITEM.iconSize}
-            className="text-text-2"
-          />
-        )}
-      </span>
-      <span className="truncate">{branch.name}</span>
-    </button>
+      <button
+        type="button"
+        data-testid={`branch-dropdown-row-${branch.name}`}
+        {...keyboardProps}
+        className={`${DROPDOWN_CLASSES.item} ${
+          isCurrent ? DROPDOWN_CLASSES.itemSelected : DROPDOWN_CLASSES.itemHover
+        } w-full justify-start`}
+      >
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+          {isCurrent ? (
+            <HugeiconsIcon
+              icon={Tick01Icon}
+              data-icon="check"
+              size={DROPDOWN_ITEM.iconSize}
+              className="text-primary-6"
+            />
+          ) : branch.worktreePath ? (
+            <HugeiconsIcon
+              icon={FolderClosedIcon}
+              data-icon="folder"
+              size={DROPDOWN_ITEM.iconSize}
+              className="text-text-2"
+            />
+          ) : (
+            <HugeiconsIcon
+              icon={WorkflowCircle05Icon}
+              data-icon="git-branch"
+              size={DROPDOWN_ITEM.iconSize}
+              className="text-text-2"
+            />
+          )}
+        </span>
+        <span className="truncate">{branch.name}</span>
+      </button>
+    </SpotlightDetailPane>
   );
 };
 
@@ -300,6 +310,7 @@ export const BranchDropdown: React.FC<BranchDropdownProps> = ({
   return createPortal(
     <div
       ref={panelRef}
+      data-spotlight-detail-anchor
       data-spotlight-tabs-scope
       className={`${DROPDOWN_CLASSES.panel} fixed flex flex-col`}
       style={{

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts
@@ -116,6 +116,7 @@ describe("WorkingDirectoryDropdown rows", () => {
     act(() => root.unmount());
     container.remove();
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   afterAll(() => {
@@ -131,27 +132,34 @@ describe("WorkingDirectoryDropdown rows", () => {
     expect(row?.textContent).not.toContain(EXTERNAL_RECENT_PATH);
   });
 
-  it("reveals the path in a tooltip while the row is hovered", () => {
+  it("reveals the path in a detail pane while the row is hovered", () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      }
+    );
     renderDropdown();
 
     const row = externalRecentRow();
-    expect(document.querySelector(".native-tooltip")).toBeNull();
+    expect(document.querySelector("[data-spotlight-detail-pane]")).toBeNull();
 
     act(() => {
       row?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       vi.advanceTimersByTime(500);
     });
 
-    expect(document.querySelector(".native-tooltip")?.textContent).toBe(
-      EXTERNAL_RECENT_PATH
-    );
+    expect(
+      document.querySelector("[data-spotlight-detail-pane]")?.textContent
+    ).toContain(EXTERNAL_RECENT_PATH);
 
     act(() => {
       row?.dispatchEvent(new MouseEvent("mouseout", { bubbles: true }));
       vi.advanceTimersByTime(500);
     });
 
-    expect(document.querySelector(".native-tooltip")).toBeNull();
+    expect(document.querySelector("[data-spotlight-detail-pane]")).toBeNull();
   });
 
   it("marks the panel as a menu so side tooltips clear its border", () => {

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.tsx
@@ -28,7 +28,6 @@ import {
   DROPDOWN_ITEM,
   DROPDOWN_PANEL,
 } from "@src/components/Dropdown/tokens";
-import Tooltip from "@src/components/Tooltip";
 import {
   isSystemHomeRepoItem,
   isSystemPathRepoItem,
@@ -46,6 +45,7 @@ import {
 } from "@src/store/ui/workspaceFoldersAtom";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
+import { SpotlightDetailPane } from "../../components/SpotlightDetailPane";
 import { ICONS } from "../../config";
 import {
   EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD,
@@ -61,8 +61,6 @@ import { importWorkingDirectoryPath } from "./workingDirectoryPathImport";
 
 const LIST_MAX_HEIGHT = 360;
 const MIN_DROPDOWN_WIDTH = 320;
-/** Long enough that scanning the list doesn't flash a popup on every row. */
-const ROW_DETAIL_TOOLTIP_DELAY = 200;
 
 type DropdownRepoItem =
   | { kind: "repo"; repo: RepoItem }
@@ -108,43 +106,6 @@ interface WorkspaceRowProps {
   keyboardProps: ReturnType<UseDropdownListNavigationReturn["getItemProps"]>;
 }
 
-interface RowDetailTooltipProps {
-  /** Secondary text to reveal on hover — a repo description, or the
-   *  filesystem path for externally-used and open-path rows. Rows without
-   *  one render bare. */
-  detail?: string;
-  children: React.ReactElement;
-}
-
-/**
- * Reveals a row's secondary text on hover instead of on a second line.
- *
- * A second line overflows the token-fixed 32px row and pushes the list past
- * its max height, so the detail moves into a framed side tooltip. Tooltip
- * measures side placements from the enclosing `role="menu"` panel and offsets
- * by `DROPDOWN_PANEL.submenuGap`, so the popup clears the panel border by the
- * same distance a submenu would rather than landing on top of it.
- */
-const RowDetailTooltip: React.FC<RowDetailTooltipProps> = ({
-  detail,
-  children,
-}) => {
-  if (!detail) return children;
-
-  return (
-    <Tooltip
-      content={detail}
-      position="right"
-      mouseEnterDelay={ROW_DETAIL_TOOLTIP_DELAY}
-      framedPanel
-      framedPanelWide
-      smartPlacement
-    >
-      {children}
-    </Tooltip>
-  );
-};
-
 const RepoRow: React.FC<RepoRowProps> = ({
   repo,
   isCurrent,
@@ -156,11 +117,17 @@ const RepoRow: React.FC<RepoRowProps> = ({
     : isSystemPath || repo.kind === REPO_KIND.FOLDER
       ? ICONS.folder
       : ICONS.repo;
-  // System-path rows are self-describing ("Home"), so they keep no hover text.
-  const hoverDetail = isSystemPath ? undefined : repo.description;
 
   return (
-    <RowDetailTooltip detail={hoverDetail}>
+    <SpotlightDetailPane
+      item={{
+        id: repo.id,
+        label: repo.name,
+        icon: Icon,
+        type: "repo",
+        data: { ...repo, isCurrentSelection: isCurrent },
+      }}
+    >
       <button
         type="button"
         role="menuitem"
@@ -184,7 +151,7 @@ const RepoRow: React.FC<RepoRowProps> = ({
         </span>
         <span className="min-w-0 flex-1 truncate text-left">{repo.name}</span>
       </button>
-    </RowDetailTooltip>
+    </SpotlightDetailPane>
   );
 };
 
@@ -194,7 +161,7 @@ const WorkspaceRow: React.FC<WorkspaceRowProps> = ({
 }) => {
   const { workspace, isActive } = entry;
 
-  return (
+  const row = (
     <button
       type="button"
       role="menuitem"
@@ -221,13 +188,32 @@ const WorkspaceRow: React.FC<WorkspaceRowProps> = ({
       </span>
     </button>
   );
+  return (
+    <SpotlightDetailPane
+      item={{
+        id: workspace.workspaceId,
+        label: workspace.name,
+        icon: ICONS.workspace,
+        desc: entry.folderNames.join(", "),
+        data: {
+          isCurrentSelection: isActive,
+          detailFolders: workspace.folders.map((folder, index) => ({
+            name: entry.folderNames[index],
+            path: folder.folderPath,
+          })),
+        },
+      }}
+    >
+      {row}
+    </SpotlightDetailPane>
+  );
 };
 
 const OpenPathRow: React.FC<OpenPathRowProps> = ({ item, keyboardProps }) => {
   const Icon = typeof item.icon === "string" ? ICONS.folder : item.icon;
 
   return (
-    <RowDetailTooltip detail={item.desc}>
+    <SpotlightDetailPane item={item}>
       <button
         type="button"
         role="menuitem"
@@ -240,7 +226,7 @@ const OpenPathRow: React.FC<OpenPathRowProps> = ({ item, keyboardProps }) => {
         </span>
         <span className="min-w-0 flex-1 truncate text-left">{item.label}</span>
       </button>
-    </RowDetailTooltip>
+    </SpotlightDetailPane>
   );
 };
 

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/useWorkingDirectoryPaletteWorkspaces.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/useWorkingDirectoryPaletteWorkspaces.tsx
@@ -396,6 +396,10 @@ export function useWorkingDirectoryPaletteWorkspaces({
         icon: ICONS.workspace,
         type: "repo" as const,
         data: {
+          detailFolders: ws.folders.map((folder, index) => ({
+            name: names[index],
+            path: folder.folderPath,
+          })),
           isCurrentSelection: isActive,
           outsideOrgScope: isOutsideOrgScope(ws),
           updatedAt: ws.updatedAt,

--- a/src/scaffold/GlobalSpotlight/shared/types.ts
+++ b/src/scaffold/GlobalSpotlight/shared/types.ts
@@ -28,6 +28,8 @@ export type StatusType = "ongoing" | "completed" | "failed";
 
 /** Data object attached to SpotlightItem */
 export interface SpotlightItemData {
+  /** Structured members for multi-folder hover previews. */
+  detailFolders?: { name: string; path: string }[];
   /** Whether this is an open tab */
   isOpenTab?: boolean;
   /** Parent action ID for child items */

--- a/src/scaffold/GlobalSpotlight/shell/SpotlightShellChrome.tsx
+++ b/src/scaffold/GlobalSpotlight/shell/SpotlightShellChrome.tsx
@@ -121,7 +121,10 @@ export const SpotlightShellChrome: React.FC<SpotlightShellChromeProps> = ({
   };
 
   const panel = (
-    <div ref={inputHostRef}>
+    <div
+      ref={inputHostRef}
+      {...(footer == null ? { "data-spotlight-detail-anchor": true } : {})}
+    >
       <div
         className="overflow-hidden rounded-2xl border border-border-2 bg-bg-2 shadow-xl"
         style={{
@@ -137,7 +140,7 @@ export const SpotlightShellChrome: React.FC<SpotlightShellChromeProps> = ({
 
   const shell =
     footer != null ? (
-      <div className="flex w-full flex-col gap-2">
+      <div data-spotlight-detail-anchor className="flex w-full flex-col gap-2">
         {panel}
         <div className="flex w-full justify-center" onClick={refocusInput}>
           {footer}


### PR DESCRIPTION
## Problem

Spotlight rows provide little room to inspect repository, branch, workspace, and path details. Multi-folder entries expose only the primary path, hiding the other members.

## Solution

Add a shared two-row detail pane using the existing hover-card lifecycle. Show the item name plus a concise summary without branch timestamps; multi-folder entries show separate folder-name chips with full paths on hover.

On wide windows the pane clears Spotlight's right edge and aligns with the hovered row. In narrow windows it is centered beneath the complete footer pill bar with the same 8px gap used above that bar. The outer scrolling surface owns the rounded border and shadow, preventing square clipping. Wire the shared row renderer and compact repo/workspace/branch/path peers to the same pane.

## Potential risks

This extends the shared hover primitive with opt-in placement and surface styling; existing session-card defaults remain unchanged and are regression-tested. Metadata is already loaded: hovering adds no Git or IPC requests. Observers/listeners exist only for the active pane and are removed on close. Very short windows can constrain the space available below the footer. Native light/dark rendering, screenshots and CPU/RSS measurements remain unverified; desktop control was not authorized. No dependency, persistence, schema, or wire changes are included. Revert this PR to restore prior hover behavior.

## Verification

- `pnpm test -- src/components/SessionHoverCard/SessionHoverCard.test.ts src/components/SessionHoverCard/sidePanePlacement.test.ts src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.test.ts src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts src/scaffold/GlobalSpotlight/palettes/BranchPalette/__tests__/BranchPalette.test.ts` — 30 tests passed.
- Tests cover concise metadata, folder chips, row alignment, centered below-footer placement, shared rounded surface, singleton ownership, pointer transfer, Escape, scroll dismissal, resize and unmount.
- `pnpm run typecheck:fast` — passed.
- Normal pre-commit hooks run changed-file ESLint/Prettier and staged TypeScript checks.
- `git diff --cached --check` — passed; isolated diff inspected for scope, secrets, private paths and generated files.
- Native screenshots and performance measurements were not run; the checked-in lifecycle report records the limitation.

## Audit

UI: 0 fixes, 5 justified keeps, 0 abstractions. Architecture layers 1–7 and 9–10 reviewed; wire audit skipped because no wire change exists.
