### PR TITLE
refactor(chat-items): share tool usage sum across activity groups

### DIFF
--- a/src/engines/ChatPanel/ChatItems/ActionSummaryGroup/index.tsx
+++ b/src/engines/ChatPanel/ChatItems/ActionSummaryGroup/index.tsx
@@ -17,17 +17,14 @@ import {
   ChatLoadingBlock,
   StackedBlock,
 } from "@src/engines/ChatPanel/blocks/primitives";
-import {
-  type SessionEvent,
-  TOOL_USAGE_ARGS_KEY,
-  type ToolUsageMetadata,
-} from "@src/engines/SessionCore/core/types";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { getChatLazyComponent } from "@src/engines/SessionCore/rendering/registry/events";
 import { HugeiconsIcon, WaypointsIcon } from "@src/icons";
 import { getRegistryEventType } from "@src/lib/activityData/activityNormalizers";
 
 import type { ActionSummaryCategory } from "../../ChatHistory/chatItemPipeline/classifiers";
 import type { ActionSummaryEntry } from "../../ChatHistory/chatItemPipeline/types";
+import { readToolUsage, sumToolUsage } from "../toolUsage";
 
 // ============================================
 // Types
@@ -111,52 +108,6 @@ function buildGroupSummary(
 // Render Item — delegates to registry component
 // ============================================
 
-function readToolUsage(event: SessionEvent): ToolUsageMetadata | undefined {
-  if (event.toolUsage) return event.toolUsage;
-  const raw = event.args?.[TOOL_USAGE_ARGS_KEY];
-  if (!raw || typeof raw !== "object") return undefined;
-  return raw as ToolUsageMetadata;
-}
-
-function aggregateToolUsage(
-  items: readonly CategorizedEvent[]
-): ToolUsageMetadata | undefined {
-  const usages = items
-    .map((item) => readToolUsage(item.event))
-    .filter((usage): usage is ToolUsageMetadata => Boolean(usage));
-  if (usages.length === 0) return undefined;
-  return usages.reduce<ToolUsageMetadata>(
-    (total, usage) => ({
-      decisionCompletionTokens:
-        total.decisionCompletionTokens + usage.decisionCompletionTokens,
-      resultContextTokens:
-        total.resultContextTokens + usage.resultContextTokens,
-      followupCompletionTokens:
-        total.followupCompletionTokens + usage.followupCompletionTokens,
-      inputBytes: total.inputBytes + usage.inputBytes,
-      outputBytes: total.outputBytes + usage.outputBytes,
-      relatedCacheReadTokens:
-        total.relatedCacheReadTokens + usage.relatedCacheReadTokens,
-      relatedCacheWriteTokens:
-        total.relatedCacheWriteTokens + usage.relatedCacheWriteTokens,
-      attributionMethod:
-        total.attributionMethod === usage.attributionMethod
-          ? total.attributionMethod
-          : usage.attributionMethod,
-    }),
-    {
-      decisionCompletionTokens: 0,
-      resultContextTokens: 0,
-      followupCompletionTokens: 0,
-      inputBytes: 0,
-      outputBytes: 0,
-      relatedCacheReadTokens: 0,
-      relatedCacheWriteTokens: 0,
-      attributionMethod: usages[0].attributionMethod,
-    }
-  );
-}
-
 function renderEventBlock(
   { event, isLastItem }: CategorizedEvent,
   _index: number
@@ -213,7 +164,9 @@ const ActionSummaryGroup: React.FC<ActionSummaryGroupProps> = ({
     firstEvent?.functionName ||
     firstEvent?.uiCanonical ||
     firstEvent?.actionType;
-  const groupToolUsage = aggregateToolUsage(orderedItems);
+  const groupToolUsage = sumToolUsage(
+    orderedItems.map((item) => readToolUsage(item.event))
+  );
 
   return (
     <div

--- a/src/engines/ChatPanel/ChatItems/EditActivityGroup/index.tsx
+++ b/src/engines/ChatPanel/ChatItems/EditActivityGroup/index.tsx
@@ -14,17 +14,15 @@ import {
   ChatLoadingBlock,
   StackedBlock,
 } from "@src/engines/ChatPanel/blocks/primitives";
-import {
-  type SessionEvent,
-  TOOL_USAGE_ARGS_KEY,
-  type ToolUsageMetadata,
-} from "@src/engines/SessionCore/core/types";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { extractEditData } from "@src/engines/SessionCore/rendering/props/editExtractors";
 import { getChatLazyComponent } from "@src/engines/SessionCore/rendering/registry/events";
 import {
   getRegistryEventType,
   normalizeFunctionName,
 } from "@src/lib/activityData/activityNormalizers";
+
+import { readToolUsage, sumToolUsage } from "../toolUsage";
 
 interface EditActivityGroupProps {
   events: SessionEvent[];
@@ -113,53 +111,6 @@ function suppressLoadingForNonLastRunningEvent(
   };
 }
 
-function readToolUsage(event: SessionEvent): ToolUsageMetadata | undefined {
-  if (event.toolUsage) return event.toolUsage;
-  const raw = event.args?.[TOOL_USAGE_ARGS_KEY];
-  if (!raw || typeof raw !== "object") return undefined;
-  return raw as ToolUsageMetadata;
-}
-
-function aggregateToolUsage(
-  items: readonly EditEventItem[]
-): ToolUsageMetadata | undefined {
-  const usages = items
-    .map((item) => readToolUsage(item.event))
-    .filter((usage): usage is ToolUsageMetadata => Boolean(usage));
-  if (usages.length === 0) return undefined;
-
-  return usages.reduce<ToolUsageMetadata>(
-    (total, usage) => ({
-      decisionCompletionTokens:
-        total.decisionCompletionTokens + usage.decisionCompletionTokens,
-      resultContextTokens:
-        total.resultContextTokens + usage.resultContextTokens,
-      followupCompletionTokens:
-        total.followupCompletionTokens + usage.followupCompletionTokens,
-      inputBytes: total.inputBytes + usage.inputBytes,
-      outputBytes: total.outputBytes + usage.outputBytes,
-      relatedCacheReadTokens:
-        total.relatedCacheReadTokens + usage.relatedCacheReadTokens,
-      relatedCacheWriteTokens:
-        total.relatedCacheWriteTokens + usage.relatedCacheWriteTokens,
-      attributionMethod:
-        total.attributionMethod === usage.attributionMethod
-          ? total.attributionMethod
-          : usage.attributionMethod,
-    }),
-    {
-      decisionCompletionTokens: 0,
-      resultContextTokens: 0,
-      followupCompletionTokens: 0,
-      inputBytes: 0,
-      outputBytes: 0,
-      relatedCacheReadTokens: 0,
-      relatedCacheWriteTokens: 0,
-      attributionMethod: usages[0].attributionMethod,
-    }
-  );
-}
-
 function renderEditEvent({ event, isLastItem }: EditEventItem) {
   return (
     <ActivityBlock
@@ -194,7 +145,9 @@ const EditActivityGroup: React.FC<EditActivityGroupProps> = ({
   const hasDiffStats = diffStats.additions > 0 || diffStats.deletions > 0;
 
   const firstEvent = items[0].event;
-  const groupToolUsage = aggregateToolUsage(items);
+  const groupToolUsage = sumToolUsage(
+    items.map((item) => readToolUsage(item.event))
+  );
 
   return (
     <div

--- a/src/engines/ChatPanel/ChatItems/TerminalActivityGroup/index.tsx
+++ b/src/engines/ChatPanel/ChatItems/TerminalActivityGroup/index.tsx
@@ -18,14 +18,12 @@ import {
   ChatLoadingBlock,
   StackedBlock,
 } from "@src/engines/ChatPanel/blocks/primitives";
-import {
-  type SessionEvent,
-  TOOL_USAGE_ARGS_KEY,
-  type ToolUsageMetadata,
-} from "@src/engines/SessionCore/core/types";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { getChatLazyComponent } from "@src/engines/SessionCore/rendering/registry/events";
 import { getRegistryEventType } from "@src/lib/activityData/activityNormalizers";
 import { sessionByIdAtom } from "@src/store/session/sessionAtom";
+
+import { readToolUsage, sumToolUsage } from "../toolUsage";
 
 interface TerminalActivityGroupProps {
   events: SessionEvent[];
@@ -121,53 +119,6 @@ function suppressLoadingForNonLastRunningEvent(
   };
 }
 
-function readToolUsage(event: SessionEvent): ToolUsageMetadata | undefined {
-  if (event.toolUsage) return event.toolUsage;
-  const raw = event.args?.[TOOL_USAGE_ARGS_KEY];
-  if (!raw || typeof raw !== "object") return undefined;
-  return raw as ToolUsageMetadata;
-}
-
-function aggregateToolUsage(
-  items: readonly TerminalEventItem[]
-): ToolUsageMetadata | undefined {
-  const usages = items
-    .map((item) => readToolUsage(item.event))
-    .filter((usage): usage is ToolUsageMetadata => Boolean(usage));
-  if (usages.length === 0) return undefined;
-
-  return usages.reduce<ToolUsageMetadata>(
-    (total, usage) => ({
-      decisionCompletionTokens:
-        total.decisionCompletionTokens + usage.decisionCompletionTokens,
-      resultContextTokens:
-        total.resultContextTokens + usage.resultContextTokens,
-      followupCompletionTokens:
-        total.followupCompletionTokens + usage.followupCompletionTokens,
-      inputBytes: total.inputBytes + usage.inputBytes,
-      outputBytes: total.outputBytes + usage.outputBytes,
-      relatedCacheReadTokens:
-        total.relatedCacheReadTokens + usage.relatedCacheReadTokens,
-      relatedCacheWriteTokens:
-        total.relatedCacheWriteTokens + usage.relatedCacheWriteTokens,
-      attributionMethod:
-        total.attributionMethod === usage.attributionMethod
-          ? total.attributionMethod
-          : usage.attributionMethod,
-    }),
-    {
-      decisionCompletionTokens: 0,
-      resultContextTokens: 0,
-      followupCompletionTokens: 0,
-      inputBytes: 0,
-      outputBytes: 0,
-      relatedCacheReadTokens: 0,
-      relatedCacheWriteTokens: 0,
-      attributionMethod: usages[0].attributionMethod,
-    }
-  );
-}
-
 function renderTerminalEvent(
   { event, isLastItem }: TerminalEventItem,
   _index: number
@@ -220,7 +171,9 @@ const TerminalActivityGroup: React.FC<TerminalActivityGroupProps> = ({
   if (items.length === 0) return null;
 
   const firstEvent = items[0].event;
-  const groupToolUsage = aggregateToolUsage(items);
+  const groupToolUsage = sumToolUsage(
+    items.map((item) => readToolUsage(item.event))
+  );
   const groupSummary = buildGroupSummary(events, t);
 
   return (

--- a/src/engines/ChatPanel/ChatItems/__tests__/toolUsage.test.ts
+++ b/src/engines/ChatPanel/ChatItems/__tests__/toolUsage.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TOOL_USAGE_ARGS_KEY,
+  type ToolUsageMetadata,
+} from "@src/engines/SessionCore/core/types";
+import { makeSessionEvent } from "@src/engines/SessionCore/rendering/props/__tests__/fixtures";
+
+import { readToolUsage, sumToolUsage } from "../toolUsage";
+
+function makeUsage(
+  overrides: Partial<ToolUsageMetadata> = {}
+): ToolUsageMetadata {
+  return {
+    decisionCompletionTokens: 1,
+    resultContextTokens: 2,
+    followupCompletionTokens: 3,
+    inputBytes: 4,
+    outputBytes: 5,
+    relatedCacheReadTokens: 6,
+    relatedCacheWriteTokens: 7,
+    attributionMethod: "exact",
+    ...overrides,
+  };
+}
+
+describe("readToolUsage", () => {
+  it("prefers the typed toolUsage field", () => {
+    const typed = makeUsage({ inputBytes: 40 });
+    const event = {
+      ...makeSessionEvent({
+        args: { [TOOL_USAGE_ARGS_KEY]: makeUsage({ inputBytes: 99 }) },
+      }),
+      toolUsage: typed,
+    };
+
+    expect(readToolUsage(event)).toBe(typed);
+  });
+
+  it("falls back to the raw args slot", () => {
+    const raw = makeUsage({ outputBytes: 50 });
+    const event = makeSessionEvent({ args: { [TOOL_USAGE_ARGS_KEY]: raw } });
+
+    expect(readToolUsage(event)).toBe(raw);
+  });
+
+  it("returns undefined when neither source is an object", () => {
+    expect(readToolUsage(makeSessionEvent())).toBeUndefined();
+    expect(
+      readToolUsage(makeSessionEvent({ args: { [TOOL_USAGE_ARGS_KEY]: "x" } }))
+    ).toBeUndefined();
+  });
+});
+
+describe("sumToolUsage", () => {
+  it("returns undefined for empty input", () => {
+    expect(sumToolUsage([])).toBeUndefined();
+  });
+
+  it("returns undefined when no entry carries usage", () => {
+    expect(sumToolUsage([undefined, undefined])).toBeUndefined();
+  });
+
+  it("sums every numeric field and ignores entries without usage", () => {
+    const total = sumToolUsage([
+      makeUsage(),
+      undefined,
+      makeUsage({
+        decisionCompletionTokens: 10,
+        resultContextTokens: 20,
+        followupCompletionTokens: 30,
+        inputBytes: 40,
+        outputBytes: 50,
+        relatedCacheReadTokens: 60,
+        relatedCacheWriteTokens: 70,
+      }),
+    ]);
+
+    expect(total).toEqual({
+      decisionCompletionTokens: 11,
+      resultContextTokens: 22,
+      followupCompletionTokens: 33,
+      inputBytes: 44,
+      outputBytes: 55,
+      relatedCacheReadTokens: 66,
+      relatedCacheWriteTokens: 77,
+      attributionMethod: "exact",
+    });
+  });
+
+  it("keeps a shared attributionMethod and otherwise takes the last one", () => {
+    expect(sumToolUsage([makeUsage(), makeUsage()])?.attributionMethod).toBe(
+      "exact"
+    );
+    expect(
+      sumToolUsage([
+        makeUsage({ attributionMethod: "exact" }),
+        makeUsage({ attributionMethod: "estimated" }),
+      ])?.attributionMethod
+    ).toBe("estimated");
+  });
+});

--- a/src/engines/ChatPanel/ChatItems/toolUsage.ts
+++ b/src/engines/ChatPanel/ChatItems/toolUsage.ts
@@ -1,0 +1,63 @@
+import {
+  type SessionEvent,
+  TOOL_USAGE_ARGS_KEY,
+  type ToolUsageMetadata,
+} from "@src/engines/SessionCore/core/types";
+
+/**
+ * Reads the per-tool usage attached to an event, preferring the typed field
+ * and falling back to the raw args slot the Rust adapter writes into.
+ */
+export function readToolUsage(
+  event: SessionEvent
+): ToolUsageMetadata | undefined {
+  if (event.toolUsage) return event.toolUsage;
+  const raw = event.args?.[TOOL_USAGE_ARGS_KEY];
+  if (!raw || typeof raw !== "object") return undefined;
+  return raw as ToolUsageMetadata;
+}
+
+/**
+ * Sums tool usage across a group of events. Entries without usage are
+ * ignored; returns `undefined` when nothing contributed. When the
+ * contributing entries disagree on `attributionMethod`, the last one wins.
+ */
+export function sumToolUsage(
+  usages: ReadonlyArray<ToolUsageMetadata | undefined>
+): ToolUsageMetadata | undefined {
+  const present = usages.filter((usage): usage is ToolUsageMetadata =>
+    Boolean(usage)
+  );
+  if (present.length === 0) return undefined;
+
+  return present.reduce<ToolUsageMetadata>(
+    (total, usage) => ({
+      decisionCompletionTokens:
+        total.decisionCompletionTokens + usage.decisionCompletionTokens,
+      resultContextTokens:
+        total.resultContextTokens + usage.resultContextTokens,
+      followupCompletionTokens:
+        total.followupCompletionTokens + usage.followupCompletionTokens,
+      inputBytes: total.inputBytes + usage.inputBytes,
+      outputBytes: total.outputBytes + usage.outputBytes,
+      relatedCacheReadTokens:
+        total.relatedCacheReadTokens + usage.relatedCacheReadTokens,
+      relatedCacheWriteTokens:
+        total.relatedCacheWriteTokens + usage.relatedCacheWriteTokens,
+      attributionMethod:
+        total.attributionMethod === usage.attributionMethod
+          ? total.attributionMethod
+          : usage.attributionMethod,
+    }),
+    {
+      decisionCompletionTokens: 0,
+      resultContextTokens: 0,
+      followupCompletionTokens: 0,
+      inputBytes: 0,
+      outputBytes: 0,
+      relatedCacheReadTokens: 0,
+      relatedCacheWriteTokens: 0,
+      attributionMethod: present[0].attributionMethod,
+    }
+  );
+}


### PR DESCRIPTION
## Problem

`TerminalActivityGroup`, `EditActivityGroup` and `ActionSummaryGroup` (under `src/engines/ChatPanel/ChatItems/`) each carried a byte-identical private pair of helpers: `readToolUsage(event)` (typed `toolUsage` field first, then the `TOOL_USAGE_ARGS_KEY` args slot) and `aggregateToolUsage(items)`, a field-by-field `reduce` over `ToolUsageMetadata` (`decisionCompletionTokens`, `resultContextTokens`, `followupCompletionTokens`, `inputBytes`, `outputBytes`, `relatedCacheReadTokens`, `relatedCacheWriteTokens`, plus the `attributionMethod` reconciliation). Three copies of the same ~45 lines means any future field added to `ToolUsageMetadata` has to be summed in three places, and none of the copies had a unit test. `ReadFileGroup` was checked and does not carry a fourth copy.

## Solution

Add `src/engines/ChatPanel/ChatItems/toolUsage.ts` exporting `readToolUsage(event)` and `sumToolUsage(usages: ReadonlyArray<ToolUsageMetadata | undefined>)`. `sumToolUsage` drops `undefined` entries, returns `undefined` when nothing contributed, and otherwise sums every numeric field, keeping a shared `attributionMethod` and taking the last one on disagreement — exactly the behaviour of the three removed copies (they did not differ in any field or in the empty-case return, so no reconciliation was needed). The three groups now import both helpers and compute `sumToolUsage(items.map((item) => readToolUsage(item.event)))`; their now-unused `TOOL_USAGE_ARGS_KEY` / `ToolUsageMetadata` imports are removed. The module sits flat in `ChatItems/` next to `readFileEventData.ts`, with its test in the folder's existing `__tests__/` dir.

## Potential risks

Pure code motion with one signature change (the shared helper takes usage values rather than typed item arrays), so the observable `ToolUsageBadge` output is unchanged. The `propsNormalizer.ts` variant `readToolUsageMetadata(args, eventToolUsage)` has a different signature and was left alone as out of scope. No screenshot was captured: the app is Tauri-only and cannot be rendered here, and the change is not intended to be user-visible.

## Verification

Run from the worktree root:

- `npx prettier --write <5 changed files>` — exit 0
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <5 changed files>` — exit 0
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <5 changed files>` — exit 0
- `npx vitest run --config config/vitest.config.ts src/engines/ChatPanel/ChatItems/__tests__/toolUsage.test.ts src/engines/ChatPanel/ChatItems/TerminalActivityGroup/TerminalActivityGroup.test.ts src/engines/ChatPanel/ChatItems/EditActivityGroup/__tests__/EditActivityGroup.test.ts` — 3 files, 16 tests passed
- `pnpm run check:test-placement` — consistent across 532 directories
- `nice -n 10 npx tsgo --noEmit --pretty false` — exit 0, no output

Not run: full vitest suite, cargo, e2e. `ActionSummaryGroup` has no existing test file; it is covered only by the shared-helper unit test and the typecheck.

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
