### PR TITLE
fix(pr-checks): align pending indicators with status icons

### DIFF
--- a/src/components/PrCiStatusIndicator.tsx
+++ b/src/components/PrCiStatusIndicator.tsx
@@ -41,7 +41,12 @@ const PrCiStatusIndicator: React.FC<PrCiStatusIndicatorProps> = ({
       ) : status === "failure" ? (
         <HugeiconsIcon icon={Cancel01Icon} data-icon="x" {...iconProps} />
       ) : status === "pending" ? (
-        <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
+        <span
+          className="inline-flex shrink-0 items-center justify-center"
+          style={{ width: size, height: size }}
+        >
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
+        </span>
       ) : status === "none" ? (
         <HugeiconsIcon icon={MinusSignIcon} data-icon="minus" {...iconProps} />
       ) : (

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts
@@ -288,7 +288,7 @@ describe("WorkItemAttachmentControl", () => {
       expect(
         dialog
           ?.querySelector(
-            '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/44"] span'
+            '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/44"] .animate-pulse'
           )
           ?.classList.contains("animate-pulse")
       ).toBe(true);

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/__tests__/BranchPullRequestPicker.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/__tests__/BranchPullRequestPicker.test.ts
@@ -242,7 +242,13 @@ it.each(["spotlight", "dropdown"] as const)(
           glyphs[index]
         );
       } else {
-        expect(indicator.querySelector(".bg-current")).not.toBeNull();
+        const dot = indicator.querySelector(".bg-current");
+        expect(dot).not.toBeNull();
+        expect(dot?.parentElement?.style.width).toBe("16px");
+        expect(dot?.parentElement?.style.height).toBe("16px");
+        expect(dot?.parentElement?.classList.contains("justify-center")).toBe(
+          true
+        );
       }
       if (presentation === "dropdown") {
         expect(row.lastElementChild).toBe(indicator);


### PR DESCRIPTION
## Problem

In-progress PR checks render as a 6px dot while the completed check/cross icons occupy the configured 16px slot. The differing widths misalign the status column in Spotlight and compact PR pickers.

## Solution

Center the pending dot inside a square using the same configured icon size. Preserve the existing dot, animation, color and accessible status label. Add picker assertions for the matching slot in both presentations.

## Potential risks

The shared simple-appearance pending indicator now reserves the configured icon width and height, so other simple consumers gain consistent spacing too. Circled appearance and status data are unchanged. No timing, network, persistence or dependency behavior changes. Native visual inspection was not run; revert the wrapper change to restore the previous spacing.

## Verification

- `pnpm test -- src/scaffold/GlobalSpotlight/palettes/BranchPalette/__tests__/BranchPullRequestPicker.test.ts` — 4 tests passed, including all status states in both picker presentations and the pending indicator's 16px centered slot.
- `pnpm run typecheck:fast` — passed.
- Normal pre-commit hooks run changed-file ESLint/Prettier and staged TypeScript checks.
- `git diff --cached --check` — passed; only the indicator and its picker regression assertions are changed.
- No live screenshot was captured because desktop control requires explicit opt-in.

- CI follow-up: updated the work-item picker assertion to select the pulsing dot inside its new alignment container. `pnpm test -- src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts src/scaffold/GlobalSpotlight/palettes/BranchPalette/__tests__/BranchPullRequestPicker.test.ts` — all 9 tests passed. Normal commit hooks (Oxlint, ESLint, Prettier and staged TypeScript checks) passed. The full suite is delegated to the new CI run; the previous run had exactly these two assertion failures.
