### PR TITLE
fix(path-utils): derive file extension from basename only

### DIFF
--- a/src/store/workstation/tabs/tabFactory.ts
+++ b/src/store/workstation/tabs/tabFactory.ts
@@ -21,7 +21,7 @@ import type {
   WorkStationTabType,
 } from "./types";
 
-export { getFileName } from "@src/util/file/pathUtils";
+export { getFileExtension, getFileName } from "@src/util/file/pathUtils";
 
 // ============================================
 // Types
@@ -170,9 +170,4 @@ export function defineTabFactory<TData>(
       hideWhenOthersExist: config.hideWhenOthersExist ?? false,
     };
   };
-}
-
-export function getFileExtension(name: string): string {
-  const parts = name.split(".");
-  return parts.length > 1 ? parts[parts.length - 1] : "";
 }

--- a/src/util/file/__tests__/pathUtils.test.ts
+++ b/src/util/file/__tests__/pathUtils.test.ts
@@ -40,6 +40,27 @@ describe("getFileExtension", () => {
   it("returns empty for empty string", () => {
     expect(getFileExtension("")).toBe("");
   });
+
+  it("uses the last dot of multi-dot file names", () => {
+    expect(getFileExtension("file.test.ts")).toBe("ts");
+    expect(getFileExtension("jquery.min.js")).toBe("js");
+  });
+
+  it("ignores dots in directory names", () => {
+    expect(getFileExtension("src/v1.2/README")).toBe("");
+    expect(getFileExtension("dir.v2/file.ts")).toBe("ts");
+    expect(getFileExtension("a/b.c/d")).toBe("");
+  });
+
+  it("ignores dots in Windows-style directory names", () => {
+    expect(getFileExtension("C:\\x.y\\z.md")).toBe("md");
+    expect(getFileExtension("C:\\x.y\\README")).toBe("");
+  });
+
+  it("treats dotfiles inside directories like bare dotfiles", () => {
+    expect(getFileExtension("repo/.gitignore")).toBe("gitignore");
+    expect(getFileExtension("Users/me/.DS_Store")).toBe("DS_Store");
+  });
 });
 
 describe("getFileName", () => {
@@ -108,5 +129,10 @@ describe("getFileExtensionLower", () => {
   it("lowercases extension", () => {
     expect(getFileExtensionLower("Image.PNG")).toBe("png");
     expect(getFileExtensionLower("a.TxT")).toBe("txt");
+  });
+
+  it("ignores dots in directory names", () => {
+    expect(getFileExtensionLower("src/v1.2/README")).toBe("");
+    expect(getFileExtensionLower("dir.v2/Image.PNG")).toBe("png");
   });
 });

--- a/src/util/file/pathUtils.ts
+++ b/src/util/file/pathUtils.ts
@@ -80,6 +80,10 @@ export function toFsPluginPath(path: string): string {
 
 /**
  * Get file extension from file path
+ *
+ * Only the final path segment is inspected, so dots in directory names never
+ * leak into the result. Handles both `/` and `\` separators.
+ *
  * @param filePath - Full file path or filename
  * @returns File extension (without dot) or empty string if no extension
  *
@@ -87,11 +91,16 @@ export function toFsPluginPath(path: string): string {
  * getFileExtension("src/components/Button.tsx") // "tsx"
  * getFileExtension("README") // ""
  * getFileExtension(".gitignore") // "gitignore"
+ * getFileExtension("src/v1.2/README") // ""
  */
 export function getFileExtension(filePath: string): string {
   if (!filePath) return "";
-  const parts = filePath.split(".");
-  return parts.length > 1 ? parts[parts.length - 1] : "";
+  const separatorIndex = Math.max(
+    filePath.lastIndexOf("/"),
+    filePath.lastIndexOf("\\")
+  );
+  const dotIndex = filePath.lastIndexOf(".");
+  return dotIndex > separatorIndex ? filePath.slice(dotIndex + 1) : "";
 }
 
 /**


### PR DESCRIPTION
## Problem

`getFileExtension` in `src/util/file/pathUtils.ts` split the **whole path** on `.` and returned the last piece. Any dot in a directory name therefore leaked into the result whenever the file itself had no extension:

- `getFileExtension("src/v1.2/README")` returned `"2/README"` instead of `""`
- `getFileExtension("dir.v2/file")` returned `"v2/file"` instead of `""`
- `getFileExtension("C:\\x.y\\README")` returned `"y\\README"` instead of `""`

`getFileExtensionLower` delegates to it, so every extension-driven lookup that receives a full path (`isBinaryByExtension`, `getPreviewType`, `getImageMimeType`, `getVideoMimeType`, `ImagePreview`) inherited the bug. Concretely, an extensionless file under a dotted directory (`packages/app.v2/Makefile`, `~/.config/nvim/init`) was never treated as "no extension": `isBinaryByExtension` skipped its known-text-file / extensionless heuristic and returned `false` for it, and `getPreviewType` fell through on a garbage extension string.

The same function was also re-declared verbatim (minus the falsy guard) in `src/store/workstation/tabs/tabFactory.ts`, so a fix in one place would have left the other behind.

## Solution

- `getFileExtension` now only inspects the final path segment: it takes the last `.` only if it comes after the last `/` or `\` separator. All documented examples are preserved (`"src/components/Button.tsx"` → `"tsx"`, `"README"` → `""`, `".gitignore"` → `"gitignore"`, and the `".DS_Store"` → `"ds_store"` behaviour that `binaryDetection.ts` relies on). `getFileExtensionLower` already delegates and inherits the fix unchanged.
- `tabFactory.ts` drops its private copy and re-exports `getFileExtension` from `@src/util/file/pathUtils` next to the existing `getFileName` re-export, so `factories/codeEditor.ts`, `tabs/index.ts`, and `tabFactory.test.ts` keep their import paths and there is now a single implementation.
- Regression tests at the util boundary (`src/util/file/__tests__/pathUtils.test.ts`): `"src/v1.2/README"` → `""`, `"dir.v2/file.ts"` → `"ts"`, `"a/b.c/d"` → `""`, `"C:\\x.y\\z.md"` → `"md"`, `"C:\\x.y\\README"` → `""`, dotfiles inside directories, multi-dot names, plus the same dotted-directory cases through `getFileExtensionLower`.

**Not collapsed:** `src/config/languageRegistry.ts` keeps its private `getExtension`. It is *not* equivalent to `getFileExtensionLower`: when the basename has no dot it returns the whole lowercased basename instead of `""`, and the registry has real extension entries named `"makefile"` and `"dockerfile"`. `getEditorLanguageFromPath("Makefile")` and `getSyntaxHighlighterLanguageFromPath("Dockerfile")` resolve through that fallback (they do not consult the special-filename map first), so replacing it would silently drop editor-language / highlighter detection for those files. That difference is intentional behaviour, so it stays out of this PR.

## Potential risks

- **Callers of `getFileExtension` / `getFileExtensionLower` (10 production call sites, grep-verified):** `pathUtils.getBaseName` (1), `tabs/factories/codeEditor.ts` (3, via the `tabFactory` re-export), `util/file/previewTypes.ts` (3), `util/file/binaryDetection.ts` (1), `util/language/detectLanguage.ts` (1), `FilePreviewContent/ImagePreview/index.tsx` (1); plus two pass-through re-export surfaces with no consumers outside tests (`api/tauri/search/{helpers,index}.ts` and `store/workstation/tabs/index.ts`). `getBaseName`, `codeEditor.ts` and `detectLanguage.ts` already pass a basename, so their result is unchanged by construction. None of the remaining full-path callers depended on the buggy output — the leaked strings (`"2/README"`, `"v2/file"`) contained a separator and could never match any extension set — so the only observable change is that extensionless files under dotted directories now correctly hit the "no extension" branches (`isBinaryByExtension` applies its known-text-file / extensionless-binary heuristic; `getPreviewType` treats them as it already treats `README`).
- Inputs ending in a trailing separator (`"dir.v2/"`) now return `""` rather than `"v2/"`; no caller passes directory paths.
- `src/api/tauri/search/__tests__/helpers.test.ts` mocks `getFileExtension` with the old `split(".").pop()` shape; it is a mock of its own module boundary and still passes, but it does not exercise the real helper.
- No user-visible UI change and no screenshot: the app is Tauri-only and cannot be rendered here; the effect is limited to extension-derived classification of files whose parent directory contains a dot.

## Verification

Run from the worktree root (`/private/tmp/orgii-consol-fileext`, branch based on `origin/develop` at `1a0a9166d`):

- `npx prettier --write src/util/file/pathUtils.ts src/store/workstation/tabs/tabFactory.ts src/util/file/__tests__/pathUtils.test.ts` → exit 0, all three files unchanged
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <same 3 files>` → exit 0
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <same 3 files>` → exit 0
- `npx vitest run --config config/vitest.config.ts src/util/file/__tests__/pathUtils.test.ts src/util/file/__tests__/binaryDetection.test.ts src/util/file/__tests__/previewTypes.test.ts src/store/workstation/tabs/__tests__/tabFactory.test.ts src/api/tauri/search/__tests__/helpers.test.ts src/util/language` → exit 0, 8 files / 109 tests passed (pathUtils 26 incl. the new regression cases, tabFactory 36, binaryDetection 14, previewTypes 11, helpers 6, detectLanguage 9, prismHtml 6, prismLight 1)
- `nice -n 10 npx tsgo --noEmit --pretty false` → exit 0, no diagnostics

Not run: full vitest suite, `pnpm run check:test-placement` (no test file was added or moved; the new cases live in the existing `src/util/file/__tests__/pathUtils.test.ts`), cargo, e2e. No `languageRegistry` test file exists in `src/config/`, and that file was not modified.

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
