### PR TITLE
refactor(ui): adopt useElementDimensions for element measurement

### DIFF
--- a/src/components/SettingsTable/index.tsx
+++ b/src/components/SettingsTable/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  type ReactNode,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { type ReactNode, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
@@ -14,6 +8,7 @@ import Select from "@src/components/Select";
 import type { SelectOption, SelectProps } from "@src/components/Select";
 import Table, { type TableColumn } from "@src/components/Table";
 import Tooltip from "@src/components/Tooltip";
+import { useElementDimensions } from "@src/hooks/ui/layout/useElementDimensions";
 import {
   FilterIcon,
   HugeiconsIcon,
@@ -376,22 +371,13 @@ export default function SettingsTable<RowData>({
   rootClassName = "",
 }: SettingsTableProps<RowData>) {
   const searchRef = useRef<HTMLDivElement>(null);
-  const [searchHeight, setSearchHeight] = useState(0);
   const hasSelectFilterRow =
     (!!selectFilters && selectFilters.length > 0) || !!selectFiltersExtra;
   const hasSearchBar = !!searchBar || hasSelectFilterRow;
-
-  useEffect(() => {
-    const el = searchRef.current;
-    if (!el) return;
-
-    const measure = () => setSearchHeight(el.offsetHeight);
-    measure();
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [hasSearchBar]);
+  const searchHeight = useElementDimensions(searchRef, {
+    dimension: "height",
+    deps: [hasSearchBar],
+  });
 
   const resolvedFooter =
     footer ??

--- a/src/modules/shared/launchpad/components/LaunchpadDashboardTiles.tsx
+++ b/src/modules/shared/launchpad/components/LaunchpadDashboardTiles.tsx
@@ -7,13 +7,18 @@
  *
  * Extracted from LaunchpadDashboard.tsx to keep it under 600 lines.
  */
-import React, { memo, useLayoutEffect, useRef, useState } from "react";
+import React, { memo, useRef } from "react";
 
+import { useElementDimensions } from "@src/hooks/ui/layout/useElementDimensions";
 import { Add01Icon, HugeiconsIcon } from "@src/icons";
 import { CollapsibleSection } from "@src/modules/shared/layouts/blocks";
 import type { Repo } from "@src/store/repo/types";
 
 import MacFolderIcon from "./MacFolderIcon";
+
+/** Tile footprint (`w-20`) and wrap gap (`gap-2`) in px, used to derive the column count. */
+const LAUNCHPAD_TILE_WIDTH_PX = 80;
+const LAUNCHPAD_TILE_GAP_PX = 8;
 
 const LAUNCHPAD_TILE_CLASS =
   "group/launchpadtile flex w-20 shrink-0 flex-col items-center gap-1.5 border-none bg-transparent p-0 text-center outline-none";
@@ -57,29 +62,17 @@ export const LaunchpadTileWrap: React.FC<{
   action?: React.ReactNode;
 }> = ({ children, actionAfterIndex = -1, action }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [columnCount, setColumnCount] = useState(1);
+  const containerWidth = useElementDimensions(containerRef, {
+    dimension: "width",
+  });
+  const columnCount = Math.max(
+    1,
+    Math.floor(
+      (containerWidth + LAUNCHPAD_TILE_GAP_PX) /
+        (LAUNCHPAD_TILE_WIDTH_PX + LAUNCHPAD_TILE_GAP_PX)
+    )
+  );
   const items = React.Children.toArray(children);
-
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const updateColumnCount = (): void => {
-      const tileWidth = 80;
-      const gap = 8;
-      setColumnCount(
-        Math.max(
-          1,
-          Math.floor((container.clientWidth + gap) / (tileWidth + gap))
-        )
-      );
-    };
-
-    updateColumnCount();
-    const observer = new ResizeObserver(updateColumnCount);
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, []);
 
   const rowEndIndex =
     actionAfterIndex >= 0


### PR DESCRIPTION
## Problem

`src/hooks/ui/layout/useElementDimensions.ts` is the canonical measure-an-element hook (ResizeObserver + window-resize fallback, `clientWidth`/`clientHeight`, SSR-safe layout effect, equal-size dedupe), yet it had only four adopters while dozens of components hand-roll the same `useState` + `new ResizeObserver(measure)` / `observe` / `disconnect` block. Each copy re-implements observer lifecycle, skips the window-resize fallback, and re-renders on every callback even when the size did not change.

## Solution

Two sites whose observer callback is a plain measure-and-set now use the hook:

- `src/components/SettingsTable/index.tsx`: `searchHeight` comes from `useElementDimensions(searchRef, { dimension: "height", deps: [hasSearchBar] })`. The measured `div` (`settings-table-sticky-toolbar` / `shrink-0`, optional `settings-table-sticky-mask`) carries no border or scrollbar, so `clientHeight` equals the previous `offsetHeight` reading. Initial value stays `0`; the `hasSearchBar` re-measure trigger is preserved via `deps`. The now-unused `useEffect` / `useState` imports were removed.
- `src/modules/shared/launchpad/components/LaunchpadDashboardTiles.tsx` (`LaunchpadTileWrap`): the container width comes from `useElementDimensions(containerRef, { dimension: "width" })` and `columnCount` is derived during render instead of being held in its own state. Before the first measure the width is `0`, which yields the same `columnCount = 1` as before. The 80px tile / 8px gap literals are lifted to `LAUNCHPAD_TILE_WIDTH_PX` / `LAUNCHPAD_TILE_GAP_PX`.

Invariant after this change: both sites read the same `client*` measurement they read before, with the same pre-measure value and the same re-measure triggers, but the observer lifecycle lives in one place.

Six of the eight candidate sites were inspected and deliberately left as they are because their callback is not a plain measure-and-set or reads a different measurement:

- `src/components/ClampedContent.tsx` compares `scrollHeight` against `maxHeight` (the hook reads `clientHeight`, which is capped by the clamp itself, so the overflow signal would be lost).
- `src/components/FloatingWindow/index.tsx` and `src/modules/shared/components/FileHeader/BreadcrumbFileHeader.tsx` hold no size state at all; the observer fires a side effect (`fitPinnedWindow`, `scrollToRight`). Routing that through a state-backed hook would add a re-render per resize just to drive an effect, and the hook's integer dedupe would drop sub-pixel resizes those callbacks currently react to.
- `src/modules/WorkStation/shared/TableSurface/hooks/useTableViewport.ts` does read `clientWidth`/`clientHeight`, but it starts from a `{ width: 800, height: 600 }` pre-measure default the hook cannot express (it starts at `0x0`), and `handleViewportScroll` also writes `viewportSize`. Migrating it means dropping both; that is a behaviour decision, not a mechanical swap.
- `src/engines/ChatPanel/hooks/useChatViewFloatingComposerInset.ts` measures `Math.ceil(getBoundingClientRect().height)` (border-inclusive, fractional) on a callback-ref/state node with a 72px zero-height fallback; the hook's `clientHeight` on a `RefObject` is a different measurement and a different ref model.
- `src/modules/WorkStation/shared/TabBar/hooks/useTabLabelCollapse.ts` compares width deltas (`> prevWidth + 10`), defers a `scrollWidth` check to `requestAnimationFrame`, and tracks the previous width in a ref.

`useChatFooterSpacer.ts` and `components/Table/index.tsx` were excluded up front (they debounce/dedupe inside the observer).

## Potential risks

- `SettingsTable`: `offsetHeight` -> `clientHeight`. Verified equal for this element (no border, no horizontal scrollbar on the toolbar wrapper; borders live on the inner `div`). If a future style adds a border to the outer toolbar `div`, `--search-bar-h` would be short by the border width.
- `SettingsTable`: measurement moves from `useEffect` to the hook's `useLayoutEffect`, so `--search-bar-h` is now set before first paint rather than after (removes a one-frame sticky-header offset flash; not a regression). The hook also adds a window `resize` listener, which is redundant with the observer but harmless.
- `LaunchpadTileWrap`: the hook dedupes equal widths, so the component no longer re-renders on observer callbacks that did not change `clientWidth`. Column count is identical for every width.
- Both changes are user-visible layout code, but no screenshot was captured: the app is Tauri-only and cannot be rendered here.
- Not verified at runtime in the app; verification is static plus the targeted vitest files listed below.

## Verification

Run from the worktree root:

- `npx prettier --write src/components/SettingsTable/index.tsx src/modules/shared/launchpad/components/LaunchpadDashboardTiles.tsx` -> exit 0, both files unchanged.
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <same two files>` -> exit 0.
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <same two files>` -> exit 0.
- `npx vitest run --config config/vitest.config.ts src/hooks/ui/layout/useElementDimensions.test.ts src/components/SettingsTable/stickyContract.test.ts src/components/SettingsTable/SettingsTablePagination.test.ts src/app/root/__tests__/componentDependencyBoundaries.test.ts src/components/StatusDot/StatusDot.test.ts src/modules/shared/dataSource/SessionProvenanceRecentSignalsTable.test.ts src/modules/shared/dataSource/BuilderProfilePanel.test.ts src/modules/shared/dataSource/TeamRuntimePanel.test.ts src/modules/shared/components/WorkManagementTable.test.ts src/modules/MainApp/Settings/__tests__/StorageSection.browserStorage.test.ts src/modules/MainApp/Integrations/RulesMemoryEvolution/Table/RulesMemoryEvolutionTable.test.ts src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/__tests__/InlineCredentialImport.test.ts` -> 12 files, 69 tests passed (every test file that imports `SettingsTable`, plus the hook's own test). None of them stub `ResizeObserver` globally; `LaunchpadDashboardTiles` has no test file.
- `nice -n 10 npx tsgo --noEmit --pretty false` -> exit 0.

Not run: full vitest suite, cargo, e2e, `check:test-placement` (no test files added or moved).

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
