### PR TITLE
fix(spotlight): restore hover after slow mouse movement

### DIFF
--- a/src/hooks/keyboard/__tests__/useKeyboardMouseMode.test.ts
+++ b/src/hooks/keyboard/__tests__/useKeyboardMouseMode.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+import { useKeyboardMouseMode } from "../useKeyboardMouseMode";
+
+let root: Root;
+let container: HTMLDivElement;
+function Harness() {
+  const { handleMouseMove, dataKeyboardMode } = useKeyboardMouseMode();
+  return createElement("div", {
+    onMouseMove: handleMouseMove,
+    "data-mode": dataKeyboardMode,
+  });
+}
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(createElement(Harness)));
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+function move(x: number) {
+  act(() =>
+    container.firstElementChild!.dispatchEvent(
+      new MouseEvent("mousemove", { bubbles: true, clientX: x })
+    )
+  );
+}
+it("returns to mouse mode after slow accumulated movement", () => {
+  for (let x = 0; x <= 12; x += 2) move(x);
+  expect(container.firstElementChild?.getAttribute("data-mode")).toBe("false");
+});
+it("keeps keyboard priority for jitter and establishes a fresh keyboard anchor", () => {
+  move(0);
+  move(20);
+  expect(container.firstElementChild?.getAttribute("data-mode")).toBe("false");
+  move(100);
+  act(() =>
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }))
+  );
+  move(100);
+  move(102);
+  move(99);
+  expect(container.firstElementChild?.getAttribute("data-mode")).toBe("true");
+  move(110);
+  expect(container.firstElementChild?.getAttribute("data-mode")).toBe("false");
+});

--- a/src/hooks/keyboard/useKeyboardMouseMode.ts
+++ b/src/hooks/keyboard/useKeyboardMouseMode.ts
@@ -118,6 +118,7 @@ export function useKeyboardMouseMode(
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (opts.triggerKeys.includes(event.key)) {
+        mousePosRef.current = null;
         setIsKeyboardMode(true);
       }
     };
@@ -139,8 +140,7 @@ export function useKeyboardMouseMode(
       const dx = Math.abs(event.clientX - mousePosRef.current.x);
       const dy = Math.abs(event.clientY - mousePosRef.current.y);
 
-      mousePosRef.current = { x: event.clientX, y: event.clientY };
-
+      // Keep the anchor fixed: slow movement must accumulate across events.
       if (dx > opts.threshold || dy > opts.threshold) {
         setIsKeyboardMode(false);
       }


### PR DESCRIPTION
## Problem

Spotlight and model pickers suppress hover in keyboard mode. The mode switch compared each mouse event with the preceding event and reset the anchor every time, so slow movement could cross the entire list without exceeding the 8px threshold. A stale anchor could also restore mouse mode too early after later keyboard navigation.

## Solution

Keep the movement anchor fixed while in keyboard mode so small consecutive movements accumulate displacement. Reset it on keyboard navigation. Preserve the existing threshold, key bindings and keyboard-selection priority.

## Potential risks

The intended behavior change is that slow movement now restores hover; small jitter should retain keyboard priority. Automated hook tests cover both paths, but native Tauri/WebView input remains unverified. No dependencies, persistence formats or public APIs change; reverting the commit restores the previous behavior.

## Verification

Run in an isolated worktree based on current `origin/develop`:

- `pnpm exec vitest run --config config/vitest.config.ts src/hooks/keyboard/__tests__/useKeyboardMouseMode.test.ts` — both tests passed
- `pnpm run typecheck:fast` — passed
- `git diff --cached --name-only -- '*.ts' '*.tsx' | xargs pnpm exec eslint --max-warnings 0` — passed
- `git diff --cached --check` — passed
- Reviewed the two-file diff for unrelated changes and sensitive content

Native interaction/E2E was not run because desktop control was not authorized. Static screenshots would not show this movement-dependent failure, and no layout/style changes were made.
