### PR TITLE
refactor(session-replay): share replay shell composition

### DIFF
--- a/docs/architecture-audit-2026-09-08/ReplayLayoutComposition.md
+++ b/docs/architecture-audit-2026-09-08/ReplayLayoutComposition.md
@@ -1,0 +1,25 @@
+# Replay layout composition
+
+Browser, editor and diff replay now use the existing ReplayShellLayout, replacing their repeated EventWrapper / SimulatorReplayChrome / flex wrapper / WorkStationShell composition. Diff's empty/loading branch uses chrome only, as before. No change to WorkStationShell geometry, panel configuration defaults, route ownership or browser features.
+
+The wrapper contract is explicit: eventWrapper presence chooses EventWrapper regardless of whether its event has arrived. Previously the unused helper tested event === undefined, which would change subtree ancestry as data arrived. Chrome props derive from SimulatorReplayChrome so editor double-click and future supported chrome options are forwarded without duplicate prop definitions.
+
+## Entry parity
+
+| Surface            | Event wrapper                       | Content shell    | Preserved behavior                                                                              |
+| ------------------ | ----------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------- |
+| Editor             | Always present, existing mode/event | WorkStationShell | Tab click/double-click, primary side, null status bar, existing content/classes.                |
+| Browser            | Always present while replay active  | WorkStationShell | New-tab trailing action, primary/secondary configuration, status bar and inactive early return. |
+| Diff populated     | None                                | WorkStationShell | Detail content wrapper and primary side.                                                        |
+| Diff empty/loading | None                                | Chrome only      | Existing placeholder/actions remain domain-owned.                                               |
+
+## Ten-layer review
+
+Compilation and tests verify the migrated contract. Dead-code review found the existing helper had no callers; this change wires it into all three selected domains. Naming distinguishes event wrapper presence from event readiness. Semantic review separates chrome, workstation panels and domain content. Defaults retain null status bars and caller-supplied layout mode. Domain boundaries retain selection, loading and actions in callers. Developer clarity improves through one used composition owner. No wire/storage change exists. Entry parity is listed above. No source resolver or fallback priority changes.
+
+## Verification and limits
+
+- `pnpm test src/modules/WorkStation/shared/SessionReplay/ReplayShellLayout.test.ts src/modules/WorkStation/shared/WorkStationShell/__tests__/config.test.ts src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/__tests__/CodePanel.selection.test.ts src/modules/WorkStation/Diff/SessionReplay/__tests__/diffScope.test.ts` — 5 files, 27 tests passed.
+- New React DOM tests verify pane identity/draft preservation as an event arrives and layout changes, editor double-click/browser trailing dispatch, and diff wrapper selection. Lower shell/chrome/event components are mocked, so native webview/terminal persistence is not claimed from these tests.
+- Scoped diff inspection confirms original DOM wrappers/classes and caller actions are retained. No screenshots or computer control; live native integration remains unverified.
+- Independently based on develop, without the legacy retirement commit. This PR does not change global shortcuts, panel normalization or application providers; those remain separate future refactors.

--- a/docs/frontend-ui-audit-2026-09-08/ReplayLayoutComposition.md
+++ b/docs/frontend-ui-audit-2026-09-08/ReplayLayoutComposition.md
@@ -1,0 +1,11 @@
+# Replay layout composition UI audit
+
+| Line                                                            | Element                    | Verdict          | Reason                                                                                                                                     | Suggested change                                                       |
+| --------------------------------------------------------------- | -------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Browser, CodeEditor and Diff SessionReplay roots                | Repeated shell composition | abstract         | Same chrome and panel wrapper assembly appears in three domains; the existing helper was unused and lacked editor double-click forwarding. | Completed: migrate to ReplayShellLayout with the real chrome contract. |
+| ReplayShellLayout                                               | Wrapper elements/classes   | keep with reason | Matches the existing reachable wrapper structure; no geometry or styling redesign.                                                         | None.                                                                  |
+| Browser trailing action / editor tab actions / diff empty state | Domain-specific controls   | keep with reason | Selection, loading and creation remain domain-owned; shared layer only forwards slots and callbacks.                                       | None.                                                                  |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **1 abstract**.
+
+No intended visual change. Screenshots would help native regression review but were not captured because computer control was not authorized. Automated component tests cover composition and dispatch, not full visual parity.

--- a/docs/org2-performance-guard-2026-09-08/ReplayLayoutComposition.md
+++ b/docs/org2-performance-guard-2026-09-08/ReplayLayoutComposition.md
@@ -1,0 +1,13 @@
+# Replay layout composition performance review
+
+Verdict: pass for scoped composition change; no measured runtime gain claimed.
+
+| Lifecycle                          | Evidence                                                                                                                                                                                               |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Active                             | Domain content, callbacks and panel props forwarded; no new work producer.                                                                                                                             |
+| Event loading -> available         | Explicit eventWrapper object keeps wrapper presence stable; React DOM test verifies input node/draft survives and mount count stays one.                                                               |
+| Hidden / collapsed / panel moves   | Existing WorkStationShell owns geometry and mounting; its implementation is unchanged. Lower shell is mocked in the new composition test, so native instance survival requires integration validation. |
+| Empty -> populated diff            | Chrome-only and workstation branches intentionally remain distinct, matching prior behavior.                                                                                                           |
+| Repeated open / multiple instances | No new timer, listener, shared cache or provider introduced; subtree unmount remains owned by existing callers.                                                                                        |
+
+Do not infer reduced render cost from fewer lines or the memo wrapper. Existing callbacks/config objects may still change identity; runtime performance optimization is outside this PR.

--- a/src/modules/WorkStation/Browser/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/Browser/SessionReplay/index.tsx
@@ -7,7 +7,6 @@ import { Placeholder } from "@src/components/Placeholder";
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
 import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
 import { useBrowserAutomation } from "@src/engines/BrowserCore/hooks/useBrowserAutomation";
-import EventWrapper from "@src/engines/ChatPanel/adapters/EventWrapper";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 import { usePublishWorkstationTabHeader } from "@src/hooks/tabHost/useWorkstationTabHeader";
 import {
@@ -21,8 +20,7 @@ import { buildDomComponentJsonFromElementInfo } from "@src/modules/WorkStation/B
 import { useBrowserSessions } from "@src/modules/WorkStation/Browser/hooks/useBrowserSessions";
 import {
   NoTabsPlaceholder,
-  SimulatorReplayChrome,
-  WorkStationShell,
+  ReplayShellLayout,
   buildPrimarySidebarConfig,
   buildSecondaryPanelConfig,
   useSimulatorAwaitingAgentCaption,
@@ -563,44 +561,36 @@ const SessionReplayBrowserComponent: React.FC<SessionReplayBrowserProps> = ({
   }
 
   return (
-    <EventWrapper
-      event={currentEvent as unknown as BackendEvent}
-      mode={mode}
-      expand={true}
-      padding="p-0"
-    >
-      <SimulatorReplayChrome
-        tabs={browserTabs}
-        activeEventId={visibleActiveTabId}
-        onTabClick={handleBrowserTabClick}
-        trailingSlot={
-          <TabBarTrailingIconButton
-            data-action="browser.newTab"
-            title={tCommon("commands.newTab")}
-            shortcutId="browser_new_tab"
-            onClick={handleNewMyTabsSession}
-          >
-            <HugeiconsIcon
-              icon={Add01Icon}
-              data-icon="plus"
-              size={18}
-              strokeWidth={2}
-            />
-          </TabBarTrailingIconButton>
-        }
-      >
-        <div className="flex min-h-0 flex-1">
-          <WorkStationShell
-            primarySidebarConfig={primarySidebarConfig}
-            secondaryPanelConfig={secondaryPanelConfig}
-            content={mainContent}
-            statusBar={myTabsStatusBar}
-            layoutMode={primarySidebarPosition === "right" ? "right" : "left"}
-            appClassName="session-replay-browser"
+    <ReplayShellLayout
+      tabs={browserTabs}
+      activeEventId={visibleActiveTabId}
+      onTabClick={handleBrowserTabClick}
+      trailingSlot={
+        <TabBarTrailingIconButton
+          data-action="browser.newTab"
+          title={tCommon("commands.newTab")}
+          shortcutId="browser_new_tab"
+          onClick={handleNewMyTabsSession}
+        >
+          <HugeiconsIcon
+            icon={Add01Icon}
+            data-icon="plus"
+            size={18}
+            strokeWidth={2}
           />
-        </div>
-      </SimulatorReplayChrome>
-    </EventWrapper>
+        </TabBarTrailingIconButton>
+      }
+      eventWrapper={{ event: currentEvent as unknown as BackendEvent, mode }}
+      workstation={{
+        primarySidebarConfig,
+        secondaryPanelConfig,
+        statusBar: myTabsStatusBar,
+        layoutMode: primarySidebarPosition === "right" ? "right" : "left",
+        appClassName: "session-replay-browser",
+      }}
+    >
+      {mainContent}
+    </ReplayShellLayout>
   );
 };
 

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/index.tsx
@@ -19,7 +19,6 @@ import React, {
 } from "react";
 
 import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
-import EventWrapper from "@src/engines/ChatPanel/adapters/EventWrapper";
 import { getIDEEventType } from "@src/engines/SessionCore/rendering/registry/toolRegistryDomain";
 import {
   simulatorIdeTerminalRevealRequestAtom,
@@ -31,10 +30,9 @@ import {
 import type { BackendEvent } from "@src/types/session/steps";
 
 import {
+  ReplayShellLayout,
   type ReplayTab,
-  SimulatorReplayChrome,
   type TimestampedReplayTab,
-  WorkStationShell,
   buildPrimarySidebarConfig,
   capNewestWithActive,
   mergeNewestFirstByTimestamp,
@@ -483,29 +481,20 @@ const SessionReplayIDEComponent: React.FC<SimulatorIDEProps> = ({
   );
 
   return (
-    <EventWrapper
-      event={currentEvent as unknown as BackendEvent}
-      mode={mode}
-      expand={true}
-      padding="p-0"
+    <ReplayShellLayout
+      tabs={replayTabs}
+      activeEventId={replayActiveEventId}
+      onTabClick={onReplayTabClick}
+      onTabDoubleClick={onReplayTabDoubleClick}
+      eventWrapper={{ event: currentEvent as unknown as BackendEvent, mode }}
+      workstation={{
+        primarySidebarConfig,
+        layoutMode: primarySidebarPosition === "right" ? "right" : "left",
+        appClassName: "session-replay-ide",
+      }}
     >
-      <SimulatorReplayChrome
-        tabs={replayTabs}
-        activeEventId={replayActiveEventId}
-        onTabClick={onReplayTabClick}
-        onTabDoubleClick={onReplayTabDoubleClick}
-      >
-        <div className="flex min-h-0 flex-1">
-          <WorkStationShell
-            primarySidebarConfig={primarySidebarConfig}
-            content={mainContent}
-            statusBar={null}
-            layoutMode={primarySidebarPosition === "right" ? "right" : "left"}
-            appClassName="session-replay-ide"
-          />
-        </div>
-      </SimulatorReplayChrome>
-    </EventWrapper>
+      {mainContent}
+    </ReplayShellLayout>
   );
 };
 

--- a/src/modules/WorkStation/Diff/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/Diff/SessionReplay/index.tsx
@@ -34,8 +34,7 @@ import {
 } from "@src/icons";
 import {
   NoTabsPlaceholder,
-  SimulatorReplayChrome,
-  WorkStationShell,
+  ReplayShellLayout,
   buildConsolidatedSessionReplayDiffSectionItems,
   buildPrimarySidebarConfig,
   useSimulatorAwaitingAgentCaption,
@@ -446,7 +445,7 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
     !hasActiveCommitDetail
   ) {
     return (
-      <SimulatorReplayChrome
+      <ReplayShellLayout
         tabs={tabs}
         activeEventId={TAB_IDS[activeTab]}
         onTabClick={handleTabClick}
@@ -466,30 +465,23 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
             />
           )}
         </div>
-      </SimulatorReplayChrome>
+      </ReplayShellLayout>
     );
   }
 
   return (
-    <SimulatorReplayChrome
+    <ReplayShellLayout
       tabs={tabs}
       activeEventId={TAB_IDS[activeTab]}
       onTabClick={handleTabClick}
+      workstation={{
+        primarySidebarConfig,
+        layoutMode: primarySidebarPosition === "right" ? "right" : "left",
+        appClassName: "session-replay-diff",
+      }}
     >
-      <div className="flex min-h-0 flex-1">
-        <WorkStationShell
-          primarySidebarConfig={primarySidebarConfig}
-          content={
-            <div className="flex h-full min-h-0 w-full flex-col">
-              {detailContent}
-            </div>
-          }
-          statusBar={null}
-          layoutMode={primarySidebarPosition === "right" ? "right" : "left"}
-          appClassName="session-replay-diff"
-        />
-      </div>
-    </SimulatorReplayChrome>
+      <div className="flex h-full min-h-0 w-full flex-col">{detailContent}</div>
+    </ReplayShellLayout>
   );
 };
 export { finalDiffToSection } from "./diffSessionReplay.finalDiffSection";

--- a/src/modules/WorkStation/shared/SessionReplay/ReplayShellLayout.test.ts
+++ b/src/modules/WorkStation/shared/SessionReplay/ReplayShellLayout.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import React, { act, createElement as h, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ReplayShellLayout,
+  type ReplayShellLayoutProps,
+} from "./ReplayShellLayout";
+
+const mocks = vi.hoisted(() => ({ mount: vi.fn(), unmount: vi.fn() }));
+vi.mock("@src/engines/ChatPanel/adapters/EventWrapper", () => ({
+  default: ({ children, mode }: React.PropsWithChildren<{ mode: string }>) =>
+    h("section", { "data-event-mode": mode }, children),
+}));
+vi.mock("../WorkStationShell", () => ({
+  WorkStationShell: ({
+    content,
+    statusBar,
+    layoutMode,
+  }: {
+    content: React.ReactNode;
+    statusBar: React.ReactNode;
+    layoutMode: string;
+  }) => h("main", { "data-layout-mode": layoutMode }, content, statusBar),
+}));
+vi.mock("./SimulatorReplayChrome", () => ({
+  SimulatorReplayChrome: ({
+    children,
+    onTabClick,
+    onTabDoubleClick,
+    trailingSlot,
+  }: React.PropsWithChildren<{
+    onTabClick: (id: string) => void;
+    onTabDoubleClick?: (id: string) => void;
+    trailingSlot?: React.ReactNode;
+  }>) =>
+    h(
+      "div",
+      { "data-chrome": true },
+      h(
+        "button",
+        {
+          onClick: () => onTabClick("event-2"),
+          onDoubleClick: () => onTabDoubleClick?.("event-2"),
+        },
+        "Event"
+      ),
+      trailingSlot,
+      children
+    ),
+}));
+vi.mock("../NoTabsPlaceholder", () => ({ NoTabsPlaceholder: () => null }));
+vi.mock("@src/components/Placeholder", () => ({ Placeholder: () => null }));
+
+function StatefulPane() {
+  useEffect(() => {
+    mocks.mount();
+    return () => {
+      mocks.unmount();
+    };
+  }, []);
+  return h("input", { "aria-label": "Draft", defaultValue: "" });
+}
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let previousActEnvironment: boolean | undefined;
+let container: HTMLDivElement;
+let root: Root;
+beforeEach(() => {
+  previousActEnvironment = actEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  vi.clearAllMocks();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+  actEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+});
+
+describe("ReplayShellLayout", () => {
+  it("keeps pane state mounted as an event arrives and layout props change", async () => {
+    const onTabClick = vi.fn();
+    type WrappedEvent = NonNullable<
+      ReplayShellLayoutProps["eventWrapper"]
+    >["event"];
+    const render = (loaded: boolean) =>
+      h(ReplayShellLayout, {
+        tabs: [],
+        activeEventId: loaded ? "event-2" : null,
+        onTabClick,
+        // Replay callers can wrap an event that has not arrived yet.
+        eventWrapper: {
+          event: (loaded
+            ? { id: "event-2" }
+            : undefined) as unknown as WrappedEvent,
+          mode: "simulation",
+        },
+        workstation: {
+          layoutMode: loaded ? "right" : "left",
+          statusBar: h("footer", null, loaded ? "Ready" : "Loading"),
+        },
+        children: h(StatefulPane),
+      });
+    await act(async () => root.render(render(false)));
+    const input = container.querySelector("input")!;
+    input.value = "unsaved draft";
+    await act(async () => root.render(render(true)));
+    expect(container.querySelector("input")).toBe(input);
+    expect(input.value).toBe("unsaved draft");
+    expect(mocks.mount).toHaveBeenCalledTimes(1);
+    expect(mocks.unmount).not.toHaveBeenCalled();
+    expect(container.querySelector("[data-event-mode]")).not.toBeNull();
+    expect(container.querySelector("main")?.dataset.layoutMode).toBe("right");
+    expect(container.querySelector("footer")?.textContent).toBe("Ready");
+  });
+  it("preserves editor double-click and browser trailing actions", async () => {
+    const select = vi.fn();
+    const open = vi.fn();
+    const create = vi.fn();
+    await act(async () =>
+      root.render(
+        h(ReplayShellLayout, {
+          tabs: [],
+          activeEventId: null,
+          onTabClick: select,
+          onTabDoubleClick: open,
+          trailingSlot: h("button", { onClick: create }, "New tab"),
+          children: h("div", null, "Replay"),
+        })
+      )
+    );
+    const [eventButton, newButton] = container.querySelectorAll("button");
+    await act(async () => {
+      eventButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      eventButton.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+      newButton.click();
+    });
+    expect(select).toHaveBeenCalledWith("event-2");
+    expect(open).toHaveBeenCalledWith("event-2");
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+  it("keeps diff empty content chrome-only and populated content free of the event adapter", async () => {
+    const props = { tabs: [], activeEventId: null, onTabClick: vi.fn() };
+    await act(async () =>
+      root.render(
+        h(ReplayShellLayout, { ...props, children: h("div", null, "Loading") })
+      )
+    );
+    expect(container.querySelector("main")).toBeNull();
+    expect(container.querySelector("[data-chrome]")?.textContent).toContain(
+      "Loading"
+    );
+    await act(async () =>
+      root.render(
+        h(ReplayShellLayout, {
+          ...props,
+          workstation: { layoutMode: "left" },
+          children: h("div", null, "Diff"),
+        })
+      )
+    );
+    expect(container.querySelector("main")?.textContent).toBe("Diff");
+    expect(container.querySelector("[data-event-mode]")).toBeNull();
+  });
+});

--- a/src/modules/WorkStation/shared/SessionReplay/ReplayShellLayout.tsx
+++ b/src/modules/WorkStation/shared/SessionReplay/ReplayShellLayout.tsx
@@ -1,8 +1,7 @@
-import React, { memo } from "react";
+import React, { type ComponentProps, memo } from "react";
 
 import { Placeholder } from "@src/components/Placeholder";
 import EventWrapper from "@src/engines/ChatPanel/adapters/EventWrapper";
-import type { BackendEvent } from "@src/types/session/steps";
 import { classNames } from "@src/util/ui/classNames";
 
 import { NoTabsPlaceholder } from "../NoTabsPlaceholder";
@@ -13,8 +12,6 @@ import type {
   PrimarySidebarConfig,
   SecondaryPanelConfig,
 } from "../WorkStationShell/config";
-import type { SessionReplayPlaceholderMode } from "../useSimulatorPlaceholderActions";
-import type { ReplayTab } from "./ReplayTabBar";
 import { SimulatorReplayChrome } from "./SimulatorReplayChrome";
 import type { ReplayShellLayoutMode } from "./replayShellHelpers";
 
@@ -26,18 +23,12 @@ export interface ReplayShellWorkstationConfig {
   layoutMode: ReplayShellLayoutMode;
 }
 
-export interface ReplayShellLayoutProps {
-  tabs: ReplayTab[];
-  activeEventId: string | null;
-  onTabClick: (eventId: string) => void;
-  children: React.ReactNode;
-  trailingSlot?: React.ReactNode;
-  sidebarToggleDisabled?: boolean;
-  showWorkstationTabHeader?: boolean;
-  event?: unknown;
-  eventMode?: SessionReplayPlaceholderMode;
+export interface ReplayShellLayoutProps extends ComponentProps<
+  typeof SimulatorReplayChrome
+> {
+  /** Explicit wrapper presence keeps the event subtree stable while data loads. */
+  eventWrapper?: Pick<ComponentProps<typeof EventWrapper>, "event" | "mode">;
   workstation?: ReplayShellWorkstationConfig;
-  contentWrapperClassName?: string;
 }
 
 export interface ReplayShellPlaceholderProps {
@@ -65,20 +56,13 @@ export const ReplayShellPlaceholder: React.FC<ReplayShellPlaceholderProps> =
 ReplayShellPlaceholder.displayName = "ReplayShellPlaceholder";
 
 const ReplayShellLayoutComponent: React.FC<ReplayShellLayoutProps> = ({
-  tabs,
-  activeEventId,
-  onTabClick,
   children,
-  trailingSlot,
-  sidebarToggleDisabled,
-  showWorkstationTabHeader,
-  event,
-  eventMode = "simulation",
+  eventWrapper,
   workstation,
-  contentWrapperClassName,
+  ...chromeProps
 }) => {
   const body = workstation ? (
-    <div className={classNames("flex min-h-0 flex-1", contentWrapperClassName)}>
+    <div className="flex min-h-0 flex-1">
       <WorkStationShell
         primarySidebarConfig={workstation.primarySidebarConfig}
         secondaryPanelConfig={workstation.secondaryPanelConfig}
@@ -93,26 +77,17 @@ const ReplayShellLayoutComponent: React.FC<ReplayShellLayoutProps> = ({
   );
 
   const chrome = (
-    <SimulatorReplayChrome
-      tabs={tabs}
-      activeEventId={activeEventId}
-      onTabClick={onTabClick}
-      trailingSlot={trailingSlot}
-      sidebarToggleDisabled={sidebarToggleDisabled}
-      showWorkstationTabHeader={showWorkstationTabHeader}
-    >
-      {body}
-    </SimulatorReplayChrome>
+    <SimulatorReplayChrome {...chromeProps}>{body}</SimulatorReplayChrome>
   );
 
-  if (event === undefined) {
+  if (!eventWrapper) {
     return chrome;
   }
 
   return (
     <EventWrapper
-      event={event as unknown as BackendEvent}
-      mode={eventMode}
+      event={eventWrapper.event}
+      mode={eventWrapper.mode}
       expand={true}
       padding="p-0"
     >


### PR DESCRIPTION
## Problem

Browser, editor and diff replay independently assemble the same replay chrome and workstation shell. The existing ReplayShellLayout has no callers and cannot preserve the editor's double-click action; it also uses event readiness to decide wrapper presence, which would remount content when an initially missing event arrives.

## Solution

Adapt and use ReplayShellLayout in all three replay views. Derive chrome props from SimulatorReplayChrome to preserve actions and slots. Use explicit eventWrapper presence, independent of event readiness. Keep the existing DOM wrappers/classes, browser status bar and new-tab action, editor double-click, and diff's chrome-only loading/empty state.

This is independently based on develop and does not contain or require #1416. Global shortcuts, workstation panel defaults and AppLayout/provider ownership are outside this PR.

## Potential risks

Wrapper ancestry and prop forwarding can reset mounted content or lose controls. New tests verify draft/node identity while an event arrives and layout props change, plus tab double-click and trailing-action dispatch. Lower shell, event and chrome components are mocked in these tests: they do not prove native terminal/webview persistence or full visual parity. No computer control or screenshots were authorized. WorkStationShell's implementation, geometry, panel mounting policy and domain state are unchanged.

Browser and editor keep EventWrapper even when their event value is initially unavailable; diff keeps no EventWrapper. The diff empty-to-populated transition intentionally still introduces the workstation shell. No storage, dependency, wire or IPC changes. Reverting this PR restores the prior inline composition without data recovery work.

## Verification

- `pnpm test src/modules/WorkStation/shared/SessionReplay/ReplayShellLayout.test.ts src/modules/WorkStation/shared/WorkStationShell/__tests__/config.test.ts src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/__tests__/CodePanel.selection.test.ts src/modules/WorkStation/Diff/SessionReplay/__tests__/diffScope.test.ts` — 5 files, 27 tests passed.
- `pnpm typecheck` — passed on develop with the final test file included.
- `git diff --check` and comparison of original/migrated wrapper trees and caller props — passed.
- Architecture, UI and lifecycle reviews included. UI: 0 fixes, 2 kept with reasons, 1 abstraction. No runtime performance improvement claimed.
- No Rust changes; no Rust build required. Native webview/terminal and visual interaction remain unverified.
- Commit hooks passed: lint-staged and `npx tsgo --noEmit --pretty false`.
- `git merge-tree --write-tree dev/retire-legacy-workstation dev/simplify-replay-layout` — clean merge, no conflicts. This checks textual merge compatibility; combined native runtime testing was not performed.
