### PR TITLE
fix(pointer): end interrupted drag and resize sessions

### DIFF
--- a/docs/org2-performance-guard-2026-09-08/PointerRecovery.md
+++ b/docs/org2-performance-guard-2026-09-08/PointerRecovery.md
@@ -1,0 +1,33 @@
+# Interrupted pointer interaction recovery
+
+Missed releases left component-owned drag state, resize-manager locks, listeners and queued frames alive after the global cursor fallback cleared DOM styles. Recovery now ends the owning interaction on blur, hidden visibility, pointer cancellation and movement without the primary button. Capture-phase listeners see events stopped by child controls. Pointer sessions ignore other IDs. The global fallback cancels stale release timers when a new press starts and skips timers for ordinary idle releases.
+
+## Ownership and cancellation
+
+- Shared pixel/ratio resize hooks: clear interaction state/listeners and pending pixel-resize frames. Ratio listeners exist only during a drag.
+- Floating-window drag/resize: preserve current geometry, detach listeners; dragging also ends when disabled.
+- CustomScrollbar: stop thumb dragging and preserve the scroll position.
+- Column and split-panel resize: interruptions commit the last held-button size; unmount cancels pending frames without committing.
+- useResizeController and SplitGroup: unlock ResizeManager and clear local/ghost state. Controller commits its last preview; SplitGroup preserves already-applied sizes.
+- Gantt: cancellation discards the preview without writing task dates. Ordinary release still commits. State clears before consumer callbacks can throw.
+
+All state is transient UI state. No stored-payload repair, historical cleanup, migration, dependency or protocol change is needed. Right-button presses do not start these left-button drags.
+
+## Lifecycle evidence
+
+| Area               | Verdict | Evidence                                                   | Change or reason kept                                                           | Verification                                                                       |
+| ------------------ | ------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Background work    | fix     | Missing terminal events retained movement listeners        | Shared active-drag lifecycle; capture phase; no polling or new timers           | Blur, hidden, cancellation, missed release, stopped propagation and disposal tests |
+| Memory             | fix     | Retained cleanup closures and queued resize frames         | Clear owner refs, detach before terminal callbacks and cancel frames on unmount | No post-termination writes, symmetric listener removal and no pending frames       |
+| Scope/isolation    | keep    | Per-component/document owners; no network or identity data | Pointer ID checks and owner-specific commit/cancel policy                       | Foreign-pointer and manager-unlock tests                                           |
+| Rendering/hot path | keep    | DOM/frame-coalesced resize and scroll writes               | Preserve geometry math and scheduling cadence                                   | Existing resize-handle and Gantt virtualization suites                             |
+
+The shared helper has no registry, polling or scheduled work. Listeners exist only for an active session and disposal is idempotent. Network, auth and transport dimensions are inapplicable. The tested trail-panel implementation remains unchanged. Native file dragging, DnD drop targets, text/editor controls, sliders and developer-tool gestures are outside this change; this is not a guarantee against arbitrary overlays or native WebView hit-testing failures.
+
+## Verification
+
+The isolated PR worktree was checked against current origin/develop. Nine focused suites cover 93 tests: AppGlobalRecovery, the two shared resize hooks, the shared drag lifecycle and owner integration, ResizeHandle, Gantt virtualization, trail resize and theme-overlay recovery. Typecheck, changed-file lint and diff checks also pass; the PR description records the exact commands.
+
+The cross-owner `dragRecovery.test.ts` intentionally verifies the termination invariant against actual hooks/components, including no subsequent size, scroll or date writes. Normal release, pointer isolation, stopped propagation, repeated sessions and unmount are covered. Static screenshots would not demonstrate these event-sequence bugs and no layout/style changes were made.
+
+Performance verdict: blocked for native measurement. The user's computer-control opt-in preference was respected. Automated DOM lifecycle checks pass; native hover behavior, CPU and frame-time improvements are not claimed.

--- a/src/app/root/AppGlobalRecovery.tsx
+++ b/src/app/root/AppGlobalRecovery.tsx
@@ -12,11 +12,13 @@
  * Recovery triggers (in order of priority):
  * 1. `mousemove` with no buttons held  → immediate reset
  * 2. `mouseup` / `pointerup`           → debounced reset (150 ms)
- * 3. `blur` (window loses focus)       → immediate reset
+ * 3. `blur` / `pointercancel`          → immediate reset
  * 4. `visibilitychange` → hidden       → immediate reset
  *
  * The 150 ms debounce on mouseup/pointerup prevents flicker when a legitimate
  * drag ends inside the window and React still needs one frame to clean up.
+ * A new press cancels the fallback. This only repairs DOM residue; interaction
+ * owners must also end their own state and listeners when input is interrupted.
  */
 import { useEffect } from "react";
 
@@ -49,11 +51,20 @@ export function AppGlobalRecovery(): null {
       document.body.classList.contains("resize-active") ||
       STUCK_CURSORS.has(document.body.style.cursor);
 
+    const cancelScheduledCleanup = () => {
+      if (cleanupTimeoutId !== null) {
+        clearTimeout(cleanupTimeoutId);
+        cleanupTimeoutId = null;
+      }
+    };
+
     const scheduleCleanup = () => {
+      if (!hasStuckState()) return;
       if (cleanupTimeoutId) {
         clearTimeout(cleanupTimeoutId);
       }
       cleanupTimeoutId = setTimeout(() => {
+        cleanupTimeoutId = null;
         if (hasStuckState()) {
           resetStuckState();
         }
@@ -61,10 +72,7 @@ export function AppGlobalRecovery(): null {
     };
 
     const immediateCleanup = () => {
-      if (cleanupTimeoutId) {
-        clearTimeout(cleanupTimeoutId);
-        cleanupTimeoutId = null;
-      }
+      cancelScheduledCleanup();
       if (hasStuckState()) {
         resetStuckState();
       }
@@ -78,20 +86,28 @@ export function AppGlobalRecovery(): null {
 
     const handleMouseMove = (event: MouseEvent) => {
       if (event.buttons === 0 && hasStuckState()) {
-        resetStuckState();
+        immediateCleanup();
       }
     };
 
-    window.addEventListener("mousemove", handleMouseMove);
-    window.addEventListener("mouseup", scheduleCleanup);
-    window.addEventListener("pointerup", scheduleCleanup);
+    // Capture sees releases even when controls stop event propagation. A new
+    // press invalidates the previous drag's delayed fallback.
+    window.addEventListener("mousedown", cancelScheduledCleanup, true);
+    window.addEventListener("pointerdown", cancelScheduledCleanup, true);
+    window.addEventListener("pointercancel", immediateCleanup, true);
+    window.addEventListener("mousemove", handleMouseMove, true);
+    window.addEventListener("mouseup", scheduleCleanup, true);
+    window.addEventListener("pointerup", scheduleCleanup, true);
     window.addEventListener("blur", immediateCleanup);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", scheduleCleanup);
-      window.removeEventListener("pointerup", scheduleCleanup);
+      window.removeEventListener("mousedown", cancelScheduledCleanup, true);
+      window.removeEventListener("pointerdown", cancelScheduledCleanup, true);
+      window.removeEventListener("pointercancel", immediateCleanup, true);
+      window.removeEventListener("mousemove", handleMouseMove, true);
+      window.removeEventListener("mouseup", scheduleCleanup, true);
+      window.removeEventListener("pointerup", scheduleCleanup, true);
       window.removeEventListener("blur", immediateCleanup);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       if (cleanupTimeoutId) {

--- a/src/app/root/__tests__/AppGlobalRecovery.test.ts
+++ b/src/app/root/__tests__/AppGlobalRecovery.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { AppGlobalRecovery } from "../AppGlobalRecovery";
+
+let root: Root;
+let container: HTMLDivElement;
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(createElement(AppGlobalRecovery)));
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.body.style.cssText = "";
+  document.body.classList.remove("resize-active");
+  vi.useRealTimers();
+});
+it("does not let a previous release reset a new drag", () => {
+  document.body.style.cursor = "col-resize";
+  window.dispatchEvent(new MouseEvent("mouseup"));
+  window.dispatchEvent(new MouseEvent("mousedown", { buttons: 1 }));
+  vi.advanceTimersByTime(200);
+  expect(document.body.style.cursor).toBe("col-resize");
+});
+it("observes recovery even when a child stops movement propagation", () => {
+  document.body.style.cursor = "col-resize";
+  container.addEventListener("mousemove", (event) => event.stopPropagation());
+  container.dispatchEvent(
+    new MouseEvent("mousemove", { bubbles: true, buttons: 0 })
+  );
+  expect(document.body.style.cursor).toBe("");
+});
+it("does not schedule timers for ordinary idle releases", () => {
+  window.dispatchEvent(new MouseEvent("mouseup"));
+  expect(vi.getTimerCount()).toBe(0);
+});
+it("recovers on pointer cancellation", () => {
+  document.body.style.cursor = "col-resize";
+  window.dispatchEvent(new Event("pointercancel"));
+  expect(document.body.style.cursor).toBe("");
+});
+it("preserves active movement and disposes a pending fallback on unmount", () => {
+  document.body.style.cursor = "col-resize";
+  window.dispatchEvent(new MouseEvent("mousemove", { buttons: 1 }));
+  expect(document.body.style.cursor).toBe("col-resize");
+  window.dispatchEvent(new MouseEvent("mouseup"));
+  expect(vi.getTimerCount()).toBe(1);
+  act(() => root.render(null));
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/src/components/CustomScrollbar/index.tsx
+++ b/src/components/CustomScrollbar/index.tsx
@@ -14,6 +14,7 @@
  */
 import React, { useCallback, useEffect, useRef } from "react";
 
+import { listenForDrag } from "@src/shared/interaction/dragLifecycle";
 import {
   clearTransientScrollbar,
   revealTransientScrollbar,
@@ -148,6 +149,7 @@ export const CustomScrollbar: React.FC<CustomScrollbarProps> = ({
 
   const handleThumbMouseDown = useCallback(
     (event: React.MouseEvent) => {
+      if (event.button !== 0) return;
       event.preventDefault();
       event.stopPropagation();
       dragListenerCleanupRef.current?.();
@@ -162,13 +164,11 @@ export const CustomScrollbar: React.FC<CustomScrollbarProps> = ({
         handleThumbDrag(moveEvent.clientY);
       };
       const handleMouseUp = () => stopThumbDrag();
-      const cleanupDragListeners = () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
-      };
-      dragListenerCleanupRef.current = cleanupDragListeners;
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
+      dragListenerCleanupRef.current = listenForDrag({
+        onMove: handleMouseMove,
+        onEnd: handleMouseUp,
+        onCancel: stopThumbDrag,
+      });
     },
     [handleThumbDrag, stopThumbDrag]
   );

--- a/src/components/FloatingWindow/useWindowDrag.ts
+++ b/src/components/FloatingWindow/useWindowDrag.ts
@@ -16,6 +16,8 @@
  */
 import { useCallback, useEffect, useRef } from "react";
 
+import { listenForDrag } from "@src/shared/interaction/dragLifecycle";
+
 import {
   applyWindowOffset,
   clamp,
@@ -31,11 +33,11 @@ export function useWindowDrag(enabled: boolean) {
   const cleanupRef = useRef<(() => void) | null>(null);
 
   // Tear down listeners / restore the cursor if the panel unmounts mid-drag.
-  useEffect(() => () => cleanupRef.current?.(), []);
+  useEffect(() => () => cleanupRef.current?.(), [enabled]);
 
   return useCallback(
     (event: React.PointerEvent<HTMLElement>) => {
-      if (!enabled || event.button !== 0) return;
+      if (!enabled || event.button !== 0 || event.isPrimary === false) return;
       const target = event.target;
       if (target instanceof Element && target.closest(INTERACTIVE_SELECTOR)) {
         return;
@@ -50,10 +52,11 @@ export function useWindowDrag(enabled: boolean) {
       // Untransformed origin of the window, so clamps read in viewport space.
       const baseLeft = rect.left - start.x;
       const baseTop = rect.top - start.y;
+      cleanupRef.current?.();
       const startX = event.clientX;
       const startY = event.clientY;
 
-      const handleMove = (moveEvent: PointerEvent) => {
+      const handleMove = (moveEvent: MouseEvent) => {
         let nextX = start.x + (moveEvent.clientX - startX);
         let nextY = start.y + (moveEvent.clientY - startY);
         if (bounds) {
@@ -74,18 +77,19 @@ export function useWindowDrag(enabled: boolean) {
       };
 
       const finish = () => {
-        window.removeEventListener("pointermove", handleMove);
-        window.removeEventListener("pointerup", finish);
-        window.removeEventListener("pointercancel", finish);
+        dispose();
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
         cleanupRef.current = null;
       };
 
+      const dispose = listenForDrag({
+        pointerId: event.pointerId,
+        onMove: handleMove,
+        onEnd: finish,
+        onCancel: finish,
+      });
       cleanupRef.current = finish;
-      window.addEventListener("pointermove", handleMove);
-      window.addEventListener("pointerup", finish);
-      window.addEventListener("pointercancel", finish);
       document.body.style.cursor = "grabbing";
       document.body.style.userSelect = "none";
     },

--- a/src/components/FloatingWindow/useWindowResize.ts
+++ b/src/components/FloatingWindow/useWindowResize.ts
@@ -12,6 +12,8 @@
  */
 import { useCallback, useEffect, useRef } from "react";
 
+import { listenForDrag } from "@src/shared/interaction/dragLifecycle";
+
 import {
   clamp,
   findFloatingWindow,
@@ -53,7 +55,7 @@ export function useWindowResize({
 
   return useCallback(
     (edge: ResizeEdge) => (event: React.PointerEvent<HTMLElement>) => {
-      if (event.button !== 0) return;
+      if (event.button !== 0 || event.isPrimary === false) return;
       const win = findFloatingWindow(event.currentTarget);
       if (!win) return;
       const bounds = readWindowBounds(win);
@@ -67,10 +69,11 @@ export function useWindowResize({
       const startTop = Number.parseFloat(win.style.top) || 0;
       const startWidth = Number.parseFloat(win.style.width) || 0;
       const startHeight = Number.parseFloat(win.style.height) || 0;
+      cleanupRef.current?.();
       const startX = event.clientX;
       const startY = event.clientY;
 
-      const handleMove = (moveEvent: PointerEvent) => {
+      const handleMove = (moveEvent: MouseEvent) => {
         const dx = moveEvent.clientX - startX;
         const dy = moveEvent.clientY - startY;
 
@@ -112,18 +115,19 @@ export function useWindowResize({
       };
 
       const finish = () => {
-        window.removeEventListener("pointermove", handleMove);
-        window.removeEventListener("pointerup", finish);
-        window.removeEventListener("pointercancel", finish);
+        dispose();
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
         cleanupRef.current = null;
       };
 
+      const dispose = listenForDrag({
+        pointerId: event.pointerId,
+        onMove: handleMove,
+        onEnd: finish,
+        onCancel: finish,
+      });
       cleanupRef.current = finish;
-      window.addEventListener("pointermove", handleMove);
-      window.addEventListener("pointerup", finish);
-      window.addEventListener("pointercancel", finish);
       document.body.style.cursor = EDGE_CURSOR[edge];
       document.body.style.userSelect = "none";
     },

--- a/src/features/GanttChart/hooks/useGanttDrag.ts
+++ b/src/features/GanttChart/hooks/useGanttDrag.ts
@@ -10,6 +10,8 @@ import {
   useState,
 } from "react";
 
+import { listenForDrag } from "@src/shared/interaction/dragLifecycle";
+
 import { getMsPerColumn, getStartOfPeriod } from "../config";
 import type { GanttTimeScale, GanttViewScope } from "../types";
 
@@ -189,6 +191,10 @@ export function useGanttDrag({
         }
       }
 
+      // End the interaction before a consumer callback can throw.
+      setDragState(null);
+      setGhostPreview(null);
+
       // Call update callback
       if (onTaskUpdate) {
         onTaskUpdate(dragState.taskId, {
@@ -196,10 +202,6 @@ export function useGanttDrag({
           endDate: finalEnd,
         });
       }
-
-      // Clear drag state
-      setDragState(null);
-      setGhostPreview(null);
     },
     [
       dragState,
@@ -221,6 +223,7 @@ export function useGanttDrag({
       originalEnd: Date,
       e: ReactMouseEvent
     ) => {
+      if (e.button !== 0) return;
       e.stopPropagation();
 
       setDragState({
@@ -242,6 +245,7 @@ export function useGanttDrag({
       originalEnd: Date,
       e: ReactMouseEvent
     ) => {
+      if (e.button !== 0) return;
       setDragState({
         taskId,
         type: "move",
@@ -259,16 +263,22 @@ export function useGanttDrag({
 
     const onMouseUp = (event: globalThis.MouseEvent) => handleMouseUp(event);
 
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
+    const dispose = listenForDrag({
+      onMove: handleMouseMove,
+      onEnd: onMouseUp,
+      onCancel: () => {
+        setDragState(null);
+        setGhostPreview(null);
+        document.body.style.cursor = "";
+      },
+    });
 
     // Change cursor
     document.body.style.cursor =
       dragState.type === "move" ? "grabbing" : "ew-resize";
 
     return () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
+      dispose();
       document.body.style.cursor = "";
     };
   }, [dragState, handleMouseMove, handleMouseUp]);

--- a/src/hooks/ui/useRatioResize.test.ts
+++ b/src/hooks/ui/useRatioResize.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { type RefObject, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { useRatioResize } from "./useRatioResize";
+
+let root: Root;
+let container: HTMLDivElement;
+const changed = vi.fn();
+const geometryRef: RefObject<HTMLDivElement | null> = { current: null };
+function Harness() {
+  const { ratio, handleMouseDown } = useRatioResize(geometryRef, {
+    direction: "horizontal",
+    onRatioChange: changed,
+  });
+  return createElement("div", {
+    onMouseDown: handleMouseDown,
+    "data-ratio": ratio,
+  });
+}
+function mouse(target: EventTarget, type: string, x: number, buttons = 1) {
+  act(() =>
+    target.dispatchEvent(
+      new MouseEvent(type, { bubbles: true, clientX: x, buttons })
+    )
+  );
+}
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  changed.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  geometryRef.current = container;
+  root = createRoot(container);
+  act(() => root.render(createElement(Harness)));
+  vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
+    left: 0,
+    top: 0,
+    width: 200,
+    height: 100,
+  } as DOMRect);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  geometryRef.current = null;
+  document.body.style.cssText = "";
+  vi.restoreAllMocks();
+});
+it.each(["blur", "pointercancel", "hidden", "released-move", "mouseup"])(
+  "stops ratio writes on %s",
+  (reason) => {
+    const handle = container.firstElementChild!;
+    mouse(handle, "mousedown", 100);
+    mouse(document, "mousemove", 120);
+    expect(handle.getAttribute("data-ratio")).toBe("0.6");
+    if (reason === "released-move") mouse(document, "mousemove", 150, 0);
+    else
+      act(() => {
+        if (reason === "hidden") {
+          vi.spyOn(document, "visibilityState", "get").mockReturnValue(
+            "hidden"
+          );
+          document.dispatchEvent(new Event("visibilitychange"));
+        } else window.dispatchEvent(new Event(reason));
+      });
+    mouse(document, "mousemove", 180, 0);
+    expect(handle.getAttribute("data-ratio")).toBe("0.6");
+    expect(changed).toHaveBeenCalledTimes(1);
+    expect(document.body.style.cursor).toBe("");
+  }
+);
+it("has no idle movement listener and detaches after repeated drags", () => {
+  const add = vi.spyOn(document, "addEventListener");
+  const remove = vi.spyOn(document, "removeEventListener");
+  act(() => root.render(createElement(Harness)));
+  expect(add.mock.calls.filter(([type]) => type === "mousemove")).toHaveLength(
+    0
+  );
+  for (let i = 0; i < 3; i++) {
+    mouse(container.firstElementChild!, "mousedown", 100);
+    mouse(document, "mousemove", 120);
+    mouse(window, "mouseup", 120, 0);
+  }
+  const added = add.mock.calls.filter(([type]) => type === "mousemove");
+  const removed = remove.mock.calls.filter(([type]) => type === "mousemove");
+  expect(added).toHaveLength(3);
+  expect(removed).toEqual(added);
+  mouse(document, "mousemove", 180);
+  expect(changed).toHaveBeenCalledTimes(3);
+});
+it("detaches on unmount during drag", () => {
+  mouse(container.firstElementChild!, "mousedown", 100);
+  act(() => root.render(null));
+  mouse(document, "mousemove", 180);
+  expect(changed).not.toHaveBeenCalled();
+  expect(document.body.style.cursor).toBe("");
+});

--- a/src/hooks/ui/useRatioResize.ts
+++ b/src/hooks/ui/useRatioResize.ts
@@ -86,58 +86,64 @@ export function useRatioResize(
   } = options;
 
   const [ratio, setRatio] = useState(initialRatio);
-  const isDraggingRef = useRef(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => cleanupRef.current?.(), []);
 
   const handleMouseDown = useCallback(
     (event: ReactMouseEvent) => {
+      if (event.button !== 0) return;
+      cleanupRef.current?.();
       event.preventDefault();
-      isDraggingRef.current = true;
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        if ((moveEvent.buttons & 1) === 0) {
+          cleanup();
+          return;
+        }
+        const container = containerRef.current;
+        if (!container) return;
+        const rect = container.getBoundingClientRect();
+        const extent = direction === "vertical" ? rect.height : rect.width;
+        if (extent <= 0) return;
+        const offset =
+          direction === "vertical"
+            ? moveEvent.clientY - rect.top
+            : moveEvent.clientX - rect.left;
+        const clampedRatio = Math.min(
+          maxRatio,
+          Math.max(minRatio, offset / extent)
+        );
+        setRatio(clampedRatio);
+        onRatioChange?.(clampedRatio);
+      };
+      const handleVisibilityChange = () => {
+        if (document.visibilityState === "hidden") cleanup();
+      };
+      const cleanup = () => {
+        document.removeEventListener("mousemove", handleMouseMove, true);
+        window.removeEventListener("mouseup", cleanup, true);
+        window.removeEventListener("pointercancel", cleanup, true);
+        window.removeEventListener("blur", cleanup);
+        document.removeEventListener(
+          "visibilitychange",
+          handleVisibilityChange
+        );
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        cleanupRef.current = null;
+      };
+      cleanupRef.current = cleanup;
       document.body.style.cursor =
         direction === "vertical" ? "row-resize" : "col-resize";
       document.body.style.userSelect = "none";
+      document.addEventListener("mousemove", handleMouseMove, true);
+      window.addEventListener("mouseup", cleanup, true);
+      window.addEventListener("pointercancel", cleanup, true);
+      window.addEventListener("blur", cleanup);
+      document.addEventListener("visibilitychange", handleVisibilityChange);
     },
-    [direction]
+    [containerRef, minRatio, maxRatio, direction, onRatioChange]
   );
-
-  useEffect(() => {
-    const handleMouseMove = (event: globalThis.MouseEvent) => {
-      if (!isDraggingRef.current || !containerRef.current) return;
-
-      const rect = containerRef.current.getBoundingClientRect();
-
-      let newRatio: number;
-      if (direction === "vertical") {
-        newRatio = (event.clientY - rect.top) / rect.height;
-      } else {
-        newRatio = (event.clientX - rect.left) / rect.width;
-      }
-
-      const clampedRatio = Math.min(maxRatio, Math.max(minRatio, newRatio));
-      setRatio(clampedRatio);
-      onRatioChange?.(clampedRatio);
-    };
-
-    const handleMouseUp = () => {
-      if (isDraggingRef.current) {
-        isDraggingRef.current = false;
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-      }
-    };
-
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseup", handleMouseUp);
-
-    return () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-      if (isDraggingRef.current) {
-        isDraggingRef.current = false;
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-      }
-    };
-  }, [containerRef, minRatio, maxRatio, direction, onRatioChange]);
 
   return { ratio, handleMouseDown };
 }

--- a/src/hooks/ui/useResizeHandle.test.ts
+++ b/src/hooks/ui/useResizeHandle.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { act, createElement, useState } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { useResizeHandle } from "./useResizeHandle";
+
+let root: Root;
+let container: HTMLDivElement;
+const ended = vi.fn();
+function Harness() {
+  const [size, setSize] = useState(200);
+  const { handleMouseDown, isResizing } = useResizeHandle(size, setSize, {
+    direction: "horizontal",
+    minSize: 100,
+    maxSize: 500,
+    onResizeEnd: ended,
+  });
+  return createElement("div", {
+    onMouseDown: handleMouseDown,
+    "data-size": size,
+    "data-resizing": isResizing,
+  });
+}
+function mouse(target: EventTarget, type: string, x: number, buttons = 1) {
+  act(() =>
+    target.dispatchEvent(
+      new MouseEvent(type, { bubbles: true, clientX: x, buttons })
+    )
+  );
+}
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  ended.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(createElement(Harness)));
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.body.style.cssText = "";
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+it.each(["blur", "pointercancel", "hidden", "released-move"])(
+  "ends the owning resize on %s and prevents later writes",
+  (reason) => {
+    const handle = container.firstElementChild!;
+    mouse(handle, "mousedown", 0);
+    mouse(document, "mousemove", 30);
+    act(() => vi.advanceTimersByTime(20));
+    expect(handle.getAttribute("data-size")).toBe("230");
+    if (reason === "released-move") mouse(document, "mousemove", 100, 0);
+    else
+      act(() => {
+        if (reason === "hidden") {
+          vi.spyOn(document, "visibilityState", "get").mockReturnValue(
+            "hidden"
+          );
+          document.dispatchEvent(new Event("visibilitychange"));
+        } else window.dispatchEvent(new Event(reason));
+      });
+    mouse(document, "mousemove", 180, 0);
+    act(() => vi.advanceTimersByTime(30));
+    expect(handle.getAttribute("data-size")).toBe("230");
+    expect(handle.getAttribute("data-resizing")).toBe("false");
+    expect(document.body.style.cursor).toBe("");
+    expect(ended).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  }
+);
+it("cancels pending work on unmount", () => {
+  mouse(container.firstElementChild!, "mousedown", 0);
+  mouse(document, "mousemove", 30);
+  act(() => root.render(null));
+  expect(vi.getTimerCount()).toBe(0);
+  mouse(document, "mousemove", 100);
+  expect(vi.getTimerCount()).toBe(0);
+});
+it("observes a release stopped by a child and starts the next drag cleanly", () => {
+  const handle = container.firstElementChild!;
+  handle.addEventListener("mouseup", (event) => event.stopPropagation());
+  for (let i = 0; i < 3; i++) {
+    mouse(handle, "mousedown", 0);
+    mouse(handle, "mousemove", 10);
+    act(() => vi.advanceTimersByTime(20));
+    mouse(handle, "mouseup", 10, 0);
+  }
+  expect(handle.getAttribute("data-size")).toBe("230");
+  expect(ended).toHaveBeenCalledTimes(3);
+  expect(vi.getTimerCount()).toBe(0);
+});
+it("does not retain duplicate sessions after another press", () => {
+  const handle = container.firstElementChild!;
+  mouse(handle, "mousedown", 0);
+  mouse(document, "mousemove", 10);
+  mouse(handle, "mousedown", 50);
+  mouse(document, "mousemove", 60);
+  act(() => vi.advanceTimersByTime(20));
+  mouse(window, "mouseup", 60, 0);
+  expect(handle.getAttribute("data-size")).toBe("210");
+  expect(ended).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/src/hooks/ui/useResizeHandle.ts
+++ b/src/hooks/ui/useResizeHandle.ts
@@ -111,6 +111,8 @@ export function useResizeHandle(
 
   const handleMouseDown = useCallback(
     (event: ReactMouseEvent) => {
+      if (event.button !== 0) return;
+      dragCleanupRef.current?.();
       event.preventDefault();
 
       const startPos =
@@ -138,6 +140,10 @@ export function useResizeHandle(
       };
 
       const handleMouseMove = (moveEvent: globalThis.MouseEvent) => {
+        if ((moveEvent.buttons & 1) === 0) {
+          handleMouseUp();
+          return;
+        }
         if (!hasDragged) {
           hasDragged = true;
           setIsResizing(true);
@@ -156,9 +162,24 @@ export function useResizeHandle(
         }
       };
 
+      const handleVisibilityChange = () => {
+        if (document.visibilityState === "hidden") handleMouseUp();
+      };
+
+      const removeListeners = () => {
+        document.removeEventListener("mousemove", handleMouseMove, true);
+        window.removeEventListener("mouseup", handleMouseUp, true);
+        window.removeEventListener("pointercancel", handleMouseUp, true);
+        window.removeEventListener("blur", handleMouseUp);
+        document.removeEventListener(
+          "visibilitychange",
+          handleVisibilityChange
+        );
+        dragCleanupRef.current = null;
+      };
+
       const handleMouseUp = () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
+        removeListeners();
 
         // Cancel any pending RAF
         if (rafIdRef.current !== null) {
@@ -174,12 +195,14 @@ export function useResizeHandle(
         onResizeEnd?.();
       };
 
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
+      document.addEventListener("mousemove", handleMouseMove, true);
+      window.addEventListener("mouseup", handleMouseUp, true);
+      window.addEventListener("pointercancel", handleMouseUp, true);
+      window.addEventListener("blur", handleMouseUp);
+      document.addEventListener("visibilitychange", handleVisibilityChange);
 
       dragCleanupRef.current = () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
+        removeListeners();
         if (rafIdRef.current !== null) {
           cancelAnimationFrame(rafIdRef.current);
           rafIdRef.current = null;

--- a/src/scaffold/Resize/components/ResizableSplitPanel.tsx
+++ b/src/scaffold/Resize/components/ResizableSplitPanel.tsx
@@ -7,6 +7,7 @@
 import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 
 import { useResizeContextMenu } from "@src/hooks/ui/useResizeContextMenu";
+import { listenForDrag } from "@src/shared/interaction/dragLifecycle";
 
 import { VerticalResizeHandle } from "./ResizeHandle";
 
@@ -109,6 +110,7 @@ const ResizableSplitPanel: React.FC<ResizableSplitPanelProps> = ({
    */
   const handleMouseDown = useCallback(
     (event: React.MouseEvent) => {
+      if (event.button !== 0) return;
       event.preventDefault();
 
       // Ignore double-click (detail >= 2) to prevent accidental triggers
@@ -155,8 +157,9 @@ const ResizableSplitPanel: React.FC<ResizableSplitPanelProps> = ({
       };
 
       const handleMouseUp = () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
+        dispose();
+        dragCleanupRef.current = null;
+        isResizingRef.current = false;
 
         // Only do cleanup if we actually started dragging
         if (hasDraggedRef.current) {
@@ -174,15 +177,19 @@ const ResizableSplitPanel: React.FC<ResizableSplitPanelProps> = ({
           setLeftWidth(pendingWidthRef.current);
           onSplitChange?.(pendingWidthRef.current);
         }
-        isResizingRef.current = false;
       };
 
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
+      const dispose = listenForDrag({
+        onMove: handleMouseMove,
+        onEnd: handleMouseUp,
+        onCancel: handleMouseUp,
+      });
 
       dragCleanupRef.current = () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
+        dispose();
+        dragCleanupRef.current = null;
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        rafRef.current = 0;
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
         isResizingRef.current = false;

--- a/src/scaffold/Resize/components/SplitGroup.tsx
+++ b/src/scaffold/Resize/components/SplitGroup.tsx
@@ -35,6 +35,8 @@ import React, {
   useState,
 } from "react";
 
+import { listenForDrag } from "@src/shared/interaction/dragLifecycle";
+
 import { useResizeManager } from "../ResizeManager";
 import type { ResizeAxis, ResizeSession, SplitGroupProps } from "../types";
 import { GhostLayer } from "./GhostLayer";
@@ -165,7 +167,8 @@ export const SplitGroup: React.FC<SplitGroupProps> = memo(
      */
     const handleMouseDown = useCallback(
       (event: React.MouseEvent, index: number) => {
-        if (globalIsResizing) return;
+        if (event.button !== 0 || globalIsResizing || dragCleanupRef.current)
+          return;
 
         event.preventDefault();
         event.stopPropagation();
@@ -260,8 +263,7 @@ export const SplitGroup: React.FC<SplitGroupProps> = memo(
          * Handle mouse up
          */
         const handleEnd = () => {
-          document.removeEventListener("mousemove", handleMove);
-          document.removeEventListener("mouseup", handleEnd);
+          dispose();
           dragCleanupRef.current = null;
 
           // Hide ghost
@@ -274,12 +276,15 @@ export const SplitGroup: React.FC<SplitGroupProps> = memo(
           setActiveResizeIndex(null);
         };
 
-        document.addEventListener("mousemove", handleMove);
-        document.addEventListener("mouseup", handleEnd);
+        const dispose = listenForDrag({
+          onMove: handleMove,
+          onEnd: handleEnd,
+          onCancel: handleEnd,
+        });
 
         dragCleanupRef.current = () => {
-          document.removeEventListener("mousemove", handleMove);
-          document.removeEventListener("mouseup", handleEnd);
+          dispose();
+          dragCleanupRef.current = null;
           if (ghostRef.current) {
             ghostRef.current.style.display = "none";
           }

--- a/src/scaffold/Resize/hooks/useColumnResize.ts
+++ b/src/scaffold/Resize/hooks/useColumnResize.ts
@@ -23,6 +23,8 @@
  */
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
+import { listenForDrag } from "@src/shared/interaction/dragLifecycle";
+
 interface UseColumnResizeOptions {
   width: number;
   setWidth: (width: number) => void;
@@ -64,6 +66,7 @@ export function useColumnResize({
 
   const handleMouseDown = useCallback(
     (event: React.MouseEvent) => {
+      if (event.button !== 0) return;
       event.preventDefault();
 
       if (event.detail >= 2) return;
@@ -97,8 +100,10 @@ export function useColumnResize({
       };
 
       const handleMouseUp = () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
+        dispose();
+        dragCleanupRef.current = null;
+        isResizingRef.current = false;
+        setIsResizing(false);
 
         if (hasDraggedRef.current) {
           if (rafRef.current) cancelAnimationFrame(rafRef.current);
@@ -108,13 +113,13 @@ export function useColumnResize({
           if (columnRef.current) columnRef.current.style.width = "";
           setWidth(pendingWidthRef.current);
         }
-        isResizingRef.current = false;
-        setIsResizing(false);
       };
 
       dragCleanupRef.current = () => {
-        document.removeEventListener("mousemove", handleMouseMove);
-        document.removeEventListener("mouseup", handleMouseUp);
+        dispose();
+        dragCleanupRef.current = null;
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        rafRef.current = 0;
         if (hasDraggedRef.current) {
           document.body.style.cursor = "";
           document.body.style.userSelect = "";
@@ -123,8 +128,11 @@ export function useColumnResize({
         setIsResizing(false);
       };
 
-      document.addEventListener("mousemove", handleMouseMove);
-      document.addEventListener("mouseup", handleMouseUp);
+      const dispose = listenForDrag({
+        onMove: handleMouseMove,
+        onEnd: handleMouseUp,
+        onCancel: handleMouseUp,
+      });
     },
     [width, setWidth, min, max, inverted]
   );

--- a/src/scaffold/Resize/hooks/useResizeController.ts
+++ b/src/scaffold/Resize/hooks/useResizeController.ts
@@ -29,6 +29,8 @@ import {
   useState,
 } from "react";
 
+import { listenForDrag } from "@src/shared/interaction/dragLifecycle";
+
 import { useResizeManager } from "../ResizeManager";
 import type { ResizeControllerOptions, ResizeSession } from "../types";
 
@@ -97,7 +99,8 @@ export function useResizeController(
   const start = useCallback(
     (event: ReactMouseEvent, currentSize: number) => {
       // Prevent if another resize is active
-      if (globalIsResizing) return;
+      if (event.button !== 0 || globalIsResizing || dragCleanupRef.current)
+        return;
 
       event.preventDefault();
       event.stopPropagation();
@@ -180,8 +183,7 @@ export function useResizeController(
        * Handle mouse up - Commit to state
        */
       const handleEnd = () => {
-        document.removeEventListener("mousemove", handleMove);
-        document.removeEventListener("mouseup", handleEnd);
+        dispose();
         dragCleanupRef.current = null;
 
         // Hide ghost layer
@@ -199,12 +201,15 @@ export function useResizeController(
       };
 
       // Attach global listeners
-      document.addEventListener("mousemove", handleMove);
-      document.addEventListener("mouseup", handleEnd);
+      const dispose = listenForDrag({
+        onMove: handleMove,
+        onEnd: handleEnd,
+        onCancel: handleEnd,
+      });
 
       dragCleanupRef.current = () => {
-        document.removeEventListener("mousemove", handleMove);
-        document.removeEventListener("mouseup", handleEnd);
+        dispose();
+        dragCleanupRef.current = null;
         if (ghostRef.current) {
           ghostRef.current.style.display = "none";
         }

--- a/src/shared/interaction/dragLifecycle.test.ts
+++ b/src/shared/interaction/dragLifecycle.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it, vi } from "vitest";
+
+import { listenForDrag } from "./dragLifecycle";
+
+let dispose = () => {};
+afterEach(() => {
+  dispose();
+  vi.restoreAllMocks();
+});
+function event(type: string, buttons = 1, pointerId = 7) {
+  const value = new MouseEvent(type, { bubbles: true, buttons });
+  Object.defineProperty(value, "pointerId", { value: pointerId });
+  return value;
+}
+it.each(["blur", "hidden", "pointercancel", "released-move"])(
+  "terminates once on %s before later movement",
+  (reason) => {
+    const onMove = vi.fn();
+    const onCancel = vi.fn();
+    const onEnd = vi.fn();
+    dispose = listenForDrag({ onMove, onCancel, onEnd });
+    window.dispatchEvent(event("mousemove"));
+    if (reason === "hidden") {
+      vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    } else
+      window.dispatchEvent(
+        reason === "released-move" ? event("mousemove", 0) : event(reason)
+      );
+    window.dispatchEvent(event("mousemove"));
+    window.dispatchEvent(event("mouseup", 0));
+    window.dispatchEvent(new Event("blur"));
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onEnd).not.toHaveBeenCalled();
+  }
+);
+it("ignores foreign pointers and catches a stopped release for the owning pointer", () => {
+  const onMove = vi.fn();
+  const onCancel = vi.fn();
+  const onEnd = vi.fn();
+  dispose = listenForDrag({ pointerId: 7, onMove, onCancel, onEnd });
+  window.dispatchEvent(event("pointermove", 1, 8));
+  window.dispatchEvent(event("pointercancel", 0, 8));
+  window.dispatchEvent(event("pointerup", 0, 8));
+  expect(onMove).not.toHaveBeenCalled();
+  expect(onCancel).not.toHaveBeenCalled();
+  expect(onEnd).not.toHaveBeenCalled();
+  const node = document.createElement("div");
+  document.body.appendChild(node);
+  node.addEventListener("pointerup", (e) => e.stopPropagation());
+  node.dispatchEvent(event("pointermove"));
+  node.dispatchEvent(event("pointerup", 0));
+  window.dispatchEvent(event("pointermove"));
+  expect(onMove).toHaveBeenCalledTimes(1);
+  expect(onEnd).toHaveBeenCalledTimes(1);
+  node.remove();
+});
+it("detaches every registration on disposal without callbacks or timers", () => {
+  const addWindow = vi.spyOn(window, "addEventListener");
+  const removeWindow = vi.spyOn(window, "removeEventListener");
+  const addDocument = vi.spyOn(document, "addEventListener");
+  const removeDocument = vi.spyOn(document, "removeEventListener");
+  const timer = vi.spyOn(window, "setTimeout");
+  const onCancel = vi.fn();
+  const onEnd = vi.fn();
+  for (let i = 0; i < 3; i++) {
+    dispose = listenForDrag({ onMove: vi.fn(), onCancel, onEnd });
+    dispose();
+    dispose();
+  }
+  expect(removeWindow.mock.calls).toEqual(addWindow.mock.calls);
+  expect(removeDocument.mock.calls).toEqual(addDocument.mock.calls);
+  expect(onCancel).not.toHaveBeenCalled();
+  expect(onEnd).not.toHaveBeenCalled();
+  expect(timer).not.toHaveBeenCalled();
+});

--- a/src/shared/interaction/dragLifecycle.ts
+++ b/src/shared/interaction/dragLifecycle.ts
@@ -1,0 +1,64 @@
+interface DragLifecycleOptions {
+  /** Omit for a mouse session; pointer sessions only accept their owning ID. */
+  pointerId?: number;
+  onMove: (event: MouseEvent) => void;
+  onEnd: (event: MouseEvent) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Listeners belong to one active drag. Detach before notifying its owner so
+ * queued/reentrant input cannot write after termination. Disposing on unmount
+ * only detaches; owners decide whether to commit, preserve, or discard previews.
+ */
+export function listenForDrag({
+  pointerId,
+  onMove,
+  onEnd,
+  onCancel,
+}: DragLifecycleOptions): () => void {
+  const moveType = pointerId === undefined ? "mousemove" : "pointermove";
+  const endType = pointerId === undefined ? "mouseup" : "pointerup";
+  let active = true;
+  const owns = (event: MouseEvent) =>
+    pointerId === undefined || (event as PointerEvent).pointerId === pointerId;
+  const dispose = () => {
+    if (!active) return;
+    active = false;
+    window.removeEventListener(moveType, move, true);
+    window.removeEventListener(endType, end, true);
+    window.removeEventListener("pointercancel", cancelPointer, true);
+    window.removeEventListener("blur", cancel);
+    document.removeEventListener("visibilitychange", visibility);
+  };
+  const cancel = () => {
+    if (!active) return;
+    dispose();
+    onCancel();
+  };
+  const move = (event: MouseEvent) => {
+    if (!active || !owns(event)) return;
+    if ((event.buttons & 1) === 0) {
+      cancel();
+      return;
+    }
+    onMove(event);
+  };
+  const end = (event: MouseEvent) => {
+    if (!active || !owns(event) || event.button !== 0) return;
+    dispose();
+    onEnd(event);
+  };
+  const cancelPointer = (event: PointerEvent) => {
+    if (owns(event)) cancel();
+  };
+  const visibility = () => {
+    if (document.visibilityState === "hidden") cancel();
+  };
+  window.addEventListener(moveType, move, true);
+  window.addEventListener(endType, end, true);
+  window.addEventListener("pointercancel", cancelPointer, true);
+  window.addEventListener("blur", cancel);
+  document.addEventListener("visibilitychange", visibility);
+  return dispose;
+}

--- a/src/shared/interaction/dragRecovery.test.ts
+++ b/src/shared/interaction/dragRecovery.test.ts
@@ -1,0 +1,295 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { jsx } from "react/jsx-runtime";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { CustomScrollbar } from "@src/components/CustomScrollbar";
+import { useWindowDrag } from "@src/components/FloatingWindow/useWindowDrag";
+import { useWindowResize } from "@src/components/FloatingWindow/useWindowResize";
+import { useGanttDrag } from "@src/features/GanttChart/hooks/useGanttDrag";
+import {
+  ResizeProvider,
+  useResizeManager,
+} from "@src/scaffold/Resize/ResizeManager";
+import ResizableSplitPanel from "@src/scaffold/Resize/components/ResizableSplitPanel";
+import SplitGroup from "@src/scaffold/Resize/components/SplitGroup";
+import { useColumnResize } from "@src/scaffold/Resize/hooks/useColumnResize";
+import { useResizeController } from "@src/scaffold/Resize/hooks/useResizeController";
+
+vi.mock("@src/hooks/ui/useResizeContextMenu", () => ({
+  useResizeContextMenu: () => undefined,
+}));
+vi.mock("@src/util/ui/transientScrollbars", () => ({
+  clearTransientScrollbar: vi.fn(),
+  revealTransientScrollbar: vi.fn(),
+}));
+
+let host: HTMLDivElement;
+let root: Root;
+const commit = vi.fn();
+const rect = {
+  left: 0,
+  top: 0,
+  right: 800,
+  bottom: 600,
+  width: 800,
+  height: 600,
+} as DOMRect;
+function send(
+  target: EventTarget,
+  type: string,
+  x = 0,
+  buttons = 1,
+  pointerId = 7
+) {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    clientX: x,
+    clientY: x,
+    buttons,
+  });
+  Object.defineProperties(event, {
+    pointerId: { value: pointerId },
+    isPrimary: { value: true },
+  });
+  act(() => target.dispatchEvent(event));
+}
+function interrupt(reason: string, pointer = false) {
+  if (reason === "hidden") {
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+  } else if (reason === "pointercancel") {
+    send(window, "pointercancel", 0, 0);
+  } else if (reason === "released-move")
+    send(window, pointer ? "pointermove" : "mousemove", 400, 0);
+  else if (reason === "unmount") act(() => root.render(null));
+  else act(() => window.dispatchEvent(new Event(reason)));
+}
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  commit.mockClear();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+  );
+  host = document.createElement("div");
+  document.body.appendChild(host);
+  root = createRoot(host);
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(
+    rect
+  );
+});
+afterEach(() => {
+  act(() => root.unmount());
+  host.remove();
+  document.body.style.cssText = "";
+  document.body.classList.remove("resize-active");
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+function FloatingHarness({ kind }: { kind: "drag" | "resize" }) {
+  const drag = useWindowDrag(true);
+  const resize = useWindowResize({ minWidth: 100, minHeight: 100 });
+  return createElement(
+    "div",
+    { "data-draggable-window": "" },
+    createElement("div", {
+      "data-handle": "",
+      onPointerDown: kind === "drag" ? drag : resize("se"),
+    })
+  );
+}
+for (const kind of ["drag", "resize"] as const) {
+  it.each(["blur", "hidden", "pointercancel", "released-move", "unmount"])(
+    `floating ${kind} stops on %s`,
+    (reason) => {
+      act(() => root.render(createElement(FloatingHarness, { kind })));
+      const panel = host.firstElementChild as HTMLElement;
+      vi.spyOn(panel, "getBoundingClientRect").mockReturnValue({
+        ...rect,
+        width: 200,
+        height: 200,
+        right: 200,
+        bottom: 200,
+      });
+      const handle = host.querySelector("[data-handle]")!;
+      send(handle, "pointerdown");
+      send(window, "pointermove", 30);
+      const before =
+        kind === "drag" ? panel.style.transform : panel.style.width;
+      expect(before).toBe(
+        kind === "drag" ? "translate3d(30px, 30px, 0)" : "230px"
+      );
+      interrupt(reason, true);
+      send(window, "pointermove", 100);
+      send(window, "pointerup", 100, 0);
+      expect(kind === "drag" ? panel.style.transform : panel.style.width).toBe(
+        before
+      );
+      expect(document.body.style.cursor).toBe("");
+    }
+  );
+}
+function ColumnHarness() {
+  const { columnRef, handleMouseDown, isResizing } = useColumnResize({
+    width: 200,
+    setWidth: commit,
+    min: 100,
+    max: 500,
+  });
+  useEffect(() => {
+    columnRef.current = host;
+  }, [columnRef]);
+  return createElement("div", {
+    "data-handle": "",
+    "data-resizing": isResizing,
+    onMouseDown: handleMouseDown,
+  });
+}
+function ControllerHarness() {
+  const api = useResizeController({
+    axis: "x",
+    min: 100,
+    max: 500,
+    onCommit: commit,
+  });
+  const manager = useResizeManager();
+  return createElement("div", {
+    "data-handle": "",
+    "data-resizing": manager.isResizing,
+    onMouseDown: (e) => api.start(e, 200),
+  });
+}
+for (const kind of ["column", "controller", "split", "group"] as const) {
+  it.each([
+    "blur",
+    "hidden",
+    "pointercancel",
+    "released-move",
+    "mouseup",
+    "unmount",
+  ])(`${kind} resize stops on %s`, (reason) => {
+    const child =
+      kind === "column"
+        ? createElement(ColumnHarness)
+        : kind === "controller"
+          ? createElement(ControllerHarness)
+          : kind === "split"
+            ? createElement(ResizableSplitPanel, {
+                defaultLeftWidth: 200,
+                leftPanel: "left",
+                rightPanel: "right",
+                onSplitChange: commit,
+              })
+            : jsx(SplitGroup, {
+                axis: "x",
+                sizes: [200, 200],
+                onSizesChange: commit,
+                children: ["left", "right"],
+              });
+    act(() => root.render(createElement(ResizeProvider, null, child)));
+    const handle = host.querySelector("[data-handle], [role=separator]")!;
+    expect(handle).not.toBeNull();
+    send(handle, "mousedown");
+    send(window, "mousemove", 30);
+    if (reason === "mouseup") send(handle, "mouseup", 30, 0);
+    else interrupt(reason);
+    const count = commit.mock.calls.length;
+    send(window, "mousemove", 200);
+    send(window, "mouseup", 200, 0);
+    act(() => vi.advanceTimersByTime(30));
+    expect(commit).toHaveBeenCalledTimes(count);
+    if (reason !== "unmount") {
+      expect(commit).toHaveBeenLastCalledWith(
+        kind === "group" ? [230, 170] : 230
+      );
+      send(handle, "mousedown");
+      send(window, "mouseup", 0, 0);
+      expect(document.body.classList.contains("resize-active")).toBe(false);
+    }
+    expect(document.body.style.cursor).toBe("");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+}
+function GanttHarness() {
+  const api = useGanttDrag({
+    viewScope: "1d",
+    columnWidth: 24,
+    viewStart: new Date("2026-09-08T00:00:00Z"),
+    onTaskUpdate: commit,
+  });
+  return createElement("div", {
+    "data-active": !!api.dragState,
+    "data-preview": !!api.ghostPreview,
+    onMouseDown: (e) =>
+      api.handleMoveStart(
+        "task",
+        new Date("2026-09-08T00:00:00Z"),
+        new Date("2026-09-10T00:00:00Z"),
+        e
+      ),
+  });
+}
+it.each(["blur", "hidden", "pointercancel", "released-move"])(
+  "Gantt cancels preview without writing dates on %s",
+  (reason) => {
+    act(() => root.render(createElement(GanttHarness)));
+    const handle = host.firstElementChild!;
+    send(handle, "mousedown");
+    send(window, "mousemove", 24);
+    expect(handle.getAttribute("data-preview")).toBe("true");
+    interrupt(reason);
+    send(window, "mousemove", 48);
+    send(window, "mouseup", 48, 0);
+    expect(handle.getAttribute("data-active")).toBe("false");
+    expect(handle.getAttribute("data-preview")).toBe("false");
+    expect(commit).not.toHaveBeenCalled();
+    expect(document.body.style.cursor).toBe("");
+  }
+);
+it("Gantt still commits an ordinary release once", () => {
+  act(() => root.render(createElement(GanttHarness)));
+  send(host.firstElementChild!, "mousedown");
+  send(window, "mousemove", 24);
+  send(window, "mouseup", 24, 0);
+  expect(commit).toHaveBeenCalledTimes(1);
+});
+it.each(["blur", "hidden", "pointercancel", "released-move", "unmount"])(
+  "scrollbar stops moving the scroller on %s",
+  (reason) => {
+    const scroller = document.createElement("div");
+    Object.defineProperties(scroller, {
+      scrollHeight: { value: 1000 },
+      clientHeight: { value: 100 },
+    });
+    act(() =>
+      root.render(
+        createElement(CustomScrollbar, {
+          scrollElement: scroller,
+          totalLines: 100,
+        })
+      )
+    );
+    const track = host.querySelector(".custom-scrollbar-track")!;
+    Object.defineProperty(track, "clientHeight", { value: 100 });
+    act(() => vi.advanceTimersByTime(20));
+    send(host.querySelector(".custom-scrollbar-thumb")!, "mousedown");
+    send(window, "mousemove", 10);
+    const before = scroller.scrollTop;
+    expect(before).toBeGreaterThan(0);
+    interrupt(reason);
+    send(window, "mousemove", 70);
+    send(window, "mouseup", 70, 0);
+    expect(scroller.scrollTop).toBe(before);
+    expect(document.body.style.cursor).toBe("");
+  }
+);


### PR DESCRIPTION
## Problem

Releasing a drag outside the app, hiding the window, or losing pointer input could leave drag/resize owners active after the global fallback reset the cursor. Subsequent movement could keep resizing, scrolling or updating a Gantt preview, and ResizeManager could remain locked. The fallback also let an old release timer reset a newly started drag.

## Solution

End the owning interaction on blur, hidden visibility, pointer cancellation and movement without the primary button. Share capture-phase listener disposal across floating windows, scrollbars, column/split resizers, resize-manager callers and Gantt; pointer sessions accept only their own pointer ID. Harden the shared pixel/ratio resizers and cancel queued frames on unmount. Preserve the last valid resize/scroll geometry, but discard interrupted Gantt previews without writing task dates. Cancel stale global fallback timers on a new press and avoid timers for ordinary idle releases.

## Potential risks

- Capture-phase termination and interrupted-resize commits affect event ordering; regression tests cover owner state and subsequent writes, but native Tauri/WebView input has not been exercised.
- Gantt cancellation intentionally discards the preview; only an ordinary release writes task dates. Other native/DnD/editor gestures and arbitrary overlays are outside this PR.
- No dependency, schema, persistence-format or wire changes. Reverting the commit restores the previous behavior; no data migration or cleanup is required.

## Verification

Run in an isolated worktree based on current `origin/develop`:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/interaction/dragLifecycle.test.ts src/shared/interaction/dragRecovery.test.ts src/scaffold/Resize/components/ResizeHandle.test.ts src/features/GanttChart/GanttChart.virtualization.test.ts src/app/root/__tests__/AppGlobalRecovery.test.ts src/hooks/ui/useResizeHandle.test.ts src/hooks/ui/useRatioResize.test.ts src/modules/shared/layouts/FocusedChatWorkstationRail/TrailPanelResizeHandle.test.ts src/util/ui/theme/__tests__/themeTransitionCover.test.ts` — 93 tests passed across nine suites
- `pnpm run typecheck:fast` — passed
- `git diff --cached --name-only -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0` — passed
- `git diff --cached --check` — passed
- Reviewed the scoped diff for unrelated changes, secrets and generated artifacts

Native interaction/E2E and CPU/frame-time profiling were not run. Desktop control was not authorized. Static screenshots would not demonstrate these event-sequence failures, and the PR changes no visual layout or styles. Automated DOM tests cover interruption, normal release, pointer isolation, stopped propagation, repeated sessions, manager unlock and unmount cleanup.
