### PR TITLE
refactor(store): migrate hand-rolled storage atoms to createZodJsonStorage

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/__tests__/sidebarGroupByAtom.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/sidebarGroupByAtom.test.ts
@@ -1,10 +1,34 @@
 // @vitest-environment jsdom
-import { createStore } from "jotai";
+import { type Atom, createStore } from "jotai";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { sidebarGroupVisibleCountAtom } from "../sidebarGroupByAtom";
+import {
+  sidebarGroupByAtom,
+  sidebarGroupVisibleCountAtom,
+  sidebarHiddenWorkspacesAtom,
+  sidebarIncludeExternalAtom,
+} from "../sidebarGroupByAtom";
 
 const STORAGE_KEY = "orgii:sidebarGroupVisibleCount";
+const GROUP_BY_KEY = "orgii:sidebarGroupBy";
+const INCLUDE_EXTERNAL_KEY = "orgii:sidebarIncludeExternal";
+const HIDDEN_WORKSPACES_KEY = "orgii:sidebarHiddenWorkspaces";
+
+/**
+ * `atomWithStorage` re-reads persisted bytes per store in `onMount`, which
+ * only fires once the atom is SUBSCRIBED — a bare `store.get` would return
+ * the module-init snapshot instead.
+ */
+function hydratedStore(atom: Atom<unknown>) {
+  const store = createStore();
+  store.sub(atom, () => undefined);
+  return store;
+}
+
+function readStored<T>(key: string, atom: Atom<T>, raw: string): T {
+  window.localStorage.setItem(key, raw);
+  return hydratedStore(atom).get(atom);
+}
 
 describe("sidebarGroupVisibleCountAtom", () => {
   beforeEach(() => {
@@ -20,9 +44,64 @@ describe("sidebarGroupVisibleCountAtom", () => {
     expect(window.localStorage.getItem(STORAGE_KEY)).toBe("5");
   });
 
-  it("rejects unsupported persisted values at the storage boundary", () => {
-    window.localStorage.setItem(STORAGE_KEY, "7");
+  it("reads back a supported persisted choice", () => {
+    expect(readStored(STORAGE_KEY, sidebarGroupVisibleCountAtom, "5")).toBe(5);
+  });
 
-    expect(createStore().get(sidebarGroupVisibleCountAtom)).toBe(10);
+  it("rejects unsupported persisted values at the storage boundary", () => {
+    expect(readStored(STORAGE_KEY, sidebarGroupVisibleCountAtom, "7")).toBe(10);
+    expect(
+      readStored(STORAGE_KEY, sidebarGroupVisibleCountAtom, "{corrupt")
+    ).toBe(10);
+  });
+});
+
+describe("sidebar group-by preferences", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("persists under the existing storage keys", () => {
+    const store = createStore();
+    store.set(sidebarGroupByAtom, "byWorkspace");
+    store.set(sidebarIncludeExternalAtom, false);
+    store.set(sidebarHiddenWorkspacesAtom, ["/repo/a"]);
+
+    expect(window.localStorage.getItem(GROUP_BY_KEY)).toBe('"byWorkspace"');
+    expect(window.localStorage.getItem(INCLUDE_EXTERNAL_KEY)).toBe("false");
+    expect(window.localStorage.getItem(HIDDEN_WORKSPACES_KEY)).toBe(
+      '["/repo/a"]'
+    );
+  });
+
+  it("reads back valid stored values", () => {
+    expect(readStored(GROUP_BY_KEY, sidebarGroupByAtom, '"byAgent"')).toBe(
+      "byAgent"
+    );
+    expect(
+      readStored(INCLUDE_EXTERNAL_KEY, sidebarIncludeExternalAtom, "false")
+    ).toBe(false);
+    expect(
+      readStored(
+        HIDDEN_WORKSPACES_KEY,
+        sidebarHiddenWorkspacesAtom,
+        JSON.stringify(["/repo/a", "", 3, "/repo/a", "/repo/b"])
+      )
+    ).toEqual(["/repo/a", "/repo/b"]);
+  });
+
+  it("falls back to defaults for corrupt JSON or unknown values", () => {
+    expect(readStored(GROUP_BY_KEY, sidebarGroupByAtom, "{corrupt")).toBe(
+      "byTime"
+    );
+    expect(readStored(GROUP_BY_KEY, sidebarGroupByAtom, '"byMood"')).toBe(
+      "byTime"
+    );
+    expect(
+      readStored(INCLUDE_EXTERNAL_KEY, sidebarIncludeExternalAtom, '"yes"')
+    ).toBe(true);
+    expect(
+      readStored(HIDDEN_WORKSPACES_KEY, sidebarHiddenWorkspacesAtom, "{corrupt")
+    ).toEqual([]);
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/sidebarSessionOrder.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/sidebarSessionOrder.test.ts
@@ -67,4 +67,18 @@ describe("sidebar session ordering", () => {
     expect(fresh.get(sidebarSessionOrderAtom)).toEqual(["b", "a"]);
     unsub();
   });
+  it("falls back to defaults for corrupt or unknown persisted values", () => {
+    localStorage.setItem("orgii:sidebarSessionSort", '"alphabetical"');
+    localStorage.setItem("orgii:sidebarSessionOrder", "[corrupt");
+    const store = createStore();
+    const unsubs = [
+      store.sub(sidebarSessionSortAtom, () => undefined),
+      store.sub(sidebarSessionOrderAtom, () => undefined),
+    ];
+    expect(store.get(sidebarSessionSortAtom)).toBe("updated");
+    expect(store.get(sidebarSessionOrderAtom)).toEqual([]);
+    for (const unsub of unsubs) unsub();
+    localStorage.removeItem("orgii:sidebarSessionSort");
+    localStorage.removeItem("orgii:sidebarSessionOrder");
+  });
 });

--- a/src/scaffold/NavigationSidebar/connectors/sidebarGroupByAtom.ts
+++ b/src/scaffold/NavigationSidebar/connectors/sidebarGroupByAtom.ts
@@ -7,6 +7,9 @@
  * `src/store/`.
  */
 import { atomWithStorage } from "jotai/utils";
+import { z } from "zod/v4";
+
+import { createZodJsonStorage } from "@src/util/core/storage/zodStorage";
 
 import {
   DEFAULT_SESSION_GROUP_VISIBLE_COUNT,
@@ -28,77 +31,30 @@ const DEFAULT_MODE: GroupByMode = "byTime";
 const DEFAULT_PROJECTS_MODE: ProjectsGroupByMode = "byOrg";
 const DEFAULT_INCLUDE_EXTERNAL = true;
 
-const KNOWN_MODES = new Set<GroupByMode>(GROUP_BY_MODES);
-const KNOWN_PROJECTS_MODES = new Set<ProjectsGroupByMode>(
-  PROJECTS_GROUP_BY_MODES
-);
-const KNOWN_GROUP_VISIBLE_COUNTS = new Set<number>(
-  SESSION_GROUP_VISIBLE_COUNTS
-);
-
-function parseStored(raw: unknown): GroupByMode {
-  if (typeof raw !== "string") return DEFAULT_MODE;
-  if (KNOWN_MODES.has(raw as GroupByMode)) return raw as GroupByMode;
-  return DEFAULT_MODE;
-}
-
-function parseStoredProjects(raw: unknown): ProjectsGroupByMode {
-  if (typeof raw !== "string") return DEFAULT_PROJECTS_MODE;
-  if (KNOWN_PROJECTS_MODES.has(raw as ProjectsGroupByMode)) {
-    return raw as ProjectsGroupByMode;
-  }
-  return DEFAULT_PROJECTS_MODE;
-}
-
-function parseStoredBoolean(raw: unknown): boolean {
-  return typeof raw === "boolean" ? raw : DEFAULT_INCLUDE_EXTERNAL;
-}
-
-function parseStoredGroupVisibleCount(raw: unknown): SessionGroupVisibleCount {
-  return typeof raw === "number" && KNOWN_GROUP_VISIBLE_COUNTS.has(raw)
-    ? (raw as SessionGroupVisibleCount)
-    : DEFAULT_SESSION_GROUP_VISIBLE_COUNT;
-}
-
-function parseStoredWorkspaceKeys(raw: unknown): string[] {
-  if (!Array.isArray(raw)) return [];
-  return Array.from(
-    new Set(
-      raw.filter(
-        (value): value is string =>
-          typeof value === "string" && value.length > 0
+const StoredGroupByModeSchema = z.enum([...GROUP_BY_MODES]);
+const StoredProjectsGroupByModeSchema = z.enum([...PROJECTS_GROUP_BY_MODES]);
+const StoredIncludeExternalSchema = z.boolean();
+const StoredGroupVisibleCountSchema = z.literal([
+  ...SESSION_GROUP_VISIBLE_COUNTS,
+]);
+/** Non-empty string keys, de-duplicated; anything else in the list is dropped. */
+const StoredWorkspaceKeysSchema = z
+  .array(z.unknown())
+  .transform((raw) =>
+    Array.from(
+      new Set(
+        raw.filter(
+          (value): value is string =>
+            typeof value === "string" && value.length > 0
+        )
       )
     )
   );
-}
-
-export function createStorage<T>(parseValue: (raw: unknown) => T) {
-  return {
-    getItem(key: string, initialValue: T): T {
-      if (typeof window === "undefined") return initialValue;
-      try {
-        const stored = window.localStorage.getItem(key);
-        if (stored == null) return initialValue;
-        return parseValue(JSON.parse(stored) as unknown);
-      } catch {
-        return initialValue;
-      }
-    },
-    setItem(key: string, value: T) {
-      if (typeof window === "undefined") return;
-      window.localStorage.setItem(key, JSON.stringify(value));
-    },
-    removeItem(key: string) {
-      if (typeof window === "undefined") return;
-      window.localStorage.removeItem(key);
-    },
-  };
-}
 
 export const sidebarGroupByAtom = atomWithStorage<GroupByMode>(
   STORAGE_KEY,
   DEFAULT_MODE,
-  createStorage(parseStored),
+  createZodJsonStorage(StoredGroupByModeSchema),
   { getOnInit: true }
 );
 sidebarGroupByAtom.debugLabel = "sidebarGroupByAtom";
@@ -106,7 +62,7 @@ sidebarGroupByAtom.debugLabel = "sidebarGroupByAtom";
 const projectsSidebarGroupByAtom = atomWithStorage<ProjectsGroupByMode>(
   PROJECTS_STORAGE_KEY,
   DEFAULT_PROJECTS_MODE,
-  createStorage(parseStoredProjects),
+  createZodJsonStorage(StoredProjectsGroupByModeSchema),
   { getOnInit: true }
 );
 projectsSidebarGroupByAtom.debugLabel = "projectsSidebarGroupByAtom";
@@ -114,7 +70,7 @@ projectsSidebarGroupByAtom.debugLabel = "projectsSidebarGroupByAtom";
 export const sidebarIncludeExternalAtom = atomWithStorage<boolean>(
   INCLUDE_EXTERNAL_STORAGE_KEY,
   DEFAULT_INCLUDE_EXTERNAL,
-  createStorage(parseStoredBoolean),
+  createZodJsonStorage(StoredIncludeExternalSchema),
   { getOnInit: true }
 );
 sidebarIncludeExternalAtom.debugLabel = "sidebarIncludeExternalAtom";
@@ -123,7 +79,7 @@ export const sidebarGroupVisibleCountAtom =
   atomWithStorage<SessionGroupVisibleCount>(
     GROUP_VISIBLE_COUNT_STORAGE_KEY,
     DEFAULT_SESSION_GROUP_VISIBLE_COUNT,
-    createStorage(parseStoredGroupVisibleCount),
+    createZodJsonStorage(StoredGroupVisibleCountSchema),
     { getOnInit: true }
   );
 sidebarGroupVisibleCountAtom.debugLabel = "sidebarGroupVisibleCountAtom";
@@ -139,7 +95,7 @@ sidebarGroupVisibleCountAtom.debugLabel = "sidebarGroupVisibleCountAtom";
 export const sidebarHiddenWorkspacesAtom = atomWithStorage<string[]>(
   HIDDEN_WORKSPACES_STORAGE_KEY,
   [],
-  createStorage(parseStoredWorkspaceKeys),
+  createZodJsonStorage(StoredWorkspaceKeysSchema),
   { getOnInit: true }
 );
 sidebarHiddenWorkspacesAtom.debugLabel = "sidebarHiddenWorkspacesAtom";
@@ -152,7 +108,7 @@ sidebarHiddenWorkspacesAtom.debugLabel = "sidebarHiddenWorkspacesAtom";
 export const sidebarPinnedWorkspacesAtom = atomWithStorage<string[]>(
   PINNED_WORKSPACES_STORAGE_KEY,
   [],
-  createStorage(parseStoredWorkspaceKeys),
+  createZodJsonStorage(StoredWorkspaceKeysSchema),
   { getOnInit: true }
 );
 sidebarPinnedWorkspacesAtom.debugLabel = "sidebarPinnedWorkspacesAtom";

--- a/src/scaffold/NavigationSidebar/connectors/sidebarSessionOrder.ts
+++ b/src/scaffold/NavigationSidebar/connectors/sidebarSessionOrder.ts
@@ -1,8 +1,9 @@
 import { atomWithStorage } from "jotai/utils";
+import { z } from "zod/v4";
 
 import type { Session } from "@src/store/session";
+import { createZodJsonStorage } from "@src/util/core/storage/zodStorage";
 
-import { createStorage } from "./sidebarGroupByAtom";
 import { sortSessionsByActivity } from "./workstationSidebarData";
 
 export const SESSION_SORT_MODES = ["priority", "updated", "manual"] as const;
@@ -23,17 +24,13 @@ export function parseSessionOrder(raw: unknown): string[] {
 export const sidebarSessionSortAtom = atomWithStorage<SessionSortMode>(
   "orgii:sidebarSessionSort",
   "updated",
-  createStorage((raw) =>
-    SESSION_SORT_MODES.includes(raw as SessionSortMode)
-      ? (raw as SessionSortMode)
-      : "updated"
-  ),
+  createZodJsonStorage(z.enum(SESSION_SORT_MODES)),
   { getOnInit: true }
 );
 export const sidebarSessionOrderAtom = atomWithStorage<string[]>(
   "orgii:sidebarSessionOrder",
   [],
-  createStorage(parseSessionOrder),
+  createZodJsonStorage(z.array(z.unknown()).transform(parseSessionOrder)),
   { getOnInit: true }
 );
 

--- a/src/store/session/__tests__/creatorDefaultExecModeAtom.test.ts
+++ b/src/store/session/__tests__/creatorDefaultExecModeAtom.test.ts
@@ -1,0 +1,56 @@
+import { createStore } from "jotai/vanilla";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { creatorDefaultExecModeAtom } from "../creatorDefaultExecModeAtom";
+
+const STORAGE_KEY = "orgii:agentExecMode";
+
+/**
+ * `atomWithStorage` re-reads persisted bytes per store in `onMount`, which
+ * only fires once the atom is SUBSCRIBED — a bare `store.get` would return
+ * the module-init snapshot instead.
+ */
+function hydratedStore() {
+  const store = createStore();
+  store.sub(creatorDefaultExecModeAtom, () => undefined);
+  return store;
+}
+
+beforeEach(() => {
+  localStorage.removeItem(STORAGE_KEY);
+});
+
+describe("creatorDefaultExecModeAtom", () => {
+  it("persists under the legacy storage key", () => {
+    const store = hydratedStore();
+    store.set(creatorDefaultExecModeAtom, "plan");
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('"plan"');
+  });
+
+  it("migrates the legacy explore value to ask", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify("explore"));
+
+    expect(hydratedStore().get(creatorDefaultExecModeAtom)).toBe("ask");
+  });
+
+  it("reads back every wire value, not only the picker entries", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify("wingman"));
+
+    expect(hydratedStore().get(creatorDefaultExecModeAtom)).toBe("wingman");
+  });
+
+  it("falls back to build for corrupt JSON", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+
+    expect(hydratedStore().get(creatorDefaultExecModeAtom)).toBe("build");
+  });
+
+  it("falls back to build for unknown or non-string values", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify("turbo"));
+    expect(hydratedStore().get(creatorDefaultExecModeAtom)).toBe("build");
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(42));
+    expect(hydratedStore().get(creatorDefaultExecModeAtom)).toBe("build");
+  });
+});

--- a/src/store/session/__tests__/creatorDefaultProductModeAtom.test.ts
+++ b/src/store/session/__tests__/creatorDefaultProductModeAtom.test.ts
@@ -1,0 +1,41 @@
+import { createStore } from "jotai/vanilla";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { creatorDefaultProductModeAtom } from "../creatorDefaultProductModeAtom";
+
+const STORAGE_KEY = "orgii:creatorProductMode";
+
+function hydratedStore() {
+  const store = createStore();
+  store.sub(creatorDefaultProductModeAtom, () => undefined);
+  return store;
+}
+
+beforeEach(() => {
+  localStorage.removeItem(STORAGE_KEY);
+});
+
+describe("creatorDefaultProductModeAtom", () => {
+  it("persists under the existing storage key", () => {
+    const store = hydratedStore();
+    store.set(creatorDefaultProductModeAtom, "project");
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('"project"');
+  });
+
+  it("reads back the project selection and an explicit null", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify("project"));
+    expect(hydratedStore().get(creatorDefaultProductModeAtom)).toBe("project");
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(null));
+    expect(hydratedStore().get(creatorDefaultProductModeAtom)).toBeNull();
+  });
+
+  it("falls back to null for corrupt JSON or any other value", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(hydratedStore().get(creatorDefaultProductModeAtom)).toBeNull();
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify("build"));
+    expect(hydratedStore().get(creatorDefaultProductModeAtom)).toBeNull();
+  });
+});

--- a/src/store/session/__tests__/pinnedActionsAtom.test.ts
+++ b/src/store/session/__tests__/pinnedActionsAtom.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { createStore } from "jotai/vanilla";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  type PinnedAction,
   getPinnedActionKey,
+  pinnedActionsAtom,
   slashItemToPinnedAction,
 } from "../pinnedActionsAtom";
+
+const STORAGE_KEY = "orgii:pinnedActions";
+
+function hydratedStore() {
+  const store = createStore();
+  store.sub(pinnedActionsAtom, () => undefined);
+  return store;
+}
 
 describe("pinned action identity", () => {
   it("matches a persisted skill after its display source and name change", () => {
@@ -62,5 +73,45 @@ describe("pinned action identity", () => {
       source: "Workspace Skills",
       serverName: undefined,
     });
+  });
+});
+
+describe("pinnedActionsAtom persistence", () => {
+  const reviewPin: PinnedAction = {
+    name: "Review code",
+    skillName: "review-code",
+    category: "skill",
+    source: "Workspace Skills",
+  };
+
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it("persists under the existing storage key", () => {
+    const store = hydratedStore();
+    store.set(pinnedActionsAtom, [reviewPin]);
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual([reviewPin]);
+  });
+
+  it("reads back stored pins and drops the legacy setup-repo pin", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { name: "setup-repo", category: "skill", source: "builtin" },
+        reviewPin,
+      ])
+    );
+
+    expect(hydratedStore().get(pinnedActionsAtom)).toEqual([reviewPin]);
+  });
+
+  it("falls back to no pins for corrupt JSON or a non-array payload", () => {
+    localStorage.setItem(STORAGE_KEY, "[not json");
+    expect(hydratedStore().get(pinnedActionsAtom)).toEqual([]);
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ name: "x" }));
+    expect(hydratedStore().get(pinnedActionsAtom)).toEqual([]);
   });
 });

--- a/src/store/session/creatorDefaultExecModeAtom.ts
+++ b/src/store/session/creatorDefaultExecModeAtom.ts
@@ -18,42 +18,22 @@
  * user installs.
  */
 import { atomWithStorage } from "jotai/utils";
+import { z } from "zod/v4";
 
-import { normalizeAgentExecMode } from "@src/config/sessionCreatorConfig";
+import { ALL_AGENT_EXEC_MODES } from "@src/config/sessionCreatorConfig";
 import type { AgentExecMode } from "@src/features/SessionCreator/config";
+import { createZodJsonStorage } from "@src/util/core/storage/zodStorage";
 
 const STORAGE_KEY = "orgii:agentExecMode";
 
-function migrateLegacyMode(raw: unknown): AgentExecMode {
-  if (typeof raw !== "string") return "build";
-  if (raw === "explore") return "ask";
-  return normalizeAgentExecMode(raw) ?? "build";
-}
-
-const storage = {
-  getItem(key: string, initialValue: AgentExecMode): AgentExecMode {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored == null) return initialValue;
-      const parsed = JSON.parse(stored) as unknown;
-      return migrateLegacyMode(parsed);
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: AgentExecMode) {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(key, JSON.stringify(value));
-  },
-  removeItem(key: string) {
-    if (typeof window === "undefined") return;
-    window.localStorage.removeItem(key);
-  },
-};
+const StoredAgentExecModeSchema = z.preprocess(
+  (raw) => (raw === "explore" ? "ask" : raw),
+  z.enum([...ALL_AGENT_EXEC_MODES])
+);
 
 export const creatorDefaultExecModeAtom = atomWithStorage<AgentExecMode>(
   STORAGE_KEY,
   "build",
-  storage
+  createZodJsonStorage(StoredAgentExecModeSchema),
+  { getOnInit: true }
 );

--- a/src/store/session/creatorDefaultProductModeAtom.ts
+++ b/src/store/session/creatorDefaultProductModeAtom.ts
@@ -9,38 +9,21 @@
  * new session so it boots inside the persistent work graph.
  */
 import { atomWithStorage } from "jotai/utils";
+import { z } from "zod/v4";
 
 import { PRODUCT_MODE_PROJECT } from "@src/config/sessionCreatorConfig";
+import { createZodJsonStorage } from "@src/util/core/storage/zodStorage";
 
 const STORAGE_KEY = "orgii:creatorProductMode";
 
 export type CreatorDefaultProductMode = typeof PRODUCT_MODE_PROJECT | null;
 
-const storage = {
-  getItem(
-    key: string,
-    initialValue: CreatorDefaultProductMode
-  ): CreatorDefaultProductMode {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored == null) return initialValue;
-      return JSON.parse(stored) === PRODUCT_MODE_PROJECT
-        ? PRODUCT_MODE_PROJECT
-        : null;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: CreatorDefaultProductMode) {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(key, JSON.stringify(value));
-  },
-  removeItem(key: string) {
-    if (typeof window === "undefined") return;
-    window.localStorage.removeItem(key);
-  },
-};
+const StoredProductModeSchema = z.literal(PRODUCT_MODE_PROJECT).nullable();
 
 export const creatorDefaultProductModeAtom =
-  atomWithStorage<CreatorDefaultProductMode>(STORAGE_KEY, null, storage);
+  atomWithStorage<CreatorDefaultProductMode>(
+    STORAGE_KEY,
+    null,
+    createZodJsonStorage(StoredProductModeSchema),
+    { getOnInit: true }
+  );

--- a/src/store/session/pinnedActionsAtom.ts
+++ b/src/store/session/pinnedActionsAtom.ts
@@ -8,8 +8,10 @@
  * Storage key: `orgii:pinnedActions`
  */
 import { atomWithStorage } from "jotai/utils";
+import { z } from "zod/v4";
 
 import type { SlashItem } from "@src/types/extensions";
+import { createZodJsonStorage } from "@src/util/core/storage/zodStorage";
 
 /** A pinned action — a minimal snapshot of the slash item's identity. */
 export interface PinnedAction {
@@ -73,31 +75,17 @@ function migrate(actions: PinnedAction[]): PinnedAction[] {
   );
 }
 
-const storage = {
-  getItem(key: string, initialValue: PinnedAction[]): PinnedAction[] {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored == null) return initialValue;
-      const parsed = JSON.parse(stored) as unknown;
-      if (!Array.isArray(parsed)) return initialValue;
-      return migrate(parsed as PinnedAction[]);
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: PinnedAction[]) {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(key, JSON.stringify(value));
-  },
-  removeItem(key: string) {
-    if (typeof window === "undefined") return;
-    window.localStorage.removeItem(key);
-  },
-};
+/**
+ * Any JSON array is accepted, matching what earlier builds wrote and read
+ * back without per-entry validation; only the legacy filter above runs.
+ */
+const StoredPinnedActionsSchema = z
+  .array(z.unknown())
+  .transform((actions) => migrate(actions as PinnedAction[]));
 
 export const pinnedActionsAtom = atomWithStorage<PinnedAction[]>(
   STORAGE_KEY,
   DEFAULT_PINNED,
-  storage
+  createZodJsonStorage(StoredPinnedActionsSchema),
+  { getOnInit: true }
 );

--- a/src/store/ui/__tests__/kanbanViewStateAtom.test.ts
+++ b/src/store/ui/__tests__/kanbanViewStateAtom.test.ts
@@ -1,0 +1,120 @@
+import { type Atom, createStore } from "jotai/vanilla";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  kanbanAgentTypeFilterAtom,
+  kanbanAutoArchiveTtlAtom,
+  kanbanManualArchivedSessionIdsAtom,
+  kanbanSidebarFilterAtom,
+  kanbanTimeFilterAtom,
+} from "../kanbanViewStateAtom";
+
+const KEYS = {
+  agentType: "orgii:kanbanAgentTypeFilter",
+  sidebar: "orgii:kanbanSidebarFilter",
+  time: "orgii:kanbanTimeFilter",
+  autoArchive: "orgii:kanbanAutoArchiveTtl",
+  manualArchived: "orgii:kanbanManualArchivedSessions",
+} as const;
+
+function hydratedStore(atom: Atom<unknown>) {
+  const store = createStore();
+  store.sub(atom, () => undefined);
+  return store;
+}
+
+function readStored<T>(key: string, atom: Atom<T>, raw: string): T {
+  localStorage.setItem(key, raw);
+  return hydratedStore(atom).get(atom);
+}
+
+beforeEach(() => {
+  for (const key of Object.values(KEYS)) localStorage.removeItem(key);
+});
+
+describe("kanban persisted preferences", () => {
+  it("writes each preference under its existing storage key", () => {
+    const store = createStore();
+    store.set(kanbanAgentTypeFilterAtom, "claude_code");
+    store.set(kanbanSidebarFilterAtom, "archived");
+    store.set(kanbanTimeFilterAtom, "7d");
+    store.set(kanbanAutoArchiveTtlAtom, "never");
+    store.set(kanbanManualArchivedSessionIdsAtom, ["s1"]);
+
+    expect(localStorage.getItem(KEYS.agentType)).toBe('"claude_code"');
+    expect(localStorage.getItem(KEYS.sidebar)).toBe('"archived"');
+    expect(localStorage.getItem(KEYS.time)).toBe('"7d"');
+    expect(localStorage.getItem(KEYS.autoArchive)).toBe('"never"');
+    expect(localStorage.getItem(KEYS.manualArchived)).toBe('["s1"]');
+  });
+
+  it("reads back valid stored values", () => {
+    expect(
+      readStored(KEYS.agentType, kanbanAgentTypeFilterAtom, '"custom:agent"')
+    ).toBe("custom:agent");
+    expect(
+      readStored(KEYS.sidebar, kanbanSidebarFilterAtom, '"blocking"')
+    ).toBe("blocking");
+    expect(readStored(KEYS.time, kanbanTimeFilterAtom, '"12h"')).toBe("12h");
+    expect(readStored(KEYS.autoArchive, kanbanAutoArchiveTtlAtom, '"3d"')).toBe(
+      "3d"
+    );
+  });
+
+  it("falls back to defaults for corrupt JSON", () => {
+    expect(
+      readStored(KEYS.agentType, kanbanAgentTypeFilterAtom, "{corrupt")
+    ).toBe("all");
+    expect(readStored(KEYS.sidebar, kanbanSidebarFilterAtom, "{corrupt")).toBe(
+      "all"
+    );
+    expect(readStored(KEYS.time, kanbanTimeFilterAtom, "{corrupt")).toBe("3d");
+    expect(
+      readStored(KEYS.autoArchive, kanbanAutoArchiveTtlAtom, "{corrupt")
+    ).toBe("24h");
+    expect(
+      readStored(
+        KEYS.manualArchived,
+        kanbanManualArchivedSessionIdsAtom,
+        "{corrupt"
+      )
+    ).toEqual([]);
+  });
+
+  it("rejects values outside each accepted set", () => {
+    expect(readStored(KEYS.agentType, kanbanAgentTypeFilterAtom, '""')).toBe(
+      "all"
+    );
+    expect(readStored(KEYS.sidebar, kanbanSidebarFilterAtom, '"done"')).toBe(
+      "all"
+    );
+    expect(readStored(KEYS.time, kanbanTimeFilterAtom, '"never"')).toBe("3d");
+    expect(
+      readStored(KEYS.autoArchive, kanbanAutoArchiveTtlAtom, '"99h"')
+    ).toBe("24h");
+  });
+
+  it("keeps only string ids and bounds the manual-archive list on read and write", () => {
+    expect(
+      readStored(
+        KEYS.manualArchived,
+        kanbanManualArchivedSessionIdsAtom,
+        JSON.stringify(["a", 1, null, "b"])
+      )
+    ).toEqual(["a", "b"]);
+
+    const many = Array.from({ length: 1001 }, (_, i) => `s${i}`);
+    expect(
+      readStored(
+        KEYS.manualArchived,
+        kanbanManualArchivedSessionIdsAtom,
+        JSON.stringify(many)
+      )
+    ).toHaveLength(1000);
+
+    createStore().set(kanbanManualArchivedSessionIdsAtom, many);
+    expect(JSON.parse(localStorage.getItem(KEYS.manualArchived)!)).toHaveLength(
+      1000
+    );
+  });
+});

--- a/src/store/ui/kanbanViewStateAtom.ts
+++ b/src/store/ui/kanbanViewStateAtom.ts
@@ -21,6 +21,7 @@
  */
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
+import { z } from "zod/v4";
 
 import {
   DEFAULT_KANBAN_TIME_FILTER,
@@ -31,6 +32,7 @@ import {
   type KanbanSidebarFilter,
   type KanbanTimeFilter,
 } from "@src/features/TaskKanban/config";
+import { createZodJsonStorage } from "@src/util/core/storage/zodStorage";
 
 const AGENT_TYPE_FILTER_STORAGE_KEY = "orgii:kanbanAgentTypeFilter";
 const SIDEBAR_FILTER_STORAGE_KEY = "orgii:kanbanSidebarFilter";
@@ -39,192 +41,35 @@ const AUTO_ARCHIVE_TTL_STORAGE_KEY = "orgii:kanbanAutoArchiveTtl";
 const MANUAL_ARCHIVED_STORAGE_KEY = "orgii:kanbanManualArchivedSessions";
 const MAX_MANUAL_ARCHIVED_SESSION_IDS = 1000;
 
-const KNOWN_KANBAN_SIDEBAR_FILTERS = new Set<KanbanSidebarFilter>([
-  KANBAN_SIDEBAR_FILTER.ALL,
-  KANBAN_SIDEBAR_FILTER.TODO,
-  KANBAN_SIDEBAR_FILTER.IN_PROGRESS,
-  KANBAN_SIDEBAR_FILTER.BLOCKING,
-  KANBAN_SIDEBAR_FILTER.TURN_FINISHED,
-  KANBAN_SIDEBAR_FILTER.ARCHIVED,
-]);
+const StoredAgentTypeFilterSchema = z.string().min(1);
 
-const KNOWN_TIME_FILTERS = new Set<KanbanTimeFilter>([
-  "12h",
-  "24h",
-  "3d",
-  "7d",
-]);
+const StoredSidebarFilterSchema = z.enum(Object.values(KANBAN_SIDEBAR_FILTER));
 
-const KNOWN_AUTO_ARCHIVE_TTLS = new Set<KanbanAutoArchiveTtl>([
-  "never",
-  "12h",
-  "24h",
-  "3d",
-  "7d",
-]);
+const StoredTimeFilterSchema = z.enum(["12h", "24h", "3d", "7d"]);
 
-function isKanbanAgentTypeFilter(
-  value: unknown
-): value is KanbanAgentTypeFilter {
-  return typeof value === "string" && value.length > 0;
-}
+const StoredAutoArchiveTtlSchema = z.enum(["never", "12h", "24h", "3d", "7d"]);
 
-function isKanbanSidebarFilter(value: unknown): value is KanbanSidebarFilter {
-  return (
-    typeof value === "string" &&
-    KNOWN_KANBAN_SIDEBAR_FILTERS.has(value as KanbanSidebarFilter)
+const StoredManualArchivedSessionIdsSchema = z
+  .array(z.unknown())
+  .transform((value) =>
+    value
+      .filter((item): item is string => typeof item === "string")
+      .slice(0, MAX_MANUAL_ARCHIVED_SESSION_IDS)
   );
-}
-
-function isKanbanTimeFilter(value: unknown): value is KanbanTimeFilter {
-  return (
-    typeof value === "string" &&
-    KNOWN_TIME_FILTERS.has(value as KanbanTimeFilter)
-  );
-}
-
-function isKanbanAutoArchiveTtl(value: unknown): value is KanbanAutoArchiveTtl {
-  return (
-    typeof value === "string" &&
-    KNOWN_AUTO_ARCHIVE_TTLS.has(value as KanbanAutoArchiveTtl)
-  );
-}
-
-function parseStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.filter((item): item is string => typeof item === "string");
-}
-
-const kanbanAgentTypeFilterStorage = {
-  getItem(
-    key: string,
-    initialValue: KanbanAgentTypeFilter
-  ): KanbanAgentTypeFilter {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored == null) return initialValue;
-      const parsed: unknown = JSON.parse(stored);
-      return isKanbanAgentTypeFilter(parsed) ? parsed : initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: KanbanAgentTypeFilter) {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(key, JSON.stringify(value));
-  },
-  removeItem(key: string) {
-    if (typeof window === "undefined") return;
-    window.localStorage.removeItem(key);
-  },
-};
-
-const kanbanSidebarFilterStorage = {
-  getItem(key: string, initialValue: KanbanSidebarFilter): KanbanSidebarFilter {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored == null) return initialValue;
-      const parsed: unknown = JSON.parse(stored);
-      return isKanbanSidebarFilter(parsed) ? parsed : initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: KanbanSidebarFilter) {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(key, JSON.stringify(value));
-  },
-  removeItem(key: string) {
-    if (typeof window === "undefined") return;
-    window.localStorage.removeItem(key);
-  },
-};
-
-const timeFilterStorage = {
-  getItem(key: string, initialValue: KanbanTimeFilter): KanbanTimeFilter {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored == null) return initialValue;
-      const parsed: unknown = JSON.parse(stored);
-      return isKanbanTimeFilter(parsed) ? parsed : initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: KanbanTimeFilter) {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(key, JSON.stringify(value));
-  },
-  removeItem(key: string) {
-    if (typeof window === "undefined") return;
-    window.localStorage.removeItem(key);
-  },
-};
-
-const autoArchiveTtlStorage = {
-  getItem(
-    key: string,
-    initialValue: KanbanAutoArchiveTtl
-  ): KanbanAutoArchiveTtl {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored == null) return initialValue;
-      const parsed: unknown = JSON.parse(stored);
-      return isKanbanAutoArchiveTtl(parsed) ? parsed : initialValue;
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: KanbanAutoArchiveTtl) {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(key, JSON.stringify(value));
-  },
-  removeItem(key: string) {
-    if (typeof window === "undefined") return;
-    window.localStorage.removeItem(key);
-  },
-};
-
-const manualArchivedSessionIdsStorage = {
-  getItem(key: string, initialValue: string[]): string[] {
-    if (typeof window === "undefined") return initialValue;
-    try {
-      const stored = window.localStorage.getItem(key);
-      if (stored == null) return initialValue;
-      const parsed: unknown = JSON.parse(stored);
-      return parseStringArray(parsed).slice(0, MAX_MANUAL_ARCHIVED_SESSION_IDS);
-    } catch {
-      return initialValue;
-    }
-  },
-  setItem(key: string, value: string[]) {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(
-      key,
-      JSON.stringify(value.slice(0, MAX_MANUAL_ARCHIVED_SESSION_IDS))
-    );
-  },
-  removeItem(key: string) {
-    if (typeof window === "undefined") return;
-    window.localStorage.removeItem(key);
-  },
-};
 
 export const kanbanAgentTypeFilterAtom = atomWithStorage<KanbanAgentTypeFilter>(
   AGENT_TYPE_FILTER_STORAGE_KEY,
   KANBAN_AGENT_TYPE_FILTER.ALL,
-  kanbanAgentTypeFilterStorage
+  createZodJsonStorage(StoredAgentTypeFilterSchema),
+  { getOnInit: true }
 );
 kanbanAgentTypeFilterAtom.debugLabel = "kanban/agentTypeFilter";
 
 export const kanbanSidebarFilterAtom = atomWithStorage<KanbanSidebarFilter>(
   SIDEBAR_FILTER_STORAGE_KEY,
   KANBAN_SIDEBAR_FILTER.ALL,
-  kanbanSidebarFilterStorage
+  createZodJsonStorage(StoredSidebarFilterSchema),
+  { getOnInit: true }
 );
 kanbanSidebarFilterAtom.debugLabel = "kanban/sidebarFilter";
 
@@ -232,21 +77,27 @@ kanbanSidebarFilterAtom.debugLabel = "kanban/sidebarFilter";
 export const kanbanTimeFilterAtom = atomWithStorage<KanbanTimeFilter>(
   TIME_FILTER_STORAGE_KEY,
   DEFAULT_KANBAN_TIME_FILTER,
-  timeFilterStorage
+  createZodJsonStorage(StoredTimeFilterSchema),
+  { getOnInit: true }
 );
 kanbanTimeFilterAtom.debugLabel = "kanban/timeFilter";
 
 export const kanbanAutoArchiveTtlAtom = atomWithStorage<KanbanAutoArchiveTtl>(
   AUTO_ARCHIVE_TTL_STORAGE_KEY,
   "24h",
-  autoArchiveTtlStorage
+  createZodJsonStorage(StoredAutoArchiveTtlSchema),
+  { getOnInit: true }
 );
 kanbanAutoArchiveTtlAtom.debugLabel = "kanban/autoArchiveTtl";
 
 export const kanbanManualArchivedSessionIdsAtom = atomWithStorage<string[]>(
   MANUAL_ARCHIVED_STORAGE_KEY,
   [],
-  manualArchivedSessionIdsStorage
+  createZodJsonStorage(StoredManualArchivedSessionIdsSchema, {
+    serialize: (value) =>
+      JSON.stringify(value.slice(0, MAX_MANUAL_ARCHIVED_SESSION_IDS)),
+  }),
+  { getOnInit: true }
 );
 kanbanManualArchivedSessionIdsAtom.debugLabel =
   "kanban/manualArchivedSessionIds";


### PR DESCRIPTION
## Problem

Six modules still hand-roll a Jotai `atomWithStorage` storage object (`{ getItem, setItem, removeItem }` with `typeof window === "undefined"` guards and bare `JSON.parse` inside try/catch): `src/store/session/creatorDefaultExecModeAtom.ts`, `src/store/session/creatorDefaultProductModeAtom.ts`, `src/store/session/pinnedActionsAtom.ts`, `src/store/ui/kanbanViewStateAtom.ts` (five atoms), `src/scaffold/NavigationSidebar/connectors/sidebarGroupByAtom.ts` (six atoms, via a local `createStorage` helper) and its only consumer `sidebarSessionOrder.ts` (two atoms). The rest of `src/store/**` already uses the house idiom `createZodJsonStorage` from `src/util/core/storage/zodStorage.ts`.

The copies are not just duplicated code; they lack two behaviours the shared helper provides:

- No quota recovery: `setItem` calls `window.localStorage.setItem` directly, so a `QuotaExceededError` throws straight through the atom write path instead of evicting allowlisted caches and retrying (`setBrowserStorageItemWithRecovery`).
- No `subscribe`: without the cross-window `storage`-event resync, a second window hydrates once and every later write clobbers edits made in the other window (last-writer-wins, as the helper's own doc comment describes).

## Solution

Each atom now passes `createZodJsonStorage(Schema)` with `{ getOnInit: true }`, matching the existing adopters (`viewAtom.ts`, `displayPrefsAtoms.ts`, ...). The Zod schemas encode exactly the value set the old parsers accepted:

- `creatorDefaultExecModeAtom`: `z.preprocess(explore -> ask, z.enum([...ALL_AGENT_EXEC_MODES]))` keeps the legacy `"explore"` migration and accepts every wire value, as before.
- `creatorDefaultProductModeAtom`: `z.literal(PRODUCT_MODE_PROJECT).nullable()`.
- `pinnedActionsAtom`: `z.array(z.unknown()).transform(migrate)` — deliberately as permissive as the old code (any array; the `setup-repo` legacy filter still runs), so no stored pin is newly rejected.
- `kanbanViewStateAtom`: `z.string().min(1)`, `z.enum(Object.values(KANBAN_SIDEBAR_FILTER))`, the literal time-filter / auto-archive enums, and a string-filtering array transform bounded to 1000 ids on read, with a `serialize` option keeping the same bound on write.
- `sidebarGroupByAtom` / `sidebarSessionOrder`: enums derived from the existing `GROUP_BY_MODES`, `PROJECTS_GROUP_BY_MODES`, `SESSION_SORT_MODES` arrays, `z.literal([...SESSION_GROUP_VISIBLE_COUNTS])`, `z.boolean()`, and a dedupe/filter transform for workspace-key lists; the exported `createStorage` helper is deleted and its one caller updated.

Invariants: no localStorage key string changed, no default changed, no accepted-value set changed. Corrupt JSON and out-of-set values still resolve to the atom default.

## Potential risks

- Behaviour change (intended): multi-window edits now propagate. With `subscribe` wired, changing e.g. the kanban time filter or sidebar grouping in one window updates the other window live, where previously each window kept its own hydrated copy until reload.
- Behaviour change (intended): a quota-exceeded write now runs the allowlisted-cache eviction and retry, and on final failure logs `[zodStorage] persist failed` and degrades to in-memory state instead of throwing through the setter.
- `getOnInit: true` is new for the four atoms that did not have it (creator exec/product mode, pinned actions, kanban). The stored value is now read at module init rather than only on first mount, so the first render shows the persisted value instead of the default followed by an onMount update. No non-React `store.get` callers of these atoms exist (grepped `src/`).
- `pinnedActionsAtom` intentionally still accepts any JSON array without per-entry validation, to honour the "accepted set must not change" invariant. Tightening it to a typed `PinnedAction` schema is a separate design decision and is not done here.
- No screenshot: the change is storage plumbing with no visual delta, and the app is Tauri-only so it cannot be rendered here.

## Verification

All commands run from the worktree root on this branch.

- `npx prettier --write <12 changed files>` — exit 0.
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <12 changed files>` — exit 0, no diagnostics.
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <12 changed files>` — exit 0.
- `npx vitest run --config config/vitest.config.ts` on the six test files touching the migrated modules (`creatorDefaultExecModeAtom.test.ts`, `creatorDefaultProductModeAtom.test.ts`, `pinnedActionsAtom.test.ts`, `kanbanViewStateAtom.test.ts`, `sidebarGroupByAtom.test.ts`, `sidebarSessionOrder.test.ts`) — 6 files, 30 tests passed. New coverage per atom: valid/legacy stored value reads back, corrupt JSON falls back to the default, the literal storage key is asserted, and `"explore"` reads back as `"ask"`.
- `npx vitest run --config config/vitest.config.ts` on the dependent suites `KanbanHeaderFilters/index.test.ts`, `KanbanSearchInput.test.ts`, `chatPanelTabsAtom.test.ts`, `SlashCommandPortal/useEntries.test.ts`, `cleanup.retention.test.ts` — 5 files, 88 tests passed.
- `nice -n 10 npx tsgo --noEmit --pretty false` — exit 0.
- `pnpm run check:test-placement` — "Test placement is consistent across 532 directories."

Not run: the full vitest suite, cargo, e2e, and a live two-window check of the new cross-window resync (Tauri-only app).

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
