### PR TITLE
fix(spotlight): stack multi-repo card details

### DIFF
--- a/docs/frontend-ui-audit-2026-09-07/SpotlightMultiRepoDetails.md
+++ b/docs/frontend-ui-audit-2026-09-07/SpotlightMultiRepoDetails.md
@@ -1,0 +1,12 @@
+# Spotlight multi-repo details UI audit
+
+| Line                         | Element                    | Verdict          | Reason                                                                                                                    | Suggested change |
+| ---------------------------- | -------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `SpotlightDetailPane.tsx:74` | Stacked repository details | keep with reason | Passive layout uses standard spacing tokens; each repository follows the existing individual card name/path structure     | None             |
+| `SpotlightDetailPane.tsx:78` | Repository icon            | keep with reason | Uses AnyIcon, ICONS.repo, and the shared Spotlight icon size                                                              | None             |
+| `SpotlightDetailPane.tsx:85` | Repository path            | keep with reason | Matches individual card text styling and truncation; title preserves access to the full path                              | None             |
+| `SpotlightDetailPane.tsx:68` | Card container             | keep with reason | Existing HoverCardBase owns interaction; the section retains its accessible workspace label and viewport width constraint | None             |
+
+Verdict totals: **0 fix**, **4 keep with reason**, **0 abstract**.
+
+Verification: focused SpotlightDetailPane Vitest suite passed (5 tests). Desktop visual verification was not run because computer control was not requested.

--- a/src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.test.ts
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.test.ts
@@ -118,17 +118,19 @@ describe("Spotlight row detail panes", () => {
     expect(pane()?.textContent).not.toContain("2026-09-07");
     expect(select).not.toHaveBeenCalled();
   });
-  it("shows multi-folder names as separate chips instead of the primary path", () => {
+  it("stacks each repository name and visible path without a workspace heading", () => {
     hover("folders");
-    const chips = pane()?.querySelector("[data-spotlight-folder-chips]");
-    expect(chips?.children).toHaveLength(2);
-    expect(chips?.textContent).toContain("client");
-    expect(chips?.textContent).toContain("server");
-    expect(pane()?.textContent).not.toContain("/work/client");
-    expect(chips?.firstElementChild?.getAttribute("title")).toBe(
-      "/work/client"
-    );
-    expect(pane()?.children).toHaveLength(2);
+    const repos = pane()?.querySelector("[data-spotlight-repo-details]");
+    expect(repos?.children).toHaveLength(2);
+    for (const [index, name] of ["client", "server"].entries()) {
+      const detail = repos!.children[index];
+      expect(detail.children[0].textContent).toBe(name);
+      expect(detail.children[0].querySelector("svg")).not.toBeNull();
+      expect(detail.children[1].textContent).toBe(`/work/${name}`);
+      expect(detail.children[1].getAttribute("title")).toBe(`/work/${name}`);
+    }
+    expect(pane()?.textContent).not.toContain("Workspace");
+    expect(pane()?.querySelector("[data-spotlight-folder-chips]")).toBeNull();
   });
   it("lets the pointer enter the pane without dismissing or selecting the row", () => {
     hover("repo");

--- a/src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
 import HoverCardBase from "@src/components/SessionHoverCard/HoverCardBase";
-import Tag from "@src/components/Tag";
 
 import { ICONS } from "../config";
 import { SPOTLIGHT_CONFIG, SPOTLIGHT_TOKENS } from "../constants";
@@ -71,38 +70,43 @@ export function SpotlightDetailPane({ item, children }: Props) {
           data-spotlight-detail-pane
           className={`w-80 max-w-[calc(100vw-16px)] p-4 text-text-1 select-text ${SPOTLIGHT_TOKENS.subFontSize}`}
         >
-          <div className="flex items-start gap-2 font-medium">
-            {item.icon && (
-              <AnyIcon
-                icon={item.icon}
-                size={SPOTLIGHT_TOKENS.iconSize}
-                className="shrink-0 text-text-2"
-              />
-            )}
-            <span className="min-w-0 truncate">{item.label}</span>
-          </div>
           {folders?.length ? (
-            <div
-              className="mt-2 flex gap-1.5 overflow-x-auto pb-1"
-              data-spotlight-folder-chips
-            >
+            <div className="flex flex-col gap-4" data-spotlight-repo-details>
               {folders.map((folder, index) => (
-                <span key={index} className="shrink-0" title={folder.path}>
-                  <Tag
-                    size="small"
-                    icon={<AnyIcon icon={ICONS.folder} size={12} />}
+                <div key={index}>
+                  <div className="flex items-start gap-2 font-medium">
+                    <AnyIcon
+                      icon={ICONS.repo}
+                      size={SPOTLIGHT_TOKENS.iconSize}
+                      className="shrink-0 text-text-2"
+                    />
+                    <span className="min-w-0 truncate">{folder.name}</span>
+                  </div>
+                  <div
+                    className="mt-2 truncate text-text-2"
+                    title={folder.path}
                   >
-                    <span className="block max-w-48 truncate">
-                      {folder.name}
-                    </span>
-                  </Tag>
-                </span>
+                    {folder.path}
+                  </div>
+                </div>
               ))}
             </div>
           ) : (
-            <div className="mt-2 truncate text-text-2" title={summary}>
-              {summary}
-            </div>
+            <>
+              <div className="flex items-start gap-2 font-medium">
+                {item.icon && (
+                  <AnyIcon
+                    icon={item.icon}
+                    size={SPOTLIGHT_TOKENS.iconSize}
+                    className="shrink-0 text-text-2"
+                  />
+                )}
+                <span className="min-w-0 truncate">{item.label}</span>
+              </div>
+              <div className="mt-2 truncate text-text-2" title={summary}>
+                {summary}
+              </div>
+            </>
           )}
         </section>
       )}


### PR DESCRIPTION
## Problem

Multi-repo Spotlight hover cards show a workspace heading and horizontal folder chips, leaving each repository path hidden in a tooltip instead of presenting the same details as individual repository cards.

## Solution

Stack each repository's code icon and name above its visible path. Remove the group heading and folder chips from the multi-repo card while retaining the existing individual-card presentation. Update the component regression test and include the scoped UI audit.

## Potential risks

Stacked entries increase card height for workspaces with many repositories. Long names and paths retain the existing truncation behavior, with the full path available through the title. Desktop appearance across themes and constrained viewports has not been visually verified because computer control was not authorized. This presentation-only change introduces no persistence, API, dependency, or lifecycle changes.

## Verification

- `pnpm test src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.test.ts` — passed, 5 tests, on the isolated branch based on latest origin/develop
- `pnpm exec eslint src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.tsx src/scaffold/GlobalSpotlight/components/SpotlightDetailPane.test.ts` — passed
- `git diff --check` — passed
- Reviewed the scoped diff for unrelated changes, secrets, private paths, and generated artifacts
- UI audit: 0 fixes, 4 keep-with-reason findings, 0 abstractions
- Commit hooks passed lint-staged (oxlint, ESLint, Prettier) and the staged-file TypeScript gate. The full test suite was not run for this localized presentation change. Desktop screenshots and manual visual checks were not collected because computer control was not requested
