### PR TITLE
test(hooks): add reusable lifecycle resource contracts

### DIFF
--- a/docs/org2-performance-guard-2026-09-08/HookLifecycleContracts.md
+++ b/docs/org2-performance-guard-2026-09-08/HookLifecycleContracts.md
@@ -1,0 +1,16 @@
+# Hook lifecycle contracts
+
+`createHookLifecycleHarness` builds on the existing real React DOM smoke harness. It mounts under StrictMode, exposes only committed values, rerenders without replacing the component, and creates a fresh root/container after unmount. Reading after disposal fails explicitly. Tests restore spies and fake clocks even on assertion failure.
+
+The production contracts cover useMouseMoved and useKeepAliveWindow. Three repeated cycles exercise mount, unchanged rerender, visible/inactive state, unmount and remount. These are not mocked hook implementations. Async keyed-request behavior remains covered separately by the existing useAsyncData tests; this PR does not claim a generic proof for all hooks.
+
+| Area               | Verdict | Evidence                                                                                         | Change or reason kept                                                        | Verification                      |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | --------------------------------- |
+| Background work    | keep    | Mouse listener registrations paired with the same callback removals, including StrictMode replay | Assert one active registration while visible and zero after inactive/unmount | Three lifecycle cycles            |
+| Memory             | keep    | Warm state capped at two entries; deactivated entries expire                                     | Assert eviction and zero residual fake timers                                | Three scope/expiry/unmount cycles |
+| Scope/isolation    | keep    | Each remount uses a new root and container                                                       | Assert fresh state after prior disposal                                      | Repeated mounts                   |
+| Rendering/hot path | keep    | Test-only helper reads committed values via layout effect                                        | No production logic changed                                                  | Targeted lint and typecheck       |
+
+Performance verdict: pass for the two tested lifecycle contracts. These are deterministic resource-count tests, not CPU/RSS measurements. Native Tauri, account/network transitions and unrelated hooks are outside this test-only change. No UI screenshots or computer control are needed.
+
+Verification: `pnpm exec vitest run --config config/vitest.config.ts src/test/hookLifecycleHarness.test.ts` (two tests passed); targeted ESLint; `pnpm typecheck:fast`; `git diff --check`. Tests are discovered by the existing CI unit suite; no new dependency or runner is required.

--- a/src/test/hookLifecycleHarness.test.ts
+++ b/src/test/hookLifecycleHarness.test.ts
@@ -1,0 +1,85 @@
+/* @vitest-environment jsdom */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useKeepAliveWindow } from "@src/hooks/ui/useKeepAliveWindow";
+import { useMouseMoved } from "@src/hooks/ui/useMouseMoved";
+
+import { createHookLifecycleHarness } from "./hookLifecycleHarness";
+import { dispatch, settle } from "./reactSmokeHarness";
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("production hook lifecycle contracts", () => {
+  it("balances subscriptions through StrictMode, hidden state and remount", async () => {
+    const add = vi.spyOn(window, "addEventListener");
+    const remove = vi.spyOn(window, "removeEventListener");
+    const harness = createHookLifecycleHarness(
+      ({ visible }: { visible: boolean }) => useMouseMoved(visible)
+    );
+    cleanup.push(harness.unmount);
+    const registrations = () =>
+      add.mock.calls.filter(([event]) => event === "mousemove");
+    const removals = () =>
+      remove.mock.calls.filter(([event]) => event === "mousemove");
+    const balance = () => registrations().length - removals().length;
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await harness.render({ visible: true });
+      expect(balance()).toBe(1);
+      await harness.render({ visible: true });
+      expect(balance()).toBe(1);
+      expect(harness.read().current).toBe(false);
+      await dispatch(() => window.dispatchEvent(new MouseEvent("mousemove")));
+      expect(harness.read().current).toBe(true);
+      await harness.render({ visible: false });
+      expect(balance()).toBe(0);
+      expect(harness.read().current).toBe(false);
+      await harness.render({ visible: true });
+      expect(balance()).toBe(1);
+      await harness.unmount();
+      expect(balance()).toBe(0);
+      expect(() => harness.read()).toThrow("Render the hook");
+    }
+    // Verify callback identity, not just matching add/remove totals.
+    for (const [, callback] of registrations()) {
+      expect(removals().some(([, removed]) => removed === callback)).toBe(true);
+    }
+  });
+
+  it("bounds warm state and leaves no grace timer after repeated unmounts", async () => {
+    vi.useFakeTimers();
+    const present = ["a", "b", "c"];
+    const harness = createHookLifecycleHarness(
+      ({ active }: { active: string | null }) =>
+        useKeepAliveWindow(active, present, { graceMs: 100, maxWarm: 2 })
+    );
+    cleanup.push(harness.unmount);
+    const baselineTimers = vi.getTimerCount();
+    for (let cycle = 0; cycle < 3; cycle++) {
+      await harness.render({ active: "a" });
+      expect([...harness.read()]).toEqual(["a"]);
+      expect(vi.getTimerCount()).toBe(baselineTimers);
+      await harness.render({ active: "b" });
+      expect(harness.read().size).toBe(2);
+      expect(vi.getTimerCount()).toBe(baselineTimers + 1);
+      await harness.render({ active: "c" });
+      expect([...harness.read()]).toEqual(["b", "c"]);
+      expect(vi.getTimerCount()).toBe(baselineTimers + 1);
+      await harness.render({ active: null });
+      await settle(101);
+      expect(harness.read().size).toBe(0);
+      expect(vi.getTimerCount()).toBe(baselineTimers);
+      await harness.render({ active: "a" });
+      await harness.render({ active: "b" });
+      await harness.unmount();
+      expect(vi.getTimerCount()).toBe(baselineTimers);
+      await settle(1_000);
+      expect(vi.getTimerCount()).toBe(baselineTimers);
+    }
+  });
+});

--- a/src/test/hookLifecycleHarness.ts
+++ b/src/test/hookLifecycleHarness.ts
@@ -1,0 +1,38 @@
+import { StrictMode, createElement, useLayoutEffect } from "react";
+
+import { createSmokeRoot } from "./reactSmokeHarness";
+
+/** Real effects/cleanup; every remount gets a new React root and DOM container. */
+export function createHookLifecycleHarness<Props extends object, Result>(
+  useHook: (props: Props) => Result
+) {
+  let root: ReturnType<typeof createSmokeRoot> | null = null;
+  let committed: { value: Result } | null = null;
+
+  function Probe(props: Props) {
+    const value = useHook(props);
+    useLayoutEffect(() => {
+      committed = { value };
+    }, [value]);
+    return null;
+  }
+
+  return {
+    async render(props: Props) {
+      root ??= createSmokeRoot();
+      await root.render(
+        createElement(StrictMode, null, createElement(Probe, props))
+      );
+    },
+    read(): Result {
+      if (!committed)
+        throw new Error("Render the hook before reading its committed value");
+      return committed.value;
+    },
+    async unmount() {
+      await root?.unmount();
+      root = null;
+      committed = null;
+    },
+  };
+}


### PR DESCRIPTION
## Problem

Reference/lint checks cannot prove hook cleanup. The existing React smoke harness does not offer a reusable hook-level contract for repeated mount, inactive state and disposal cycles.

## Solution

Add a small StrictMode hook harness using the existing real React DOM infrastructure. Cover two production hooks: useMouseMoved must pair listener callback identities through visible/inactive/remount cycles, and useKeepAliveWindow must bound retained entries and leave no timer after expiry or unmount. Each contract runs three cycles, and cleanup restores spies/clocks on failures.

## Potential risks

This tests deterministic resource ownership, not native CPU/RSS behavior or all hooks. Account/network transitions and async transport races are outside these two contracts. No production code, dependency or UI changes. Roll back by removing the test helper, its tests and accompanying scope/evidence document.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/test/hookLifecycleHarness.test.ts`: two production-hook lifecycle tests passed.
- `pnpm exec eslint src/test/hookLifecycleHarness.ts src/test/hookLifecycleHarness.test.ts --max-warnings 0`: passed.
- `pnpm typecheck:fast`: passed.
- `git diff --check` and normal commit hooks: passed.
- No native UI/E2E or CPU measurements; no performance improvement claimed. Tests are collected by the existing CI unit suite.
