### PR TITLE
refactor(hooks): adopt useMounted in hand-rolled mounted refs

### DIFF
--- a/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgSyncStatus.ts
+++ b/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgSyncStatus.ts
@@ -56,6 +56,7 @@ import {
 } from "@src/features/Org2Cloud/org2CloudSyncJournal";
 import { useShareableScopeKeyVersion } from "@src/features/TeamCollaboration/repoScopeResolver";
 import { sessionOrgTagsAtom } from "@src/features/TeamCollaboration/sessionOrgTagsAtom";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import {
   dataSourceConfigAtom,
   externalSessionsEnabledAtom,
@@ -340,12 +341,7 @@ export function useCloudOrgSyncStatus(orgId: string): CloudOrgSyncStatus {
   }, [accessToken]);
 
   const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  useMountedCleanup(mountedRef);
 
   const runSync = useCallback(() => {
     if (running) return;

--- a/src/engines/SessionCore/hooks/session/useSessionDiscovery.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionDiscovery.ts
@@ -21,6 +21,7 @@ import type {
   KeyInfo,
 } from "@src/api/tauri/rpc/schemas/validation";
 import { loadSharedLocalKeys } from "@src/hooks/keyVault/sharedLocalKeyStore";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { createLogger } from "@src/hooks/logger";
 import {
   agentRegistryAtom,
@@ -161,18 +162,12 @@ export function useSessionDiscovery(
   const [error, setError] = useState<string | null>(null);
   const hasLoadedRef = useRef(false);
   const mountedRef = useRef(true);
+  useMountedCleanup(mountedRef);
 
   const setAgentRegistry = useSetAtom(agentRegistryAtom);
   const setAgentRegistryDiscoveryState = useSetAtom(
     agentRegistryDiscoveryStateAtom
   );
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
 
   const availableAgents = useMemo(
     () => agents.filter((agent) => agent.available),

--- a/src/hooks/perf/useRuntimeRamStats.ts
+++ b/src/hooks/perf/useRuntimeRamStats.ts
@@ -8,6 +8,7 @@ import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreP
 import { getLoadedPayloadStats } from "@src/engines/SessionCore/payloads";
 import { getLoadedTurnRegistryStats } from "@src/engines/SessionCore/turns/loadedTurnRegistry";
 import { getHydratedEventStats } from "@src/engines/Simulator/apps/core/fullEventHydrationRegistry";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import { screenshotCacheStatsAtom } from "@src/store/workstation/browser/browserAutomationAtom";
 
@@ -122,6 +123,7 @@ export function useRuntimeRamStats(enabled: boolean): UseRuntimeRamStatsResult {
   const sampleAbortRef = useRef<AbortController | null>(null);
   const sampleGenerationRef = useRef(0);
   const mountedRef = useRef(true);
+  useMountedCleanup(mountedRef);
 
   const collectRows = useCallback((): RuntimeRamPartRow[] => {
     const events = store.get(eventsAtom);
@@ -271,7 +273,6 @@ export function useRuntimeRamStats(enabled: boolean): UseRuntimeRamStatsResult {
   }, [store, t]);
 
   useEffect(() => {
-    mountedRef.current = true;
     const cancel = () => {
       sampleGenerationRef.current += 1;
       sampleAbortRef.current?.abort();
@@ -284,7 +285,6 @@ export function useRuntimeRamStats(enabled: boolean): UseRuntimeRamStatsResult {
     };
     document.addEventListener("visibilitychange", onVisibility);
     return () => {
-      mountedRef.current = false;
       cancel();
       document.removeEventListener("visibilitychange", onVisibility);
     };

--- a/src/modules/MainApp/TeamInbox/TeamInboxView.tsx
+++ b/src/modules/MainApp/TeamInbox/TeamInboxView.tsx
@@ -1,15 +1,10 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { HeaderSectionSeparator } from "@src/components/HeaderSectionSeparator";
 import PageNotice from "@src/components/PageNotice";
 import { Placeholder } from "@src/components/Placeholder";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { usePublishWorkstationTabHeader } from "@src/hooks/tabHost/useWorkstationTabHeader";
 import {
   type ManagedPrItem,
@@ -185,13 +180,7 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
     [initialCombinedLoadPending, pullRequests]
   );
   const mountedRef = useRef(true);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  useMountedCleanup(mountedRef);
 
   const loadNoticeKey =
     (loadState.status === "error" || loadState.status === "warning") &&

--- a/src/modules/MainApp/TeamInbox/useTeamInboxMutePreferences.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxMutePreferences.ts
@@ -8,6 +8,8 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
+
 import type {
   LoadState,
   TeamInboxDataSource,
@@ -50,14 +52,8 @@ export function useTeamInboxMutePreferences({
   const mutePreferencesLoading =
     mutePreferencesAreCurrent && mutePreferences.loading;
   const mountedRef = useRef(true);
+  useMountedCleanup(mountedRef);
   const activeDataSourceRef = useRef(dataSource);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     activeDataSourceRef.current = dataSource;

--- a/src/modules/MainApp/TeamInbox/useTeamInboxPagination.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxPagination.ts
@@ -8,6 +8,8 @@
  */
 import { useEffect, useRef, useState } from "react";
 
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
+
 import {
   type LoadState,
   type TeamInboxDataSource,
@@ -68,12 +70,11 @@ export function useTeamInboxPagination({
   );
   const [loadingMore, setLoadingMore] = useState(false);
   const mountedRef = useRef(true);
+  useMountedCleanup(mountedRef);
   const loadMoreAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    mountedRef.current = true;
     return () => {
-      mountedRef.current = false;
       loadMoreAbortRef.current?.abort();
       loadMoreAbortRef.current = null;
     };

--- a/src/modules/ProjectManager/WorkItems/hooks/useWorkItemPropertyView.ts
+++ b/src/modules/ProjectManager/WorkItems/hooks/useWorkItemPropertyView.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { type ScopePropertyValue, projectApi } from "@src/api/http/project";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { createLogger } from "@src/hooks/logger";
 import { useProjectDataChanged } from "@src/hooks/project";
 
@@ -42,6 +43,7 @@ export function useWorkItemPropertyView({
   const generationRef = useRef(0);
   const inFlightRef = useRef<PropertyViewRefresh | null>(null);
   const mountedRef = useRef(true);
+  useMountedCleanup(mountedRef);
   const activeRef = useRef(isActive);
   const scopeKeyRef = useRef(scopeKey);
 
@@ -100,9 +102,7 @@ export function useWorkItemPropertyView({
   }, [isActive, orgId, projectSlug, scopeKey]);
 
   useEffect(() => {
-    mountedRef.current = true;
     return () => {
-      mountedRef.current = false;
       generationRef.current += 1;
     };
   }, []);

--- a/src/modules/WorkStation/Browser/Panels/BrowserSecondaryPanel/components/WebDevTools/components/ConsoleTab/index.tsx
+++ b/src/modules/WorkStation/Browser/Panels/BrowserSecondaryPanel/components/WebDevTools/components/ConsoleTab/index.tsx
@@ -24,6 +24,7 @@ import {
   HEADER_BUTTON,
   HEADER_ICON_SIZE,
 } from "@src/config/workstation/tokens";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import {
   BrushCleaningIcon,
   Copy01Icon,
@@ -243,11 +244,10 @@ export const ConsoleTab: React.FC<ConsoleTabProps> = memo(
     const [copiedId, setCopiedId] = useState<string | null>(null);
     const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const mountedRef = useRef(true);
+    useMountedCleanup(mountedRef);
 
     useEffect(() => {
-      mountedRef.current = true;
       return () => {
-        mountedRef.current = false;
         if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
       };
     }, []);

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPrDetail.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPrDetail.ts
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { getGitRemotes } from "@src/api/http/git/remotes";
 import type { GitHubIssueUser } from "@src/api/tauri/github";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import {
   getCachedPrDetail,
   isPrDetailStale,
@@ -68,12 +69,7 @@ export function useWorkstationPrDetail({
   }, [scopeKey]);
 
   const mountedRef = useRef(true);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  useMountedCleanup(mountedRef);
 
   // Freshest PR head SHA, kept in a ref so inline-comment creation can read it
   // without re-subscribing its callback on every atom write.

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
@@ -11,13 +11,7 @@
  * `PrimarySidebarLayoutWithSections`.
  */
 import { useAtomValue } from "jotai";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GitWorktreeEntry } from "@src/api/http/git/types";
@@ -27,6 +21,7 @@ import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types
 import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { sessionIdAtom } from "@src/engines/SessionCore";
 import { useFileReviewBatchActions } from "@src/hooks/fileReview";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
 import {
   ArrowLeft02Icon,
@@ -137,11 +132,7 @@ export function useSourceControlSidebarModule({
   const sourceControlRef = useRef<SourceControlTabHandle>(null);
   const historyRefreshRef = useRef<(() => void) | null>(null);
   const mountedRef = useRef(true);
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
+  useMountedCleanup(mountedRef);
 
   const [showFilter, setShowFilter] = useState(false);
   const [viewMode, setViewMode] = useState<"list-tree" | "list">("list-tree");

--- a/src/modules/shared/dataSource/SessionProvenanceHookPlatformsTable.tsx
+++ b/src/modules/shared/dataSource/SessionProvenanceHookPlatformsTable.tsx
@@ -24,6 +24,7 @@ import SettingsTable, {
 import Switch from "@src/components/Switch";
 import Tag, { type TagProps } from "@src/components/Tag";
 import { INFO_CARD_TOKENS } from "@src/config/detailPanelTokens";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { ComputerTerminal01Icon, HugeiconsIcon } from "@src/icons";
 import {
   SECTION_GAP_CLASSES,
@@ -107,6 +108,7 @@ const SessionProvenanceHookPlatformsTable: React.FC = () => {
     new Set()
   );
   const mountedRef = useRef(true);
+  useMountedCleanup(mountedRef);
   const statusRequestRef = useRef(0);
 
   const [masterEnabled, setMasterEnabled] = useState(true);
@@ -196,10 +198,8 @@ const SessionProvenanceHookPlatformsTable: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    mountedRef.current = true;
     void loadStatuses();
     return () => {
-      mountedRef.current = false;
       statusRequestRef.current += 1;
     };
   }, [loadStatuses]);

--- a/src/modules/shared/dataSource/SessionProvenanceRecentSignalsTable.tsx
+++ b/src/modules/shared/dataSource/SessionProvenanceRecentSignalsTable.tsx
@@ -17,6 +17,7 @@ import SettingsTable, {
 import Tag, { type TagProps } from "@src/components/Tag";
 import { parseUnifiedDiffToOldNew } from "@src/engines/SessionCore/rendering/props/extractorShared";
 import { CodeMirrorDiff } from "@src/features/CodeMirror/Diff";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
 import {
   SECTION_GAP_CLASSES,
@@ -212,6 +213,7 @@ const SessionProvenanceRecentSignalsTable: React.FC = () => {
   const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
   const [open, setOpen] = useState(false);
   const mountedRef = useRef(true);
+  useMountedCleanup(mountedRef);
   const requestGenerationRef = useRef(0);
   const inFlightRef = useRef<
     Promise<SessionProvenanceRecentSignal[]> | undefined
@@ -267,11 +269,9 @@ const SessionProvenanceRecentSignalsTable: React.FC = () => {
   }, [load, open, signals]);
 
   useEffect(() => {
-    mountedRef.current = true;
     return () => {
       // Tauri invokes are not abortable. Invalidate late completions so an
       // unmounted Hooks view cannot retain or publish stale signal rows.
-      mountedRef.current = false;
       requestGenerationRef.current += 1;
     };
   }, []);

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchPullRequestPicker.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchPullRequestPicker.tsx
@@ -19,6 +19,7 @@ import {
 } from "@src/components/Dropdown/tokens";
 import { Placeholder } from "@src/components/Placeholder";
 import { useDropdownEngine } from "@src/hooks/dropdown";
+import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { ArrowDown01Icon, Refresh04Icon } from "@src/icons";
 import { useSelector as useSelectorKernel } from "@src/scaffold/GlobalSpotlight/hooks/selectors/useSelector";
 import { preparePullRequestBranch } from "@src/services/git/operations/preparePullRequestBranch";
@@ -84,14 +85,9 @@ export function BranchPullRequestPicker({
   const [selectionError, setSelectionError] = useState<string | null>(null);
   const pendingRef = useRef(false);
   const mountedRef = useRef(true);
+  useMountedCleanup(mountedRef);
   const inputRef = useRef<HTMLInputElement>(null);
   const fallbackAnchor = useRef<HTMLElement>(null);
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
 
   const select = useCallback(
     async (pr: OpenPRItem) => {


### PR DESCRIPTION
## Problem

Thirteen hooks and components each hand-roll the same "am I still mounted" flag: a `useRef(true)` (or `useRef(false)` re-armed in an effect) plus a `useEffect(() => () => { ref.current = false }, [])`, sometimes with `ref.current = true` at the top of the effect. The repo already has the canonical helper for this in `src/hooks/lifecycle/useMounted.ts` (`useMounted()` / `useMountedCleanup(ref)`), and eleven other call sites already use it. The remaining copies are pure duplication: every one is a component-lifetime flag read as `mountedRef.current` to drop late async results after unmount.

Affected files: `useSessionDiscovery`, `useCloudOrgSyncStatus`, `useRuntimeRamStats`, `BranchPullRequestPicker`, `useSourceControlSidebarModule`, `useWorkItemPropertyView`, `SessionProvenanceRecentSignalsTable`, `SessionProvenanceHookPlatformsTable`, `useTeamInboxPagination`, `TeamInboxView`, `useTeamInboxMutePreferences`, `useWorkstationPrDetail`, `ConsoleTab`.

## Solution

Each site keeps its `const mountedRef = useRef(true);` declaration and replaces the hand-written effect with `useMountedCleanup(mountedRef);`. The two-line form (rather than `useMounted()`) is deliberate and is what the helper's docblock prescribes: every one of these refs is read inside a `useCallback`, and when the ref came from `useMounted()` the React Compiler lint (`react-compiler/preserve-manual-memoization`) and `react-hooks/exhaustive-deps` both flagged the ref as an unlisted dependency (16 errors / 25 warnings on the first attempt). Keeping the `useRef` visible in the component makes the ref statically known and leaves every existing `mountedRef.current` read and every `useCallback` dependency array byte-for-byte unchanged.

Effects that also owned other cleanup keep that work and only lose the flag lines: `useRuntimeRamStats` (abort + visibilitychange listener), `useWorkItemPropertyView` and `SessionProvenanceRecentSignalsTable` (request-generation bump), `SessionProvenanceHookPlatformsTable` (initial `loadStatuses()` + request bump), `useTeamInboxPagination` (abort controller), `ConsoleTab` (copied-id timer). `TeamInboxView` and `useSourceControlSidebarModule` drop their now-unused `useEffect` import.

`useMountedCleanup` registers its effect at the same hook position the removed effect occupied, so unmount-cleanup ordering relative to sibling effects is unchanged.

Left alone on purpose: `src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationIssues.ts`. Its mounted ref is also read inside a *different* effect's cleanup (the "Clean up atoms on unmount" effect, which relies on cleanup ordering against the mounted flag). Once the component no longer contains a visible `mountedRef.current = ...` assignment, `react-hooks/exhaustive-deps` reports "The ref value 'mountedRef.current' will likely have changed by the time this effect cleanup function runs" at that read. Adopting the helper there would need either an eslint-disable or a behaviour change to that cleanup, both out of scope for a mechanical consolidation, so the file is untouched.

## Potential risks

- `mountedRef.current = true` at the top of the removed effects is gone. Under React StrictMode's dev-only effect replay (mount, cleanup, mount) the ref would now stay `false` after the replay, whereas the old code re-armed it. This app does not render under `StrictMode` (the only usage is `src/test/hookLifecycleHarness.ts`, which none of the touched modules' tests use), and the eleven pre-existing `useMounted` call sites already have this exact property, so this PR does not introduce a new class of behaviour; it does widen the surface should StrictMode ever be enabled.
- `SessionProvenanceHookPlatformsTable`'s removed flag lines lived in an effect keyed on `[loadStatuses]`. `loadStatuses` is `useCallback(..., [])`, so that effect runs exactly once per mount and the flag was already component-lifetime; this is noted because it is the one site where the dependency array was not literally `[]`.
- No user-visible UI change; no screenshot captured (Tauri-only app, cannot be rendered here). Pure refactor with no runtime behaviour intended to change.
- Unverified: the full vitest suite, cargo, and e2e were not run (see below).

## Verification

Run from the worktree root on `refactor/adopt-use-mounted`:

- `npx prettier --write <13 changed files>` -> EXIT=0 (two files re-wrapped; final pass all unchanged)
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <13 changed files>` -> EXIT=0
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <changed files>` -> run twice:
  1. first attempt with `useMounted()`: EXIT=1, 16 errors / 25 warnings (`preserve-manual-memoization` + `exhaustive-deps`) across all files -> switched to the two-line `useRef(true)` + `useMountedCleanup(ref)` form
  2. second run: EXIT=1 with exactly 1 warning, the `useWorkstationIssues.ts` ref-in-cleanup case described above -> that file reverted to its `origin/develop` content; the 13 committed files reported 0 problems in that run
- `npx vitest run --config config/vitest.config.ts` over the 14 sibling test files for the touched modules (`useRuntimeRamStats.test.ts`, `useCloudOrgSyncStatus.test.ts`, `SessionProvenanceRecentSignalsTable.test.ts`, `BranchPullRequestPicker.test.ts`, `BranchPalette.test.ts`, `useWorkstationPrDetail.test.ts`, `workstationIssueHelpers.test.ts`, `PrDetailPanel.test.ts`, `TeamInboxView.layout.test.ts`, `useTeamInboxPullRequests.test.ts`, `useTeamInboxDataSource.test.ts`, `TeamInboxList.test.ts`, `workItemsData.test.ts`, `useWorkItemRevisionConflict.test.ts`) -> 14 files / 157 tests passed, both before and after the two-line switch. `src/hooks/lifecycle/` has no test files.
- `nice -n 10 npx tsgo --noEmit --pretty false` -> EXIT=0, run twice (after the `useMounted()` pass and again after the two-line switch, with `useWorkstationIssues.ts` still modified). Not re-run a third time after reverting `useWorkstationIssues.ts` to its `origin/develop` bytes: that file's exports are unchanged by the revert, so no other module's types can be affected.
- Not run: full vitest suite, cargo, e2e, `check:test-placement` (no test files added or moved).

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
