### PR TITLE
refactor(spotlight): reuse useDispatchCategoryOptions in dispatch palette

### DIFF
--- a/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/DispatchCategoryDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/DispatchCategoryDropdown.tsx
@@ -40,7 +40,10 @@ import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import type { SpotlightItem } from "../../types";
 import type { DispatchCategoryPaletteProps } from "./types";
-import { useDispatchCategoryOptions } from "./useDispatchCategoryOptions";
+import {
+  buildGroupedSpotlightItems,
+  useDispatchCategoryOptions,
+} from "./useDispatchCategoryOptions";
 
 const LIST_MAX_HEIGHT = 360;
 const VIEWPORT_MARGIN = 12;
@@ -216,27 +219,13 @@ export const DispatchCategoryDropdown: React.FC<
 
   // Build a flat list of items + headers for rendering. When searching
   // we drop headers since the grouping no longer holds.
-  const items = useMemo((): SpotlightItem[] => {
-    if (isSearching) {
-      return filteredOptions.map((option) => optionToItem(option));
-    }
-    const result: SpotlightItem[] = [];
-    for (const group of groups) {
-      result.push({
-        id: group.headerId,
-        label: group.headerLabel,
-        desc: "",
-        icon: "",
-        type: "option" as const,
-        data: { isHeader: true },
-        action: () => {},
-      });
-      for (const option of group.options) {
-        result.push(optionToItem(option, group.headerId));
-      }
-    }
-    return result;
-  }, [isSearching, filteredOptions, groups, optionToItem]);
+  const items = useMemo(
+    (): SpotlightItem[] =>
+      isSearching
+        ? filteredOptions.map((option) => optionToItem(option))
+        : buildGroupedSpotlightItems(groups, optionToItem),
+    [isSearching, filteredOptions, groups, optionToItem]
+  );
 
   useEffect(() => {
     if (!isOpen) return;

--- a/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/cliLaunchModeFilter.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/cliLaunchModeFilter.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { CLI_LAUNCH_MODE } from "@src/store/session/creatorStateAtom";
+
+import { isCliAgentHiddenByLaunchMode } from "./cliLaunchModeFilter";
+
+describe("isCliAgentHiddenByLaunchMode", () => {
+  it("never filters when the surface has no launch-mode switch", () => {
+    expect(
+      isCliAgentHiddenByLaunchMode({
+        cliLaunchMode: undefined,
+        agentType: "kiro",
+        supportsGui: false,
+      })
+    ).toBe(false);
+  });
+
+  it("keeps every installed runtime in the TUI list", () => {
+    expect(
+      isCliAgentHiddenByLaunchMode({
+        cliLaunchMode: CLI_LAUNCH_MODE.TUI,
+        agentType: "kiro",
+        supportsGui: false,
+      })
+    ).toBe(false);
+  });
+
+  it("hides runtimes without GUI support from the GUI list", () => {
+    expect(
+      isCliAgentHiddenByLaunchMode({
+        cliLaunchMode: CLI_LAUNCH_MODE.GUI,
+        agentType: "kiro",
+        supportsGui: false,
+      })
+    ).toBe(true);
+    expect(
+      isCliAgentHiddenByLaunchMode({
+        cliLaunchMode: CLI_LAUNCH_MODE.GUI,
+        agentType: "claude_code",
+        supportsGui: true,
+      })
+    ).toBe(false);
+  });
+
+  it("keeps allowlisted continuation targets visible in the GUI list", () => {
+    const nativeTargets = ["claude_code", "codex"] as const;
+
+    expect(
+      isCliAgentHiddenByLaunchMode({
+        cliLaunchMode: CLI_LAUNCH_MODE.GUI,
+        agentType: "claude_code",
+        supportsGui: false,
+        allowedCliAgentTypes: nativeTargets,
+      })
+    ).toBe(false);
+    expect(
+      isCliAgentHiddenByLaunchMode({
+        cliLaunchMode: CLI_LAUNCH_MODE.GUI,
+        agentType: "kiro",
+        supportsGui: false,
+        allowedCliAgentTypes: nativeTargets,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/cliLaunchModeFilter.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/cliLaunchModeFilter.ts
@@ -1,0 +1,24 @@
+import type { CliAgentType } from "@src/api/tauri/rpc/schemas/validation";
+import {
+  CLI_LAUNCH_MODE,
+  type CliLaunchMode,
+} from "@src/store/session/creatorStateAtom";
+
+/**
+ * Whether the picker's GUI/TUI launch-mode switch hides an installed CLI
+ * agent. Only the GUI list is filtered: a runtime without GUI launch support
+ * cannot start a managed GUI run. Existing-conversation continuation passes an
+ * explicit shell-out allowlist; that runtime path does not require the
+ * optional GUI capability, so allowlisted runtimes stay visible. Surfaces
+ * without the switch pass `undefined` and never filter.
+ */
+export function isCliAgentHiddenByLaunchMode(args: {
+  cliLaunchMode: CliLaunchMode | undefined;
+  agentType: CliAgentType;
+  supportsGui: boolean;
+  allowedCliAgentTypes?: readonly CliAgentType[];
+}): boolean {
+  if (args.cliLaunchMode !== CLI_LAUNCH_MODE.GUI) return false;
+  if (args.supportsGui) return false;
+  return !args.allowedCliAgentTypes?.includes(args.agentType);
+}

--- a/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/index.tsx
@@ -6,107 +6,30 @@
  * - Installed CLI agents (Cursor, Claude Code, Codex, etc.)
  * - User-defined custom agents
  *
- * Each agent row shows compatible credential badges on the right.
+ * Each agent row shows compatible credential badges on the right. Option
+ * data, grouping, and row adaptation come from `useDispatchCategoryOptions`,
+ * shared with the anchored `DispatchCategoryDropdown`; this component owns
+ * the Spotlight chrome and the GUI/TUI launch-mode switch.
  */
-import { useAtomValue, useSetAtom } from "jotai";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { rpc } from "@src/api/tauri/rpc";
-import { CliAgentTypeSchema } from "@src/api/tauri/rpc/schemas/validation";
-import type { DispatchCategory } from "@src/api/tauri/session";
-import { isApiKeyProvider } from "@src/assets/providers";
-import ModelIcon from "@src/components/ModelIcon";
-import { resolveAgentIcon } from "@src/config/agentIcons";
-import { getCliTransportLabel } from "@src/config/cliAgents";
-import { type KeyVaultAccount, useKeyVault } from "@src/hooks/keyVault";
-import {
-  getCliCompatibleAccounts,
-  getRustCompatibleAccounts,
-  useAgentCompatibility,
-} from "@src/hooks/models/useAgentCompatibility";
 import { useFilteredItems } from "@src/hooks/search";
-import { useEnsureAgentDefs } from "@src/modules/MainApp/AgentOrgs/hooks/useEnsureAgentDefs";
-import {
-  builtInAgentsAtom,
-  customAgentsAtom,
-} from "@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom";
-import type { OrgMember } from "@src/modules/MainApp/AgentOrgs/types";
-import { useCliAgents } from "@src/modules/MainApp/Integrations/KeyVault/CliClients/hooks/useCliAgents";
 import { useSelector as useSelectorKernel } from "@src/scaffold/GlobalSpotlight/hooks/selectors/useSelector";
-import {
-  CLI_LAUNCH_MODE,
-  type CliLaunchMode,
-  cliAgentVisibilityOverridesAtom,
-  isCliAgentEnabled,
-  recentAgentSelectionsAtom,
-  recordRecentAgentSelectionAtom,
-} from "@src/store/session";
-import { agentRegistryAtom } from "@src/store/session/agentRegistryAtom";
-import { SESSION_TARGET_KIND } from "@src/store/session/creatorStateAtom";
-import { invokeTauri } from "@src/util/platform/tauri/init";
+import { CLI_LAUNCH_MODE, type CliLaunchMode } from "@src/store/session";
 
 import { ManageAgentsFooterAction } from "../../components";
 import { useAccountFooterForHovered } from "../../hooks";
 import { PaletteBody, ShellFooterAction, SpotlightShell } from "../../shell";
 import type { PathSegment, SpotlightItem } from "../../types";
 import { CliAgentListFilterSwitch } from "./CliAgentListFilterSwitch";
-import { cliAgentCapabilityDisabled } from "./cliAgentCapability";
-import { credentialedAccounts } from "./credentialedAccounts";
-import { createHumanSessionOption } from "./humanSessionOption";
-import type { AgentOption, DispatchCategoryPaletteProps } from "./types";
+import type { DispatchCategoryPaletteProps } from "./types";
+import {
+  buildGroupedSpotlightItems,
+  useDispatchCategoryOptions,
+} from "./useDispatchCategoryOptions";
 
 export type { AgentSelection, DispatchCategoryPaletteProps } from "./types";
-
-// ============ HELPERS ============
-
-function buildCredentialBadge(
-  compatibleAccounts: KeyVaultAccount[]
-): React.ReactNode {
-  const availableAccounts = credentialedAccounts(compatibleAccounts);
-  const totalCount = availableAccounts.length;
-  const dotColor = totalCount > 0 ? "bg-success-6" : "bg-danger-6";
-  const textColor = totalCount > 0 ? "text-text-2" : "text-text-3";
-
-  const uniquePlanTypes = [
-    ...new Set(
-      availableAccounts
-        .filter((acc) => !isApiKeyProvider(acc.modelType))
-        .map((acc) => acc.modelType)
-    ),
-  ];
-  const uniqueKeyTypes = [
-    ...new Set(
-      availableAccounts
-        .filter((acc) => isApiKeyProvider(acc.modelType))
-        .map((acc) => acc.modelType)
-    ),
-  ];
-
-  return (
-    <div className="flex items-center gap-1.5">
-      {uniquePlanTypes.map((planType) => (
-        <ModelIcon key={planType} agentType={planType} size={14} />
-      ))}
-      {uniqueKeyTypes.map((keyType) => (
-        <ModelIcon key={keyType} agentType={keyType} size="small" />
-      ))}
-      {(uniquePlanTypes.length > 0 || uniqueKeyTypes.length > 0) && (
-        <span className="text-[11px] text-text-4">&middot;</span>
-      )}
-      <span
-        className={`text-[11px] whitespace-nowrap tabular-nums ${textColor}`}
-      >
-        {totalCount}
-      </span>
-      <span
-        className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${dotColor}`}
-      />
-    </div>
-  );
-}
-
-// ============ COMPONENT ============
 
 export const DispatchCategoryPalette: React.FC<
   DispatchCategoryPaletteProps
@@ -128,292 +51,33 @@ export const DispatchCategoryPalette: React.FC<
   titleIcon,
   placeholderLabel,
 }) => {
-  const { t } = useTranslation("sessions");
   const { t: tCommon } = useTranslation("common");
   const [searchQuery, setSearchQuery] = useState("");
   const [cliAgentListFilterMode, setCliAgentListFilterMode] =
     useState<CliLaunchMode>(CLI_LAUNCH_MODE.GUI);
-  const [allOrgs, setAllOrgs] = useState<OrgMember[]>([]);
-  const { agents: cliAgentList } = useCliAgents({ enabled: isOpen });
-  const cliVisibilityOverrides = useAtomValue(cliAgentVisibilityOverridesAtom);
-  const { accounts } = useKeyVault({ autoLoad: true });
-  const { registry } = useAgentCompatibility();
-  const setAgentRegistry = useSetAtom(agentRegistryAtom);
-  const recentAgentSelections = useAtomValue(recentAgentSelectionsAtom);
-  const recordRecentAgentSelection = useSetAtom(recordRecentAgentSelectionAtom);
 
-  const shouldShowCliOnly =
-    cliOnly || cliAgentListFilterMode === CLI_LAUNCH_MODE.TUI;
-  const shouldFilterCliToGuiSupport =
-    cliAgentListFilterMode === CLI_LAUNCH_MODE.GUI;
-
-  // Ensure agent definitions are loaded into global atoms (no-op if already loaded)
-  useEnsureAgentDefs();
-  const builtInAgents = useAtomValue(builtInAgentsAtom);
-  const customAgents = useAtomValue(customAgentsAtom);
-
-  // Merge built-in primary agents and custom agents into a single dispatchable list
-  const allAgents = useMemo(
-    () => [
-      ...builtInAgents.filter((agent) => agent.tier === "primary"),
-      ...customAgents,
-    ],
-    [builtInAgents, customAgents]
-  );
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    let cancelled = false;
-
-    if (!hideOrgs) {
-      invokeTauri<OrgMember[]>("agent_orgs_list")
-        .then((result) => {
-          if (cancelled) return;
-          setAllOrgs(result);
-        })
-        .catch(() => {});
-    }
-
-    rpc.validation
-      .getAvailableApiProviders()
-      .then((apiProviders) => {
-        if (cancelled) return;
-        setAgentRegistry((prev) => ({ ...prev, apiProviders }));
-      })
-      .catch(() => {});
-
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen, hideOrgs, setAgentRegistry]);
-
-  const installedCliAgents = useMemo(
-    () =>
-      cliAgentList.filter(
-        (agent) =>
-          agent.installed &&
-          isCliAgentEnabled(agent.name, agent.installed, cliVisibilityOverrides)
-      ),
-    [cliAgentList, cliVisibilityOverrides]
-  );
-
-  useEffect(() => {
-    if (cliAgentList.length > 0) {
-      setAgentRegistry((prev) => ({ ...prev, agents: cliAgentList }));
-    }
-  }, [cliAgentList, setAgentRegistry]);
-
-  const rustCompatibleAccounts = useMemo(
-    () => credentialedAccounts(getRustCompatibleAccounts(registry, accounts)),
-    [registry, accounts]
-  );
-
-  const rustIncompatibleAccounts = useMemo(() => {
-    const compatibleSet = new Set(rustCompatibleAccounts.map((acc) => acc.id));
-    return accounts.filter(
-      (acc) =>
-        acc.status === "ready" &&
-        acc.enabled &&
-        acc.hasKey &&
-        !compatibleSet.has(acc.id)
-    );
-  }, [accounts, rustCompatibleAccounts]);
-
-  // ============ AGENT OPTIONS (grouped) ============
-
-  const builtInRustOptions = useMemo((): AgentOption[] => {
-    const rustBadge = buildCredentialBadge(rustCompatibleAccounts);
-    return allAgents
-      .filter((agent) => agent.builtIn)
-      .map((agent) => ({
-        id: agent.id,
-        name: agent.name,
-        desc: "",
-        iconId: agent.iconId ?? undefined,
-        category: "rust_agent" as DispatchCategory,
-        targetKind: SESSION_TARGET_KIND.AGENT,
-        agentDefinitionId: agent.id,
-        isBuiltIn: true,
-        isCli: false,
-        isOrg: false,
-        rightContent: rustBadge,
-      }));
-  }, [allAgents, rustCompatibleAccounts]);
-
-  const humanOptions = useMemo(
-    (): AgentOption[] =>
-      includeHumanSession
-        ? [createHumanSessionOption(t("creator.humanSession.name"))]
-        : [],
-    [includeHumanSession, t]
-  );
-
-  const cliOptions = useMemo((): AgentOption[] => {
-    return installedCliAgents.flatMap((agent) => {
-      // `agent.name` is a wire-format string; reject any value that isn't
-      // in the canonical CLI agent set rather than smuggling it through
-      // a `as CliAgentType` cast (which used to crash downstream consumers
-      // when a stale registry entry slipped in).
-      const parsed = CliAgentTypeSchema.safeParse(agent.name);
-      if (!parsed.success) return [];
-      const agentType = parsed.data;
-      // Existing-conversation continuation passes an explicit shell-out
-      // allowlist. That runtime path does not require the optional GUI launch
-      // capability used by New Session's GUI/TUI filter.
-      if (
-        shouldFilterCliToGuiSupport &&
-        agent.supportsGui !== true &&
-        !allowedCliAgentTypes?.includes(agentType)
-      ) {
-        return [];
-      }
-      const disabled = cliAgentCapabilityDisabled(
-        agentType,
-        allowedCliAgentTypes
-      );
-      // CLI agents only show plan (subscription) accounts in the badge —
-      // API key accounts are not relevant for the session-launch decision.
-      const compatibleAccounts = credentialedAccounts(
-        getCliCompatibleAccounts(registry, agentType, accounts)
-      ).filter((account) => !isApiKeyProvider(account.modelType));
-      return [
-        {
-          id: `cli:${agent.name}`,
-          name: agent.displayName,
-          desc: "",
-          category: "cli_agent" as DispatchCategory,
-          targetKind: SESSION_TARGET_KIND.CLI_AGENT,
-          cliAgentType: agentType,
-          isBuiltIn: true,
-          isCli: true,
-          isOrg: false,
-          disabled,
-          disabledLabel: disabled ? tCommon("status.notSupported") : undefined,
-          rightContent: buildCredentialBadge(compatibleAccounts),
-        },
-      ];
-    });
-  }, [
-    allowedCliAgentTypes,
-    installedCliAgents,
-    shouldFilterCliToGuiSupport,
+  const {
+    allOptions,
+    groups,
     accounts,
-    registry,
-    tCommon,
-  ]);
-
-  const customAgentOptions = useMemo((): AgentOption[] => {
-    const rustBadge = buildCredentialBadge(rustCompatibleAccounts);
-    return allAgents
-      .filter((agent) => !agent.builtIn)
-      .map((agent) => ({
-        id: agent.id,
-        name: agent.name,
-        desc: agent.description || "",
-        iconId: agent.iconId ?? undefined,
-        category: "rust_agent" as DispatchCategory,
-        targetKind: SESSION_TARGET_KIND.AGENT,
-        agentDefinitionId: agent.id,
-        isBuiltIn: false,
-        isCli: false,
-        isOrg: false,
-        rightContent: rustBadge,
-      }));
-  }, [allAgents, rustCompatibleAccounts]);
-
-  const orgOptions = useMemo((): AgentOption[] => {
-    const rustBadge = buildCredentialBadge(rustCompatibleAccounts);
-    return allOrgs.map((org) => ({
-      id: `org:${org.id}`,
-      name: org.name,
-      desc: "",
-      iconId: "network",
-      category: "rust_agent" as DispatchCategory,
-      targetKind: SESSION_TARGET_KIND.AGENT_ORG,
-      agentOrgId: org.id,
-      isBuiltIn: false,
-      isCli: false,
-      isOrg: true,
-      rightContent: rustBadge,
-    }));
-  }, [allOrgs, rustCompatibleAccounts]);
-
-  // External IDE: drives a separate Cursor.app instance via CDP. No
-  // key vault entry, no Rust agent, no CLI process — Cursor manages
-  // its own auth + model. We surface it as a distinct group so users
-  // don't conflate it with "Cursor CLI" (which IS a CLI agent and
-  // does need a key).
-  //
-  // `cliAgentType: CLI_AGENT.CURSOR` here is purely for icon rendering
-  // parity with the Cursor CLI row — the dispatch routing checks
-  // `category === "cursor_ide"` (not `cliAgentType`), so this is
-  // safe and avoids the `text-text-2`-dimmed brand-icon adapter.
-  const externalIdeOptions = useMemo((): AgentOption[] => {
-    return [
-      // {
-      //   id: "external-ide:cursor",
-      //   name: t("creator.cursorIde.label"),
-      //   desc: "",
-      //   iconId: "cursor",
-      //   category: "cursor_ide" as DispatchCategory,
-      //   // Reuse CLI_AGENT target kind: like CLI agents, Cursor IDE is
-      //   // an external thing we drive (vs. a Rust agent or org that
-      //   // runs inside ORGII). Avoids polluting SessionTargetKind.
-      //   targetKind: SESSION_TARGET_KIND.CLI_AGENT,
-      //   cliAgentType: CLI_AGENT.CURSOR,
-      //   isBuiltIn: true,
-      //   isCli: false,
-      //   isOrg: false,
-      // },
-    ];
-  }, []);
-
-  const allOptions = useMemo(
-    () =>
-      shouldShowCliOnly
-        ? [...cliOptions]
-        : [
-            ...humanOptions,
-            ...builtInRustOptions,
-            ...(hideCliAgents ? [] : cliOptions),
-            ...externalIdeOptions,
-            ...customAgentOptions,
-            ...(hideOrgs ? [] : orgOptions),
-          ],
-    [
-      shouldShowCliOnly,
-      humanOptions,
-      builtInRustOptions,
-      cliOptions,
-      externalIdeOptions,
-      customAgentOptions,
-      orgOptions,
-      hideOrgs,
-      hideCliAgents,
-    ]
-  );
-
-  const recentOptions = useMemo((): AgentOption[] => {
-    return recentAgentSelections.flatMap((selection) => {
-      const option = allOptions.find((candidate) => {
-        if (selection.targetKind === SESSION_TARGET_KIND.AGENT_ORG) {
-          return candidate.agentOrgId === selection.agentOrgId;
-        }
-        if (selection.category === "cli_agent") {
-          return candidate.cliAgentType === selection.cliAgentType;
-        }
-        if (selection.category === "cursor_ide") {
-          return candidate.category === "cursor_ide";
-        }
-        if (selection.category === "human_session") {
-          return candidate.category === "human_session";
-        }
-        return candidate.agentDefinitionId === selection.agentDefinitionId;
-      });
-      return option ? [option] : [];
-    });
-  }, [allOptions, recentAgentSelections]);
+    rustCompatibleAccounts,
+    rustIncompatibleAccounts,
+    optionToItem,
+  } = useDispatchCategoryOptions({
+    isOpen,
+    hideOrgs,
+    hideCliAgents,
+    allowedCliAgentTypes,
+    cliOnly,
+    cliLaunchMode: cliAgentListFilterMode,
+    includeHumanSession,
+    currentCategory,
+    currentAgentDefinitionId,
+    currentAgentOrgId,
+    currentCliAgentType,
+    onSelect,
+    onClose,
+  });
 
   const { filteredItems: filteredOptions } = useFilteredItems({
     items: allOptions,
@@ -425,173 +89,13 @@ export const DispatchCategoryPalette: React.FC<
 
   const isSearching = searchQuery.trim().length > 0;
 
-  const optionToItem = useCallback(
-    (option: AgentOption, itemIdPrefix?: string): SpotlightItem => {
-      const isCurrent = option.isOrg
-        ? currentCategory === "rust_agent" &&
-          option.agentOrgId === currentAgentOrgId
-        : option.isCli
-          ? currentCategory === "cli_agent" &&
-            option.cliAgentType === currentCliAgentType
-          : option.category === "cursor_ide" ||
-              option.category === "human_session"
-            ? currentCategory === option.category
-            : currentCategory === "rust_agent" &&
-              option.agentDefinitionId === currentAgentDefinitionId;
-
-      // Render through ModelIcon (raw brand SVG) whenever we have a
-      // `cliAgentType` — both CLI agent rows and the Cursor IDE row
-      // (which carries `cursor_cli` purely for icon parity). Other
-      // rows fall back to the icon adapter via `resolveAgentIcon`.
-      const icon = option.cliAgentType
-        ? (iconProps: Record<string, unknown>) => (
-            <ModelIcon
-              agentType={option.cliAgentType!}
-              size={(iconProps as { size?: number }).size || 16}
-            />
-          )
-        : resolveAgentIcon(option.iconId);
-
-      return {
-        id: itemIdPrefix ? `${itemIdPrefix}:${option.id}` : option.id,
-        label: option.name,
-        desc: option.desc,
-        icon,
-        type: "action" as const,
-        data: {
-          isSelector: true,
-          optionId: option.id,
-          isCurrentSelection: isCurrent,
-          // Execution transport for managed GUI runs (ACP vs shell-out).
-          // CLI agent rows only — Rust agents, orgs, and the Cursor IDE row
-          // (which carries `cliAgentType` purely for icon parity) never get it.
-          inlineTag:
-            option.isCli && option.cliAgentType
-              ? getCliTransportLabel(option.cliAgentType)
-              : undefined,
-          disabled: option.disabled,
-          tagLabel: option.disabledLabel,
-          rightContent: option.rightContent,
-          testId: option.isOrg
-            ? `session-creator-agent-option-org-${option.agentOrgId}`
-            : option.category === "human_session"
-              ? "session-creator-option-human-session"
-              : option.agentDefinitionId
-                ? `session-creator-agent-option-def-${option.agentDefinitionId}`
-                : option.cliAgentType
-                  ? `session-creator-agent-option-cli-${option.cliAgentType}`
-                  : undefined,
-        },
-        action: () => {
-          if (option.disabled) return;
-          recordRecentAgentSelection({
-            category: option.category,
-            targetKind: option.targetKind,
-            agentDefinitionId: option.agentDefinitionId,
-            agentOrgId: option.agentOrgId,
-            cliAgentType: option.cliAgentType,
-          });
-          onSelect({
-            category: option.category,
-            targetKind: option.targetKind,
-            agentDefinitionId: option.agentDefinitionId,
-            agentOrgId: option.agentOrgId,
-            cliAgentType: option.cliAgentType,
-            cliLaunchMode: option.isCli ? cliAgentListFilterMode : undefined,
-            agentName: option.name,
-            agentIconId: option.iconId,
-          });
-          onClose();
-        },
-      };
-    },
-    [
-      currentCategory,
-      currentAgentDefinitionId,
-      currentAgentOrgId,
-      currentCliAgentType,
-      cliAgentListFilterMode,
-      recordRecentAgentSelection,
-      onSelect,
-      onClose,
-    ]
+  const items = useMemo(
+    (): SpotlightItem[] =>
+      isSearching
+        ? filteredOptions.map((option) => optionToItem(option))
+        : buildGroupedSpotlightItems(groups, optionToItem),
+    [isSearching, filteredOptions, groups, optionToItem]
   );
-
-  const items = useMemo((): SpotlightItem[] => {
-    if (isSearching) {
-      return filteredOptions.map((option) => optionToItem(option));
-    }
-
-    const result: SpotlightItem[] = [];
-
-    const pushGroup = (
-      headerId: string,
-      headerLabel: string,
-      options: AgentOption[]
-    ) => {
-      if (options.length === 0) return;
-      result.push({
-        id: headerId,
-        label: headerLabel,
-        desc: "",
-        icon: "",
-        type: "option" as const,
-        data: { isHeader: true },
-        action: () => {},
-      });
-      for (const option of options) {
-        result.push(optionToItem(option, headerId));
-      }
-    };
-
-    pushGroup(
-      "__header_recent__",
-      tCommon("selectors.labels.recent"),
-      recentOptions
-    );
-    if (!shouldShowCliOnly) {
-      pushGroup("__header_builtin__", t("creator.builtIns"), [
-        ...humanOptions,
-        ...builtInRustOptions,
-      ]);
-    }
-    if (!hideCliAgents) {
-      pushGroup("__header_cli__", t("creator.cliAgents"), cliOptions);
-    }
-    if (!shouldShowCliOnly) {
-      pushGroup(
-        "__header_external_ide__",
-        t("creator.externalIdes"),
-        externalIdeOptions
-      );
-      pushGroup(
-        "__header_custom__",
-        t("creator.customAgents"),
-        customAgentOptions
-      );
-      if (!hideOrgs) {
-        pushGroup("__header_orgs__", t("creator.agentOrgs"), orgOptions);
-      }
-    }
-
-    return result;
-  }, [
-    isSearching,
-    shouldShowCliOnly,
-    filteredOptions,
-    recentOptions,
-    humanOptions,
-    builtInRustOptions,
-    cliOptions,
-    hideCliAgents,
-    externalIdeOptions,
-    customAgentOptions,
-    orgOptions,
-    hideOrgs,
-    optionToItem,
-    t,
-    tCommon,
-  ]);
 
   // ============ KERNEL ============
 

--- a/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/useDispatchCategoryOptions.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/useDispatchCategoryOptions.tsx
@@ -41,11 +41,16 @@ import {
   recordRecentAgentSelectionAtom,
 } from "@src/store/session";
 import { agentRegistryAtom } from "@src/store/session/agentRegistryAtom";
-import { SESSION_TARGET_KIND } from "@src/store/session/creatorStateAtom";
+import {
+  CLI_LAUNCH_MODE,
+  type CliLaunchMode,
+  SESSION_TARGET_KIND,
+} from "@src/store/session/creatorStateAtom";
 import { invokeTauri } from "@src/util/platform/tauri/init";
 
 import type { SpotlightItem } from "../../types";
 import { cliAgentCapabilityDisabled } from "./cliAgentCapability";
+import { isCliAgentHiddenByLaunchMode } from "./cliLaunchModeFilter";
 import { credentialedAccounts } from "./credentialedAccounts";
 import { createHumanSessionOption } from "./humanSessionOption";
 import type { AgentOption, AgentSelection } from "./types";
@@ -63,6 +68,14 @@ interface UseDispatchCategoryOptionsArgs {
   allowedCliAgentTypes?: readonly CliAgentType[];
   /** When true, only CLI agent entries are included (Rust-native agents and orgs are hidden). */
   cliOnly?: boolean;
+  /**
+   * Launch-mode filter owned by the Spotlight's GUI/TUI switch. TUI narrows
+   * the list to CLI agents like `cliOnly`; GUI drops installed CLI agents that
+   * cannot launch a GUI run unless `allowedCliAgentTypes` admits them. CLI
+   * selections carry the mode as `cliLaunchMode`. Surfaces without the switch
+   * (the anchored dropdown) leave it undefined and get the unfiltered list.
+   */
+  cliLaunchMode?: CliLaunchMode;
   includeHumanSession?: boolean;
   currentCategory: DispatchCategory;
   currentAgentDefinitionId?: string;
@@ -80,6 +93,33 @@ interface UseDispatchCategoryOptionsResult {
   rustCompatibleAccounts: KeyVaultAccount[];
   rustIncompatibleAccounts: KeyVaultAccount[];
   optionToItem: (option: AgentOption, itemIdPrefix?: string) => SpotlightItem;
+}
+
+/**
+ * Flattens option groups into the header + row items both pickers render.
+ * Rows are prefixed with their group id so the same option can appear under
+ * "Recent" and under its own group without colliding.
+ */
+export function buildGroupedSpotlightItems(
+  groups: DispatchCategoryOptionGroup[],
+  optionToItem: UseDispatchCategoryOptionsResult["optionToItem"]
+): SpotlightItem[] {
+  const result: SpotlightItem[] = [];
+  for (const group of groups) {
+    result.push({
+      id: group.headerId,
+      label: group.headerLabel,
+      desc: "",
+      icon: "",
+      type: "option" as const,
+      data: { isHeader: true },
+      action: () => {},
+    });
+    for (const option of group.options) {
+      result.push(optionToItem(option, group.headerId));
+    }
+  }
+  return result;
 }
 
 function buildCredentialBadge(
@@ -137,6 +177,7 @@ export function useDispatchCategoryOptions(
     hideCliAgents = false,
     allowedCliAgentTypes,
     cliOnly = false,
+    cliLaunchMode,
     includeHumanSession = false,
     currentCategory,
     currentAgentDefinitionId,
@@ -145,6 +186,8 @@ export function useDispatchCategoryOptions(
     onSelect,
     onClose,
   } = args;
+
+  const showCliOnly = cliOnly || cliLaunchMode === CLI_LAUNCH_MODE.TUI;
 
   const { t } = useTranslation("sessions");
   const { t: tCommon } = useTranslation("common");
@@ -258,14 +301,29 @@ export function useDispatchCategoryOptions(
 
   const cliOptions = useMemo((): AgentOption[] => {
     return installedCliAgents.flatMap((agent) => {
+      // `agent.name` is a wire-format string; reject any value that isn't
+      // in the canonical CLI agent set rather than smuggling it through
+      // a `as CliAgentType` cast (which used to crash downstream consumers
+      // when a stale registry entry slipped in).
       const parsed = CliAgentTypeSchema.safeParse(agent.name);
       if (!parsed.success) return [];
       const agentType = parsed.data;
+      if (
+        isCliAgentHiddenByLaunchMode({
+          cliLaunchMode,
+          agentType,
+          supportsGui: agent.supportsGui,
+          allowedCliAgentTypes,
+        })
+      ) {
+        return [];
+      }
       const disabled = cliAgentCapabilityDisabled(
         agentType,
         allowedCliAgentTypes
       );
-      // CLI agents only show plan (subscription) accounts in the badge.
+      // CLI agents only show plan (subscription) accounts in the badge —
+      // API key accounts are not relevant for the session-launch decision.
       const compatibleAccounts = credentialedAccounts(
         getCliCompatibleAccounts(registry, agentType, accounts)
       ).filter((account) => !isApiKeyProvider(account.modelType));
@@ -287,7 +345,14 @@ export function useDispatchCategoryOptions(
         },
       ];
     });
-  }, [allowedCliAgentTypes, installedCliAgents, accounts, registry, tCommon]);
+  }, [
+    allowedCliAgentTypes,
+    cliLaunchMode,
+    installedCliAgents,
+    accounts,
+    registry,
+    tCommon,
+  ]);
 
   const customAgentOptions = useMemo((): AgentOption[] => {
     const rustBadge = buildCredentialBadge(rustCompatibleAccounts);
@@ -327,6 +392,16 @@ export function useDispatchCategoryOptions(
     }));
   }, [allOrgs, rustCompatibleAccounts]);
 
+  // External IDE: drives a separate Cursor.app instance via CDP. No
+  // key vault entry, no Rust agent, no CLI process — Cursor manages
+  // its own auth + model. We surface it as a distinct group so users
+  // don't conflate it with "Cursor CLI" (which IS a CLI agent and
+  // does need a key).
+  //
+  // `cliAgentType: CLI_AGENT.CURSOR` here is purely for icon rendering
+  // parity with the Cursor CLI row — the dispatch routing checks
+  // `category === "cursor_ide"` (not `cliAgentType`), so this is
+  // safe and avoids the `text-text-2`-dimmed brand-icon adapter.
   const externalIdeOptions = useMemo((): AgentOption[] => {
     return [
       // {
@@ -346,7 +421,7 @@ export function useDispatchCategoryOptions(
 
   const allOptions = useMemo(
     () =>
-      cliOnly
+      showCliOnly
         ? [...cliOptions]
         : [
             ...humanOptions,
@@ -357,7 +432,7 @@ export function useDispatchCategoryOptions(
             ...(hideOrgs ? [] : orgOptions),
           ],
     [
-      cliOnly,
+      showCliOnly,
       humanOptions,
       builtInRustOptions,
       cliOptions,
@@ -405,7 +480,7 @@ export function useDispatchCategoryOptions(
       tCommon("selectors.labels.recent"),
       recentOptions
     );
-    if (!cliOnly) {
+    if (!showCliOnly) {
       push("__header_builtin__", t("creator.builtIns"), [
         ...humanOptions,
         ...builtInRustOptions,
@@ -414,7 +489,7 @@ export function useDispatchCategoryOptions(
     if (!hideCliAgents) {
       push("__header_cli__", t("creator.cliAgents"), cliOptions);
     }
-    if (!cliOnly) {
+    if (!showCliOnly) {
       push(
         "__header_external_ide__",
         t("creator.externalIdes"),
@@ -427,7 +502,7 @@ export function useDispatchCategoryOptions(
     }
     return result;
   }, [
-    cliOnly,
+    showCliOnly,
     recentOptions,
     humanOptions,
     builtInRustOptions,
@@ -455,6 +530,10 @@ export function useDispatchCategoryOptions(
             : currentCategory === "rust_agent" &&
               option.agentDefinitionId === currentAgentDefinitionId;
 
+      // Render through ModelIcon (raw brand SVG) whenever we have a
+      // `cliAgentType` — both CLI agent rows and the Cursor IDE row
+      // (which carries `cursor_cli` purely for icon parity). Other
+      // rows fall back to the icon adapter via `resolveAgentIcon`.
       const icon = option.cliAgentType
         ? (iconProps: Record<string, unknown>) => (
             <ModelIcon
@@ -510,6 +589,7 @@ export function useDispatchCategoryOptions(
             agentDefinitionId: option.agentDefinitionId,
             agentOrgId: option.agentOrgId,
             cliAgentType: option.cliAgentType,
+            cliLaunchMode: option.isCli ? cliLaunchMode : undefined,
             agentName: option.name,
             agentIconId: option.iconId,
           });
@@ -522,6 +602,7 @@ export function useDispatchCategoryOptions(
       currentAgentDefinitionId,
       currentAgentOrgId,
       currentCliAgentType,
+      cliLaunchMode,
       recordRecentAgentSelection,
       onSelect,
       onClose,


### PR DESCRIPTION
## Problem

`useDispatchCategoryOptions` was extracted from `DispatchCategoryPalette` so the Spotlight palette and the anchored `DispatchCategoryDropdown` would build the same agent list, but only the dropdown ever adopted it. `src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/index.tsx` (710 LOC) still carried the full inline copy: data fetching, credential badge, option builders for built-in / CLI / custom / org agents, recent-selection matching, grouping, and `optionToItem`. jscpd reported about 285 duplicated lines between the two files.

Because the copies were maintained separately, they drifted:

- The palette owns the GUI/TUI `CliAgentListFilterSwitch` (`f48c0e6ef`). Only the palette narrowed the list to CLI agents in TUI mode, dropped CLI agents with `supportsGui === false` from the GUI list (unless the caller's `allowedCliAgentTypes` admitted them), and put `cliLaunchMode` on the emitted `AgentSelection`. The hook had none of that.
- The hook attaches `availableKeys` to each option and row (`519a49d39`, for the dropdown's key-count tooltip). The palette never did.
- Later shared fixes (`25d0a198f`: credentialed-account filtering, capability-gated disabled rows) had to be applied to both files by hand.

Every other duplicated region was byte-identical apart from comments.

## Solution

`DispatchCategoryPalette` now consumes `useDispatchCategoryOptions` and its inline copy is deleted. The palette keeps only what is Spotlight-specific: search state, the GUI/TUI switch, the selector kernel, the hovered-account footer, and the shell chrome.

The one genuine palette-only behaviour moved into the hook behind a new optional `cliLaunchMode?: CliLaunchMode` argument:

- `undefined` (the dropdown) keeps today's dropdown behaviour exactly: no GUI filtering, `cliOnly` alone decides CLI-only, no `cliLaunchMode` on selections.
- `"tui"` narrows the list to CLI agents (same as `cliOnly`).
- `"gui"` hides installed CLI agents without GUI support unless they are in `allowedCliAgentTypes`.
- CLI selections carry the mode as `cliLaunchMode`, which `SessionCreator` already reads.

The GUI-list filtering rule lives in a pure helper, `cliLaunchModeFilter.ts` (`isCliAgentHiddenByLaunchMode`), following the directory's existing `cliAgentCapability.ts` / `credentialedAccounts.ts` pattern, with a unit test. The header + row flattening that both pickers did identically is now one exported `buildGroupedSpotlightItems` in the hook file.

Resulting invariant: there is a single option pipeline; any future fix to option building, grouping, or row adaptation reaches both pickers.

All exports of `index.tsx` are unchanged (`DispatchCategoryPalette`, `AgentSelection`, `DispatchCategoryPaletteProps`); `DispatchCategoryPaletteProps` is unchanged, so `SessionCreatorOrgMembersPanel`, `RunnerListPanel`, `RoutineWizard`, `DispatchCategoryPicker`, and the ~10 `AgentSelection` type importers need no changes.

## Potential risks

- Palette rows now carry `availableKeys` in `SpotlightItem.data` (the hook always attached it). `SpotlightItemRow` does not read that key (it renders `rightContent`, `inlineTag`, `tagLabel`, `disabled`, `isHeader`), so the Spotlight rendering is unchanged; the extra reference is inert.
- The dropdown is intentionally left without the launch-mode filter, matching its behaviour before this PR. That means the dropdown still shows GUI-incapable CLI agents and emits selections without `cliLaunchMode`. This is pre-existing and not changed here; if the product wants parity, it is a one-line `cliLaunchMode` argument now.
- The palette's `optionToItem`, `allOptions`, and `groups` memoization dependencies are the same set as before (with `cliLaunchMode` replacing the local mode state); no change to re-render behaviour is expected, but this was not measured.
- User-visible UI: none intended. The Spotlight palette should render identical rows in identical order for every combination of `cliOnly` / `hideOrgs` / `hideCliAgents` / `allowedCliAgentTypes` / GUI-TUI mode. No screenshot was captured: the app is Tauri-only and cannot be rendered in this environment.
- The hook itself has no render test (it needs the CLI-agent, key-vault, compatibility, and Jotai stores mocked); coverage for the new option is at the pure-helper boundary.

## Verification

Run from the worktree root on `refactor/adopt-dispatch-category-options-hook` (based on `origin/develop` at `1a0a9166d`):

- `npx prettier --write <5 changed files>` -> exit 0, all files unchanged after formatting.
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <5 changed files>` -> exit 0.
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <5 changed files>` -> exit 0.
- `npx vitest run --config config/vitest.config.ts` over `cliLaunchModeFilter.test.ts` (new), `cliAgentCapability.test.ts`, `credentialedAccounts.test.ts`, `humanSessionOption.test.ts`, `src/features/SessionCreator/multiRunner/contract.test.ts`, `src/engines/ChatPanel/InputArea/components/ModelPill.test.ts` -> 6 files, 42 tests passed.
- `nice -n 10 npx tsgo --noEmit --pretty false` -> EXIT=0.
- `pnpm run check:test-placement` -> "Test placement is consistent across 532 directories."
- Manual: `diff` of every jscpd-reported region between `index.tsx` and `useDispatchCategoryOptions.tsx` before the change; the only non-comment differences were the launch-mode filter (palette only) and `availableKeys` (hook only), both accounted for above.

Not run: full vitest suite, cargo, e2e, knip, jscpd (not installed locally), and no in-app rendering of the palette or dropdown.

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
