### PR TITLE
refactor(chat-panel): consolidate surface ownership

### DIFF
--- a/docs/frontend-ui-audit-2026-09-08/ChatPanelSurface.md
+++ b/docs/frontend-ui-audit-2026-09-08/ChatPanelSurface.md
@@ -1,0 +1,13 @@
+# ChatPanel surface UI audit
+
+| Line                                                      | Element                                       | Verdict          | Reason                                                                                                 | Suggested change |
+| --------------------------------------------------------- | --------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------ | ---------------- |
+| `src/engines/ChatPanel/index.tsx:118`                     | Surface subscription and content-state inputs | keep with reason | Shared shell, controls, tokens and accessibility remain unchanged; only state ownership changes        | None             |
+| `src/engines/ChatPanel/hooks/chatPanelContentState.ts:28` | Surface-to-render flags                       | keep with reason | Uses the canonical discriminant instead of a second precedence tree; no visual primitive is introduced | None             |
+| `src/engines/ChatPanel/panels/WorkItemPanelView.tsx:219`  | Work-item refresh                             | keep with reason | Existing functional refresh and controls remain; comment documents synchronous tab ownership           | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+No styling, layout, copy, or control changes. Screenshots would not demonstrate
+the state-ownership invariant; automated transition and rendered component
+tests provide the relevant evidence. Real desktop visual checks were not run.

--- a/docs/org2-performance-guard-2026-09-08/ChatPanelSurface.md
+++ b/docs/org2-performance-guard-2026-09-08/ChatPanelSurface.md
@@ -1,0 +1,45 @@
+# Chat-panel surface ownership
+
+Architecture coverage: compilation, reachability, naming, mutually exclusive
+semantic axes, defaults, state ownership, developer clarity, and initialization
+parity. Wire identifiers remain unchanged. Backend/provider resolver layers
+were skipped because this is frontend-only. No session-switch orchestration
+files were changed.
+
+The authoritative selection is now one discriminated state. Existing selection
+and content-mode atoms are writable projections rather than independent stores.
+Creator target/context, Launchpad visibility, workspace subnavigation and
+maximization remain separate axes because their retention semantics differ.
+Rendering and UI context snapshots use the same active-surface projection.
+
+For tab-backed work items, the tab owns the payload and the selection retains
+only its tab ID. A functional selection update edits that tab synchronously.
+Direct navigation without a work-item tab retains one inline payload instead.
+The React mirror effect and its patch atom are removed. Runtime-independent
+selection types prevent tab factories/models from importing their own state.
+
+| Area               | Verdict | Evidence                                                                 | Change or reason kept                                             | Verification                                                                         |
+| ------------------ | ------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Background work    | fix     | Work-item edits previously required a mounted React mirror effect        | Update owning tab at the atom write boundary                      | Regression runs without a mounted ChatPanel                                          |
+| Memory             | keep    | One selected variant per Jotai store; tab-backed work items retain an ID | No additional registry, history, timer or cache                   | Variant-transition and store-isolation tests                                         |
+| Scope/isolation    | keep    | Work-item matching uses org/project/short-ID identity                    | Preserve existing identity function and functional refresh guards | Same short ID in different orgs and late refresh tests                               |
+| Rendering/hot path | fix     | Two independent precedence trees could disagree                          | Render flags use the same surface as UI snapshots; no mirror loop | All-pairs navigation matrix, no-op subscription regression, component/context suites |
+
+Lifecycle: initial session surface; navigation replaces the selected variant;
+inactive/hidden edits do not require a React effect; close/revoke actions remove
+the owning tab and use existing fallback navigation. No polling, cloud sync,
+auth, transport, or persistence policy changes. Existing tab-storage debounce
+is unchanged. No historical persisted cleanup is needed or performed.
+
+Verification:
+
+- `pnpm test src/engines/ChatPanel src/store/chatPanel src/store/ui/chatPanel src/services/context`: 1,530 tests passed in 223 files
+- `pnpm typecheck:fast`: passed
+- `pnpm check:circular`: reports only the pre-existing `SessionHoverCard/HoverCardBase.tsx` / `singletonStore.ts` cycle, independently reproduced without this change; no new cycles
+- Changed-file ESLint, formatting, and `git diff --check` passed
+
+Real desktop navigation, hidden/visible CPU/RSS and remount measurements were
+not run; computer control was not authorized. No speedup claim is made.
+
+Performance verdict: blocked for real desktop lifecycle/CPU/RSS measurement;
+automated state ownership and regression checks pass.

--- a/src/engines/ChatPanel/hooks/chatPanelContentState.ts
+++ b/src/engines/ChatPanel/hooks/chatPanelContentState.ts
@@ -1,23 +1,15 @@
 import {
   CHAT_PANEL_CONTENT_MODE,
   type ChatPanelContentMode,
-  type ChatPanelSelectedCloudOrg,
-  type ChatPanelSelectedProject,
-  type ChatPanelSelectedProjectOrg,
-  type ChatPanelSelectedWorkItem,
-  type ChatPanelSelectedWorkspace,
 } from "@src/store/ui/chatPanel/selectionAtoms";
+import type { ChatPanelSurfaceState } from "@src/store/ui/chatPanel/surfaceAtoms";
+import { CHAT_PANEL_SURFACE_KIND } from "@src/types/ui/chatPanel";
 
-interface UseChatPanelContentStateOptions {
+interface ChatPanelContentStateOptions {
   active: boolean;
   contentMode: ChatPanelContentMode;
   currentSessionId: string | null;
-  exploreOpen: boolean;
-  selectedCloudOrg: ChatPanelSelectedCloudOrg | null;
-  selectedProject: ChatPanelSelectedProject | null;
-  selectedProjectOrg: ChatPanelSelectedProjectOrg | null;
-  selectedWorkItem: ChatPanelSelectedWorkItem | null;
-  selectedWorkspace: ChatPanelSelectedWorkspace | null;
+  surface: ChatPanelSurfaceState;
 }
 
 export interface ChatPanelContentState {
@@ -33,50 +25,28 @@ export interface ChatPanelContentState {
   showWorkspaceOverviewContent: boolean;
 }
 
-export function useChatPanelContentState({
+export function resolveChatPanelContentState({
   active,
   contentMode,
   currentSessionId,
-  exploreOpen,
-  selectedCloudOrg,
-  selectedProject,
-  selectedProjectOrg,
-  selectedWorkItem,
-  selectedWorkspace,
-}: UseChatPanelContentStateOptions): ChatPanelContentState {
+  surface,
+}: ChatPanelContentStateOptions): ChatPanelContentState {
   const showSessionContent =
     active &&
+    surface.kind === CHAT_PANEL_SURFACE_KIND.SESSION &&
     contentMode === CHAT_PANEL_CONTENT_MODE.SESSION &&
     Boolean(currentSessionId);
-  const showWorkItemContent = Boolean(selectedWorkItem) && !showSessionContent;
-  const showProjectContent =
-    Boolean(selectedProject) && !showSessionContent && !showWorkItemContent;
+  const showWorkItemContent =
+    surface.kind === CHAT_PANEL_SURFACE_KIND.WORK_ITEM;
+  const showProjectContent = surface.kind === CHAT_PANEL_SURFACE_KIND.PROJECT;
   const showProjectOrgContent =
-    Boolean(selectedProjectOrg) &&
-    !showSessionContent &&
-    !showWorkItemContent &&
-    !showProjectContent;
+    surface.kind === CHAT_PANEL_SURFACE_KIND.PROJECT_ORG;
   const showExploreContent =
-    exploreOpen &&
-    !showSessionContent &&
-    !showWorkItemContent &&
-    !showProjectContent &&
-    !showProjectOrgContent;
+    surface.kind === CHAT_PANEL_SURFACE_KIND.WORKSPACE_EXPLORE;
   const showCloudOrgContent =
-    Boolean(selectedCloudOrg) &&
-    !showSessionContent &&
-    !showWorkItemContent &&
-    !showProjectContent &&
-    !showProjectOrgContent &&
-    !showExploreContent;
+    surface.kind === CHAT_PANEL_SURFACE_KIND.CLOUD_ORG;
   const showWorkspaceOverviewContent =
-    Boolean(selectedWorkspace) &&
-    !showSessionContent &&
-    !showWorkItemContent &&
-    !showProjectContent &&
-    !showProjectOrgContent &&
-    !showExploreContent &&
-    !showCloudOrgContent;
+    surface.kind === CHAT_PANEL_SURFACE_KIND.WORKSPACE_OVERVIEW;
   const showExplicitNonSessionContent =
     contentMode === CHAT_PANEL_CONTENT_MODE.NON_SESSION;
   const showPanelContent =

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import React, { memo, useCallback, useEffect, useState } from "react";
+import React, { memo, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
@@ -15,7 +15,6 @@ import { useShouldOffsetChatPanelHeader } from "@src/hooks/ui/sidebar/useCollaps
 import { getPrimaryPaneBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
 import {
   openRuntimeInChatPanelTabAtom,
-  patchChatPanelWorkItemTabAtom,
   syncActiveChatPanelTabStateAtom,
   toggleActiveChatPanelMaximizedAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
@@ -32,15 +31,13 @@ import { tuiModeAtom } from "@src/store/session/tuiModeAtom";
 import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";
 import {
   chatPanelContentModeAtom,
-  chatPanelExploreOpenAtom,
   chatPanelSelectedCloudOrgAtom,
-  chatPanelSelectedProjectAtom,
-  chatPanelSelectedProjectOrgAtom,
-  chatPanelSelectedWorkItemAtom,
-  chatPanelSelectedWorkspaceAtom,
   chatPanelStartPageOpenAtom,
 } from "@src/store/ui/chatPanel/selectionAtoms";
-import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
+import {
+  activeChatPanelSurfaceAtom,
+  chatPanelMaximizedAtom,
+} from "@src/store/ui/chatPanel/surfaceAtoms";
 import { chatWidthAtom } from "@src/store/ui/chatPanel/widthAtoms";
 import { openSideChatAtom } from "@src/store/ui/sideChatAtom";
 import { isHumanSession } from "@src/util/session/sessionDispatch";
@@ -75,8 +72,8 @@ import {
   shouldCollapseChatPanelTabRow,
   shouldOverlayChatSessionHeaders,
 } from "./header/chatPanelHeaderLayout";
+import { resolveChatPanelContentState } from "./hooks/chatPanelContentState";
 import { useChatPanelAccessReconciliation } from "./hooks/useChatPanelAccessReconciliation";
-import { useChatPanelContentState } from "./hooks/useChatPanelContentState";
 import { useChatPanelCreationContent } from "./hooks/useChatPanelCreationContent";
 import { useChatPanelHeaderActions } from "./hooks/useChatPanelHeaderActions";
 import { useChatPanelNavigationActions } from "./hooks/useChatPanelNavigationActions";
@@ -120,21 +117,8 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
 
     const contentMode = useAtomValue(chatPanelContentModeAtom);
     const startPageOpen = useAtomValue(chatPanelStartPageOpenAtom);
-    const selectedWorkItem = useAtomValue(chatPanelSelectedWorkItemAtom);
-    const selectedProject = useAtomValue(chatPanelSelectedProjectAtom);
-    const selectedProjectOrg = useAtomValue(chatPanelSelectedProjectOrgAtom);
-    const selectedWorkspace = useAtomValue(chatPanelSelectedWorkspaceAtom);
     const selectedCloudOrg = useAtomValue(chatPanelSelectedCloudOrgAtom);
-    const exploreOpen = useAtomValue(chatPanelExploreOpenAtom);
-    const patchWorkItemTab = useSetAtom(patchChatPanelWorkItemTabAtom);
-
-    // Work-item edits flow through `chatPanelSelectedWorkItemAtom`; mirror them
-    // back onto the owning work-item tab so re-activating the tab does not
-    // replay a stale payload. No-ops when the payload reference is unchanged
-    // (e.g. the seed written on tab activation).
-    useEffect(() => {
-      if (selectedWorkItem) patchWorkItemTab(selectedWorkItem);
-    }, [selectedWorkItem, patchWorkItemTab]);
+    const surface = useAtomValue(activeChatPanelSurfaceAtom);
 
     const userChatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
     const syncActiveTabState = useSetAtom(syncActiveChatPanelTabStateAtom);
@@ -279,16 +263,11 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       openSideChat(null);
     }, [openSideChat]);
 
-    const contentState = useChatPanelContentState({
+    const contentState = resolveChatPanelContentState({
       active,
       contentMode,
       currentSessionId: currentSessionId ?? null,
-      exploreOpen,
-      selectedCloudOrg,
-      selectedProject,
-      selectedProjectOrg,
-      selectedWorkItem,
-      selectedWorkspace,
+      surface,
     });
     const showFocusedWorkstationControls =
       shouldMountFocusedChatWorkstationControls({

--- a/src/engines/ChatPanel/panels/WorkItemPanelView.tsx
+++ b/src/engines/ChatPanel/panels/WorkItemPanelView.tsx
@@ -216,12 +216,9 @@ export const WorkItemPanelView: React.FC<WorkItemPanelViewProps> = ({
     [currentUser, onUpdateWorkItem, selectedWorkItem, setSelectedWorkItem]
   );
 
-  // The owning work-item tab's stored payload is mirrored from
-  // `chatPanelSelectedWorkItemAtom` by ChatPanel's patch effect. Refresh must
-  // therefore write only the selection atom: writing the tab here as well
-  // seeds a second, content-equal object into the tab slot, and the
-  // selection<->tab mirror then shuffles the two distinct references forever
-  // (React "maximum update depth"). One writer, one reference.
+  // The selection atom reads and updates the owning tab directly. Refresh
+  // uses a functional update so a late response cannot replace a newly
+  // selected item. No render effect or second payload copy is involved.
   const refreshSelectedWorkItemOnce = useCallback(async () => {
     try {
       if (selectedWorkItem.projectSlug) {

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -50,6 +50,7 @@ import {
   chatPanelCreateProjectContextAtom,
   chatPanelCreateTargetAtom,
   chatPanelSelectedWorkItemAtom,
+  chatPanelSelectionStateAtom,
   chatPanelStartPageOpenAtom,
 } from "@src/store/ui/chatPanel/selectionAtoms";
 import {
@@ -405,6 +406,116 @@ describe("closeWorkItemChatPanelTabAtom", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("updates the tab-owned work item synchronously without a mounted ChatPanel or mirror effect", async () => {
+    const {
+      store,
+      openWorkItemInChatPanelTabAtom,
+      chatPanelSelectedWorkItemAtom,
+      chatPanelTabsAtom,
+    } = await loadChatPanelTabAtoms();
+    // Mount storage before seeding; its first subscription intentionally resets
+    // persisted tabs to Launchpad, matching application startup.
+    const onTabsChange = vi.fn();
+    const unsubscribe = store.sub(chatPanelTabsAtom, onTabsChange);
+    const workItem = {
+      shortId: "W-1",
+      projectSlug: "project",
+      projectId: "project",
+      projectName: "Project",
+      orgId: "org-a",
+      workItem: { session_id: "W-1", name: "Before" },
+    } as never;
+    store.set(openWorkItemInChatPanelTabAtom, workItem);
+    const tabId = store.get(activeChatPanelTabAtom)!.id;
+    store.set(
+      chatPanelSelectedWorkItemAtom,
+      (current) =>
+        current && {
+          ...current,
+          workItem: { ...current.workItem, name: "After" },
+        }
+    );
+    const edited = store.get(chatPanelSelectedWorkItemAtom);
+    expect(
+      store.get(chatPanelTabsAtom).tabs.find((tab) => tab.id === tabId)
+    ).toMatchObject({ title: "After", workItem: edited });
+    expect(store.get(chatPanelSelectionStateAtom)).toEqual({
+      kind: "workItem",
+      target: { tabId },
+    });
+    onTabsChange.mockClear();
+    store.set(chatPanelSelectedWorkItemAtom, (current) => current);
+    expect(onTabsChange).not.toHaveBeenCalled();
+    unsubscribe();
+    store.set(chatPanelNavigateAtom, { kind: CHAT_PANEL_SURFACE_KIND.SESSION });
+    store.set(activateChatPanelTabAtom, tabId);
+    expect(store.get(chatPanelSelectedWorkItemAtom)).toBe(edited);
+    const refreshed = {
+      ...edited!,
+      workItem: { ...edited!.workItem, name: "Refreshed" },
+    };
+    store.set(chatPanelTabsAtom, (state) => ({
+      ...state,
+      tabs: state.tabs.map((tab) =>
+        tab.id === tabId ? { ...tab, workItem: refreshed } : tab
+      ),
+    }));
+    expect(store.get(chatPanelSelectedWorkItemAtom)).toBe(refreshed);
+  });
+
+  it("keeps matching short IDs in different orgs isolated and ignores stale functional refreshes", async () => {
+    const {
+      store,
+      openWorkItemInChatPanelTabAtom,
+      chatPanelSelectedWorkItemAtom,
+      chatPanelTabsAtom,
+    } = await loadChatPanelTabAtoms();
+    const first = {
+      shortId: "W-1",
+      projectId: "p",
+      projectSlug: "p",
+      projectName: "Project",
+      orgId: "org-a",
+      workItem: { session_id: "W-1", name: "A" },
+    } as never;
+    const second = {
+      shortId: "W-1",
+      projectId: "p",
+      projectSlug: "p",
+      projectName: "Project",
+      orgId: "org-b",
+      workItem: { session_id: "W-1", name: "B" },
+    } as never;
+    store.set(openWorkItemInChatPanelTabAtom, first);
+    store.set(openWorkItemInChatPanelTabAtom, second);
+    const before = store.get(chatPanelTabsAtom);
+    store.set(chatPanelSelectedWorkItemAtom, (current) =>
+      current?.orgId === "org-a"
+        ? { ...current, workItem: { ...current.workItem, name: "Late A" } }
+        : current
+    );
+    expect(store.get(chatPanelTabsAtom)).toBe(before);
+    expect(store.get(chatPanelSelectedWorkItemAtom)).toBe(second);
+    store.set(
+      chatPanelSelectedWorkItemAtom,
+      (current) =>
+        current && {
+          ...current,
+          workItem: { ...current.workItem, name: "Updated B" },
+        }
+    );
+    expect(
+      store
+        .get(chatPanelTabsAtom)
+        .tabs.find((tab) => tab.workItem?.orgId === "org-a")?.workItem
+    ).toBe(first);
+    expect(
+      store
+        .get(chatPanelTabsAtom)
+        .tabs.find((tab) => tab.workItem?.orgId === "org-b")?.title
+    ).toBe("Updated B");
   });
 
   it("removes the tab-owned payload and clears the active selection", async () => {

--- a/src/store/chatPanel/chatPanelTabFactories.ts
+++ b/src/store/chatPanel/chatPanelTabFactories.ts
@@ -13,7 +13,7 @@ import type {
   ChatPanelSelectedProject,
   ChatPanelSelectedWorkItem,
   ChatPanelSelectedWorkspace,
-} from "@src/store/ui/chatPanel/selectionAtoms";
+} from "@src/store/ui/chatPanel/selectionTypes";
 import type { WorkManagementSection } from "@src/store/workstation/workstationTabBarAtoms";
 import type {
   GitHubIssueDetailTabData,

--- a/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
@@ -394,40 +394,6 @@ export const setChatPanelTabTitleAtom = atom(
   }
 );
 
-/**
- * Keep a work-item tab's stored payload in sync with in-place edits made
- * through `chatPanelSelectedWorkItemAtom` (rename / status change / refresh).
- * Without this, switching away and back would replay the stale payload and
- * revert the edit. Matched by organization, project, and short ID; a no-op
- * (returns the previous state) when the payload reference is unchanged — e.g.
- * the seed written on tab activation — so it never churns tab state or
- * persistence.
- */
-export const patchChatPanelWorkItemTabAtom = atom(
-  null,
-  (_get, set, workItem: ChatPanelSelectedWorkItem) => {
-    const workItemKey = getChatPanelWorkItemTabKey(workItem);
-    set(chatPanelTabsAtom, (prev) => {
-      const target = prev.tabs.find(
-        (tab) =>
-          tab.type === "work-item" &&
-          tab.workItem !== undefined &&
-          getChatPanelWorkItemTabKey(tab.workItem) === workItemKey
-      );
-      if (!target || target.workItem === workItem) return prev;
-      return {
-        ...prev,
-        tabs: prev.tabs.map((tab) =>
-          tab.id === target.id
-            ? { ...tab, workItem, title: workItem.workItem.name || tab.title }
-            : tab
-        ),
-      };
-    });
-  }
-);
-patchChatPanelWorkItemTabAtom.debugLabel = "patchChatPanelWorkItemTab";
-
 /** Toggle TUI mode on the given tab */
 export const toggleChatPanelTabTuiModeAtom = atom(
   null,

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -17,7 +17,6 @@ export {
   closeRevokedCloudChannelChatPanelTabsAtom,
   closeWorkItemChatPanelTabAtom,
   nextChatPanelTabAtom,
-  patchChatPanelWorkItemTabAtom,
   prevChatPanelTabAtom,
   reconcileDiscussionChannelTabsAtom,
   reorderChatPanelTabsAtom,

--- a/src/store/chatPanel/chatPanelTabsModel.ts
+++ b/src/store/chatPanel/chatPanelTabsModel.ts
@@ -6,7 +6,7 @@ import type {
   ChatPanelSelectedProjectOrg,
   ChatPanelSelectedWorkItem,
   ChatPanelSelectedWorkspace,
-} from "@src/store/ui/chatPanel/selectionAtoms";
+} from "@src/store/ui/chatPanel/selectionTypes";
 import {
   WORK_MANAGEMENT_SECTION,
   type WorkManagementSection,

--- a/src/store/ui/chatPanel/selectionAtoms.ts
+++ b/src/store/ui/chatPanel/selectionAtoms.ts
@@ -1,201 +1,196 @@
-/**
- * Chat-panel selection state: what the slot is currently pointed at (create
- * target, work item, project, project org, workspace, cloud org, Explore) and
- * the workspace-overview sub-tab.
- */
 import { atom } from "jotai";
 
-import type { Project } from "@src/types/core/project";
-import type { WorkItem } from "@src/types/core/workItem";
-import type { ProjectOrgSurfaceView } from "@src/types/ui/projectOrg";
+import { getChatPanelWorkItemTabKey } from "@src/store/chatPanel/chatPanelTabFactories";
+import { chatPanelTabsAtom } from "@src/store/chatPanel/chatPanelTabsState";
 
-//
-// The docked chat-panel slot can host either the live session view or
-// Settings. Which one occupies the slot is fully URL-derived (any
-// `/orgii/app/settings/*` path → Settings; otherwise → session), so
-// there is no atom for it — `AppLayout`/`AppShell` compute the mode
-// directly from `useLocation()` and pass it down. The only persistent
-// axis is "maximized", which is orthogonal to the mode and survives
-// reloads.
+import {
+  CHAT_PANEL_CONTENT_MODE,
+  type ChatPanelContentMode,
+  type ChatPanelCreateProjectContext,
+  type ChatPanelCreateTarget,
+  type ChatPanelSelectedCloudOrg,
+  type ChatPanelSelectedProject,
+  type ChatPanelSelectedProjectOrg,
+  type ChatPanelSelectedWorkItem,
+  type ChatPanelSelectedWorkspace,
+  DEFAULT_CHAT_PANEL_CREATE_TARGET,
+  WORKSPACE_OVERVIEW_TAB,
+  type WorkspaceOverviewTab,
+} from "./selectionTypes";
 
-/**
- * What content occupies the chat-panel slot. Derived from the URL by
- * the layout shell; this type is exported only as a wire format for the
- * shell → layout prop hand-off.
- */
-export type ChatPanelMode = "session" | "settings";
-
-export const CHAT_PANEL_CREATE_TARGET = {
-  AGENT_SESSION: "agentSession",
-  /** One prompt, several harnesses, started at once and compared after. */
-  PARALLEL_RUN: "parallelRun",
-  PROJECT: "project",
-  WORK_ITEM: "workItem",
-} as const;
-
-export type ChatPanelCreateTarget =
-  (typeof CHAT_PANEL_CREATE_TARGET)[keyof typeof CHAT_PANEL_CREATE_TARGET];
-
-export const DEFAULT_CHAT_PANEL_CREATE_TARGET: ChatPanelCreateTarget =
-  CHAT_PANEL_CREATE_TARGET.AGENT_SESSION;
+// Preserve public import paths; tab models/factories import the types directly.
+export * from "./selectionTypes";
 
 export const chatPanelCreateTargetAtom = atom<ChatPanelCreateTarget>(
   DEFAULT_CHAT_PANEL_CREATE_TARGET
 );
-chatPanelCreateTargetAtom.debugLabel = "chatPanelCreateTargetAtom";
-
-export const chatPanelStartPageOpenAtom = atom<boolean>(true);
-chatPanelStartPageOpenAtom.debugLabel = "chatPanelStartPageOpenAtom";
-
-export interface ChatPanelCreateProjectContext {
-  orgId: string;
-  scopeBreadcrumbLabel?: string;
-}
-
+export const chatPanelStartPageOpenAtom = atom(true);
 export const chatPanelCreateProjectContextAtom =
   atom<ChatPanelCreateProjectContext | null>(null);
-chatPanelCreateProjectContextAtom.debugLabel =
-  "chatPanelCreateProjectContextAtom";
-
-export const CHAT_PANEL_CONTENT_MODE = {
-  SESSION: "session",
-  NON_SESSION: "nonSession",
-} as const;
-
-export type ChatPanelContentMode =
-  (typeof CHAT_PANEL_CONTENT_MODE)[keyof typeof CHAT_PANEL_CONTENT_MODE];
-
-export const chatPanelContentModeAtom = atom<ChatPanelContentMode>(
-  CHAT_PANEL_CONTENT_MODE.SESSION
-);
-chatPanelContentModeAtom.debugLabel = "chatPanelContentModeAtom";
-
-export interface ChatPanelSelectedWorkItem {
-  workItem: WorkItem;
-  projectId: string;
-  projectName: string;
-  projectSlug: string;
-  shortId: string;
-  orgId?: string;
-  orgName?: string;
-  sourceProject?: {
-    project: Project;
-    projectSlug: string;
-    orgId: string;
-    orgName?: string;
-  };
-}
-
-export const chatPanelSelectedWorkItemAtom =
-  atom<ChatPanelSelectedWorkItem | null>(null);
-chatPanelSelectedWorkItemAtom.debugLabel = "chatPanelSelectedWorkItemAtom";
-
-export interface ChatPanelSelectedProject {
-  project: Project;
-  projectSlug: string;
-  projectSyncAdapterId?: string | null;
-  orgId: string;
-  orgName?: string;
-}
-
-export const chatPanelSelectedProjectAtom =
-  atom<ChatPanelSelectedProject | null>(null);
-chatPanelSelectedProjectAtom.debugLabel = "chatPanelSelectedProjectAtom";
-
-export interface ChatPanelSelectedProjectOrg {
-  orgId: string;
-  orgName: string;
-  orgScope: "personal_org" | "project_org";
-  orgSyncProvider?: string | null;
-  /** Optional surface requested by the action opening/focusing this ORG. */
-  initialView?: ProjectOrgSurfaceView;
-  /** Changes when an opener explicitly requests `initialView` again. */
-  initialViewRequestId?: number;
-}
-
-export const chatPanelSelectedProjectOrgAtom =
-  atom<ChatPanelSelectedProjectOrg | null>(null);
-chatPanelSelectedProjectOrgAtom.debugLabel = "chatPanelSelectedProjectOrgAtom";
-
-export interface ChatPanelSelectedWorkspace {
-  kind: "workspace" | "repo";
-  id: string;
-  name: string;
-  path?: string;
-  folderCount?: number;
-  repoIds?: string[];
-}
-
-export const chatPanelSelectedWorkspaceAtom =
-  atom<ChatPanelSelectedWorkspace | null>(null);
-chatPanelSelectedWorkspaceAtom.debugLabel = "chatPanelSelectedWorkspaceAtom";
-
-/**
- * Managed ORG2 Cloud org selected for the CLOUD_ORG management panel
- * (cloud orgs come from the managed backend, `org2CloudOrgsAtom`).
- */
-export interface ChatPanelSelectedCloudOrg {
-  orgId: string;
-  /** Optional management surface requested by the action opening this ORG. */
-  initialView?: CloudOrgManagementView;
-  /** Changes when an opener explicitly requests `initialView` again. */
-  initialViewRequestId?: number;
-}
-
-export type CloudOrgManagementView = "general" | "sync" | "members";
-
-export const CLOUD_ORG_MANAGEMENT_VIEW = {
-  GENERAL: "general",
-  SYNC: "sync",
-  MEMBERS: "members",
-} as const satisfies Record<string, CloudOrgManagementView>;
-
-/** The explicit provider variant owned by the shared organization tab. */
-export type ChatPanelSelectedOrganization =
-  | {
-      kind: "cloud";
-      cloudOrg: ChatPanelSelectedCloudOrg;
-    }
-  | {
-      kind: "local";
-      projectOrg: ChatPanelSelectedProjectOrg;
-    };
-
-export const chatPanelSelectedCloudOrgAtom =
-  atom<ChatPanelSelectedCloudOrg | null>(null);
-chatPanelSelectedCloudOrgAtom.debugLabel = "chatPanelSelectedCloudOrgAtom";
-
-/**
- * Whether the chat-panel slot is rendering the GitHub repo search /
- * "Explore" view. Mutually exclusive with the workspace dashboard,
- * project, work item, and session surfaces at the render layer
- * (precedence enforced in `ChatPanel/index.tsx`). Entry points that
- * open Explore must clear those sibling atoms.
- */
-export const chatPanelExploreOpenAtom = atom<boolean>(false);
-chatPanelExploreOpenAtom.debugLabel = "chatPanelExploreOpenAtom";
-
-/**
- * Selected tab on the chat-panel workspace overview surface
- * (`WorkspaceOverviewPanelView`). The overview/details split is
- * orthogonal to which workspace is selected; entry points that drill
- * into a specific repo (e.g. the dashboard's "Open details" button)
- * set this to `"details"` along with `chatPanelSelectedWorkspaceAtom`.
- *
- * Persisted only in-memory — switching between workspace overview
- * targets preserves the selected tab unless navigation explicitly
- * requests a different tab.
- */
-export const WORKSPACE_OVERVIEW_TAB = {
-  OVERVIEW: "overview",
-  DETAILS: "details",
-} as const;
-
-export type WorkspaceOverviewTab =
-  (typeof WORKSPACE_OVERVIEW_TAB)[keyof typeof WORKSPACE_OVERVIEW_TAB];
-
 export const chatPanelWorkspaceOverviewTabAtom = atom<WorkspaceOverviewTab>(
   WORKSPACE_OVERVIEW_TAB.OVERVIEW
 );
+chatPanelCreateTargetAtom.debugLabel = "chatPanelCreateTargetAtom";
+chatPanelStartPageOpenAtom.debugLabel = "chatPanelStartPageOpenAtom";
+chatPanelCreateProjectContextAtom.debugLabel =
+  "chatPanelCreateProjectContextAtom";
 chatPanelWorkspaceOverviewTabAtom.debugLabel =
   "chatPanelWorkspaceOverviewTabAtom";
+
+/** Exactly one non-session selection can own the slot. Creator controls and
+ * workspace subnavigation remain orthogonal, independently retained axes. */
+interface SelectionPayloads {
+  project: ChatPanelSelectedProject;
+  projectOrg: ChatPanelSelectedProjectOrg;
+  workspace: ChatPanelSelectedWorkspace;
+  cloudOrg: ChatPanelSelectedCloudOrg;
+}
+
+type ChatPanelSelectionState =
+  | { kind: "session" | "creation" | "explore" }
+  | {
+      kind: "workItem";
+      target: { tabId: string } | { inline: ChatPanelSelectedWorkItem };
+    }
+  | {
+      [K in keyof SelectionPayloads]: { kind: K; value: SelectionPayloads[K] };
+    }[keyof SelectionPayloads];
+
+export const chatPanelSelectionStateAtom = atom<ChatPanelSelectionState>({
+  kind: "session",
+});
+chatPanelSelectionStateAtom.debugLabel = "chatPanelSelectionStateAtom";
+
+type Update<T> = T | ((previous: T) => T);
+
+function selectionAtom<T extends object>(
+  read: (selection: ChatPanelSelectionState) => T | null,
+  select: (value: T) => ChatPanelSelectionState
+) {
+  return atom(
+    (get): T | null => read(get(chatPanelSelectionStateAtom)),
+    (get, set, update: Update<T | null>) => {
+      const previous = read(get(chatPanelSelectionStateAtom));
+      const value = typeof update === "function" ? update(previous) : update;
+      if (value === previous) return;
+      if (value) {
+        set(chatPanelSelectionStateAtom, select(value));
+      } else if (previous) {
+        set(chatPanelSelectionStateAtom, { kind: "creation" });
+      }
+    }
+  );
+}
+
+export const chatPanelSelectedProjectAtom = selectionAtom(
+  (state) => (state.kind === "project" ? state.value : null),
+  (value) => ({ kind: "project", value })
+);
+export const chatPanelSelectedProjectOrgAtom = selectionAtom(
+  (state) => (state.kind === "projectOrg" ? state.value : null),
+  (value) => ({ kind: "projectOrg", value })
+);
+export const chatPanelSelectedWorkspaceAtom = selectionAtom(
+  (state) => (state.kind === "workspace" ? state.value : null),
+  (value) => ({ kind: "workspace", value })
+);
+export const chatPanelSelectedCloudOrgAtom = selectionAtom(
+  (state) => (state.kind === "cloudOrg" ? state.value : null),
+  (value) => ({ kind: "cloudOrg", value })
+);
+chatPanelSelectedProjectAtom.debugLabel = "chatPanelSelectedProjectAtom";
+chatPanelSelectedProjectOrgAtom.debugLabel = "chatPanelSelectedProjectOrgAtom";
+chatPanelSelectedWorkspaceAtom.debugLabel = "chatPanelSelectedWorkspaceAtom";
+chatPanelSelectedCloudOrgAtom.debugLabel = "chatPanelSelectedCloudOrgAtom";
+
+/** Work-item tabs own their payload; selection retains only the tab ID.
+ * Direct navigation without a tab retains one inline payload instead. */
+export const chatPanelSelectedWorkItemAtom = atom(
+  (get): ChatPanelSelectedWorkItem | null => {
+    const selection = get(chatPanelSelectionStateAtom);
+    if (selection.kind !== "workItem") return null;
+    const target = selection.target;
+    return "inline" in target
+      ? target.inline
+      : (get(chatPanelTabsAtom).tabs.find((tab) => tab.id === target.tabId)
+          ?.workItem ?? null);
+  },
+  (get, set, update: Update<ChatPanelSelectedWorkItem | null>) => {
+    const previous = get(chatPanelSelectedWorkItemAtom);
+    const value = typeof update === "function" ? update(previous) : update;
+    if (!value) {
+      if (get(chatPanelSelectionStateAtom).kind === "workItem") {
+        set(chatPanelSelectionStateAtom, { kind: "creation" });
+      }
+      return;
+    }
+    const state = get(chatPanelTabsAtom);
+    const key = getChatPanelWorkItemTabKey(value);
+    const target = state.tabs.find(
+      (tab) =>
+        tab.type === "work-item" &&
+        tab.workItem &&
+        getChatPanelWorkItemTabKey(tab.workItem) === key
+    );
+    if (target) {
+      if (target.workItem !== value) {
+        set(chatPanelTabsAtom, {
+          ...state,
+          tabs: state.tabs.map((tab) =>
+            tab.id === target.id
+              ? {
+                  ...tab,
+                  workItem: value,
+                  title: value.workItem.name || tab.title,
+                }
+              : tab
+          ),
+        });
+      }
+      const selection = get(chatPanelSelectionStateAtom);
+      if (
+        selection.kind === "workItem" &&
+        "tabId" in selection.target &&
+        selection.target.tabId === target.id
+      )
+        return;
+      set(chatPanelSelectionStateAtom, {
+        kind: "workItem",
+        target: { tabId: target.id },
+      });
+    } else if (value !== previous) {
+      set(chatPanelSelectionStateAtom, {
+        kind: "workItem",
+        target: { inline: value },
+      });
+    }
+  }
+);
+chatPanelSelectedWorkItemAtom.debugLabel = "chatPanelSelectedWorkItemAtom";
+
+export const chatPanelContentModeAtom = atom(
+  (get): ChatPanelContentMode =>
+    get(chatPanelSelectionStateAtom).kind === "session"
+      ? CHAT_PANEL_CONTENT_MODE.SESSION
+      : CHAT_PANEL_CONTENT_MODE.NON_SESSION,
+  (get, set, update: Update<ChatPanelContentMode>) => {
+    const previous = get(chatPanelContentModeAtom);
+    const mode = typeof update === "function" ? update(previous) : update;
+    if (mode === previous) return;
+    set(chatPanelSelectionStateAtom, {
+      kind: mode === CHAT_PANEL_CONTENT_MODE.SESSION ? "session" : "creation",
+    });
+  }
+);
+chatPanelContentModeAtom.debugLabel = "chatPanelContentModeAtom";
+
+export const chatPanelExploreOpenAtom = atom(
+  (get) => get(chatPanelSelectionStateAtom).kind === "explore",
+  (get, set, update: Update<boolean>) => {
+    const previous = get(chatPanelExploreOpenAtom);
+    const open = typeof update === "function" ? update(previous) : update;
+    if (open === previous) return;
+    set(chatPanelSelectionStateAtom, { kind: open ? "explore" : "creation" });
+  }
+);
+chatPanelExploreOpenAtom.debugLabel = "chatPanelExploreOpenAtom";

--- a/src/store/ui/chatPanel/selectionTypes.ts
+++ b/src/store/ui/chatPanel/selectionTypes.ts
@@ -1,0 +1,141 @@
+/** Chat-panel selection payloads and independently retained navigation axes. */
+import type { Project } from "@src/types/core/project";
+import type { WorkItem } from "@src/types/core/workItem";
+import type { ProjectOrgSurfaceView } from "@src/types/ui/projectOrg";
+
+//
+// The docked chat-panel slot can host either the live session view or
+// Settings. Which one occupies the slot is fully URL-derived (any
+// `/orgii/app/settings/*` path → Settings; otherwise → session), so
+// there is no atom for it — `AppLayout`/`AppShell` compute the mode
+// directly from `useLocation()` and pass it down. The only persistent
+// axis is "maximized", which is orthogonal to the mode and survives
+// reloads.
+
+/**
+ * What content occupies the chat-panel slot. Derived from the URL by
+ * the layout shell; this type is exported only as a wire format for the
+ * shell → layout prop hand-off.
+ */
+export type ChatPanelMode = "session" | "settings";
+
+export const CHAT_PANEL_CREATE_TARGET = {
+  AGENT_SESSION: "agentSession",
+  /** One prompt, several harnesses, started at once and compared after. */
+  PARALLEL_RUN: "parallelRun",
+  PROJECT: "project",
+  WORK_ITEM: "workItem",
+} as const;
+
+export type ChatPanelCreateTarget =
+  (typeof CHAT_PANEL_CREATE_TARGET)[keyof typeof CHAT_PANEL_CREATE_TARGET];
+
+export const DEFAULT_CHAT_PANEL_CREATE_TARGET: ChatPanelCreateTarget =
+  CHAT_PANEL_CREATE_TARGET.AGENT_SESSION;
+
+export interface ChatPanelCreateProjectContext {
+  orgId: string;
+  scopeBreadcrumbLabel?: string;
+}
+
+export const CHAT_PANEL_CONTENT_MODE = {
+  SESSION: "session",
+  NON_SESSION: "nonSession",
+} as const;
+
+export type ChatPanelContentMode =
+  (typeof CHAT_PANEL_CONTENT_MODE)[keyof typeof CHAT_PANEL_CONTENT_MODE];
+
+export interface ChatPanelSelectedWorkItem {
+  workItem: WorkItem;
+  projectId: string;
+  projectName: string;
+  projectSlug: string;
+  shortId: string;
+  orgId?: string;
+  orgName?: string;
+  sourceProject?: {
+    project: Project;
+    projectSlug: string;
+    orgId: string;
+    orgName?: string;
+  };
+}
+
+export interface ChatPanelSelectedProject {
+  project: Project;
+  projectSlug: string;
+  projectSyncAdapterId?: string | null;
+  orgId: string;
+  orgName?: string;
+}
+
+export interface ChatPanelSelectedProjectOrg {
+  orgId: string;
+  orgName: string;
+  orgScope: "personal_org" | "project_org";
+  orgSyncProvider?: string | null;
+  /** Optional surface requested by the action opening/focusing this ORG. */
+  initialView?: ProjectOrgSurfaceView;
+  /** Changes when an opener explicitly requests `initialView` again. */
+  initialViewRequestId?: number;
+}
+
+export interface ChatPanelSelectedWorkspace {
+  kind: "workspace" | "repo";
+  id: string;
+  name: string;
+  path?: string;
+  folderCount?: number;
+  repoIds?: string[];
+}
+
+/**
+ * Managed ORG2 Cloud org selected for the CLOUD_ORG management panel
+ * (cloud orgs come from the managed backend, `org2CloudOrgsAtom`).
+ */
+export interface ChatPanelSelectedCloudOrg {
+  orgId: string;
+  /** Optional management surface requested by the action opening this ORG. */
+  initialView?: CloudOrgManagementView;
+  /** Changes when an opener explicitly requests `initialView` again. */
+  initialViewRequestId?: number;
+}
+
+export type CloudOrgManagementView = "general" | "sync" | "members";
+
+export const CLOUD_ORG_MANAGEMENT_VIEW = {
+  GENERAL: "general",
+  SYNC: "sync",
+  MEMBERS: "members",
+} as const satisfies Record<string, CloudOrgManagementView>;
+
+/** The explicit provider variant owned by the shared organization tab. */
+export type ChatPanelSelectedOrganization =
+  | {
+      kind: "cloud";
+      cloudOrg: ChatPanelSelectedCloudOrg;
+    }
+  | {
+      kind: "local";
+      projectOrg: ChatPanelSelectedProjectOrg;
+    };
+
+/**
+ * Selected tab on the chat-panel workspace overview surface
+ * (`WorkspaceOverviewPanelView`). The overview/details split is
+ * orthogonal to which workspace is selected; entry points that drill
+ * into a specific repo (e.g. the dashboard's "Open details" button)
+ * set this to `"details"` along with `chatPanelSelectedWorkspaceAtom`.
+ *
+ * Persisted only in-memory — switching between workspace overview
+ * targets preserves the selected tab unless navigation explicitly
+ * requests a different tab.
+ */
+export const WORKSPACE_OVERVIEW_TAB = {
+  OVERVIEW: "overview",
+  DETAILS: "details",
+} as const;
+
+export type WorkspaceOverviewTab =
+  (typeof WORKSPACE_OVERVIEW_TAB)[keyof typeof WORKSPACE_OVERVIEW_TAB];

--- a/src/store/ui/chatPanel/surfaceAtoms.test.ts
+++ b/src/store/ui/chatPanel/surfaceAtoms.test.ts
@@ -1,0 +1,157 @@
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import { resolveChatPanelContentState } from "@src/engines/ChatPanel/hooks/chatPanelContentState";
+import { CHAT_PANEL_SURFACE_KIND as KIND } from "@src/types/ui/chatPanel";
+
+import {
+  CHAT_PANEL_CONTENT_MODE,
+  CHAT_PANEL_CREATE_TARGET,
+  type ChatPanelSelectedProject,
+  type ChatPanelSelectedWorkItem,
+  chatPanelContentModeAtom,
+  chatPanelCreateProjectContextAtom,
+  chatPanelCreateTargetAtom,
+  chatPanelExploreOpenAtom,
+  chatPanelSelectedCloudOrgAtom,
+  chatPanelSelectedProjectAtom,
+  chatPanelSelectedProjectOrgAtom,
+  chatPanelSelectedWorkItemAtom,
+  chatPanelSelectedWorkspaceAtom,
+  chatPanelWorkspaceOverviewTabAtom,
+} from "./selectionAtoms";
+import {
+  type ChatPanelNavigateCommand,
+  activeChatPanelSurfaceAtom,
+  chatPanelNavigateAtom,
+} from "./surfaceAtoms";
+
+const project = {
+  project: { id: "p", name: "Project" },
+  projectSlug: "project",
+  orgId: "org",
+} as ChatPanelSelectedProject;
+const workItem = {
+  workItem: { session_id: "w", name: "Work" },
+  shortId: "W-1",
+  projectId: "p",
+  projectName: "Project",
+  projectSlug: "project",
+  orgId: "org",
+} as ChatPanelSelectedWorkItem;
+
+const commands: ChatPanelNavigateCommand[] = [
+  { kind: KIND.SESSION },
+  { kind: KIND.NEW_PROJECT, createProjectContext: { orgId: "org" } },
+  { kind: KIND.NEW_WORK_ITEM },
+  { kind: KIND.PROJECT, project },
+  {
+    kind: KIND.PROJECT_ORG,
+    projectOrg: { orgId: "org", orgName: "Org", orgScope: "project_org" },
+  },
+  { kind: KIND.WORK_ITEM, workItem },
+  { kind: KIND.WORKSPACE_EXPLORE },
+  {
+    kind: KIND.WORKSPACE_OVERVIEW,
+    workspace: { kind: "repo", id: "repo", name: "Repo" },
+  },
+  { kind: KIND.CLOUD_ORG, cloudOrg: { orgId: "cloud" } },
+];
+
+describe("canonical chat-panel surface", () => {
+  it.each(commands)(
+    "navigates from every prior surface to $kind without stale selections",
+    (destination) => {
+      const store = createStore();
+      for (const source of commands) {
+        store.set(chatPanelNavigateAtom, source);
+        store.set(chatPanelNavigateAtom, destination);
+        const surface = store.get(activeChatPanelSurfaceAtom);
+        expect(surface.kind).toBe(destination.kind);
+        const selections = [
+          store.get(chatPanelSelectedProjectAtom),
+          store.get(chatPanelSelectedProjectOrgAtom),
+          store.get(chatPanelSelectedWorkItemAtom),
+          store.get(chatPanelSelectedWorkspaceAtom),
+          store.get(chatPanelSelectedCloudOrgAtom),
+          store.get(chatPanelExploreOpenAtom),
+        ].filter(Boolean);
+        expect(selections.length).toBe(
+          [KIND.SESSION, KIND.NEW_PROJECT, KIND.NEW_WORK_ITEM].some(
+            (kind) => kind === destination.kind
+          )
+            ? 0
+            : 1
+        );
+        const view = resolveChatPanelContentState({
+          active: true,
+          currentSessionId: "still-loaded-session",
+          contentMode: store.get(chatPanelContentModeAtom),
+          surface,
+        });
+        expect(view.showSessionContent).toBe(destination.kind === KIND.SESSION);
+        expect(view.showCloudOrgContent).toBe(
+          destination.kind === KIND.CLOUD_ORG
+        );
+        expect(view.showWorkspaceOverviewContent).toBe(
+          destination.kind === KIND.WORKSPACE_OVERVIEW
+        );
+        expect(view.showWorkItemContent).toBe(
+          destination.kind === KIND.WORK_ITEM
+        );
+        expect(view.showProjectContent).toBe(destination.kind === KIND.PROJECT);
+        expect(view.showProjectOrgContent).toBe(
+          destination.kind === KIND.PROJECT_ORG
+        );
+        expect(view.showExploreContent).toBe(
+          destination.kind === KIND.WORKSPACE_EXPLORE
+        );
+      }
+    }
+  );
+
+  it("direct selection writes replace siblings and unrelated clears do not erase the surface", () => {
+    const store = createStore();
+    store.set(chatPanelSelectedWorkspaceAtom, {
+      kind: "workspace",
+      id: "w",
+      name: "Workspace",
+    });
+    store.set(chatPanelSelectedCloudOrgAtom, { orgId: "cloud" });
+    store.set(chatPanelSelectedProjectAtom, null);
+    expect(store.get(chatPanelSelectedWorkspaceAtom)).toBeNull();
+    expect(store.get(activeChatPanelSurfaceAtom)).toEqual({
+      kind: KIND.CLOUD_ORG,
+      cloudOrg: { orgId: "cloud" },
+    });
+    store.set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.SESSION);
+    expect(store.get(chatPanelSelectedCloudOrgAtom)).toBeNull();
+    expect(store.get(activeChatPanelSurfaceAtom).kind).toBe(KIND.SESSION);
+    expect(createStore().get(chatPanelContentModeAtom)).toBe(
+      CHAT_PANEL_CONTENT_MODE.SESSION
+    );
+  });
+
+  it("preserves workspace subnavigation and independent Launchpad creator controls", () => {
+    const store = createStore();
+    store.set(chatPanelWorkspaceOverviewTabAtom, "details");
+    store.set(chatPanelNavigateAtom, commands[7]);
+    expect(store.get(chatPanelWorkspaceOverviewTabAtom)).toBe("details");
+    store.set(chatPanelNavigateAtom, {
+      ...commands[7],
+      kind: KIND.WORKSPACE_OVERVIEW,
+      workspace: { kind: "repo", id: "r2", name: "Repo 2" },
+      tab: "overview",
+    });
+    expect(store.get(chatPanelWorkspaceOverviewTabAtom)).toBe("overview");
+    store.set(chatPanelNavigateAtom, { kind: KIND.SESSION });
+    store.set(chatPanelCreateTargetAtom, CHAT_PANEL_CREATE_TARGET.PARALLEL_RUN);
+    expect(store.get(activeChatPanelSurfaceAtom).kind).toBe(KIND.SESSION);
+    store.set(chatPanelNavigateAtom, commands[1]);
+    expect(store.get(chatPanelCreateProjectContextAtom)).toEqual({
+      orgId: "org",
+    });
+    store.set(chatPanelNavigateAtom, commands[4]);
+    expect(store.get(chatPanelCreateProjectContextAtom)).toBeNull();
+  });
+});

--- a/src/store/ui/chatPanel/surfaceAtoms.ts
+++ b/src/store/ui/chatPanel/surfaceAtoms.ts
@@ -11,7 +11,6 @@ import { CHAT_PANEL_SURFACE_KIND } from "@src/types/ui/chatPanel";
 import { createZodJsonStorage } from "@src/util/core/storage/zodStorage";
 
 import {
-  CHAT_PANEL_CONTENT_MODE,
   CHAT_PANEL_CREATE_TARGET,
   type ChatPanelCreateProjectContext,
   type ChatPanelSelectedCloudOrg,
@@ -22,7 +21,6 @@ import {
   DEFAULT_CHAT_PANEL_CREATE_TARGET,
   WORKSPACE_OVERVIEW_TAB,
   type WorkspaceOverviewTab,
-  chatPanelContentModeAtom,
   chatPanelCreateProjectContextAtom,
   chatPanelCreateTargetAtom,
   chatPanelExploreOpenAtom,
@@ -31,6 +29,7 @@ import {
   chatPanelSelectedProjectOrgAtom,
   chatPanelSelectedWorkItemAtom,
   chatPanelSelectedWorkspaceAtom,
+  chatPanelSelectionStateAtom,
   chatPanelStartPageOpenAtom,
   chatPanelWorkspaceOverviewTabAtom,
 } from "./selectionAtoms";
@@ -100,13 +99,7 @@ type SetAtom = <Value, Args extends unknown[], Result>(
   ...args: Args
 ) => Result;
 
-function resetChatPanelSurfaceState(set: SetAtom): void {
-  set(chatPanelSelectedWorkItemAtom, null);
-  set(chatPanelSelectedProjectAtom, null);
-  set(chatPanelSelectedProjectOrgAtom, null);
-  set(chatPanelSelectedWorkspaceAtom, null);
-  set(chatPanelSelectedCloudOrgAtom, null);
-  set(chatPanelExploreOpenAtom, false);
+function resetChatPanelNavigationOptions(set: SetAtom): void {
   set(chatPanelCreateProjectContextAtom, null);
   set(chatPanelCreateTargetAtom, DEFAULT_CHAT_PANEL_CREATE_TARGET);
   set(chatPanelWorkspaceOverviewTabAtom, WORKSPACE_OVERVIEW_TAB.OVERVIEW);
@@ -116,15 +109,15 @@ export const chatPanelNavigateAtom = atom(
   null,
   (get, set, command: ChatPanelNavigateCommand) => {
     const currentWorkspaceOverviewTab = get(chatPanelWorkspaceOverviewTabAtom);
-    resetChatPanelSurfaceState(set);
+    resetChatPanelNavigationOptions(set);
     set(chatPanelStartPageOpenAtom, false);
 
     switch (command.kind) {
       case CHAT_PANEL_SURFACE_KIND.SESSION:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.SESSION);
+        set(chatPanelSelectionStateAtom, { kind: "session" });
         return;
       case CHAT_PANEL_SURFACE_KIND.NEW_PROJECT:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.NON_SESSION);
+        set(chatPanelSelectionStateAtom, { kind: "creation" });
         set(chatPanelCreateTargetAtom, CHAT_PANEL_CREATE_TARGET.PROJECT);
         set(
           chatPanelCreateProjectContextAtom,
@@ -132,7 +125,7 @@ export const chatPanelNavigateAtom = atom(
         );
         return;
       case CHAT_PANEL_SURFACE_KIND.NEW_WORK_ITEM:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.NON_SESSION);
+        set(chatPanelSelectionStateAtom, { kind: "creation" });
         set(chatPanelCreateTargetAtom, CHAT_PANEL_CREATE_TARGET.WORK_ITEM);
         set(
           chatPanelCreateProjectContextAtom,
@@ -140,23 +133,18 @@ export const chatPanelNavigateAtom = atom(
         );
         return;
       case CHAT_PANEL_SURFACE_KIND.PROJECT:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.NON_SESSION);
         set(chatPanelSelectedProjectAtom, command.project);
         return;
       case CHAT_PANEL_SURFACE_KIND.PROJECT_ORG:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.NON_SESSION);
         set(chatPanelSelectedProjectOrgAtom, command.projectOrg);
         return;
       case CHAT_PANEL_SURFACE_KIND.WORK_ITEM:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.NON_SESSION);
         set(chatPanelSelectedWorkItemAtom, command.workItem);
         return;
       case CHAT_PANEL_SURFACE_KIND.WORKSPACE_EXPLORE:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.NON_SESSION);
         set(chatPanelExploreOpenAtom, true);
         return;
       case CHAT_PANEL_SURFACE_KIND.WORKSPACE_OVERVIEW:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.NON_SESSION);
         set(chatPanelSelectedWorkspaceAtom, command.workspace);
         set(
           chatPanelWorkspaceOverviewTabAtom,
@@ -164,7 +152,6 @@ export const chatPanelNavigateAtom = atom(
         );
         return;
       case CHAT_PANEL_SURFACE_KIND.CLOUD_ORG:
-        set(chatPanelContentModeAtom, CHAT_PANEL_CONTENT_MODE.NON_SESSION);
         set(chatPanelSelectedCloudOrgAtom, command.cloudOrg);
         return;
     }
@@ -173,63 +160,48 @@ export const chatPanelNavigateAtom = atom(
 chatPanelNavigateAtom.debugLabel = "chatPanelNavigateAtom";
 
 export const activeChatPanelSurfaceAtom = atom<ChatPanelSurfaceState>((get) => {
-  const selectedWorkItem = get(chatPanelSelectedWorkItemAtom);
-  if (selectedWorkItem) {
-    return {
-      kind: CHAT_PANEL_SURFACE_KIND.WORK_ITEM,
-      workItem: selectedWorkItem,
-    };
+  const selection = get(chatPanelSelectionStateAtom);
+  switch (selection.kind) {
+    case "project":
+      return {
+        kind: CHAT_PANEL_SURFACE_KIND.PROJECT,
+        project: selection.value,
+      };
+    case "projectOrg":
+      return {
+        kind: CHAT_PANEL_SURFACE_KIND.PROJECT_ORG,
+        projectOrg: selection.value,
+      };
+    case "workspace":
+      return {
+        kind: CHAT_PANEL_SURFACE_KIND.WORKSPACE_OVERVIEW,
+        workspace: selection.value,
+        tab: get(chatPanelWorkspaceOverviewTabAtom),
+      };
+    case "cloudOrg":
+      return {
+        kind: CHAT_PANEL_SURFACE_KIND.CLOUD_ORG,
+        cloudOrg: selection.value,
+      };
+    case "explore":
+      return { kind: CHAT_PANEL_SURFACE_KIND.WORKSPACE_EXPLORE };
+    case "workItem": {
+      const workItem = get(chatPanelSelectedWorkItemAtom);
+      return workItem
+        ? { kind: CHAT_PANEL_SURFACE_KIND.WORK_ITEM, workItem }
+        : { kind: CHAT_PANEL_SURFACE_KIND.SESSION };
+    }
+    case "creation": {
+      const target = get(chatPanelCreateTargetAtom);
+      if (target === CHAT_PANEL_CREATE_TARGET.PROJECT)
+        return { kind: CHAT_PANEL_SURFACE_KIND.NEW_PROJECT };
+      if (target === CHAT_PANEL_CREATE_TARGET.WORK_ITEM)
+        return { kind: CHAT_PANEL_SURFACE_KIND.NEW_WORK_ITEM };
+      return { kind: CHAT_PANEL_SURFACE_KIND.SESSION };
+    }
+    case "session":
+      return { kind: CHAT_PANEL_SURFACE_KIND.SESSION };
   }
-
-  const selectedProject = get(chatPanelSelectedProjectAtom);
-  if (selectedProject) {
-    return { kind: CHAT_PANEL_SURFACE_KIND.PROJECT, project: selectedProject };
-  }
-
-  const selectedProjectOrg = get(chatPanelSelectedProjectOrgAtom);
-  if (selectedProjectOrg) {
-    return {
-      kind: CHAT_PANEL_SURFACE_KIND.PROJECT_ORG,
-      projectOrg: selectedProjectOrg,
-    };
-  }
-
-  if (get(chatPanelExploreOpenAtom)) {
-    return { kind: CHAT_PANEL_SURFACE_KIND.WORKSPACE_EXPLORE };
-  }
-
-  const selectedWorkspace = get(chatPanelSelectedWorkspaceAtom);
-  if (selectedWorkspace) {
-    return {
-      kind: CHAT_PANEL_SURFACE_KIND.WORKSPACE_OVERVIEW,
-      workspace: selectedWorkspace,
-      tab: get(chatPanelWorkspaceOverviewTabAtom),
-    };
-  }
-
-  const selectedCloudOrg = get(chatPanelSelectedCloudOrgAtom);
-  if (selectedCloudOrg) {
-    return {
-      kind: CHAT_PANEL_SURFACE_KIND.CLOUD_ORG,
-      cloudOrg: selectedCloudOrg,
-    };
-  }
-
-  const contentMode = get(chatPanelContentModeAtom);
-  const createTarget = get(chatPanelCreateTargetAtom);
-  if (
-    contentMode === CHAT_PANEL_CONTENT_MODE.NON_SESSION &&
-    createTarget === CHAT_PANEL_CREATE_TARGET.PROJECT
-  ) {
-    return { kind: CHAT_PANEL_SURFACE_KIND.NEW_PROJECT };
-  }
-  if (
-    contentMode === CHAT_PANEL_CONTENT_MODE.NON_SESSION &&
-    createTarget === CHAT_PANEL_CREATE_TARGET.WORK_ITEM
-  ) {
-    return { kind: CHAT_PANEL_SURFACE_KIND.NEW_WORK_ITEM };
-  }
-  return { kind: CHAT_PANEL_SURFACE_KIND.SESSION };
 });
 activeChatPanelSurfaceAtom.debugLabel = "activeChatPanelSurfaceAtom";
 


### PR DESCRIPTION
## Problem

Chat-panel content mode and six selection states were independently writable. Rendering and UI context snapshots used different precedence trees. Work-item edits also depended on a mounted React effect to copy selection payloads back to tabs, creating duplicate ownership and stale-replay risk.

## Solution

Use one mutually exclusive selection state with writable projections for existing callers. Render flags and UI context snapshots consume the same surface projection. For tab-backed work items, selection retains only the tab ID and edits update the owning tab synchronously; direct navigation without a tab retains an inline payload. Remove the mirror effect and patch atom. Separate runtime-independent selection types from state to avoid dependency cycles. Rename the pure content resolver so it no longer masquerades as a React hook.

Creator target/context, Launchpad visibility, workspace subnavigation and maximization retain their independent semantics. Session-switch orchestration is deliberately untouched. Main-checkout concurrent edits were not incorporated or modified.

## Potential risks

Direct selection writes now replace sibling selections instead of relying on render precedence. Surface transitions, creation, tab ownership, org-scoped updates and stale functional refreshes have regression coverage. Real desktop navigation/remount and CPU/RSS measurements are unverified. No persisted data deletion, storage format, IPC or wire identifier changes; revert the PR to restore previous ownership. Visual styles and layout are unchanged, so screenshots would not prove the state invariant. The existing SessionHoverCard dependency cycle remains outside scope.

## Verification

- `pnpm test src/engines/ChatPanel src/store/chatPanel src/store/ui/chatPanel src/services/context`: 1530 tests passed in 223 files.
- `pnpm test src/store/ui/chatPanel/surfaceAtoms.test.ts src/store/chatPanel/__tests__`: 107 tests passed after the pure-resolver rename.
- `pnpm typecheck:fast`: passed.
- `pnpm check:circular`: only the pre-existing SessionHoverCard/HoverCardBase.tsx and singletonStore.ts cycle; independently reproduced without this change. No new cycles.
- Commit hooks passed oxlint, ESLint, formatting and TypeScript. `git diff --check` passed.
- Architecture/lifecycle reports included. UI audit: 0 fix, 3 keep, 0 abstract; no new visual primitives.
- Reviewed final diff for single responsibility and secrets. Session viewAtom, chat-panel navigation actions and tab-presentation orchestration have no diff. No computer-control or real desktop verification was performed.