### PR TITLE
fix(org-picker): show selected organization in scope labels

### DIFF
--- a/src/features/SessionCreator/components/SessionInfoLine.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine.tsx
@@ -37,7 +37,10 @@ import {
   isSystemHomeRepoItem,
   isSystemPathRepoItem,
 } from "@src/features/SessionCreator/utils/systemPathSource";
-import { useActiveCloudOrgRepoFilter } from "@src/features/TeamCollaboration/useActiveCloudOrgRepoFilter";
+import {
+  useActiveCloudOrgName,
+  useActiveCloudOrgRepoFilter,
+} from "@src/features/TeamCollaboration/useActiveCloudOrgRepoFilter";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import { BranchPalette } from "@src/scaffold/GlobalSpotlight/palettes/BranchPalette";
 import { BranchDropdown } from "@src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown";
@@ -380,6 +383,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   // the pickers group rows into "This org" / "Outside this org" instead,
   // and out-of-scope repos are legitimate picks (they simply launch
   // without the org tag — autoTagLaunchedSessionToActiveCloudOrg guards).
+  const activeCloudOrgName = useActiveCloudOrgName();
   const orgScopeRepoFilter = useActiveCloudOrgRepoFilter();
 
   const handleBranchSelect = useCallback(
@@ -640,6 +644,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
           placement={dropdownDirection === "up" ? "top" : "bottom"}
           leadingRepos={systemPathSourceItems}
           repoFilter={orgScopeRepoFilter ?? undefined}
+          orgScopeName={activeCloudOrgName ?? undefined}
         />
       ) : (
         <WorkingDirectoryPalette
@@ -651,6 +656,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
           hideActionClose
           leadingRepos={systemPathSourceItems}
           repoFilter={orgScopeRepoFilter ?? undefined}
+          orgScopeName={activeCloudOrgName ?? undefined}
         />
       )}
 

--- a/src/features/TeamCollaboration/useActiveCloudOrgRepoFilter.ts
+++ b/src/features/TeamCollaboration/useActiveCloudOrgRepoFilter.ts
@@ -1,7 +1,11 @@
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
 
-import { sidebarActiveCloudOrgIdAtom } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
+import {
+  getSidebarActiveCloudOrg,
+  org2CloudOrgsAtom,
+  sidebarActiveCloudOrgIdAtom,
+} from "@src/features/Org2Cloud/org2CloudOrgsAtom";
 import { org2CloudRepoScopesAtom } from "@src/features/Org2Cloud/org2CloudSyncAtoms";
 
 import {
@@ -11,6 +15,16 @@ import {
 import { useShareableScopeKeyVersion } from "./repoScopeResolver";
 
 export type OrgScopeRepoPredicate = (repo: OrgScopeFilterRepo) => boolean;
+
+export function useActiveCloudOrgName(): string | null {
+  const activeCloudOrgId = useAtomValue(sidebarActiveCloudOrgIdAtom);
+  const cloudOrgs = useAtomValue(org2CloudOrgsAtom);
+
+  return useMemo(
+    () => getSidebarActiveCloudOrg(activeCloudOrgId, cloudOrgs)?.name ?? null,
+    [activeCloudOrgId, cloudOrgs]
+  );
+}
 
 export function useActiveCloudOrgRepoFilter(): OrgScopeRepoPredicate | null {
   const activeCloudOrgId = useAtomValue(sidebarActiveCloudOrgIdAtom);

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1626,8 +1626,9 @@
         "systemPaths": "Systempfade",
         "usedElsewhere": "In anderen Apps verwendet",
         "workspace": "Arbeitsverzeichnis",
-        "thisOrg": "Dieses Arbeitsverzeichnis",
-        "outsideOrg": "Außerhalb dieses Arbeitsverzeichnisses"
+        "thisOrg": "Diese Organisation",
+        "outsideOrg": "Außerhalb dieser Organisation",
+        "outsideNamedOrg": "Außerhalb von {{org}}"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1591,8 +1591,9 @@
         "systemPaths": "System Paths",
         "usedElsewhere": "Used in other apps",
         "workspace": "Working Directory",
-        "thisOrg": "This working directory",
-        "outsideOrg": "Outside this working directory"
+        "thisOrg": "This organization",
+        "outsideOrg": "Outside this organization",
+        "outsideNamedOrg": "Outside {{org}}"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1626,8 +1626,9 @@
         "systemPaths": "Rutas del sistema",
         "usedElsewhere": "Usado en otras aplicaciones",
         "workspace": "Directorio de trabajo",
-        "thisOrg": "Este directorio de trabajo",
-        "outsideOrg": "Fuera de este directorio de trabajo"
+        "thisOrg": "Esta organización",
+        "outsideOrg": "Fuera de esta organización",
+        "outsideNamedOrg": "Fuera de {{org}}"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1626,8 +1626,9 @@
         "systemPaths": "Chemins système",
         "usedElsewhere": "Utilisé dans d’autres applications",
         "workspace": "Répertoire de travail",
-        "thisOrg": "Ce répertoire de travail",
-        "outsideOrg": "En dehors de ce répertoire de travail"
+        "thisOrg": "Cette organisation",
+        "outsideOrg": "En dehors de cette organisation",
+        "outsideNamedOrg": "En dehors de {{org}}"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1625,8 +1625,9 @@
         "systemPaths": "システムパス",
         "usedElsewhere": "他のアプリで使用",
         "workspace": "作業ディレクトリ",
-        "thisOrg": "この作業ディレクトリ",
-        "outsideOrg": "この作業ディレクトリの外"
+        "thisOrg": "この組織",
+        "outsideOrg": "この組織の外",
+        "outsideNamedOrg": "{{org}} の外"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1625,8 +1625,9 @@
         "systemPaths": "시스템 경로",
         "usedElsewhere": "다른 앱에서 사용됨",
         "workspace": "작업 디렉터리",
-        "thisOrg": "이 작업 디렉터리",
-        "outsideOrg": "이 작업 디렉터리 외부"
+        "thisOrg": "이 조직",
+        "outsideOrg": "이 조직 외부",
+        "outsideNamedOrg": "{{org}} 외부"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1644,8 +1644,9 @@
         "systemPaths": "Ścieżki systemowe",
         "usedElsewhere": "Używane w innych aplikacjach",
         "workspace": "Katalog roboczy",
-        "thisOrg": "Ten katalog roboczy",
-        "outsideOrg": "Poza tym katalogiem roboczym"
+        "thisOrg": "Ta organizacja",
+        "outsideOrg": "Poza tą organizacją",
+        "outsideNamedOrg": "Poza {{org}}"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1626,8 +1626,9 @@
         "systemPaths": "Caminhos do sistema",
         "usedElsewhere": "Usado em outros aplicativos",
         "workspace": "Diretório de trabalho",
-        "thisOrg": "Este diretório de trabalho",
-        "outsideOrg": "Fora deste diretório de trabalho"
+        "thisOrg": "Esta organização",
+        "outsideOrg": "Fora desta organização",
+        "outsideNamedOrg": "Fora de {{org}}"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1644,8 +1644,9 @@
         "systemPaths": "Системные пути",
         "usedElsewhere": "Используется в других приложениях",
         "workspace": "Рабочий каталог",
-        "thisOrg": "Этот рабочий каталог",
-        "outsideOrg": "За пределами этого рабочего каталога"
+        "thisOrg": "Эта организация",
+        "outsideOrg": "Вне этой организации",
+        "outsideNamedOrg": "Вне {{org}}"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1627,8 +1627,9 @@
         "systemPaths": "Sistem Yolları",
         "usedElsewhere": "Diğer uygulamalarda kullanıldı",
         "workspace": "Çalışma dizini",
-        "thisOrg": "Bu çalışma dizini",
-        "outsideOrg": "Bu çalışma dizininin dışında"
+        "thisOrg": "Bu kuruluş",
+        "outsideOrg": "Bu kuruluşun dışında",
+        "outsideNamedOrg": "{{org}} dışında"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1625,8 +1625,9 @@
         "systemPaths": "Đường dẫn hệ thống",
         "usedElsewhere": "Được dùng trong các ứng dụng khác",
         "workspace": "Thư mục làm việc",
-        "thisOrg": "Thư mục làm việc này",
-        "outsideOrg": "Ngoài thư mục làm việc này"
+        "thisOrg": "Tổ chức này",
+        "outsideOrg": "Bên ngoài tổ chức này",
+        "outsideNamedOrg": "Bên ngoài {{org}}"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1640,8 +1640,9 @@
         "systemPaths": "系統路徑",
         "usedElsewhere": "在其他應用程式中使用",
         "workspace": "工作目錄",
-        "thisOrg": "此工作目錄",
-        "outsideOrg": "此工作目錄之外"
+        "thisOrg": "此組織",
+        "outsideOrg": "此組織之外",
+        "outsideNamedOrg": "{{org}}之外"
       },
       "tabs": {},
       "addOptions": {

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1545,8 +1545,9 @@
         "systemPaths": "系统路径",
         "usedElsewhere": "在其他应用中使用",
         "workspace": "工作目录",
-        "thisOrg": "此工作目录",
-        "outsideOrg": "此工作目录之外"
+        "thisOrg": "此组织",
+        "outsideOrg": "此组织之外",
+        "outsideNamedOrg": "{{org}}之外"
       },
       "tabs": {},
       "addOptions": {

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, createElement, createRef } from "react";
+import { type ComponentProps, act, createElement, createRef } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import {
   afterAll,
@@ -17,9 +17,28 @@ import { REPO_KIND } from "@src/store/repo";
 import { WorkingDirectoryDropdown } from "./WorkingDirectoryDropdown";
 
 const EXTERNAL_RECENT_PATH = "/Users/tester/Documents/GitHub/business-plan";
+const SAVED_REPOS = [
+  {
+    id: "inside-org",
+    name: "Inside org",
+    fs_uri: "/inside-org",
+    kind: REPO_KIND.GIT,
+  },
+  {
+    id: "outside-org",
+    name: "Outside org",
+    fs_uri: "/outside-org",
+    kind: REPO_KIND.GIT,
+  },
+];
 
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, options?: { org?: string }) =>
+      key === "selectors.repo.sections.outsideNamedOrg"
+        ? `Outside ${options?.org}`
+        : key,
+  }),
 }));
 
 vi.mock("@src/api/tauri/repo", () => ({
@@ -29,8 +48,8 @@ vi.mock("@src/api/tauri/repo", () => ({
 vi.mock("@src/scaffold/GlobalSpotlight/hooks", () => ({
   EXTERNAL_RECENT_PATH_WORKSPACE_THRESHOLD: 5,
   useSharedRepoList: () => ({
-    repos: [],
-    filteredRepos: [],
+    repos: SAVED_REPOS,
+    filteredRepos: SAVED_REPOS,
     repoLoading: false,
     refreshReposForce: vi.fn(),
   }),
@@ -83,7 +102,9 @@ describe("WorkingDirectoryDropdown rows", () => {
     IS_REACT_ACT_ENVIRONMENT?: boolean;
   };
 
-  const renderDropdown = () => {
+  const renderDropdown = (
+    overrides: Partial<ComponentProps<typeof WorkingDirectoryDropdown>> = {}
+  ) => {
     act(() => {
       root.render(
         createElement(WorkingDirectoryDropdown, {
@@ -91,6 +112,7 @@ describe("WorkingDirectoryDropdown rows", () => {
           onClose: vi.fn(),
           onSelect: vi.fn(),
           anchorRef: createRef<HTMLElement>(),
+          ...overrides,
         })
       );
     });
@@ -160,5 +182,16 @@ describe("WorkingDirectoryDropdown rows", () => {
     const panel = document.querySelector('[role="menu"]');
     expect(panel).not.toBeNull();
     expect(externalRecentRow()?.closest('[role="menu"]')).toBe(panel);
+  });
+
+  it("labels organization-scoped sections with the selected org name", () => {
+    renderDropdown({
+      orgScopeName: "ORG2 OSS",
+      repoFilter: (repo) => repo.fs_uri === "/inside-org",
+    });
+
+    expect(document.body.textContent).toContain("ORG2 OSS");
+    expect(document.body.textContent).toContain("Outside ORG2 OSS");
+    expect(document.body.textContent).not.toContain("working directory");
   });
 });

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.tsx
@@ -260,6 +260,8 @@ interface WorkingDirectoryDropdownProps {
     repo_url?: string | null;
     fs_uri?: string | null;
   }) => boolean;
+  /** Display name for the organization represented by `repoFilter`. */
+  orgScopeName?: string;
 }
 
 export const WorkingDirectoryDropdown: React.FC<
@@ -273,6 +275,7 @@ export const WorkingDirectoryDropdown: React.FC<
   placement = "bottom",
   leadingRepos = [],
   repoFilter,
+  orgScopeName,
 }) => {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -527,14 +530,24 @@ export const WorkingDirectoryDropdown: React.FC<
       if (thisOrgItems.length > 0) {
         nextSections.push({
           key: "thisOrg",
-          label: t("selectors.repo.sections.thisOrg", "This org"),
+          label:
+            orgScopeName ??
+            t("selectors.repo.sections.thisOrg", "This organization"),
           items: thisOrgItems,
         });
       }
       if (outsideOrgItems.length > 0) {
         nextSections.push({
           key: "outsideOrg",
-          label: t("selectors.repo.sections.outsideOrg", "Outside this org"),
+          label: orgScopeName
+            ? t("selectors.repo.sections.outsideNamedOrg", {
+                org: orgScopeName,
+                defaultValue: "Outside {{org}}",
+              })
+            : t(
+                "selectors.repo.sections.outsideOrg",
+                "Outside this organization"
+              ),
           items: outsideOrgItems,
         });
       }
@@ -592,6 +605,7 @@ export const WorkingDirectoryDropdown: React.FC<
     outsideOrgWorkspaceIds,
     leadingRepos,
     openPathItem,
+    orgScopeName,
     searchQuery,
     t,
   ]);

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx
@@ -73,6 +73,7 @@ export const WorkingDirectoryPalette: React.FC<
   hideActionClose = false,
   leadingRepos = [],
   repoFilter,
+  orgScopeName,
   onGoBackToParent,
 }) => {
   const { t } = useTranslation();
@@ -127,13 +128,17 @@ export const WorkingDirectoryPalette: React.FC<
         "workspaceForm.multiRepoWorkspace",
         "Multi-Repo Working Directory"
       ),
-      sectionThisOrgLabel: t("selectors.repo.sections.thisOrg", "This org"),
-      sectionOutsideOrgLabel: t(
-        "selectors.repo.sections.outsideOrg",
-        "Outside this org"
-      ),
+      sectionThisOrgLabel:
+        orgScopeName ??
+        t("selectors.repo.sections.thisOrg", "This organization"),
+      sectionOutsideOrgLabel: orgScopeName
+        ? t("selectors.repo.sections.outsideNamedOrg", {
+            org: orgScopeName,
+            defaultValue: "Outside {{org}}",
+          })
+        : t("selectors.repo.sections.outsideOrg", "Outside this organization"),
     }),
-    [t, isManageMode, switchPathLabel]
+    [t, isManageMode, switchPathLabel, orgScopeName]
   );
 
   const wasOpenRef = React.useRef(false);

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/types.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/types.ts
@@ -41,6 +41,8 @@ export interface WorkingDirectoryPaletteProps extends BasePaletteProps {
     repo_url?: string | null;
     fs_uri?: string | null;
   }) => boolean;
+  /** Display name for the organization represented by `repoFilter`. */
+  orgScopeName?: string;
 }
 
 export interface WorkingDirectoryPaletteText {


### PR DESCRIPTION
## Problem

Organization-scoped working-directory pickers label their repository groups with working-directory terminology. This is misleading after organizations were migrated away from workspace naming, and it hides which selected organization defines the scope.

## Solution

Resolve the active cloud organization name from the authoritative organization roster and pass it to both the anchored dropdown and Spotlight picker. In-scope rows now use the selected organization name directly, while out-of-scope rows use a localized `Outside {{org}}` label, such as `Outside ORG2 OSS`. Generic organization fallbacks remain for the brief state where the roster name is unavailable. All 13 supported common locales were updated.

## Potential risks

The change is presentation-only: it does not alter repository filtering, organization membership, persistence, IPC, or wire contracts. The main residual risk is translation phrasing for organization names in non-English locales; every locale contains the same interpolation contract and valid JSON. If the active organization roster is temporarily unavailable, the UI deliberately falls back to localized generic organization wording.

## Verification

- `pnpm test -- src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts` — passed, 4 tests
- `pnpm exec eslint <six changed TypeScript files> --max-warnings 0 --report-unused-disable-directives` — passed
- `pnpm typecheck:fast` — passed
- `pnpm run lint` — passed
- `pnpm run check:circular` — passed, no circular dependencies across 6,598 modules
- `pnpm run check:test-placement` — passed across 519 directories
- Parsed all 13 changed `common.json` files with `JSON.parse` — passed
- Confirmed `outsideNamedOrg` exists in all 13 supported locales
- `node scripts/quality/check-missing-i18n-keys.mjs --namespace common --prefix selectors.repo.sections` — reports an existing unrelated `recent` key gap in 11 locales; the new key has no missing locale
- `git diff --check` — passed
- No screenshot was captured because desktop computer control was not authorized for this source task; the exact `Outside ORG2 OSS` output is covered by the regression test
- Full test suite was not run; the owning picker test and project-wide static checks were run instead
- Integrated latest develop after #1386–#1389 merged; resolved the shared dropdown test fixture to retain both ten saved repositories and named organization cases. `pnpm test -- src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/WorkingDirectoryDropdown.test.ts` — 5 tests passed; `pnpm run typecheck:fast` and normal commit hooks passed.
