### PR TITLE
fix(sidebar): use switch for include external filter

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
@@ -24,6 +24,7 @@ import {
 } from "@src/components/Dropdown/tokens";
 import IconButton from "@src/components/IconButton";
 import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip";
+import Switch from "@src/components/Switch";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import {
   ArrowRight01Icon,
@@ -237,10 +238,6 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
       [close, closeSubmenu, onSelectGroupVisibleCount]
     );
 
-    const handleToggleIncludeExternal = useCallback(() => {
-      onToggleIncludeExternal(!includeExternal);
-    }, [includeExternal, onToggleIncludeExternal]);
-
     const handleConfigureExternalSources = useCallback(() => {
       onConfigureExternalSources?.();
       close();
@@ -451,7 +448,17 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                 <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
                 <DropdownItem
                   dataTestId="sidebar-include-external"
-                  selected={includeExternal}
+                  role="none"
+                  suffix={
+                    <span onKeyDown={(event) => event.stopPropagation()}>
+                      <Switch
+                        size="small"
+                        checked={includeExternal}
+                        onCheckedChange={onToggleIncludeExternal}
+                        ariaLabel={t("sidebar.filters.includeExternal")}
+                      />
+                    </span>
+                  }
                   icon={
                     <HugeiconsIcon
                       icon={FolderSymlinkIcon}
@@ -461,7 +468,6 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                     />
                   }
                   onMouseEnter={closeSubmenu}
-                  onClick={handleToggleIncludeExternal}
                 >
                   {t("sidebar.filters.includeExternal")}
                 </DropdownItem>

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts
@@ -17,6 +17,7 @@ import { SessionFilterButton } from "../SessionFilterButton";
 const mocks = vi.hoisted(() => ({
   closeDropdown: vi.fn(),
   toggleDropdown: vi.fn(),
+  toggleIncludeExternal: vi.fn(),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -73,7 +74,7 @@ describe("SessionFilterButton", () => {
           includeExternal: true,
           onSelect,
           onSelectGroupVisibleCount,
-          onToggleIncludeExternal: vi.fn(),
+          onToggleIncludeExternal: mocks.toggleIncludeExternal,
           onRefreshSessions: vi.fn(),
           onCollapseAll: vi.fn(),
           onMarkAllRead: vi.fn(),
@@ -135,8 +136,24 @@ describe("SessionFilterButton", () => {
     expect(
       includeExternal?.querySelector('[data-icon="folder-symlink"]')
     ).not.toBeNull();
-    // Selected, so the trailing check still marks the state the icon labels.
-    expect(includeExternal?.getAttribute("aria-selected")).toBe("true");
+    const toggle = includeExternal?.querySelector('[role="switch"]');
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+    expect(toggle?.getAttribute("aria-label")).toBe(
+      "sidebar.filters.includeExternal"
+    );
+  });
+
+  it("toggles Include External once and keeps the menu open", async () => {
+    const toggle = queryTestId(
+      "sidebar-include-external"
+    )?.querySelector<HTMLButtonElement>('[role="switch"]');
+    await act(async () => toggle?.click());
+    expect(mocks.toggleIncludeExternal).toHaveBeenCalledTimes(1);
+    expect(mocks.toggleIncludeExternal).toHaveBeenCalledWith(
+      false,
+      expect.anything()
+    );
+    expect(mocks.closeDropdown).not.toHaveBeenCalled();
   });
 
   it("opens the icon-free second level with the active mode checked", async () => {


### PR DESCRIPTION
## Problem

The sidebar filter menu displays Include External as a selected action with a checkmark. This binary setting should use a switch so its on/off state is explicit.

## Solution

Replace the selected action state with the shared small Switch, bound to the existing value and callback. Keep the leading icon and menu open when toggled. Give the switch a localized accessible name and stop its key events from reaching the dropdown row's activation handler.

## Potential risks

The switch is now the activation target; clicking the surrounding label or row no longer toggles the setting. Desktop keyboard behavior, theme appearance, and narrow viewport layout have not been manually verified. No persistence, dependency, or API changes are included.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts` — passed, 11 tests; covers the accessible checked state, one toggle callback, and keeping the menu open.
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts --max-warnings 0` — passed.
- Commit hooks ran oxlint, ESLint, Prettier, and the staged-file-gated TypeScript check successfully.
- `git fetch origin develop` and `git rev-list --left-right --count origin/develop...HEAD` — branch is 0 commits behind and 1 ahead.
- `git diff origin/develop...HEAD --check` — passed. Reviewed the two-file diff for scope, secrets, debug output, and generated artifacts.
- Desktop visual verification and screenshots were not performed because computer control was not authorized. Full test suite was not run for this localized UI change.
