### PR TITLE
fix(sidebar): restore responsive collapse and expansion

### DIFF
--- a/docs/org2-performance-guard-2026-09-08/ResponsiveSidebar.md
+++ b/docs/org2-performance-guard-2026-09-08/ResponsiveSidebar.md
@@ -1,0 +1,12 @@
+# Responsive sidebar
+
+| Area               | Verdict | Evidence                                                                      | Change or reason kept                                                                                   | Verification                                |
+| ------------------ | ------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| Background work    | keep    | AppShell owns the existing useViewportWidth resize listener and pending frame | Reuse listener; no polling or additional listeners; existing cleanup removes listener and cancels frame | useViewportWidth.test.ts passed             |
+| Memory             | keep    | Two fixed-size atoms per store                                                | No collections or retained resources                                                                    | Source inspection                           |
+| Scope/isolation    | keep    | Responsive state belongs to each Jotai store                                  | Automatic transitions do not write localStorage; existing preference key unchanged                      | Separate-store and persistence tests passed |
+| Rendering/hot path | keep    | Existing viewport updates coalesce per animation frame                        | Responsive atom writes only on breakpoint crossings                                                     | Same-side resize notification test passed   |
+
+Lifecycle: initialize collapse from window width; idle/hidden windows add no scheduled work; resize events use the existing frame; returning to a wide window restores the saved preference. AppShell unmount retains no new resources. Network, account, session, and transport lifecycles are unaffected. Manual narrow-window choices last until the next crossing.
+
+Verification: `pnpm test src/store/ui/__tests__/sidebarAtom.test.ts src/engines/ChatPanel/hooks/useViewportWidth.test.ts` passed (12 tests); `pnpm typecheck:fast` passed; targeted ESLint passed. `git diff --check` passed on the isolated PR branch based on current develop. Native visual/CPU verification was not run because computer control was not authorized; no runtime performance improvement is claimed.

--- a/src/hooks/ui/sidebar/useSidebarState.ts
+++ b/src/hooks/ui/sidebar/useSidebarState.ts
@@ -2,10 +2,10 @@
  * useSidebarState Hook
  *
  * Manages the single global sidebar: width, collapse, drag-to-resize,
- * and preference persistence. Width is user-driven only — the sidebar
- * no longer auto-collapses or re-clamps on window resize. Narrow
- * viewports are handled by `useNarrowChatFocus`, which maximizes the
- * chat panel instead of squeezing the sidebar.
+ * and collapse preference persistence. The shared sidebar atom temporarily
+ * collapses narrow windows while preserving the expanded width and saved
+ * wide-window preference. `useNarrowChatFocus` separately
+ * maximizes eligible docked chat panels when the workbench is too narrow.
  *
  * Drag listeners are attached synchronously in handleMouseDown (not via
  * useEffect) so there is zero render-cycle delay. This also avoids
@@ -31,7 +31,7 @@ import {
 export interface UseSidebarStateReturn {
   /** Current sidebar width in pixels (0 if collapsed) */
   width: number;
-  /** Persisted expanded width, even while the sidebar is collapsed. */
+  /** Current expanded width, even while the sidebar is collapsed. */
   expandedWidth: number;
   /** Whether sidebar is collapsed */
   isCollapsed: boolean;
@@ -50,11 +50,8 @@ export interface UseSidebarStateReturn {
 }
 
 export function useSidebarState(): UseSidebarStateReturn {
-  // Sidebar width is user-driven only: we no longer auto-shrink the max
-  // width on window resize, so the user's chosen width stays stable
-  // until they drag the handle themselves. See `useNarrowChatFocus` for
-  // the narrow-viewport adaptation — it covers the missing chrome by
-  // maximizing the chat panel instead of squeezing the sidebar.
+  // Width constraints are fixed; responsive collapse preserves the user's
+  // chosen expanded width.
   const maxWidth = MAX_SIDEBAR_WIDTH;
 
   // Global state — split read/write for isDragging so setter is stable

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -50,6 +50,7 @@ import {
   DEFAULT_SIDEBAR_WIDTH,
   sidebarCollapsedAtom,
   sidebarWidthAtom,
+  updateSidebarViewportAtom,
 } from "@src/store/ui/sidebarAtom";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import { chatPanelPositionAtom } from "@src/store/ui/workStationLayout/chatPositionAtoms";
@@ -157,6 +158,10 @@ const AppShell = () => {
   const stationMode = useAtomValue(stationModeAtom);
   const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
   const viewportWidth = useViewportWidth();
+  const updateSidebarViewport = useSetAtom(updateSidebarViewportAtom);
+  useEffect(() => {
+    if (viewportWidth !== undefined) updateSidebarViewport(viewportWidth);
+  }, [viewportWidth, updateSidebarViewport]);
   const stationChatVisibility = useAtomValue(stationChatVisibilityAtom);
   const sidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
   const sidebarWidth = useAtomValue(sidebarWidthAtom);

--- a/src/modules/useNarrowChatFocus.ts
+++ b/src/modules/useNarrowChatFocus.ts
@@ -5,17 +5,17 @@
  * browser / launchpad / kanban / agent surface actually renders) is
  * too narrow to be usable.
  *
- * The breakpoint deliberately tracks the workbench width, NOT the OS
- * window width and NOT the full content column to the right of the
- * sidebar. So:
+ * The breakpoint tracks the available workbench width. This hook changes
+ * chat maximization only; responsive sidebar visibility is managed separately.
+ *
+ * Workbench width changes with the surrounding layout:
  *
  * - Dragging the chat handle wider shrinks the workbench → can flip
  *   into a maximized chat slot once it crosses below the breakpoint.
  * - Collapsing the sidebar widens the workbench → can flip the chat
  *   slot back out of maximized.
- * - Resizing the OS window changes everything proportionally, so it
- *   feels "window-driven" too — but only because the workbench is a
- *   downstream of those layout choices.
+ * - Resizing the OS window changes the available workbench width and
+ *   can cross this breakpoint as well as the separate sidebar breakpoint.
  *
  * Below `NARROW_CHAT_FOCUS_BREAKPOINT_PX`, `chatPanelMaximizedAtom`
  * is forced to `true` (the same maximized layout the toolbar's

--- a/src/store/ui/__tests__/sidebarAtom.test.ts
+++ b/src/store/ui/__tests__/sidebarAtom.test.ts
@@ -7,6 +7,9 @@ import {
   requestSessionSidebarRevealAtom,
   sessionBranchTagsVisibleAtom,
   sessionSidebarRevealRequestAtom,
+  sidebarCollapsedAtom,
+  sidebarWidthAtom,
+  updateSidebarViewportAtom,
 } from "../sidebarAtom";
 
 beforeEach(() => {
@@ -115,5 +118,61 @@ describe("requestSessionSidebarRevealAtom", () => {
 
     store.set(requestSessionSidebarRevealAtom, { sessionId: "session-c" });
     expect(store.get(sessionSidebarRevealRequestAtom)?.requestId).toBe(3);
+  });
+});
+
+describe("responsive sidebar", () => {
+  function wideStore(collapsed = false) {
+    const store = createStore();
+    store.set(updateSidebarViewportAtom, 1200);
+    store.set(sidebarCollapsedAtom, collapsed);
+    return store;
+  }
+
+  it("collapses below 960 and restores at 960 without persisting automatic changes", () => {
+    const store = wideStore();
+    store.set(sidebarWidthAtom, 280);
+    for (let cycle = 0; cycle < 3; cycle++) {
+      store.set(updateSidebarViewportAtom, 959);
+      expect(store.get(sidebarCollapsedAtom)).toBe(true);
+      expect(localStorage.getItem("orgii_sidebar_collapsed")).toBe("false");
+      store.set(updateSidebarViewportAtom, 960);
+      expect(store.get(sidebarCollapsedAtom)).toBe(false);
+      expect(store.get(sidebarWidthAtom)).toBe(280);
+    }
+  });
+
+  it("preserves a manually collapsed wide-window preference", () => {
+    const store = wideStore(true);
+    store.set(updateSidebarViewportAtom, 700);
+    store.set(sidebarCollapsedAtom, false);
+    store.set(updateSidebarViewportAtom, 1200);
+    expect(store.get(sidebarCollapsedAtom)).toBe(true);
+    expect(localStorage.getItem("orgii_sidebar_collapsed")).toBe("true");
+  });
+
+  it("allows manual expansion while narrow until the next crossing", () => {
+    const store = wideStore();
+    store.set(updateSidebarViewportAtom, 700);
+    store.set(sidebarCollapsedAtom, false);
+    store.set(updateSidebarViewportAtom, 800);
+    expect(store.get(sidebarCollapsedAtom)).toBe(false);
+    store.set(updateSidebarViewportAtom, 1200);
+    store.set(updateSidebarViewportAtom, 700);
+    expect(store.get(sidebarCollapsedAtom)).toBe(true);
+  });
+
+  it("does not publish changes for same-side resizes or share responsive state across stores", () => {
+    const first = wideStore();
+    const second = wideStore();
+    let changes = 0;
+    const unsubscribe = first.sub(sidebarCollapsedAtom, () => changes++);
+    first.set(updateSidebarViewportAtom, 1100);
+    expect(changes).toBe(0);
+    first.set(updateSidebarViewportAtom, 700);
+    first.set(updateSidebarViewportAtom, 800);
+    expect(changes).toBe(1);
+    expect(second.get(sidebarCollapsedAtom)).toBe(false);
+    unsubscribe();
   });
 });

--- a/src/store/ui/sidebarAtom.ts
+++ b/src/store/ui/sidebarAtom.ts
@@ -15,6 +15,8 @@ export const DEFAULT_SIDEBAR_WIDTH = 240;
 export const MIN_SIDEBAR_WIDTH = 200;
 export const MAX_SIDEBAR_WIDTH = 320;
 export const COLLAPSED_SIDEBAR_WIDTH = 0;
+/** Matches the app's lg breakpoint. Narrow windows temporarily hide the sidebar. */
+export const SIDEBAR_COLLAPSE_BREAKPOINT_PX = 960;
 export const SESSION_BRANCH_TAGS_VISIBLE_STORAGE_KEY =
   "orgii:sidebar:sessionBranchTagsVisible";
 
@@ -51,10 +53,34 @@ sidebarWidthAtom.debugLabel = "sidebarWidthAtom";
 const sidebarCollapsedBaseAtom = atom<boolean>(getStoredCollapsed());
 sidebarCollapsedBaseAtom.debugLabel = "sidebarCollapsedBaseAtom";
 
-/** Shared main sidebar collapsed state for Settings and session surfaces. */
+const sidebarNarrowAtom = atom(
+  typeof window !== "undefined" &&
+    window.innerWidth < SIDEBAR_COLLAPSE_BREAKPOINT_PX
+);
+const sidebarNarrowOverrideAtom = atom<boolean | null>(null);
+
+/** Update once per breakpoint crossing, preserving the saved wide-window preference. */
+export const updateSidebarViewportAtom = atom(
+  null,
+  (get, set, width: number) => {
+    const narrow = width < SIDEBAR_COLLAPSE_BREAKPOINT_PX;
+    if (get(sidebarNarrowAtom) === narrow) return;
+    set(sidebarNarrowAtom, narrow);
+    set(sidebarNarrowOverrideAtom, null);
+  }
+);
+
+/** Shared effective collapse state, with a temporary narrow-window override. */
 export const sidebarCollapsedAtom = atom(
-  (get) => get(sidebarCollapsedBaseAtom),
-  (_get, set, value: boolean) => {
+  (get) =>
+    get(sidebarNarrowAtom)
+      ? (get(sidebarNarrowOverrideAtom) ?? true)
+      : get(sidebarCollapsedBaseAtom),
+  (get, set, value: boolean) => {
+    if (get(sidebarNarrowAtom)) {
+      set(sidebarNarrowOverrideAtom, value);
+      return;
+    }
     set(sidebarCollapsedBaseAtom, value);
     persistSidebarCollapsed(value);
   }


### PR DESCRIPTION
## Problem

The global sidebar stays open when the window becomes narrow because its collapse state has no viewport input. This removes the previous automatic hide/restore behavior from Settings and session surfaces.

## Solution

Restore automatic collapse below 960px, matching the app's lg breakpoint, and restore the saved wide-window preference at 960px or wider. Preserve the expanded width and allow temporary manual overrides while narrow until the next breakpoint crossing. Automatic transitions do not overwrite the persisted preference.

Reuse AppShell's existing animation-frame-coalesced viewport listener. Add source-level regression tests for crossing boundaries, manual preferences, width preservation, unchanged-side notifications, and store isolation. Update the related comments and performance review.

## Potential risks

960px is the current app breakpoint, not a recovered historical threshold. Interaction with chat maximization and native window resizing has not been visually verified. Manual changes while narrow are temporary; wide-window preferences remain persisted under the existing key. No storage migration, dependency, IPC, or schema change is needed; reverting this commit restores the previous behavior without data recovery.

## Verification

Passed on the isolated branch based on current develop:

- `pnpm test src/store/ui/__tests__/sidebarAtom.test.ts src/engines/ChatPanel/hooks/useViewportWidth.test.ts` — 12 tests passed.
- `pnpm typecheck:fast` — passed.
- `pnpm exec eslint src/store/ui/sidebarAtom.ts src/store/ui/__tests__/sidebarAtom.test.ts src/modules/index.tsx src/hooks/ui/sidebar/useSidebarState.ts src/modules/useNarrowChatFocus.ts` — passed.
- `git diff --check` — passed.

Native UI verification and screenshots were not performed because computer control was not authorized. No measured CPU improvement is claimed. The final diff is limited to responsive sidebar behavior, its tests, comments, and performance review; it contains no credentials or generated artifacts.
