### PR TITLE
refactor(tabs): share recent history mechanics

### DIFF
--- a/docs/org2-performance-guard-2026-09-08/RecentTabHistory.md
+++ b/docs/org2-performance-guard-2026-09-08/RecentTabHistory.md
@@ -1,0 +1,22 @@
+# Recent-tab history consolidation
+
+Architecture coverage: compilation, reachability, naming, semantic identity,
+defaults, state boundaries, and developer clarity. Wire protocol, backend
+initialization, and provider resolution are unchanged and were skipped.
+
+| Area               | Verdict | Evidence                                    | Change or reason kept                                       | Verification                      |
+| ------------------ | ------- | ------------------------------------------- | ----------------------------------------------------------- | --------------------------------- |
+| Background work    | keep    | Pure synchronous history updates            | No timers, IPC, or subscriptions introduced                 | Source call-chain inspection      |
+| Memory             | keep    | Each surface retains at most five entries   | Share bounded insertion and transition mechanics            | Shared and production atom tests  |
+| Scope/isolation    | keep    | Independent ChatPanel and Workstation atoms | Preserve session identity and workspace-scoped tab identity | Scoped-identity and surface tests |
+| Rendering/hot path | keep    | Existing atom entry points remain           | No new React subscriptions                                  | Typecheck and source inspection   |
+
+Lifecycle: app start has empty histories; active transitions and close/reopen
+update them; idle/hidden/offline states do no work; app restart clears these
+in-memory histories. No persistence or session-switch transition was changed.
+
+Verification: `pnpm test src/shared/tabs/recentTabs.test.ts src/store/chatPanel/__tests__/chatPanelRecentTabs.test.ts src/store/workstation/tabs/__tests__/recentTabs.test.ts`
+passed 9 tests; `pnpm typecheck:fast` passed. No runtime speedup is claimed.
+Visual evidence is not useful for this unchanged rendering path.
+
+Performance verdict: pass (bounded synchronous state mechanics only).

--- a/src/shared/tabs/recentTabs.test.ts
+++ b/src/shared/tabs/recentTabs.test.ts
@@ -2,11 +2,55 @@ import { describe, expect, it } from "vitest";
 
 import {
   RECENT_TABS_LIMIT,
+  recordRecentItem,
   recordRecentTab,
+  recordRecentTransition,
   removeRecentTab,
 } from "./recentTabs";
 
 describe("recent tab history", () => {
+  it("supports scoped identities without merging histories or mutating inputs", () => {
+    const same = (
+      a: { scope: string; id: string },
+      b: { scope: string; id: string }
+    ) => a.scope === b.scope && a.id === b.id;
+    const initial = Object.freeze([
+      { scope: "a", id: "1" },
+      { scope: "b", id: "1" },
+    ]);
+    expect(recordRecentItem(initial, { scope: "b", id: "1" }, same)).toEqual([
+      initial[1],
+      initial[0],
+    ]);
+    expect(
+      recordRecentTransition(
+        initial,
+        { scope: "a", id: "2" },
+        (item) => item.scope === "b",
+        () => true,
+        same
+      )
+    ).toEqual([{ scope: "a", id: "2" }, initial[0]]);
+    expect(initial).toHaveLength(2);
+  });
+
+  it("removes destinations even when leaving no item, the destination itself, or an excluded item", () => {
+    const current = [{ id: "a" }, { id: "b" }];
+    const destination = (item: { id: string }) => item.id === "a";
+    const same = (a: { id: string }, b: { id: string }) => a.id === b.id;
+    for (const previous of [null, undefined, { id: "a" }, { id: "start" }]) {
+      expect(
+        recordRecentTransition(
+          current,
+          previous,
+          destination,
+          (item) => item.id !== "start",
+          same
+        )
+      ).toEqual([{ id: "b" }]);
+    }
+  });
+
   it("keeps most recently visited unique entries first and enforces the bound", () => {
     const initial = Array.from({ length: RECENT_TABS_LIMIT }, (_, index) => ({
       id: `tab-${index}`,

--- a/src/shared/tabs/recentTabs.test.ts
+++ b/src/shared/tabs/recentTabs.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   RECENT_TABS_LIMIT,
   recordRecentItem,
-  recordRecentTab,
   recordRecentTransition,
   removeRecentTab,
 } from "./recentTabs";
@@ -57,10 +56,14 @@ describe("recent tab history", () => {
     }));
 
     expect(
-      recordRecentTab(initial, { id: "tab-1" }).map((tab) => tab.id)
+      recordRecentItem(initial, { id: "tab-1" }, (a, b) => a.id === b.id).map(
+        (tab) => tab.id
+      )
     ).toEqual(["tab-1", "tab-0", "tab-2", "tab-3", "tab-4"]);
     expect(
-      recordRecentTab(initial, { id: "tab-new" }).map((tab) => tab.id)
+      recordRecentItem(initial, { id: "tab-new" }, (a, b) => a.id === b.id).map(
+        (tab) => tab.id
+      )
     ).toEqual(["tab-new", "tab-0", "tab-1", "tab-2", "tab-3"]);
   });
 

--- a/src/shared/tabs/recentTabs.ts
+++ b/src/shared/tabs/recentTabs.ts
@@ -9,10 +9,33 @@ export function recordRecentTab<T extends TabIdentity>(
   current: readonly T[],
   tab: T
 ): T[] {
-  return [tab, ...current.filter((candidate) => candidate.id !== tab.id)].slice(
-    0,
-    RECENT_TABS_LIMIT
-  );
+  return recordRecentItem(current, tab, (left, right) => left.id === right.id);
+}
+
+/** Identity belongs to the surface; ordering and the retention bound are shared. */
+export function recordRecentItem<T>(
+  current: readonly T[],
+  item: T,
+  isSame: (left: T, right: T) => boolean
+): T[] {
+  return [
+    item,
+    ...current.filter((candidate) => !isSame(candidate, item)),
+  ].slice(0, RECENT_TABS_LIMIT);
+}
+
+/** Remove the destination and remember the eligible item being left. */
+export function recordRecentTransition<T>(
+  current: readonly T[],
+  previous: T | null | undefined,
+  isDestination: (item: T) => boolean,
+  canRecord: (item: T) => boolean,
+  isSame: (left: T, right: T) => boolean
+): T[] {
+  const remaining = current.filter((item) => !isDestination(item));
+  return previous && !isDestination(previous) && canRecord(previous)
+    ? recordRecentItem(remaining, previous, isSame)
+    : remaining;
 }
 
 export function removeRecentTab<T extends TabIdentity>(

--- a/src/shared/tabs/recentTabs.ts
+++ b/src/shared/tabs/recentTabs.ts
@@ -4,14 +4,6 @@ interface TabIdentity {
   id: string;
 }
 
-/** Put one tab at the front of a bounded, de-duplicated MRU history. */
-export function recordRecentTab<T extends TabIdentity>(
-  current: readonly T[],
-  tab: T
-): T[] {
-  return recordRecentItem(current, tab, (left, right) => left.id === right.id);
-}
-
 /** Identity belongs to the surface; ordering and the retention bound are shared. */
 export function recordRecentItem<T>(
   current: readonly T[],

--- a/src/store/chatPanel/chatPanelRecentTabsState.ts
+++ b/src/store/chatPanel/chatPanelRecentTabsState.ts
@@ -1,6 +1,10 @@
 import { atom } from "jotai";
 
-import { recordRecentTab, removeRecentTab } from "@src/shared/tabs/recentTabs";
+import {
+  recordRecentItem,
+  recordRecentTransition,
+  removeRecentTab,
+} from "@src/shared/tabs/recentTabs";
 
 import type { ChatPanelTab } from "./chatPanelTabsModel";
 
@@ -27,9 +31,11 @@ function recordRecentChatPanelTab(
   current: readonly ChatPanelTab[],
   tab: ChatPanelTab
 ): ChatPanelTab[] {
-  return recordRecentTab(
-    current.filter((candidate) => !isSameRecentChatPanelTab(candidate, tab)),
-    tab
+  return recordRecentItem(
+    current,
+    tab,
+    (left, right) =>
+      left.id === right.id || isSameRecentChatPanelTab(left, right)
   );
 }
 
@@ -38,19 +44,16 @@ export const recordChatPanelTabTransitionAtom = atom(
   null,
   (_get, set, transition: ChatPanelTabTransition) => {
     const { previousTab, nextTab } = transition;
-    set(recentChatPanelTabsAtom, (current) => {
-      const withoutDestination = current.filter(
-        (candidate) => !isSameRecentChatPanelTab(candidate, nextTab)
-      );
-      if (
-        !previousTab ||
-        isSameRecentChatPanelTab(previousTab, nextTab) ||
-        previousTab.type === "start-page"
-      ) {
-        return withoutDestination;
-      }
-      return recordRecentChatPanelTab(withoutDestination, previousTab);
-    });
+    set(recentChatPanelTabsAtom, (current) =>
+      recordRecentTransition(
+        current,
+        previousTab,
+        (candidate) => isSameRecentChatPanelTab(candidate, nextTab),
+        (candidate) => candidate.type !== "start-page",
+        (left, right) =>
+          left.id === right.id || isSameRecentChatPanelTab(left, right)
+      )
+    );
   }
 );
 recordChatPanelTabTransitionAtom.debugLabel =

--- a/src/store/workstation/tabs/recentTabs.ts
+++ b/src/store/workstation/tabs/recentTabs.ts
@@ -1,6 +1,9 @@
 import { atom } from "jotai";
 
-import { RECENT_TABS_LIMIT } from "@src/shared/tabs/recentTabs";
+import {
+  recordRecentItem,
+  recordRecentTransition,
+} from "@src/shared/tabs/recentTabs";
 
 import type { WorkStationTab, WorkstationWorkspaceKey } from "./types";
 
@@ -36,10 +39,11 @@ function recordRecentEntry(
   current: readonly RecentWorkstationTabEntry[],
   entry: RecentWorkstationTabEntry
 ): RecentWorkstationTabEntry[] {
-  return [
+  return recordRecentItem(
+    current,
     entry,
-    ...current.filter((candidate) => entryId(candidate) !== entryId(entry)),
-  ].slice(0, RECENT_TABS_LIMIT);
+    (left, right) => entryId(left) === entryId(right)
+  );
 }
 
 interface WorkstationTabTransition {
@@ -52,24 +56,18 @@ export const recordWorkstationTabTransitionAtom = atom(
   null,
   (_get, set, transition: WorkstationTabTransition) => {
     const { workspace, previousTab, nextTabId } = transition;
-    set(recentWorkstationTabEntriesAtom, (current) => {
-      const withoutDestination = nextTabId
-        ? current.filter(
-            (entry) =>
-              !isSameWorkstationWorkspace(entry.workspace, workspace) ||
-              entry.tab.id !== nextTabId
-          )
-        : [...current];
-      if (
-        !previousTab ||
-        previousTab.id === nextTabId ||
-        previousTab.type === "start"
-      ) {
-        return withoutDestination;
-      }
-      const entry = { workspace, tab: previousTab };
-      return recordRecentEntry(withoutDestination, entry);
-    });
+    set(recentWorkstationTabEntriesAtom, (current) =>
+      recordRecentTransition(
+        current,
+        previousTab ? { workspace, tab: previousTab } : null,
+        (entry) =>
+          Boolean(nextTabId) &&
+          isSameWorkstationWorkspace(entry.workspace, workspace) &&
+          entry.tab.id === nextTabId,
+        (entry) => entry.tab.type !== "start",
+        (left, right) => entryId(left) === entryId(right)
+      )
+    );
   }
 );
 recordWorkstationTabTransitionAtom.debugLabel =


### PR DESCRIPTION
## Problem

Chat-panel and workstation recent tabs duplicate bounded MRU insertion and leave/destination transitions, making semantics easy to drift.

## Solution

Share identity-parameterized insertion and transition helpers. Preserve separate history atoms, five-entry bounds, session-aware chat identity, workspace-scoped workstation identity, and start-page exclusions. Session-switch transitions are untouched.

## Potential risks

Identity callbacks must retain surface-specific behavior. Regression coverage exercises production atoms and shared scoped identities. No persistence, IPC, or visual structure changes; screenshots are not useful for this logic-only refactor. No runtime speedup is claimed.

## Verification

- `pnpm test src/shared/tabs/recentTabs.test.ts src/store/chatPanel/__tests__/chatPanelRecentTabs.test.ts src/store/workstation/tabs/__tests__/recentTabs.test.ts`: 9 tests passed.
- `pnpm typecheck:fast`: passed.
- `pnpm exec eslint src/shared/tabs/recentTabs.ts src/shared/tabs/recentTabs.test.ts src/store/chatPanel/chatPanelRecentTabsState.ts src/store/workstation/tabs/recentTabs.ts`: passed.
- `git diff --check`: passed; commit hooks passed.
- Reviewed final diff for scope and secrets. Architecture and lifecycle audit included. No desktop/manual E2E run; rendering is unchanged.
- `pnpm check:circular`: reports the existing SessionHoverCard/HoverCardBase.tsx ↔ singletonStore.ts cycle; no history-module cycles.