### PR TITLE
refactor(tokens): adopt DETAIL_PANEL_TOKENS.primaryContainer

### DIFF
--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/AIImpactContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/AIImpactContent/index.tsx
@@ -160,7 +160,9 @@ const StatItem: React.FC<StatItemProps> = memo(
     const humanPct = hasRatio ? 100 - aiPct : 0;
 
     return (
-      <div className="flex flex-col gap-1.5 rounded-xl border border-border-1 bg-fill-2 p-4">
+      <div
+        className={`flex flex-col gap-1.5 ${DETAIL_PANEL_TOKENS.primaryContainer}`}
+      >
         <div className="flex items-center gap-1.5 text-[12px] font-medium text-text-3">
           {icon}
           {label}

--- a/src/modules/shared/dataSource/BuilderTypeDetailPanel.tsx
+++ b/src/modules/shared/dataSource/BuilderTypeDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
+import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import { ArrowLeft01Icon, ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
 import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 import Modal from "@src/scaffold/ModalSystem";
@@ -57,7 +58,7 @@ export function BuilderTypeDetailContent({
 
   return (
     <section
-      className="rounded-xl border border-border-1 bg-primary-container p-4"
+      className={DETAIL_PANEL_TOKENS.primaryContainer}
       aria-labelledby="builder-type-detail-title"
       data-testid="builder-type-detail"
     >

--- a/src/modules/shared/dataSource/HighlightCards.tsx
+++ b/src/modules/shared/dataSource/HighlightCards.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { Highlight, HighlightKind } from "@src/api/tauri/builderProfile";
+import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import { STAT_GRID_TOKENS } from "@src/modules/shared/layouts/blocks";
 
 /**
@@ -99,7 +100,7 @@ const HighlightCards = memo(function HighlightCards({
         return (
           <div
             key={card.id}
-            className="flex flex-col gap-1.5 rounded-xl border border-border-1 bg-primary-container p-4"
+            className={`flex flex-col gap-1.5 ${DETAIL_PANEL_TOKENS.primaryContainer}`}
             data-testid={`highlight-${card.id}`}
           >
             <span

--- a/src/modules/shared/dataSource/TeamMemberCard.tsx
+++ b/src/modules/shared/dataSource/TeamMemberCard.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 
 import ModelIcon, { type IconProvider } from "@src/components/ModelIcon";
 import PersonAvatar from "@src/components/PersonAvatar";
+import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import type {
   MemberInstalledAgent,
   MemberRuntimeListEntry,
@@ -126,7 +127,7 @@ const TeamMemberCard = memo(function TeamMemberCard({
       onClick={() => onOpen(entry.userId)}
       data-testid={`team-member-card-${entry.userId}`}
       data-stale={stale ? "true" : "false"}
-      className="flex w-full flex-col gap-3 rounded-xl border border-border-1 bg-primary-container p-4 text-left transition-colors hover:border-border-2"
+      className={`flex w-full flex-col gap-3 ${DETAIL_PANEL_TOKENS.primaryContainer} text-left transition-colors hover:border-border-2`}
     >
       <div className="flex items-center gap-3">
         <PersonAvatar

--- a/src/modules/shared/dataSource/TeamMemberDetail.tsx
+++ b/src/modules/shared/dataSource/TeamMemberDetail.tsx
@@ -26,6 +26,7 @@ import { Placeholder } from "@src/components/Placeholder";
 import ProgressBar from "@src/components/ProgressBar";
 import Select from "@src/components/Select";
 import TabPill, { type TabPillItem } from "@src/components/TabPill";
+import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import { getMemberUsage } from "@src/features/Org2Cloud/memberRuntime/memberRuntimeClient";
 import type {
   MemberRuntimeListEntry,
@@ -265,7 +266,7 @@ export default function TeamMemberDetail({
       {profile && builderType ? (
         <>
           <section
-            className="rounded-xl border border-border-1 bg-primary-container p-4"
+            className={DETAIL_PANEL_TOKENS.primaryContainer}
             data-testid="team-member-profile"
           >
             <div className="flex items-center gap-4">

--- a/src/modules/shared/dataSource/TeamRuntimeToday.tsx
+++ b/src/modules/shared/dataSource/TeamRuntimeToday.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import PersonAvatar from "@src/components/PersonAvatar";
 import Select from "@src/components/Select";
 import Tag from "@src/components/Tag";
+import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import type {
   MemberRuntimeListEntry,
   OrgRuntimeTelemetry,
@@ -55,7 +56,7 @@ interface TodayMetricProps {
 function TodayMetric({ label, value, secondary, testId }: TodayMetricProps) {
   return (
     <div
-      className="flex min-w-0 flex-col gap-1.5 rounded-xl border border-border-1 bg-primary-container p-4"
+      className={`flex min-w-0 flex-col gap-1.5 ${DETAIL_PANEL_TOKENS.primaryContainer}`}
       data-testid={testId}
     >
       <span className="truncate text-xs text-text-2">{label}</span>

--- a/src/modules/shared/dataSource/UsageStatCards.tsx
+++ b/src/modules/shared/dataSource/UsageStatCards.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 
 import type { UsageSummary } from "@src/api/tauri/usageDashboard";
 import Tooltip from "@src/components/Tooltip";
+import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import { STAT_GRID_TOKENS } from "@src/modules/shared/layouts/blocks";
 
 import UsagePricingHint from "./UsagePricingHint";
@@ -22,7 +23,7 @@ interface StatTileProps {
   tooltip?: ReactNode;
 }
 
-/** One KPI tile — mirrors the AIImpactContent StatItem card surface. */
+/** One KPI tile on the shared primary-container surface. */
 function StatTile({
   label,
   value,
@@ -45,7 +46,9 @@ function StatTile({
     <span className={valueClass}>{value}</span>
   );
   return (
-    <div className="flex flex-col gap-1.5 rounded-xl border border-border-1 bg-primary-container p-4">
+    <div
+      className={`flex flex-col gap-1.5 ${DETAIL_PANEL_TOKENS.primaryContainer}`}
+    >
       <span className="text-xs text-text-2">{label}</span>
       <div className="flex items-baseline gap-2">
         {valueNode}

--- a/src/modules/shared/dataSource/UsageTrendChart.tsx
+++ b/src/modules/shared/dataSource/UsageTrendChart.tsx
@@ -18,6 +18,7 @@ import {
   CHART_MARGIN,
   CHART_TOOLTIP,
 } from "@src/components/Chart";
+import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 
 import {
   formatCompactHour,
@@ -111,7 +112,7 @@ export default function UsageTrendChart({
   }, [points, hourly, startMs, endMs, dataEndMs, language]);
 
   return (
-    <div className="rounded-xl border border-border-1 bg-primary-container p-4">
+    <div className={DETAIL_PANEL_TOKENS.primaryContainer}>
       <div className="h-[300px] w-full [&_.recharts-surface]:outline-none [&_.recharts-wrapper]:outline-none [&_svg:focus]:outline-none">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={data} margin={CHART_MARGIN}>


### PR DESCRIPTION
## Problem

`DETAIL_PANEL_TOKENS.primaryContainer` (`src/config/detailPanelTokens.ts`) is the shared surface for settings/detail cards, but seven `src/modules/shared/dataSource/` components hardcoded its exact class string (`rounded-xl border border-border-1 bg-primary-container p-4`) instead of importing it: `UsageStatCards`, `HighlightCards`, `TeamRuntimeToday`, `UsageTrendChart`, `BuilderTypeDetailPanel`, `TeamMemberDetail`, `TeamMemberCard`. Any future change to the token silently misses those sites.

Separately, `AIImpactContent`'s `StatItem` builds the same KPI tile with `bg-fill-2` while `UsageStatCards.StatTile` carried a comment saying it "mirrors the AIImpactContent StatItem card surface" — the two tiles had already drifted apart on fill colour, so the comment was false.

## Solution

- Every listed site now reads `DETAIL_PANEL_TOKENS.primaryContainer`; sites that add layout classes compose it in a template literal (the existing pattern in `RepoDetailPage.tsx`). Files in `dataSource/` import from `@src/config/detailPanelTokens`, matching `BuilderTypesPanel`, `BuilderProfilePanel` and `index.tsx` in the same directory (and keeping the hand-written `@src/modules/shared/layouts/blocks` mocks in `BuilderProfilePanel.test.ts` / `TeamRuntimePanel.test.ts` untouched).
- `AIImpactContent/index.tsx` `StatItem` switches from the `bg-fill-2` literal to the token (the file already imported `DETAIL_PANEL_TOKENS`), so the AI Impact tiles and the Usage stat tiles share one surface. The now-redundant "mirrors" comment on `UsageStatCards.StatTile` is reworded to describe the shared surface.
- Invariant: the `primaryContainer` surface is defined once; a `grep` for the literal in `src/**/*.tsx` now returns only the token definition and the three deliberately padding-less variants below.

Deliberately left alone (not drift):
- `BuilderTypesPanel.tsx:162` (`p-3`): the file already imports `DETAIL_PANEL_TOKENS` yet chose `p-3`, and the gallery cards directly above in the same panel are also `p-3` — a consistent compact density inside that panel.
- `WeeklyQuotaHistoryPanel.tsx:99` (`rounded-lg … p-3`): rendered immediately below `StartPageQuotaGrid` in `SessionUsagePanel`, whose quota cards use exactly `rounded-lg border border-border-1 bg-primary-container` + `p-3`. It matches its neighbour, not the trend chart.
- `PrReviewThreadsPanel.tsx:116`, `PrCommitsTab.tsx:198`, `GitHubLinkedReferences/index.tsx:144`: same surface without `p-4` (their children own the padding), so the token does not apply.

## Potential risks

- User-visible fill colour change on the AI Impact stat tiles (`AIImpactContent` `StatItem`): `bg-fill-2` → `bg-primary-container`. This is intentional so the tile matches the Usage/Team stat tiles it was documented as mirroring. No screenshot was captured — the app is Tauri-only and cannot be rendered here.
- All other edits are class-string-identical substitutions (verified by diff); no layout, DOM, or behaviour change.
- `UsageStatCards` / `HighlightCards` now import the token from `@src/config/detailPanelTokens` rather than the `blocks` barrel. Both resolve to the same object; the barrel re-exports it.

## Verification

Run from the worktree root (`/private/tmp/orgii-consol-tokens`, based on `origin/develop` at `1a0a9166d`):

- `grep -rn "rounded-xl border border-border-1 bg-primary-container" src --include='*.tsx'` — before: 12 hits; after: only the token definition plus the three `p-4`-less PR/GitHub card variants listed above.
- `npx prettier --write <8 changed files>` — exit 0 (reflowed two long `className` template literals).
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <8 changed files>` — exit 0.
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <8 changed files>` — exit 0.
- `npx vitest run --config config/vitest.config.ts src/modules/shared/dataSource/{BuilderProfilePanel,BuilderTypeDetailPanel,SessionUsagePanel,TeamRuntimePanel,UsageStatCards,teamRuntimeData,usageTrendLabels}.test.ts` — 7 files, 64 tests passed. (A first attempt importing the token from the `blocks` barrel failed 11 tests because those suites mock the barrel by hand; switching to the `@src/config/detailPanelTokens` import fixed it without touching tests.)
- `nice -n 10 npx tsgo --noEmit --pretty false` — EXIT=0.

Not run: full vitest suite, cargo, e2e, `check:test-placement` (no test files added or moved).

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
