### PR TITLE
refactor(time): share clock time formatting helpers

### DIFF
--- a/src/components/TurnNavigationToolbar/formatTranscriptRoundTimeLabel.ts
+++ b/src/components/TurnNavigationToolbar/formatTranscriptRoundTimeLabel.ts
@@ -1,28 +1,4 @@
-const MIN_TIME_RANGE_MS = 60_000;
-
-function formatClockTime(ms: number): string {
-  if (!Number.isFinite(ms)) return "";
-  try {
-    return new Date(ms).toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-  } catch {
-    return "";
-  }
-}
-
-function formatClockRange(startMs: number, endMs: number): string {
-  const startClock = formatClockTime(startMs);
-  if (!startClock) return "";
-  if (endMs - startMs < MIN_TIME_RANGE_MS) return startClock;
-
-  const endClock = formatClockTime(endMs);
-  if (!endClock) return "";
-
-  return `${startClock} ~ ${endClock}`;
-}
+import { formatClockRange } from "@src/util/time/formatClockTime";
 
 export function formatTranscriptRoundTimeLabel(round: {
   startedAt?: string;

--- a/src/engines/ChatPanel/ChatHistory/utils/turnPageFormatting.ts
+++ b/src/engines/ChatPanel/ChatHistory/utils/turnPageFormatting.ts
@@ -7,11 +7,11 @@
  */
 import type { CursorIdeTurnSummary } from "@src/api/tauri/externalHistory";
 import { PILL_TYPE_LIST } from "@src/config/pillTokens";
+import { formatClockRange } from "@src/util/time/formatClockTime";
 
 import type { ChatGroupMeta } from "../hooks/useChatGroups";
 
 const ROUND_PREVIEW_MAX_LENGTH = 96;
-const MIN_TIME_RANGE_MS = 60_000;
 
 /**
  * Strip the bracket portion of pill serialization syntax (`[type:path]`)
@@ -64,28 +64,4 @@ export function formatTurnPageTimeLabel(metas: ChatGroupMeta[]): string {
   if (startMs === null || endMs === null) return "";
 
   return formatClockRange(startMs, endMs);
-}
-
-function formatClockRange(startMs: number, endMs: number): string {
-  const startClock = formatClockTime(startMs);
-  if (!startClock) return "";
-  if (endMs - startMs < MIN_TIME_RANGE_MS) return startClock;
-
-  const endClock = formatClockTime(endMs);
-  if (!endClock) return "";
-
-  return `${startClock} ~ ${endClock}`;
-}
-
-function formatClockTime(ms: number): string {
-  if (!Number.isFinite(ms)) return "";
-  try {
-    return new Date(ms).toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-  } catch {
-    return "";
-  }
 }

--- a/src/engines/ChatPanel/ChatHistory/utils/turnTimingFormatting.ts
+++ b/src/engines/ChatPanel/ChatHistory/utils/turnTimingFormatting.ts
@@ -1,3 +1,5 @@
+import { formatClockTime } from "@src/util/time/formatClockTime";
+
 export interface TurnTimingLabels {
   duration: string;
   startClock: string;
@@ -20,27 +22,13 @@ export function formatTurnDuration(durationMs: number): string {
   return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
 }
 
-/** Locale-aware 24-hour wall-clock label used by turn summaries. */
-export function formatTurnClockTime(ms: number): string {
-  if (!Number.isFinite(ms)) return "";
-  try {
-    return new Date(ms).toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-  } catch {
-    return "";
-  }
-}
-
 export function getTurnTimingLabels(
   durationMs: number,
   startMs: number | null,
   endMs: number | null
 ): TurnTimingLabels {
-  const startClock = startMs !== null ? formatTurnClockTime(startMs) : "";
-  const endClock = endMs !== null ? formatTurnClockTime(endMs) : "";
+  const startClock = startMs !== null ? formatClockTime(startMs) : "";
+  const endClock = endMs !== null ? formatClockTime(endMs) : "";
   return {
     duration: formatTurnDuration(durationMs),
     startClock,

--- a/src/util/time/__tests__/formatClockTime.test.ts
+++ b/src/util/time/__tests__/formatClockTime.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MIN_TIME_RANGE_MS,
+  formatClockRange,
+  formatClockTime,
+} from "../formatClockTime";
+
+// `config/vitest.config.ts` pins TZ to America/Los_Angeles, so 16:30Z is
+// 09:30 local (PDT) regardless of the developer's own zone.
+const START_MS = Date.UTC(2026, 6, 13, 16, 30, 0);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("formatClockTime", () => {
+  it("formats a timestamp as a zero-padded 24-hour HH:MM label", () => {
+    expect(formatClockTime(START_MS)).toBe("09:30");
+  });
+
+  it("returns an empty label for non-finite input", () => {
+    expect(formatClockTime(Number.NaN)).toBe("");
+    expect(formatClockTime(Number.POSITIVE_INFINITY)).toBe("");
+  });
+
+  it("returns an empty label when Intl formatting throws", () => {
+    vi.spyOn(Date.prototype, "toLocaleTimeString").mockImplementation(() => {
+      throw new RangeError("Invalid time zone");
+    });
+    expect(formatClockTime(START_MS)).toBe("");
+  });
+});
+
+describe("formatClockRange", () => {
+  it("collapses endpoints closer than MIN_TIME_RANGE_MS to a single label", () => {
+    expect(formatClockRange(START_MS, START_MS + MIN_TIME_RANGE_MS - 1)).toBe(
+      "09:30"
+    );
+  });
+
+  it("renders a start ~ end range once the endpoints are a minute apart", () => {
+    expect(formatClockRange(START_MS, START_MS + MIN_TIME_RANGE_MS)).toBe(
+      "09:30 ~ 09:31"
+    );
+  });
+
+  it("returns an empty label when either endpoint cannot be formatted", () => {
+    expect(formatClockRange(Number.NaN, START_MS)).toBe("");
+    expect(formatClockRange(START_MS, Number.NaN)).toBe("");
+  });
+});

--- a/src/util/time/formatClockTime.ts
+++ b/src/util/time/formatClockTime.ts
@@ -1,0 +1,40 @@
+/**
+ * Two timestamps closer than this render as a single HH:MM label instead of
+ * a `start ~ end` range: a range whose endpoints round to the same minute
+ * would read as `10:44 ~ 10:44`.
+ */
+export const MIN_TIME_RANGE_MS = 60_000;
+
+/**
+ * Locale-aware 24-hour wall-clock label (`HH:MM`) in the system zone.
+ * Non-finite input and Intl failures both yield "" so callers can treat an
+ * empty label as "no time to show".
+ */
+export function formatClockTime(ms: number): string {
+  if (!Number.isFinite(ms)) return "";
+  try {
+    return new Date(ms).toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * `HH:MM ~ HH:MM` range, collapsing to a single `HH:MM` when the endpoints
+ * are less than {@link MIN_TIME_RANGE_MS} apart. Returns "" when either
+ * endpoint cannot be formatted.
+ */
+export function formatClockRange(startMs: number, endMs: number): string {
+  const startClock = formatClockTime(startMs);
+  if (!startClock) return "";
+  if (endMs - startMs < MIN_TIME_RANGE_MS) return startClock;
+
+  const endClock = formatClockTime(endMs);
+  if (!endClock) return "";
+
+  return `${startClock} ~ ${endClock}`;
+}


### PR DESCRIPTION
## Problem

Three modules carried byte-identical private copies of the 24-hour wall-clock formatter (`toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false })` inside a try/catch that falls back to `""`):

- `src/engines/ChatPanel/ChatHistory/utils/turnPageFormatting.ts` (`formatClockTime`, `formatClockRange`, `MIN_TIME_RANGE_MS`)
- `src/engines/ChatPanel/ChatHistory/utils/turnTimingFormatting.ts` (`formatTurnClockTime`)
- `src/components/TurnNavigationToolbar/formatTranscriptRoundTimeLabel.ts` (`formatClockTime`, `formatClockRange`, `MIN_TIME_RANGE_MS`)

Two of them also duplicated `formatClockRange` and the `MIN_TIME_RANGE_MS = 60_000` collapse threshold. Any change to the clock format (locale handling, timezone preference, fallback text) had to be made three times, and nothing tested the shared behaviour directly — the existing suites only assert `/\d{2}:\d{2}/` through the wrapping label functions.

## Solution

Add `src/util/time/formatClockTime.ts` exporting `formatClockTime`, `formatClockRange`, and `MIN_TIME_RANGE_MS`, following the existing `src/util/time/formatDuration.ts` / `formatRelativeTime.ts` layout (one file per formatter, tests in `src/util/time/__tests__/`). The three modules now import from it and their local copies are deleted. `formatTurnClockTime` was exported from `turnTimingFormatting.ts` but had no importers outside that file (grepped `src/`), so it is removed rather than re-exported; `getTurnTimingLabels`, `formatTurnPageTimeLabel`, `formatCursorIdeTurnPageTimeLabel`, and `formatTranscriptRoundTimeLabel` keep their signatures and call sites unchanged.

All three bodies were confirmed identical before deletion (same option object, same `""` fallback on non-finite input and on a thrown Intl error), so the resulting invariant is "one implementation, same output at every call site."

## Potential risks

- No behaviour change is intended: the shared implementation is the exact body that was removed, and the range-collapse threshold is unchanged at 60 s. The wrapping functions' existing tests still pass.
- `formatTurnClockTime` is no longer exported from `turnTimingFormatting.ts`. `grep -rn formatTurnClockTime src` shows no remaining references, so nothing breaks, but an out-of-tree branch importing it would need to switch to `@src/util/time/formatClockTime`.
- The new unit test asserts an exact `09:30` label. It relies on the TZ pin (`America/Los_Angeles`) in `config/vitest.config.ts` and on the runner's default ICU locale rendering `HH:MM` with a colon; a runner whose default locale uses a `.` separator (e.g. `fi`, `da`) would fail that assertion. CI runs with an `en_US`-style locale, matching the existing `formatRelativeTime` suite's assumptions.
- No UI is touched, so no screenshot applies.

## Verification

All run from the worktree root on this branch:

- `npx prettier --write <5 changed files>` — exit 0 (reformatted the new test and `turnPageFormatting.ts` trailing newline; others unchanged)
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <5 changed files>` — exit 0
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <5 changed files>` — exit 0
- `npx vitest run --config config/vitest.config.ts src/util/time/__tests__/formatClockTime.test.ts src/engines/ChatPanel/ChatHistory/utils/__tests__/turnPageFormatting.test.ts src/engines/ChatPanel/ChatHistory/utils/__tests__/turnTimingFormatting.test.ts src/components/TurnNavigationToolbar/TurnNavigationToolbar.test.ts` — 4 files, 26 tests passed
- `nice -n 10 npx tsgo --noEmit --pretty false` — EXIT=0
- `pnpm run check:test-placement` — "Test placement is consistent across 532 directories."
- `grep -rn "formatTurnClockTime\|formatClockTime\|formatClockRange\|MIN_TIME_RANGE_MS" src` — only the new util and its three importers remain (plus an unrelated `formatClockTime(hour, minute)` in `NotificationFocusBlocks.tsx` that formats settings hours, not timestamps)

Not run: the full vitest suite, cargo, e2e. Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
