### PR TITLE
refactor(git): use BoundedMap for githubListCache LRU maps

### DIFF
--- a/src/services/git/githubListCache.test.ts
+++ b/src/services/git/githubListCache.test.ts
@@ -7,6 +7,7 @@ import {
   GITHUB_LIST_CACHE_TTL_MS,
   coalesceGitHubListRequest,
   flushGitHubListCachePersistence,
+  getCachedIssues,
   getCachedPrDetail,
   getCachedPrs,
   isIssueCacheStale,
@@ -168,5 +169,86 @@ describe("global GitHub list cache", () => {
 
     vi.advanceTimersByTime(60_001);
     expect(isPrDetailStale(key)).toBe(true);
+  });
+
+  it("holds four repos of issues and evicts the least-recently-read one", () => {
+    const keys = Array.from(
+      { length: 5 },
+      (_, index) => `issue-cap-${index}-${crypto.randomUUID()}`
+    );
+    const [first, second, third, fourth, fifth] = keys;
+
+    for (const key of [first, second, third, fourth]) {
+      updateCachedOpenIssues(key, []);
+    }
+    expect(getCachedIssues(fifth)).toBeNull();
+
+    // Reading `first` promotes it, so `second` becomes the eviction victim.
+    expect(getCachedIssues(first)).not.toBeNull();
+    // A staleness probe must not rescue `second` from eviction.
+    expect(isIssueCacheStale(second)).toBe(false);
+    updateCachedOpenIssues(fifth, []);
+
+    expect(getCachedIssues(second)).toBeNull();
+    expect(isIssueCacheStale(second)).toBe(true);
+    for (const key of [first, third, fourth, fifth]) {
+      expect(getCachedIssues(key)).not.toBeNull();
+    }
+  });
+
+  it("holds eight PR lists across repo/state combinations", () => {
+    const repoKeys = Array.from(
+      { length: 5 },
+      (_, index) => `pr-cap-${index}-${crypto.randomUUID()}`
+    );
+
+    for (const repoKey of repoKeys.slice(0, 4)) {
+      setCachedPrs(repoKey, [], "open");
+      setCachedPrs(repoKey, [], "closed");
+    }
+    for (const repoKey of repoKeys.slice(0, 4)) {
+      expect(getCachedPrs(repoKey, "open")).not.toBeNull();
+      expect(getCachedPrs(repoKey, "closed")).not.toBeNull();
+    }
+
+    setCachedPrs(repoKeys[4], [], "open");
+
+    expect(getCachedPrs(repoKeys[0], "open")).toBeNull();
+    expect(getCachedPrs(repoKeys[0], "closed")).not.toBeNull();
+    expect(getCachedPrs(repoKeys[4], "open")).not.toBeNull();
+  });
+
+  it("holds four PR detail snapshots and keeps in-place patches from growing the cache", () => {
+    const detail = {
+      detail: null,
+      headSha: "head",
+      baseRef: "develop",
+      conversation: [],
+      reviews: [],
+      reviewComments: [],
+      commits: [],
+      files: [],
+      checks: null,
+    };
+    const keys = Array.from(
+      { length: 5 },
+      (_, index) => `detail-cap-${index}-${crypto.randomUUID()}`
+    );
+
+    for (const key of keys.slice(0, 4)) {
+      setCachedPrDetail(key, detail);
+    }
+    expect(updateCachedPrDetail(keys[0], () => ({ headSha: "patched" }))).toBe(
+      true
+    );
+    expect(updateCachedPrDetail(keys[4], () => ({}))).toBe(false);
+
+    setCachedPrDetail(keys[4], detail);
+
+    expect(getCachedPrDetail(keys[1])).toBeNull();
+    expect(getCachedPrDetail(keys[0])?.headSha).toBe("patched");
+    for (const key of [keys[0], keys[2], keys[3], keys[4]]) {
+      expect(getCachedPrDetail(key)).not.toBeNull();
+    }
   });
 });

--- a/src/services/git/githubListCache.ts
+++ b/src/services/git/githubListCache.ts
@@ -22,6 +22,7 @@ import type {
   OpenPRItem,
   PrFile,
 } from "@src/api/tauri/github";
+import { BoundedMap } from "@src/util/collections/BoundedMap";
 import {
   BROWSER_CACHE_STORAGE_KEYS,
   estimateBrowserStorageEntryBytes,
@@ -67,33 +68,17 @@ export interface CachedPrDetail {
   cachedAt: number;
 }
 
-// JS Maps iterate in insertion order, so delete+reinsert = LRU promotion.
-function lruGet<T>(cache: Map<string, T>, key: string): T | null {
-  const entry = cache.get(key);
-  if (!entry) return null;
-  // Promote to most-recently-used by reinserting at the end
-  cache.delete(key);
-  cache.set(key, entry);
-  return entry;
-}
-
-function lruSet<T>(
-  cache: Map<string, T>,
-  key: string,
-  value: T,
-  maxSize: number = MAX_REPOS
-): void {
-  if (cache.has(key)) {
-    cache.delete(key); // remove before reinserting to update order
-  } else if (cache.size >= maxSize) {
-    // Evict least-recently-used (first key in insertion order)
-    cache.delete(cache.keys().next().value as string);
-  }
-  cache.set(key, value);
-}
-
-const issueCache = new Map<string, CachedIssues>();
-const prCache = new Map<string, CachedPrs>();
+// `BoundedMap.get` promotes the key to most-recently-used and evicts the
+// least-recently-touched entry once `maxSize` is reached; `peek` reads
+// without touching, which the staleness checks rely on.
+const issueCache = new BoundedMap<string, CachedIssues>({
+  maxSize: MAX_REPOS,
+  name: "githubListCache.issues",
+});
+const prCache = new BoundedMap<string, CachedPrs>({
+  maxSize: MAX_PR_LISTS,
+  name: "githubListCache.prs",
+});
 const inFlightListRequests = new Map<string, Promise<unknown>>();
 
 /**
@@ -138,11 +123,7 @@ function safeLocalStorage(): Storage | null {
   }
 }
 
-function hydrate<T>(
-  storageKey: string,
-  cache: Map<string, T>,
-  maxSize: number
-): void {
+function hydrate<T>(storageKey: string, cache: BoundedMap<string, T>): void {
   const store = safeLocalStorage();
   if (!store) return;
   try {
@@ -151,7 +132,7 @@ function hydrate<T>(
     const entries = JSON.parse(raw) as [string, T][];
     if (!Array.isArray(entries)) return;
     for (const [key, value] of entries) {
-      lruSet(cache, key, value, maxSize);
+      cache.set(key, value);
     }
   } catch {
     // Corrupt/legacy payload — ignore and start fresh.
@@ -159,7 +140,7 @@ function hydrate<T>(
 }
 
 function serializeCacheWithinBudget<T>(
-  cache: Map<string, T>,
+  cache: BoundedMap<string, T>,
   budgetBytes: number,
   compact: (value: T) => T
 ): string {
@@ -224,13 +205,13 @@ export function flushGitHubListCachePersistence(): void {
   flushPendingPersistence();
 }
 
-hydrate(STORAGE_KEY_ISSUES, issueCache, MAX_REPOS);
-hydrate(STORAGE_KEY_PRS, prCache, MAX_PR_LISTS);
+hydrate(STORAGE_KEY_ISSUES, issueCache);
+hydrate(STORAGE_KEY_PRS, prCache);
 
 // ── Issues ────────────────────────────────────────────────────────────────────
 
 export function getCachedIssues(repoKey: string): CachedIssues | null {
-  return lruGet(issueCache, repoKey);
+  return issueCache.get(repoKey) ?? null;
 }
 
 export type CachedIssueState = "open" | "closed";
@@ -239,7 +220,7 @@ export function isIssueCacheStale(
   repoKey: string,
   state: CachedIssueState = "open"
 ): boolean {
-  const entry = issueCache.get(repoKey);
+  const entry = issueCache.peek(repoKey);
   if (!entry) return true;
   const cachedAt = state === "open" ? entry.openCachedAt : entry.closedCachedAt;
   return (
@@ -252,8 +233,8 @@ export function updateCachedOpenIssues(
   repoKey: string,
   openIssues: GitHubIssue[]
 ) {
-  const existing = lruGet(issueCache, repoKey);
-  lruSet(issueCache, repoKey, {
+  const existing = issueCache.get(repoKey);
+  issueCache.set(repoKey, {
     openIssues: openIssues.slice(0, MAX_ISSUES_PER_SECTION),
     closedIssues: existing?.closedIssues ?? [],
     openCachedAt: Date.now(),
@@ -272,8 +253,8 @@ export function updateCachedClosedIssues(
   repoKey: string,
   closedIssues: GitHubIssue[]
 ) {
-  const existing = lruGet(issueCache, repoKey);
-  lruSet(issueCache, repoKey, {
+  const existing = issueCache.get(repoKey);
+  issueCache.set(repoKey, {
     openIssues: existing?.openIssues ?? [],
     closedIssues: closedIssues.slice(0, MAX_ISSUES_PER_SECTION),
     openCachedAt: existing?.openCachedAt ?? null,
@@ -300,14 +281,14 @@ export function getCachedPrs(
   repoKey: string,
   state: CachedPrState = "open"
 ): CachedPrs | null {
-  return lruGet(prCache, prCacheKey(repoKey, state));
+  return prCache.get(prCacheKey(repoKey, state)) ?? null;
 }
 
 export function isPrCacheStale(
   repoKey: string,
   state: CachedPrState = "open"
 ): boolean {
-  const entry = prCache.get(prCacheKey(repoKey, state));
+  const entry = prCache.peek(prCacheKey(repoKey, state));
   if (!entry) return true;
   return Date.now() - entry.cachedAt > GITHUB_LIST_CACHE_TTL_MS;
 }
@@ -317,15 +298,10 @@ export function setCachedPrs(
   prs: OpenPRItem[],
   state: CachedPrState = "open"
 ) {
-  lruSet(
-    prCache,
-    prCacheKey(repoKey, state),
-    {
-      prs: prs.slice(0, MAX_PRS),
-      cachedAt: Date.now(),
-    },
-    MAX_PR_LISTS
-  );
+  prCache.set(prCacheKey(repoKey, state), {
+    prs: prs.slice(0, MAX_PRS),
+    cachedAt: Date.now(),
+  });
   schedulePersist(STORAGE_KEY_PRS, () =>
     serializeCacheWithinBudget(
       prCache,
@@ -337,7 +313,10 @@ export function setCachedPrs(
 
 // ── Pull Request detail ─────────────────────────────────────────────────────
 
-const prDetailCache = new Map<string, CachedPrDetail>();
+const prDetailCache = new BoundedMap<string, CachedPrDetail>({
+  maxSize: MAX_PR_DETAILS,
+  name: "githubListCache.prDetails",
+});
 
 /** Cache key for a PR detail snapshot. */
 export function prDetailKey(repoFullName: string, prNumber: number): string {
@@ -345,11 +324,11 @@ export function prDetailKey(repoFullName: string, prNumber: number): string {
 }
 
 export function getCachedPrDetail(key: string): CachedPrDetail | null {
-  return lruGet(prDetailCache, key);
+  return prDetailCache.get(key) ?? null;
 }
 
 export function isPrDetailStale(key: string): boolean {
-  const entry = prDetailCache.get(key);
+  const entry = prDetailCache.peek(key);
   if (!entry) return true;
   return Date.now() - entry.cachedAt > GITHUB_LIST_CACHE_TTL_MS;
 }
@@ -358,12 +337,7 @@ export function setCachedPrDetail(
   key: string,
   detail: Omit<CachedPrDetail, "cachedAt">
 ) {
-  lruSet(
-    prDetailCache,
-    key,
-    { ...detail, cachedAt: Date.now() },
-    MAX_PR_DETAILS
-  );
+  prDetailCache.set(key, { ...detail, cachedAt: Date.now() });
 }
 
 /**
@@ -376,17 +350,12 @@ export function updateCachedPrDetail(
   key: string,
   update: (current: CachedPrDetail) => Partial<Omit<CachedPrDetail, "cachedAt">>
 ): boolean {
-  const current = prDetailCache.get(key);
+  const current = prDetailCache.peek(key);
   if (!current) return false;
-  lruSet(
-    prDetailCache,
-    key,
-    {
-      ...current,
-      ...update(current),
-      cachedAt: current.cachedAt,
-    },
-    MAX_PR_DETAILS
-  );
+  prDetailCache.set(key, {
+    ...current,
+    ...update(current),
+    cachedAt: current.cachedAt,
+  });
   return true;
 }


### PR DESCRIPTION
## Problem

`src/services/git/githubListCache.ts` hand-rolls its own LRU primitives (`lruGet` / `lruSet`: delete-and-reinsert promotion on read, evict the oldest key once `size >= maxSize`) and threads a per-call `maxSize` argument through every writer for three separate caches (`MAX_REPOS = 4` issue repos, `MAX_PR_LISTS = 8` PR lists, `MAX_PR_DETAILS = 4` PR detail snapshots). The repo already ships a tested primitive with exactly these semantics, `src/util/collections/BoundedMap.ts`, and seven other modules use it. Keeping a private copy here is drift surface: the cap is only enforced if every writer remembers to pass the right `maxSize`, and the eviction bookkeeping is re-audited on every change to this file.

## Solution

Replace the three `Map` + `lruGet` / `lruSet` sites with `BoundedMap` instances constructed with the existing caps (and a diagnostic `name`), and delete the local helpers. Mapping used:

- `lruGet(cache, k)` -> `cache.get(k) ?? null` (promotes on read; miss still returns `null`)
- `lruSet(cache, k, v, max)` -> `cache.set(k, v)` (cap is a property of the map, not a per-call argument)
- non-promoting `cache.get(k)` in the three `is*Stale` probes and in `updateCachedPrDetail` -> `cache.peek(k)` so staleness checks keep not touching LRU order
- `hydrate()` and `serializeCacheWithinBudget()` take a `BoundedMap` and rely on its oldest-first `entries()` iteration, so the persisted payload still drops least-recently-used repos first.

`BoundedMap.set` evicts when `size >= maxSize` before inserting, identical to the old `lruSet`, so every cache holds the same number of entries as before. The exported API (`getCachedIssues`, `isIssueCacheStale`, `updateCachedOpenIssues`, `updateCachedClosedIssues`, `getCachedPrs`, `isPrCacheStale`, `setCachedPrs`, `prDetailKey`, `getCachedPrDetail`, `isPrDetailStale`, `setCachedPrDetail`, `updateCachedPrDetail`, `coalesceGitHubListRequest`, `flushGitHubListCachePersistence`, the constants and types) is unchanged in name, signature, and return value; no caller was touched. `LRUCache` in `src/util/cache/lruCache.ts` was considered and rejected because it wraps values in a TTL envelope and evicts after insertion (transient `maxSize + 1`), which would change the observable capacity.

## Potential risks

- Behaviour is intended to be identical, but the LRU bookkeeping now lives in `BoundedMap`; the new tests pin capacity (4 / 8 / 4), promote-on-read eviction order, non-promoting staleness probes, and in-place `updateCachedPrDetail` patches so a semantic drift in `BoundedMap` would surface here.
- `BoundedMap.get` treats an explicitly stored `undefined` as a miss; this cache only stores object values, so the `?? null` mapping cannot mis-classify a hit.
- No UI or persisted-format change: the localStorage payload shape and budget trimming are untouched. Not exercised in the running Tauri app (no screenshot; the app cannot be rendered here).

## Verification

Run from the worktree root on `refactor/github-list-cache-bounded-map` (based on `origin/develop` at 1a0a9166d):

- `npx prettier --write src/services/git/githubListCache.ts src/services/git/githubListCache.test.ts` -> exit 0, both unchanged after formatting
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <same two files>` -> exit 0
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <same two files>` -> exit 0
- `npx vitest run --config config/vitest.config.ts src/services/git/githubListCache.test.ts src/util/collections/__tests__/BoundedMap.test.ts` -> 2 files, 43 tests passed (10 in githubListCache incl. 3 new capacity/eviction tests; 33 in BoundedMap)
- `npx vitest run --config config/vitest.config.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/__tests__/useWorkstationPrDetail.test.ts src/modules/MainApp/Settings/__tests__/StorageSection.browserStorage.test.ts src/modules/MainApp/WorkManagement/githubWorkItemsViewCache.test.ts` (consumer tests) -> 3 files, 13 tests passed
- `nice -n 10 npx tsgo --noEmit --pretty false` -> EXIT=0

Not run: full vitest suite, cargo, e2e, `check:test-placement` (no test file was added or moved; the existing `githubListCache.test.ts` was extended in place).

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
