### PR TITLE
refactor(frontend): replace local copies of shared helpers with imports

### DIFF
--- a/src/components/SessionHoverCard/CloudSessionHoverCard.tsx
+++ b/src/components/SessionHoverCard/CloudSessionHoverCard.tsx
@@ -35,17 +35,11 @@ import HoverCardBase, {
   type HoverCardPosition,
   HoverCardRow,
 } from "./HoverCardBase";
+import { COPIED_FLASH_MS, formatCompactSessionId } from "./sessionIdFormat";
 
 const logger = createLogger("CloudSessionHoverCard");
-const COPIED_FLASH_MS = 1500;
-const COMPACT_ID_EDGE_CHARS = 8;
 const SESSION_ID_BUTTON_CLASS_NAME =
   "block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-left text-text-2 underline-offset-2 transition-colors hover:text-accent-9 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-8";
-
-function formatCompactSessionId(id: string): string {
-  if (id.length <= COMPACT_ID_EDGE_CHARS * 2 + 2) return id;
-  return `${id.slice(0, COMPACT_ID_EDGE_CHARS)}…${id.slice(-COMPACT_ID_EDGE_CHARS)}`;
-}
 
 /**
  * Hover metadata card for "Team sessions" rows (cloudremote-* sidebar ids).

--- a/src/components/SessionHoverCard/SessionHoverCardContent.tsx
+++ b/src/components/SessionHoverCard/SessionHoverCardContent.tsx
@@ -55,6 +55,7 @@ import {
 import { formatDuration } from "@src/util/time/formatDuration";
 
 import { HoverCardPanel, HoverCardRow } from "./HoverCardBase";
+import { COPIED_FLASH_MS, formatCompactSessionId } from "./sessionIdFormat";
 import {
   type SessionTurnOverview,
   useSessionTurnOverview,
@@ -120,20 +121,6 @@ function formatCompactPath(path: string): string {
 
 function normalizePath(path: string): string {
   return path.replace(/\/+$/u, "");
-}
-
-/** How long the copied-check flash stays visible on the session-id row. */
-const COPIED_FLASH_MS = 1500;
-/** Characters kept on each side when middle-truncating a session id. */
-const COMPACT_ID_EDGE_CHARS = 8;
-
-/**
- * Middle-truncate a session id so both the distinctive head and tail stay
- * visible (UUIDs differ at both ends; opencode `ses_` ids differ at the tail).
- */
-function formatCompactSessionId(id: string): string {
-  if (id.length <= COMPACT_ID_EDGE_CHARS * 2 + 2) return id;
-  return `${id.slice(0, COMPACT_ID_EDGE_CHARS)}…${id.slice(-COMPACT_ID_EDGE_CHARS)}`;
 }
 
 /**

--- a/src/components/SessionHoverCard/sessionIdFormat.ts
+++ b/src/components/SessionHoverCard/sessionIdFormat.ts
@@ -1,0 +1,13 @@
+/** How long the copied-check flash stays visible on the session-id row. */
+export const COPIED_FLASH_MS = 1500;
+/** Characters kept on each side when middle-truncating a session id. */
+export const COMPACT_ID_EDGE_CHARS = 8;
+
+/**
+ * Middle-truncate a session id so both the distinctive head and tail stay
+ * visible (UUIDs differ at both ends; opencode `ses_` ids differ at the tail).
+ */
+export function formatCompactSessionId(id: string): string {
+  if (id.length <= COMPACT_ID_EDGE_CHARS * 2 + 2) return id;
+  return `${id.slice(0, COMPACT_ID_EDGE_CHARS)}…${id.slice(-COMPACT_ID_EDGE_CHARS)}`;
+}

--- a/src/components/TabPill/SidebarTabButton.tsx
+++ b/src/components/TabPill/SidebarTabButton.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from "react";
 
 import { useImmediateCursorReset } from "@src/hooks/ui/useImmediateCursorReset";
+import { classNames } from "@src/util/ui/classNames";
 
-import { cn } from "./cn";
 import { BoldStableLabel } from "./tabContent";
 import type { TabPillItem } from "./types";
 
@@ -34,7 +34,7 @@ export const SidebarTabButton: React.FC<{
       data-action-id={tab.key}
       data-testid={tab.dataTestId}
       onMouseLeave={resetCursor}
-      className={cn(
+      className={classNames(
         "group relative flex flex-1 items-center justify-center select-none",
         cursorReset || isActive ? "cursor-default" : "cursor-pointer",
         "rounded-[100px] border-none",
@@ -51,7 +51,7 @@ export const SidebarTabButton: React.FC<{
       <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-2 px-[10px]">
         {iconOnly && tab.icon && (
           <div
-            className={cn(
+            className={classNames(
               "flex shrink-0 items-center justify-center transition-colors duration-150 group-hover:text-text-1",
               isActive
                 ? "text-primary-6 group-hover:text-primary-6"
@@ -63,7 +63,7 @@ export const SidebarTabButton: React.FC<{
         )}
         {!iconOnly && (
           <span
-            className={cn(
+            className={classNames(
               "text-xs transition-colors duration-150 group-hover:text-text-1",
               isActive ? "text-text-1" : "text-text-2"
             )}

--- a/src/components/TabPill/cn.ts
+++ b/src/components/TabPill/cn.ts
@@ -1,5 +1,0 @@
-export function cn(
-  ...classes: (string | boolean | undefined | null)[]
-): string {
-  return classes.filter(Boolean).join(" ");
-}

--- a/src/components/TabPill/index.tsx
+++ b/src/components/TabPill/index.tsx
@@ -2,10 +2,10 @@ import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
+import { classNames } from "@src/util/ui/classNames";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import { SidebarTabButton } from "./SidebarTabButton";
-import { cn } from "./cn";
 import { renderTabContent } from "./tabContent";
 import type { TabPillItem, TabPillProps } from "./types";
 
@@ -161,7 +161,7 @@ const TabPill: React.FC<TabPillProps> = ({
 
   if (variant === "sidebar") {
     return (
-      <div className={cn("flex w-full items-center", className)}>
+      <div className={classNames("flex w-full items-center", className)}>
         <div
           className="flex flex-1 items-center gap-0.5 rounded-full p-1"
           style={SIDEBAR_PILL_BACKGROUND_STYLE}
@@ -218,7 +218,7 @@ const TabPill: React.FC<TabPillProps> = ({
           onMouseLeave={handleImmediateTabMouseLeave}
           disabled={tab.disabled}
           style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-          className={cn(
+          className={classNames(
             "group relative z-10 flex flex-col items-center justify-center select-none",
             cursorResetTabKey === tab.key || isActive
               ? "cursor-default"
@@ -250,7 +250,7 @@ const TabPill: React.FC<TabPillProps> = ({
           )}
           {showActiveIndicator && (
             <span
-              className={cn(
+              className={classNames(
                 "mt-1 h-1 w-1 rounded-full",
                 isActive ? "bg-primary-6" : "invisible"
               )}
@@ -274,7 +274,7 @@ const TabPill: React.FC<TabPillProps> = ({
         onMouseLeave={handleImmediateTabMouseLeave}
         disabled={tab.disabled}
         style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-        className={cn(
+        className={classNames(
           "relative z-2 flex items-center justify-center select-none",
           cursorResetTabKey === tab.key || isActive
             ? "cursor-default"
@@ -380,7 +380,7 @@ const TabPill: React.FC<TabPillProps> = ({
   return (
     <div
       style={height === undefined ? undefined : { height }}
-      className={cn(
+      className={classNames(
         "relative z-10 items-stretch",
         usePillWrapGrid
           ? "grid w-full min-w-0 grid-cols-[repeat(auto-fit,minmax(5rem,1fr))] gap-1"

--- a/src/features/CodeViewer/useDiffLines.ts
+++ b/src/features/CodeViewer/useDiffLines.ts
@@ -8,7 +8,7 @@ import { getLanguageFromPath } from "@src/config/languageMap";
 import { getLanguageFromFilePath } from "@src/util/editor/extension";
 
 import { computeDiffProgressive } from "./progressiveDiff";
-import type { DiffLine } from "./types";
+import type { DiffLine, DiffStats } from "./types";
 
 export interface UseDiffLinesOptions {
   oldValue: string;
@@ -18,11 +18,6 @@ export interface UseDiffLinesOptions {
   collapseUnchanged: boolean;
   oldStartLine: number;
   newStartLine: number;
-}
-
-export interface DiffStats {
-  additions: number;
-  deletions: number;
 }
 
 export interface UseDiffLinesResult {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SubagentDetailTab/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SubagentDetailTab/index.tsx
@@ -13,21 +13,9 @@ import Markdown from "@src/components/MarkDown";
 import PageNotice from "@src/components/PageNotice";
 import { Placeholder } from "@src/components/Placeholder";
 import { NestedActivityListForSession } from "@src/engines/ChatPanel/blocks/SubagentBlock/NestedActivityList";
+import { formatElapsedTime } from "@src/engines/ChatPanel/blocks/SubagentBlock/SubagentHelpers";
 import { ArrowRight01Icon, HugeiconsIcon, Tick01Icon } from "@src/icons";
 import type { SubagentDetailTabData } from "@src/store/workstation/tabs/types";
-
-// ============================================
-// Helpers
-// ============================================
-
-function formatElapsedTime(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = Math.round(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = seconds % 60;
-  return `${minutes}m ${remainingSeconds}s`;
-}
 
 // ============================================
 // Main Component

--- a/src/modules/WorkStation/shared/StatusBar/CiStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/CiStatusMenu.tsx
@@ -21,7 +21,6 @@ import {
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
 import { REFRESH_ICON_TOKENS } from "@src/components/RefreshIcon/tokens";
-import { resolveTimeZoneForIntl } from "@src/config/timezone";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import { useActiveRepoRef } from "@src/hooks/git/useActiveRepoRef";
 import { useBranchPullRequestStatus } from "@src/hooks/git/useBranchPullRequestStatus";
@@ -44,7 +43,6 @@ import {
   countCheckStates,
   flattenChecks,
 } from "@src/services/git/ciCheckState";
-import { toIntlLocaleTag } from "@src/util/data/formatters/date";
 import { openExternalLink } from "@src/util/platform/ipcRenderer";
 import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
 import { classNames } from "@src/util/ui/classNames";
@@ -52,25 +50,13 @@ import { classNames } from "@src/util/ui/classNames";
 import { StatusBarButton, StatusBarLabel } from "./StatusBarBase";
 import { StatusBarTooltip } from "./StatusBarTooltip";
 import { STATUS_BAR_TOKENS } from "./statusBarTokens";
+import { formatClockTime } from "./utils/formatClockTime";
 
 const MENU_ICON_SIZE = DROPDOWN_ITEM.iconSize;
 
 interface CiStatusMenuProps {
   branchName?: string;
   headRevision?: string;
-}
-
-/** Clock time of the last successful CI fetch in the user's preferred zone. */
-function formatFetchClockTime(timestamp: number, language: string): string {
-  try {
-    return new Date(timestamp).toLocaleTimeString(toIntlLocaleTag(language), {
-      hour: "2-digit",
-      minute: "2-digit",
-      timeZone: resolveTimeZoneForIntl(),
-    });
-  } catch {
-    return "";
-  }
 }
 
 function CheckStateIcon({
@@ -319,7 +305,7 @@ export const CiStatusMenu: React.FC<CiStatusMenuProps> = memo(
     });
     const lastFetchLabel =
       lastFetchedAt != null && !refreshing
-        ? formatFetchClockTime(lastFetchedAt, i18n.language)
+        ? formatClockTime(lastFetchedAt, i18n.language)
         : "";
 
     return (

--- a/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
@@ -17,7 +17,6 @@ import {
 } from "@src/components/Dropdown/tokens";
 import { ProcessStopButton } from "@src/components/ProcessStopButton";
 import { REFRESH_ICON_TOKENS } from "@src/components/RefreshIcon/tokens";
-import { resolveTimeZoneForIntl } from "@src/config/timezone";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import { createLogger } from "@src/hooks/logger";
 import {
@@ -41,13 +40,13 @@ import {
 } from "@src/store/workstation/codeEditor/workspacePortsAtom";
 import { requestNewBrowserSessionAtom } from "@src/store/workstation/workstationTabBarAtoms";
 import { copyText } from "@src/util/data/clipboard";
-import { toIntlLocaleTag } from "@src/util/data/formatters/date";
 import { classNames } from "@src/util/ui/classNames";
 
 import { StatusBarButton, StatusBarLabel } from "./StatusBarBase";
 import { StatusBarTooltip } from "./StatusBarTooltip";
 import { STATUS_BAR_TOKENS } from "./statusBarTokens";
 import { useWorkspacePortScanSync } from "./useWorkspacePortScanSync";
+import { formatClockTime } from "./utils/formatClockTime";
 import {
   refreshWorkspacePortScan,
   stopWorkspacePort,
@@ -181,19 +180,6 @@ function sectionLabelWithCount(label: string, count: number): string {
   return `${label} · ${count}`;
 }
 
-/** Clock time of the last scan, in the user's language and timezone preference. */
-function formatScanClockTime(timestamp: number, language: string): string {
-  try {
-    return new Date(timestamp).toLocaleTimeString(toIntlLocaleTag(language), {
-      hour: "2-digit",
-      minute: "2-digit",
-      timeZone: resolveTimeZoneForIntl(),
-    });
-  } catch {
-    return "";
-  }
-}
-
 export const PortsStatusMenu: React.FC = memo(() => {
   const { t, i18n } = useTranslation();
   const ports = useAtomValue(workspacePortsAtom);
@@ -321,7 +307,7 @@ export const PortsStatusMenu: React.FC = memo(() => {
 
   const lastScanLabel =
     lastScanStartedAt > 0 && !refreshing
-      ? formatScanClockTime(lastScanStartedAt, i18n.language)
+      ? formatClockTime(lastScanStartedAt, i18n.language)
       : "";
 
   return (

--- a/src/modules/WorkStation/shared/StatusBar/utils/formatClockTime.ts
+++ b/src/modules/WorkStation/shared/StatusBar/utils/formatClockTime.ts
@@ -1,0 +1,18 @@
+import { resolveTimeZoneForIntl } from "@src/config/timezone";
+import { toIntlLocaleTag } from "@src/util/data/formatters/date";
+
+/**
+ * Clock time (`HH:MM`) of a status-bar timestamp in the user's language and
+ * timezone preference. Returns "" when Intl rejects the locale or zone.
+ */
+export function formatClockTime(timestamp: number, language: string): string {
+  try {
+    return new Date(timestamp).toLocaleTimeString(toIntlLocaleTag(language), {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: resolveTimeZoneForIntl(),
+    });
+  } catch {
+    return "";
+  }
+}

--- a/src/scaffold/GlobalSpotlight/palettes/EditorPalette/hooks/useSymbolMode.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/EditorPalette/hooks/useSymbolMode.ts
@@ -28,6 +28,7 @@ import {
   SYMBOL_LABELS,
 } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/OutlineContent/config";
 import type { SymbolKind } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/OutlineContent/types";
+import { fuzzyMatch, fuzzyScore } from "@src/util/search/fuzzy";
 
 import type { SpotlightItem } from "../../../shared";
 
@@ -85,70 +86,6 @@ function normalizeSymbolKind(kind: string): SymbolKind {
   return VALID_SYMBOL_KINDS.includes(kind as SymbolKind)
     ? (kind as SymbolKind)
     : "function";
-}
-
-/** Simple fuzzy match - checks if all characters in query appear in name in order */
-function fuzzyMatch(query: string, name: string): boolean {
-  if (!query) return true;
-  const lowerQuery = query.toLowerCase();
-  const lowerName = name.toLowerCase();
-
-  let queryIdx = 0;
-  for (let nameIdx = 0; nameIdx < lowerName.length; nameIdx++) {
-    if (lowerName[nameIdx] === lowerQuery[queryIdx]) {
-      queryIdx++;
-      if (queryIdx === lowerQuery.length) return true;
-    }
-  }
-  return false;
-}
-
-/** Score a fuzzy match - higher is better */
-function fuzzyScore(query: string, name: string): number {
-  if (!query) return 0;
-  const lowerQuery = query.toLowerCase();
-  const lowerName = name.toLowerCase();
-
-  // Exact match gets highest score
-  if (lowerName === lowerQuery) return 1000;
-
-  // Starts with gets high score
-  if (lowerName.startsWith(lowerQuery)) return 500;
-
-  // Contains gets medium score
-  if (lowerName.includes(lowerQuery)) return 200;
-
-  // Fuzzy match scoring based on character positions
-  let score = 0;
-  let queryIdx = 0;
-  let prevMatchIdx = -2;
-
-  for (let nameIdx = 0; nameIdx < lowerName.length; nameIdx++) {
-    if (
-      queryIdx < lowerQuery.length &&
-      lowerName[nameIdx] === lowerQuery[queryIdx]
-    ) {
-      score += 10;
-      // Consecutive matches get bonus
-      if (nameIdx === prevMatchIdx + 1) {
-        score += 5;
-      }
-      // Start-of-word matches get bonus (after _, -, or uppercase boundary)
-      if (
-        nameIdx === 0 ||
-        name[nameIdx - 1] === "_" ||
-        name[nameIdx - 1] === "-" ||
-        (name[nameIdx] === name[nameIdx].toUpperCase() &&
-          name[nameIdx - 1] === name[nameIdx - 1].toLowerCase())
-      ) {
-        score += 3;
-      }
-      prevMatchIdx = nameIdx;
-      queryIdx++;
-    }
-  }
-
-  return score;
 }
 
 // ============================================


### PR DESCRIPTION
## Problem

Six frontend helpers exist twice with identical bodies, so a fix to one copy silently misses the other:

- `fuzzyMatch` / `fuzzyScore` are exported from `src/util/search/fuzzy.ts` and re-declared privately in `src/scaffold/GlobalSpotlight/palettes/EditorPalette/hooks/useSymbolMode.ts`.
- `DiffStats` is declared in both `src/features/CodeViewer/types.ts` and `src/features/CodeViewer/useDiffLines.ts`.
- `src/components/TabPill/cn.ts` is a rename of `classNames` from `src/util/ui/classNames.ts`.
- `formatElapsedTime` is exported from `SubagentBlock/SubagentHelpers.tsx` and re-declared privately in `SubagentDetailTab/index.tsx`.
- `formatCompactSessionId` plus the `COMPACT_ID_EDGE_CHARS` / `COPIED_FLASH_MS` constants are declared in both `SessionHoverCardContent.tsx` and `CloudSessionHoverCard.tsx`.
- `formatFetchClockTime` (CiStatusMenu) and `formatScanClockTime` (PortsStatusMenu) have the same body under two names.

Each pair was diffed before touching it; all six bodies are byte-identical apart from `export` keywords and doc comments.

## Solution

Keep exactly one definition of each helper and import it everywhere:

- `useSymbolMode.ts` imports `fuzzyMatch` / `fuzzyScore` from `@src/util/search/fuzzy`.
- `useDiffLines.ts` imports `DiffStats` from `./types` (no other module imported it from `useDiffLines`, so no re-export is needed).
- `TabPill/cn.ts` is deleted; `TabPill/index.tsx` and `SidebarTabButton.tsx` call `classNames` from `@src/util/ui/classNames`, matching the rest of the codebase.
- `SubagentDetailTab/index.tsx` imports `formatElapsedTime` from `@src/engines/ChatPanel/blocks/SubagentBlock/SubagentHelpers`. That module already imports `NestedActivityList` from the same `SubagentBlock` folder, so this adds no new `modules -> engines` edge.
- New `src/components/SessionHoverCard/sessionIdFormat.ts` owns `formatCompactSessionId`, `COMPACT_ID_EDGE_CHARS`, and `COPIED_FLASH_MS`; both hover cards import from it. The copy-flash logic itself is unchanged.
- New `src/modules/WorkStation/shared/StatusBar/utils/formatClockTime.ts` owns `formatClockTime`; `CiStatusMenu.tsx` and `PortsStatusMenu.tsx` import it and drop their now-unused `resolveTimeZoneForIntl` / `toIntlLocaleTag` imports.

Net effect: 12 files, +50 / -151 lines, no behaviour change. The invariant is that each of these helpers has a single owning module.

## Potential risks

- Pure move/dedupe refactor; no runtime logic changed, so no user-visible behaviour should differ. Both hover cards and both status-bar menus keep the same constants and formatting.
- `CiStatusMenu.test.ts` mocks `@src/config/timezone`; the mock still applies through the new `formatClockTime` module because `vi.mock` is module-global, and the test passes.
- `DiffStats` is no longer exported from `useDiffLines.ts`. A grep of `src/` found no importer of that path, so nothing breaks; any out-of-tree consumer would need to import from `./types` instead.
- The UI is Tauri-only and cannot be rendered here, so no screenshot was captured; the change is not expected to alter any pixel.
- Not run: full vitest suite, cargo, e2e.

## Verification

All commands run from the worktree root on `refactor/delete-duplicate-helper-copies` (based on `origin/develop` at `1a0a9166d`).

- `npx prettier --write <11 changed files>` -> exit 0, all files unchanged after formatting.
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <11 changed files>` -> exit 0.
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <11 changed files>` -> exit 0.
- `npx vitest run --config config/vitest.config.ts` over the 16 test files near the touched modules (`src/util/search/__tests__/fuzzy.test.ts`, the 5 `src/components/SessionHoverCard/*.test.ts`, the 3 `src/components/TabPill/*.test.ts`, the 5 `src/modules/WorkStation/shared/StatusBar/__tests__/*.test.ts`, `EditorPalette/hooks/__tests__/fileModeSearch.test.ts`, `DiffStatsBadge/__tests__/DiffStatsBadge.typography.test.ts`) -> 16 files passed, 60 tests passed.
- `nice -n 10 npx tsgo --noEmit --pretty false` -> EXIT=0.
- `pnpm run check:test-placement` not run: no test files were added or moved.
- Not run: full vitest suite, cargo, e2e.

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
