### PR TITLE
refactor(state): remove unused terminal and project atoms

### DIFF
--- a/docs/org2-performance-guard-2026-09-08/UnusedTerminalProjectAtoms.md
+++ b/docs/org2-performance-guard-2026-09-08/UnusedTerminalProjectAtoms.md
@@ -1,0 +1,65 @@
+# Unused terminal and project atom removal
+
+## Scope and reachability
+
+Remove ten audited atoms, without changing the active implementations:
+
+| Group           | Removed atoms                                                                                  | Production path retained                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Projects        | `allProjectsFlatAtom`, `anyProjectsLoadingAtom`                                                | `useAllRepoProjects` reads `allProjectsEntryAtom` directly                                                                                |
+| Terminal        | `terminalSessionCountAtom`, `createAgentSessionTerminalAtom`, `removeAgentSessionTerminalAtom` | `useTerminalState` uses normal add, close, selection and metadata actions; deleted APIs had only test callers                             |
+| Browser sidebar | `workStationBrowserSidebarCollapsedAtom`, `workStationBrowserSidebarCollapsedPersistAtom`      | Current Browser layout uses neither; pair only referenced itself and a stale comment                                                      |
+| Mini terminal   | `toggleMiniTerminalAtom`                                                                       | Trail UI calls open/close actions directly                                                                                                |
+| Run groups      | `replaceRunGroupEntryAtom`                                                                     | Launch uses upsert and comparison reads by ID; no retry caller used this action                                                           |
+| PR detail       | `workstationPrDetailTabAtomFamily`                                                             | `PrDetailTabs` reads/writes `workstationSelectedPrAtomFamily.viewState.activeTab`; removed family had only tests and eviction bookkeeping |
+
+Exact-name references were swept across `src`, `tests` and `scripts` before
+and after deletion. Test-only and cleanup-only references were distinguished
+from production reads/writes. The rendered PR-detail test now asserts the
+canonical state directly; it still exercises actual tab clicks. Tests solely
+for deleted APIs were removed. A replacement terminal lifecycle regression
+verifies that an existing legacy read-only tab can still be closed through
+the normal terminal action without losing sibling sessions.
+
+## Lifecycle and performance
+
+| Area               | Verdict | Evidence                                                                                     | Change or reason kept                                                                                 | Verification                                   |
+| ------------------ | ------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Background work    | keep    | No production listener, timer, PTY creation or transport caller depended on the removed APIs | Normal terminal lifecycle and OSC-633 callbacks unchanged                                             | Terminal management and cleanup tests          |
+| Memory             | fix     | Unused PR detail atom family had no production consumer                                      | Remove unused family and its eviction call; retain 16-scope bound for live PR state/callback families | PR retention eviction/recency tests            |
+| Scope/isolation    | keep    | Live PR keys remain repo + PR; terminal IDs and storage schemas unchanged                    | Existing localStorage contents and historical terminal records are not deleted                        | PR scope separation and legacy-tab close tests |
+| Rendering/hot path | keep    | UI uses canonical parent PR state and direct mini-terminal actions                           | No live subscription scope or allocation path changed                                                 | Rendered PR tab tests and mini-terminal tests  |
+
+Lifecycle matrix: startup keeps live initialization and existing persisted
+formats; active/inactive tab switching keeps canonical state; close retains
+normal cleanup; visible/hidden/idle/shutdown behavior introduces no new work.
+Network, account, endpoint, org and multi-instance policies are unchanged.
+The unused Browser sidebar storage key is left on disk, not migrated or
+deleted. No desktop CPU/RSS, multi-instance, or real PTY measurements were run;
+no runtime performance improvement is claimed.
+
+Performance verdict: pass for the removal-only scope. The previously identified
+run-group cache consolidation and write-only terminal command store are
+explicitly outside this PR; this verdict does not certify those existing paths.
+
+## Architecture coverage
+
+1. Compilation: full frontend typecheck.
+2. Dead code: production reachability and exact-name sweep.
+3. Naming: remove stale Browser sidebar comment.
+4. Semantics: terminal session IDs are not agent conversation IDs; keep record types and normal PTY actions.
+5. Defaults: live panel defaults and terminal fallback creation unchanged.
+6. Boundaries: no backend or domain ownership changes.
+7. Clarity: unused public APIs no longer advertise nonexistent production flows.
+8. Wire: no wire or serialized schema changes; endpoint validation not applicable.
+9. Init parity: retained production/test initialization; obsolete test-only creation path removed.
+10. Resolver symmetry: no multi-field resolver or fallback chain changed.
+
+## Verification
+
+- `pnpm typecheck:fast`: passed.
+- `pnpm test src/store/workstation/codeEditor/terminal src/store/workstation/codeEditor/workstationSelectedPrAtom.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts src/store/ui/__tests__/miniTerminalAtom.test.ts src/store/session/__tests__/runGroupsAtom.test.ts src/features/SessionCreator/multiRunner src/store/ui/workStationLayout`: 11 files, 92 tests passed.
+- Changed TypeScript files: ESLint and Prettier applied/checked.
+- `git diff --check`: passed.
+
+Rollback: revert the code commit. No persisted-data restoration is required.

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellStatusBar.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellStatusBar.ts
@@ -41,11 +41,8 @@ export function useAppShellStatusBar({
 
   useEffect(() => {
     // Panel callbacks tied to the shared `workStationPrimarySidebarCollapsedAtom`.
-    // Browser has its own sidebar atom (`workStationBrowserSidebarCollapsedAtom`)
-    // and registers its own panel callbacks from useBrowserLayoutState — do NOT
-    // overwrite the browser slot here, otherwise toggling Code Editor's sidebar
-    // would clobber Browser's primaryPanelCollapsed and make the Browser tab bar
-    // app-switcher flicker based on an unrelated app's state.
+    // Browser registers its own status-bar callbacks from useBrowserLayoutState;
+    // leave its independently owned slot untouched.
     const sharedPanelCallbacks = {
       onTogglePrimaryPanel: workStationPanels.togglePrimarySidebar,
       primaryPanelCollapsed,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
@@ -16,7 +16,6 @@ import {
 import {
   initialPrDetailViewState,
   initialSelectedPrState,
-  workstationPrDetailTabAtomFamily,
   workstationPrScopeKey,
   workstationSelectedPrAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationSelectedPrAtom";
@@ -317,9 +316,9 @@ describe("PrDetailPanel tabs", () => {
     act(() => {
       tabs[3]?.click();
     });
-    expect(store.get(workstationPrDetailTabAtomFamily(scopeKey))).toBe(
-      "changes"
-    );
+    expect(
+      store.get(workstationSelectedPrAtomFamily(scopeKey)).viewState.activeTab
+    ).toBe("changes");
     expect(tabs[3]?.getAttribute("aria-selected")).toBe("true");
     expect(
       container.querySelector('[role="tabpanel"][aria-hidden="false"]')?.id

--- a/src/store/project/allProjectsAtom.ts
+++ b/src/store/project/allProjectsAtom.ts
@@ -29,13 +29,3 @@ export const updateAllProjectsEntryAtom = atom(
   }
 );
 updateAllProjectsEntryAtom.debugLabel = "updateAllProjectsEntryAtom";
-
-export const allProjectsFlatAtom = atom(
-  (get) => get(allProjectsEntryAtom).projects
-);
-allProjectsFlatAtom.debugLabel = "allProjectsFlatAtom";
-
-export const anyProjectsLoadingAtom = atom(
-  (get) => get(allProjectsEntryAtom).loading
-);
-anyProjectsLoadingAtom.debugLabel = "anyProjectsLoadingAtom";

--- a/src/store/session/runGroupsAtom.ts
+++ b/src/store/session/runGroupsAtom.ts
@@ -115,25 +115,6 @@ export const upsertRunGroupAtom = atom(null, (get, set, group: RunGroup) => {
 });
 upsertRunGroupAtom.debugLabel = "upsertRunGroupAtom";
 
-/** Replace one entry in place — used when a failed runner is retried. */
-export const replaceRunGroupEntryAtom = atom(
-  null,
-  (get, set, input: { groupId: string; entry: RunGroupEntry }) => {
-    const group = get(runGroupsAtom)[input.groupId];
-    if (!group) return;
-    set(runGroupsAtom, {
-      ...get(runGroupsAtom),
-      [input.groupId]: {
-        ...group,
-        entries: group.entries.map((entry) =>
-          entry.ordinal === input.entry.ordinal ? input.entry : entry
-        ),
-      },
-    });
-  }
-);
-replaceRunGroupEntryAtom.debugLabel = "replaceRunGroupEntryAtom";
-
 const _runGroupByIdCache = new Map<string, Atom<RunGroup | undefined>>();
 
 export const removeRunGroupAtom = atom(null, (get, set, groupId: string) => {

--- a/src/store/ui/miniTerminalAtom.ts
+++ b/src/store/ui/miniTerminalAtom.ts
@@ -186,12 +186,3 @@ closeMiniTerminalAtom.debugLabel = "chatPanel/miniTerminal/close";
 /** Panel folded to just its header row; the PTY stays mounted behind it. */
 export const miniTerminalCollapsedAtom = atom<boolean>(false);
 miniTerminalCollapsedAtom.debugLabel = "chatPanel/miniTerminal/collapsed";
-
-export const toggleMiniTerminalAtom = atom(null, (get, set) => {
-  if (get(miniTerminalVisibleAtom)) {
-    set(closeMiniTerminalAtom);
-    return;
-  }
-  set(openMiniTerminalAtom, get(miniTerminalClaimedIdsAtom)[0] ?? null);
-});
-toggleMiniTerminalAtom.debugLabel = "chatPanel/miniTerminal/toggle";

--- a/src/store/ui/workStationLayout/primarySidebarAtoms.ts
+++ b/src/store/ui/workStationLayout/primarySidebarAtoms.ts
@@ -68,37 +68,6 @@ export const workStationPrimarySidebarCollapsedPersistAtom = atom(
   }
 );
 
-/**
- * Browser-specific primary sidebar collapsed state.
- *
- * Independent of the shared `workStationPrimarySidebarCollapsedAtom` so that
- * toggling the sidebar in the Browser tool does not affect Code Editor / Database
- * Manager, and vice versa. Defaults to `true` (hidden) because the browser
- * sidebar is an optional panel rather than a primary navigation surface.
- */
-function getStoredBrowserSidebarCollapsed(): boolean {
-  const stored = getStoredValue("browser_primary_sidebar_collapsed");
-  // Explicit stored value takes precedence; default to true (hidden).
-  if (stored !== null) return stored === "true";
-  return true;
-}
-
-export const workStationBrowserSidebarCollapsedAtom = atom<boolean>(
-  getStoredBrowserSidebarCollapsed()
-);
-workStationBrowserSidebarCollapsedAtom.debugLabel =
-  "workStationBrowserSidebarCollapsedAtom";
-
-export const workStationBrowserSidebarCollapsedPersistAtom = atom(
-  (get) => get(workStationBrowserSidebarCollapsedAtom),
-  (get, set, value: boolean | "toggle") => {
-    const next =
-      value === "toggle" ? !get(workStationBrowserSidebarCollapsedAtom) : value;
-    set(workStationBrowserSidebarCollapsedAtom, next);
-    setStoredValue("browser_primary_sidebar_collapsed", String(next));
-  }
-);
-
 function getStoredPrimarySidebarWidth(): number {
   const { minWidth, maxWidth, defaultWidth } = WORK_STATION_PRIMARY_SIDEBAR;
   const stored = getStoredValue("primary_sidebar_width");

--- a/src/store/workstation/codeEditor/terminal/__tests__/commandDetectionLifecycle.test.ts
+++ b/src/store/workstation/codeEditor/terminal/__tests__/commandDetectionLifecycle.test.ts
@@ -9,8 +9,6 @@ import {
 import {
   activeTerminalIdAtom,
   closeTerminalSessionAtom,
-  createAgentSessionTerminalAtom,
-  removeAgentSessionTerminalAtom,
   terminalSessionsAtom,
 } from "../index";
 
@@ -61,16 +59,26 @@ describe("command detection lifecycle", () => {
     expect(store.get(commandDetectionMapAtom).has("t-1")).toBe(true);
   });
 
-  it("drops the history of a removed agent-session terminal tab", () => {
-    const tabId = store.set(createAgentSessionTerminalAtom, {
-      agentSessionId: "agent-1",
-      label: "Agent",
-    });
+  it("closes an existing read-only agent tab through the normal terminal action", async () => {
+    const tabId = "agent-session-legacy-1";
+    store.set(terminalSessionsAtom, (sessions) => [
+      ...sessions,
+      {
+        id: tabId,
+        name: "Agent",
+        isActive: false,
+        readOnly: true,
+        agentSessionId: "legacy-1",
+      },
+    ]);
     store.set(commandPromptStartAtom, tabId);
-    expect(store.get(commandDetectionMapAtom).has(tabId)).toBe(true);
 
-    // Takes the agent session id (the tab id is derived from it).
-    store.set(removeAgentSessionTerminalAtom, "agent-1");
+    await store.set(closeTerminalSessionAtom, tabId);
+
+    expect(
+      store.get(terminalSessionsAtom).map((session) => session.id)
+    ).toEqual(["t-1", "t-2"]);
+    expect(store.get(activeTerminalIdAtom)).toBe("t-1");
     expect(store.get(commandDetectionMapAtom).has(tabId)).toBe(false);
   });
 });

--- a/src/store/workstation/codeEditor/terminal/__tests__/terminalAtoms.test.ts
+++ b/src/store/workstation/codeEditor/terminal/__tests__/terminalAtoms.test.ts
@@ -2,7 +2,7 @@
  * Tests for terminal session management atoms.
  *
  * These tests verify the core terminal state management logic including
- * session creation, deletion, switching, and special agent session handling.
+ * session creation, deletion, switching, and session metadata updates.
  */
 import { createStore } from "jotai/vanilla";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -15,15 +15,12 @@ import {
 import {
   activeTerminalIdAtom,
   closeTerminalSessionAtom,
-  createAgentSessionTerminalAtom,
   editorActiveTerminalSessionAtom,
   editorAddTerminalSessionAtom,
   initializedTerminalIdsAtom,
   markTerminalInitializedAtom,
-  removeAgentSessionTerminalAtom,
   renameTerminalSessionAtom,
   setActiveTerminalAtom,
-  terminalSessionCountAtom,
   terminalSessionsAtom,
   updateTerminalSessionInfoAtom,
 } from "../index";
@@ -276,74 +273,6 @@ describe("terminal atoms", () => {
 
       const activeSession = store.get(editorActiveTerminalSessionAtom);
       expect(activeSession).toBeUndefined();
-    });
-  });
-
-  describe("terminalSessionCountAtom", () => {
-    it("returns correct count", () => {
-      expect(store.get(terminalSessionCountAtom)).toBe(1);
-
-      store.set(editorAddTerminalSessionAtom, undefined);
-      expect(store.get(terminalSessionCountAtom)).toBe(2);
-
-      store.set(editorAddTerminalSessionAtom, undefined);
-      expect(store.get(terminalSessionCountAtom)).toBe(3);
-    });
-  });
-
-  describe("createAgentSessionTerminalAtom", () => {
-    it("creates read-only agent session terminal", () => {
-      const agentSessionId = "agent-123";
-
-      store.set(createAgentSessionTerminalAtom, {
-        agentSessionId,
-        label: "Agent",
-      });
-
-      const sessions = store.get(terminalSessionsAtom);
-      const agentSession = sessions.find(
-        (s) => s.id === `agent-session-${agentSessionId}`
-      );
-
-      expect(agentSession).toBeDefined();
-      expect(agentSession?.readOnly).toBe(true);
-      expect(agentSession?.agentSessionId).toBe(agentSessionId);
-    });
-  });
-
-  describe("removeAgentSessionTerminalAtom", () => {
-    it("removes agent session terminal", () => {
-      const agentSessionId = "agent-to-remove";
-
-      // Create agent session
-      store.set(createAgentSessionTerminalAtom, { agentSessionId });
-
-      // Remove it
-      store.set(removeAgentSessionTerminalAtom, agentSessionId);
-
-      const sessions = store.get(terminalSessionsAtom);
-      const agentSession = sessions.find(
-        (s) => s.id === `agent-session-${agentSessionId}`
-      );
-
-      expect(agentSession).toBeUndefined();
-    });
-
-    it("creates default session when removing last session", () => {
-      // Close all existing sessions first
-      store.set(terminalSessionsAtom, []);
-      store.set(activeTerminalIdAtom, "");
-
-      // Create only an agent session
-      const agentSessionId = "only-agent";
-      store.set(createAgentSessionTerminalAtom, { agentSessionId });
-
-      // Remove it (should create default)
-      store.set(removeAgentSessionTerminalAtom, agentSessionId);
-
-      const sessions = store.get(terminalSessionsAtom);
-      expect(sessions).toHaveLength(1);
-      expect(sessions[0].isActive).toBe(true);
     });
   });
 });

--- a/src/store/workstation/codeEditor/terminal/index.ts
+++ b/src/store/workstation/codeEditor/terminal/index.ts
@@ -173,12 +173,6 @@ export const editorActiveTerminalSessionAtom = atom((get) => {
 });
 editorActiveTerminalSessionAtom.debugLabel = "editorActiveTerminalSessionAtom";
 
-/** Number of terminal sessions */
-export const terminalSessionCountAtom = atom((get) => {
-  return get(terminalSessionsAtom).length;
-});
-terminalSessionCountAtom.debugLabel = "terminalSessionCountAtom";
-
 // ============================================
 // Persistence Atom (syncs to localStorage)
 // ============================================
@@ -369,101 +363,6 @@ export const markTerminalInitializedAtom = atom(
   }
 );
 markTerminalInitializedAtom.debugLabel = "markTerminalInitializedAtom";
-
-/** Create (or switch to) a read-only agent session terminal tab.
- *
- * Uses a deterministic ID (`agent-session-{agentSessionId}`) to prevent
- * duplicates. This tab is read-only and renders normal agent session events.
- */
-export const createAgentSessionTerminalAtom = atom(
-  null,
-  (get, set, params: { agentSessionId: string; label?: string }) => {
-    const tabId = `agent-session-${params.agentSessionId}`;
-    const sessions = get(terminalSessionsAtom);
-
-    // Already exists — just switch to it
-    if (sessions.some((session) => session.id === tabId)) {
-      set(setActiveTerminalAtom, tabId);
-      return tabId;
-    }
-
-    const newSession: TerminalSession = {
-      id: tabId,
-      name: params.label || "Agent",
-      isActive: true,
-      readOnly: true,
-      agentSessionId: params.agentSessionId,
-    };
-
-    set(terminalSessionsAtom, [
-      ...sessions.map((session) => ({ ...session, isActive: false })),
-      newSession,
-    ]);
-    set(activeTerminalIdAtom, tabId);
-
-    // Mark as initialized immediately (no PTY to wait for)
-    set(initializedTerminalIdsAtom, (prev) => new Set([...prev, tabId]));
-
-    set(terminalPersistAtom);
-    return tabId;
-  }
-);
-createAgentSessionTerminalAtom.debugLabel = "createAgentSessionTerminalAtom";
-
-/** Remove the read-only agent session terminal tab.
- *
- * Called when an OS agent session ends. Does not kill a PTY (there is none).
- */
-export const removeAgentSessionTerminalAtom = atom(
-  null,
-  (get, set, agentSessionId: string) => {
-    const tabId = `agent-session-${agentSessionId}`;
-    const sessions = get(terminalSessionsAtom);
-    const activeId = get(activeTerminalIdAtom);
-
-    const filtered = sessions.filter((session) => session.id !== tabId);
-
-    if (filtered.length === 0) {
-      // Don't remove the last tab — create a default one
-      const newId = Date.now().toString();
-      const defaultBase = defaultTerminalLabelBaseFromSettings(
-        get(settingsAtom)
-      );
-      const newSession: TerminalSession = {
-        id: newId,
-        name: generateUniqueLabelFromBase(defaultBase, []),
-        isActive: true,
-        isDefaultSession: true,
-      };
-      set(terminalSessionsAtom, [newSession]);
-      set(activeTerminalIdAtom, newId);
-      set(initializedTerminalIdsAtom, new Set([newId]));
-    } else if (activeId === tabId) {
-      // Was active — switch to first remaining
-      const newActiveId = filtered[0].id;
-      set(
-        terminalSessionsAtom,
-        filtered.map((session) => ({
-          ...session,
-          isActive: session.id === newActiveId,
-        }))
-      );
-      set(activeTerminalIdAtom, newActiveId);
-    } else {
-      set(terminalSessionsAtom, filtered);
-    }
-
-    set(initializedTerminalIdsAtom, (prev) => {
-      const next = new Set(prev);
-      next.delete(tabId);
-      return next;
-    });
-    set(removeCommandDetectionAtom, tabId);
-
-    set(terminalPersistAtom);
-  }
-);
-removeAgentSessionTerminalAtom.debugLabel = "removeAgentSessionTerminalAtom";
 
 /** Rename a terminal session (sets userTitle, highest display priority). */
 export const renameTerminalSessionAtom = atom(

--- a/src/store/workstation/codeEditor/workstationSelectedPrAtom.test.ts
+++ b/src/store/workstation/codeEditor/workstationSelectedPrAtom.test.ts
@@ -5,7 +5,6 @@ import {
   __resetRetainedPrDetailScopes,
   retainWorkstationPrDetailScope,
   workstationPrDetailCallbackAtomFamily,
-  workstationPrDetailTabAtomFamily,
   workstationPrScopeKey,
   workstationSelectedPrAtomFamily,
 } from "./workstationSelectedPrAtom";
@@ -31,7 +30,6 @@ describe("retainWorkstationPrDetailScope", () => {
     const first = scope(0);
     const firstAtoms = [
       workstationSelectedPrAtomFamily(first),
-      workstationPrDetailTabAtomFamily(first),
       workstationPrDetailCallbackAtomFamily(first),
     ];
 
@@ -41,9 +39,8 @@ describe("retainWorkstationPrDetailScope", () => {
 
     // A family hands back a NEW atom instance for a key it has released.
     expect(workstationSelectedPrAtomFamily(first)).not.toBe(firstAtoms[0]);
-    expect(workstationPrDetailTabAtomFamily(first)).not.toBe(firstAtoms[1]);
     expect(workstationPrDetailCallbackAtomFamily(first)).not.toBe(
-      firstAtoms[2]
+      firstAtoms[1]
     );
   });
 

--- a/src/store/workstation/codeEditor/workstationSelectedPrAtom.ts
+++ b/src/store/workstation/codeEditor/workstationSelectedPrAtom.ts
@@ -121,25 +121,6 @@ export const workstationSelectedPrAtomFamily = atomFamily(
   }
 );
 
-/** Active PR-detail sub-tab (Conversation / Commits / Checks / Changes). */
-export const workstationPrDetailTabAtomFamily = atomFamily(
-  (scopeKey: string) => {
-    const selectedPrAtom = workstationSelectedPrAtomFamily(scopeKey);
-    const scopedAtom = atom(
-      (get) => get(selectedPrAtom).viewState.activeTab,
-      (get, set, activeTab: PrDetailTab) => {
-        const current = get(selectedPrAtom);
-        set(selectedPrAtom, {
-          ...current,
-          viewState: { ...current.viewState, activeTab },
-        });
-      }
-    );
-    scopedAtom.debugLabel = `workstationPrDetailTabAtom(${scopeKey})`;
-    return scopedAtom;
-  }
-);
-
 export interface WorkstationPrDetailCallbacks {
   addComment: ((body: string) => Promise<void>) | null;
   submitReview: ((event: PrReviewEvent, body: string) => Promise<void>) | null;
@@ -221,7 +202,6 @@ const retainedPrDetailScopes = new BoundedMap<string, true>({
   name: "workstationPrDetailScopes",
   onEvict: (scopeKey) => {
     workstationSelectedPrAtomFamily.remove(scopeKey);
-    workstationPrDetailTabAtomFamily.remove(scopeKey);
     workstationPrDetailCallbackAtomFamily.remove(scopeKey);
   },
 });


### PR DESCRIPTION
## Problem

Ten frontend atoms expose unused APIs or a redundant PR-detail selector, making inactive state look like supported production behavior. Their references are confined to declarations, tests, an unused atom pair, and PR eviction bookkeeping; current UI entry points use other state/actions.

## Solution

Remove the audited ten atoms:

- Projects: `allProjectsFlatAtom`, `anyProjectsLoadingAtom`.
- Terminal: `terminalSessionCountAtom`, `createAgentSessionTerminalAtom`, `removeAgentSessionTerminalAtom`.
- Browser sidebar: `workStationBrowserSidebarCollapsedAtom`, `workStationBrowserSidebarCollapsedPersistAtom`.
- Mini terminal: `toggleMiniTerminalAtom`.
- Run groups: `replaceRunGroupEntryAtom`.
- PR detail: `workstationPrDetailTabAtomFamily`.

Keep live project loading, normal terminal actions, direct mini-terminal open/close actions, run-group upsert/lookup, and canonical PR-detail state unchanged. Remove obsolete tests and the stale Browser-sidebar comment. Preserve the rendered PR-tab assertion using the canonical parent atom, retain live PR-family eviction coverage, and replace the obsolete agent-terminal action test with a regression exercising normal closure of an existing read-only tab.

Audit: `docs/org2-performance-guard-2026-09-08/UnusedTerminalProjectAtoms.md`. Settings/layout consolidation, run-group cache consolidation, and the write-only terminal command store are intentionally separate work.

## Potential risks

Out-of-repository or untracked consumers of these internal exports would need updating; repository references and TypeScript consumers were checked. No persisted data, historical terminal records, or storage keys are deleted. Storage formats, dependencies, backend, IPC, and wire contracts are unchanged. Rollback is a code revert, with no data recovery step.

Desktop runtime, real PTY execution, multi-instance behavior, and the full test suite were not exercised. The legacy-tab regression uses the normal store action with mocked Tauri, not a real process. No CPU/RSS or rendering speedup is claimed. Screenshots are not useful for declaration-only removal with no intended visible change.

## Verification

- `pnpm typecheck:fast` — passed.
- `pnpm test src/store/workstation/codeEditor/terminal src/store/workstation/codeEditor/workstationSelectedPrAtom.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts src/store/ui/__tests__/miniTerminalAtom.test.ts src/store/session/__tests__/runGroupsAtom.test.ts src/features/SessionCreator/multiRunner src/store/ui/workStationLayout` — 11 files, 92 tests passed.
- `git diff --name-only --diff-filter=AM -z -- '*.ts' | xargs -0 pnpm exec eslint` — passed.
- `git diff --name-only --diff-filter=AM -z -- '*.ts' | xargs -0 pnpm exec prettier --write` — formatted changed TypeScript files; commit hooks format the audit Markdown.
- `git diff --check` — passed.
- Exact-name `rg` sweep across `src`, `tests`, and `scripts` — zero remaining removed-atom references.
- Fetched `origin/develop` before handoff; branch started at `4fea82cde` with no target-branch changes to integrate.

The final diff is scoped to these removals and supporting verification/documentation; no unrelated changes, secrets, personal paths, or generated artifacts are included.
