### PR TITLE
refactor(hooks): adopt useAsyncData in git history hooks

### DIFF
--- a/src/hooks/async/useAsyncData.test.ts
+++ b/src/hooks/async/useAsyncData.test.ts
@@ -9,14 +9,17 @@ import { type UseAsyncDataReturn, useAsyncData } from "./useAsyncData";
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
 }
 
 function deferred<T>(): Deferred<T> {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 async function flushAsync(): Promise<void> {
@@ -58,6 +61,56 @@ describe("useAsyncData", () => {
     await flushAsync();
 
     expect(result).toMatchObject({ data: "new result", loading: false });
+    await root.unmount();
+  });
+
+  it("fires onSuccess and onError only for the committed generation", async () => {
+    const requests = new Map<string, Deferred<string>>();
+    const query = vi.fn((key: string) => {
+      const request = deferred<string>();
+      requests.set(key, request);
+      return request.promise;
+    });
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const root = createSmokeRoot();
+
+    function Probe({ queryKey }: { queryKey: string }) {
+      useAsyncData({
+        key: queryKey,
+        query,
+        initialData: "initial",
+        mapError: (error) => (error === "ignored" ? null : String(error)),
+        onSuccess,
+        onError,
+      });
+      return null;
+    }
+
+    await root.render(React.createElement(Probe, { queryKey: "stale" }));
+    await root.render(React.createElement(Probe, { queryKey: "fresh" }));
+    requests.get("fresh")?.resolve("fresh result");
+    await flushAsync();
+    requests.get("stale")?.resolve("stale result");
+    await flushAsync();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith("fresh result", "fresh");
+
+    await root.render(React.createElement(Probe, { queryKey: "failing" }));
+    requests.get("failing")?.reject(new Error("boom"));
+    await flushAsync();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      "Error: boom",
+      expect.any(Error),
+      "failing"
+    );
+
+    await root.render(React.createElement(Probe, { queryKey: "suppressed" }));
+    requests.get("suppressed")?.reject("ignored");
+    await flushAsync();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
     await root.unmount();
   });
 

--- a/src/hooks/async/useAsyncData.ts
+++ b/src/hooks/async/useAsyncData.ts
@@ -25,6 +25,13 @@ export interface UseAsyncDataOptions<TData, TKey> {
   enabled?: boolean;
   fallbackData?: TData | ((error: unknown) => TData);
   mapError?: AsyncDataErrorMapper;
+  /** Fires once per query that commits successfully (latest generation only). */
+  onSuccess?: (data: TData, key: TKey) => void;
+  /**
+   * Fires once per query failure that commits, with the mapped message.
+   * Skipped when `mapError` returns null (the failure is suppressed).
+   */
+  onError?: (message: string, error: unknown, key: TKey) => void;
 }
 
 export interface UseAsyncDataReturn<TData> {
@@ -56,6 +63,8 @@ export function useAsyncData<TData, TKey>({
   enabled = true,
   fallbackData = initialData,
   mapError = defaultMapError,
+  onSuccess,
+  onError,
 }: UseAsyncDataOptions<TData, TKey>): UseAsyncDataReturn<TData> {
   const [generation, setGeneration] = useState(0);
   const [snapshot, setSnapshot] = useState<AsyncDataSnapshot<
@@ -66,13 +75,17 @@ export function useAsyncData<TData, TKey>({
   const queryRef = useRef(query);
   const fallbackDataRef = useRef(fallbackData);
   const mapErrorRef = useRef(mapError);
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
   const mountedRef = useMounted();
 
   useEffect(() => {
     queryRef.current = query;
     fallbackDataRef.current = fallbackData;
     mapErrorRef.current = mapError;
-  }, [fallbackData, mapError, query]);
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+  }, [fallbackData, mapError, onError, onSuccess, query]);
 
   const refresh = useCallback(() => {
     if (mountedRef.current) {
@@ -85,17 +98,18 @@ export function useAsyncData<TData, TKey>({
 
     if (!enabled) return;
 
-    void queryRef
-      .current(key)
-      .then((data) => {
+    // Two-argument `then` keeps a throwing `onSuccess` out of the error branch.
+    void queryRef.current(key).then(
+      (data) => {
         if (
           mountedRef.current &&
           latestGenerationRef.current === requestGeneration
         ) {
           setSnapshot({ key, generation, data, error: null });
+          onSuccessRef.current?.(data, key);
         }
-      })
-      .catch((error: unknown) => {
+      },
+      (error: unknown) => {
         if (
           !mountedRef.current ||
           latestGenerationRef.current !== requestGeneration
@@ -108,13 +122,11 @@ export function useAsyncData<TData, TKey>({
           typeof fallback === "function"
             ? (fallback as (failure: unknown) => TData)(error)
             : fallback;
-        setSnapshot({
-          key,
-          generation,
-          data,
-          error: mapErrorRef.current(error),
-        });
-      });
+        const message = mapErrorRef.current(error);
+        setSnapshot({ key, generation, data, error: message });
+        if (message !== null) onErrorRef.current?.(message, error, key);
+      }
+    );
 
     return () => {
       if (latestGenerationRef.current === requestGeneration) {

--- a/src/hooks/git/useFileHistory.test.ts
+++ b/src/hooks/git/useFileHistory.test.ts
@@ -1,0 +1,186 @@
+/* @vitest-environment jsdom */
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GitCommitInfo } from "@src/api/http/git";
+import { createHookLifecycleHarness } from "@src/test/hookLifecycleHarness";
+
+import { type UseFileHistoryOptions, useFileHistory } from "./useFileHistory";
+
+const mocks = vi.hoisted(() => ({
+  getGitCommits: vi.fn(),
+}));
+
+vi.mock("@src/api/http/git", () => ({
+  getGitCommits: mocks.getGitCommits,
+}));
+
+const COMMITS = [{ sha: "abc" }, { sha: "def" }] as unknown as GitCommitInfo[];
+
+type CommitsPayload = { commits: GitCommitInfo[]; total_count: number | null };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function createHarness() {
+  return createHookLifecycleHarness((props: UseFileHistoryOptions) =>
+    useFileHistory(props)
+  );
+}
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+  vi.clearAllMocks();
+});
+
+describe("useFileHistory", () => {
+  it("loads commits and total count and reports success once", async () => {
+    const request = deferred<CommitsPayload>();
+    mocks.getGitCommits.mockReturnValue(request.promise);
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({
+      repoId: "repo-1",
+      filePath: "src/a.ts",
+      limit: 10,
+      onSuccess,
+      onError,
+    });
+    expect(harness.read()).toMatchObject({
+      commits: [],
+      totalCount: null,
+      loading: true,
+      error: null,
+    });
+
+    request.resolve({ commits: COMMITS, total_count: 7 });
+    await flushAsync();
+    expect(mocks.getGitCommits).toHaveBeenCalledWith({
+      repo_id: "repo-1",
+      file_path: "src/a.ts",
+      limit: 10,
+    });
+    expect(harness.read()).toMatchObject({
+      commits: COMMITS,
+      totalCount: 7,
+      loading: false,
+      error: null,
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(COMMITS);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty API response as no commits without calling onSuccess", async () => {
+    mocks.getGitCommits.mockResolvedValue(undefined);
+    const onSuccess = vi.fn();
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({ repoId: "repo-1", filePath: "src/a.ts", onSuccess });
+    await flushAsync();
+    expect(harness.read()).toMatchObject({
+      commits: [],
+      totalCount: null,
+      loading: false,
+      error: null,
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch without a file path", async () => {
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({ repoId: "repo-1", filePath: null });
+    await flushAsync();
+    expect(mocks.getGitCommits).not.toHaveBeenCalled();
+    expect(harness.read()).toMatchObject({
+      commits: [],
+      totalCount: null,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("maps a rejected query to an error, clears commits and calls onError", async () => {
+    mocks.getGitCommits.mockRejectedValue(new Error("network down"));
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({
+      repoId: "repo-1",
+      filePath: "src/a.ts",
+      onSuccess,
+      onError,
+    });
+    await flushAsync();
+    expect(harness.read()).toMatchObject({
+      commits: [],
+      totalCount: null,
+      loading: false,
+      error: "network down",
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith("network down");
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("refreshes in place and refetches when the limit changes", async () => {
+    mocks.getGitCommits.mockResolvedValue({ commits: COMMITS, total_count: 2 });
+    const onSuccess = vi.fn();
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({ repoId: "repo-1", filePath: "src/a.ts", onSuccess });
+    await flushAsync();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    const callsBeforeRefresh = mocks.getGitCommits.mock.calls.length;
+    const request = deferred<CommitsPayload>();
+    mocks.getGitCommits.mockReturnValue(request.promise);
+    await act(async () => harness.read().refresh());
+    expect(harness.read()).toMatchObject({
+      commits: [],
+      totalCount: null,
+      loading: true,
+    });
+    request.resolve({ commits: COMMITS, total_count: 2 });
+    await flushAsync();
+    expect(mocks.getGitCommits.mock.calls.length).toBe(callsBeforeRefresh + 1);
+    expect(onSuccess).toHaveBeenCalledTimes(2);
+    expect(harness.read()).toMatchObject({ commits: COMMITS, loading: false });
+
+    mocks.getGitCommits.mockResolvedValue({ commits: COMMITS, total_count: 2 });
+    await harness.render({
+      repoId: "repo-1",
+      filePath: "src/a.ts",
+      limit: 5,
+      onSuccess,
+    });
+    await flushAsync();
+    expect(mocks.getGitCommits).toHaveBeenLastCalledWith({
+      repo_id: "repo-1",
+      file_path: "src/a.ts",
+      limit: 5,
+    });
+  });
+});

--- a/src/hooks/git/useFileHistory.ts
+++ b/src/hooks/git/useFileHistory.ts
@@ -3,9 +3,9 @@
  *
  * Fetches Git commit history for a specific file using the Rust Git API.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
-
 import { type GitCommitInfo, getGitCommits } from "@src/api/http/git";
+import type { GitCommitsResponse } from "@src/api/http/git/types";
+import { useAsyncData } from "@src/hooks/async/useAsyncData";
 
 export interface UseFileHistoryOptions {
   /** Repository ID */
@@ -30,10 +30,12 @@ export interface UseFileHistoryResult {
   /** Error message */
   error: string | null;
   /** Refresh history */
-  refresh: () => Promise<void>;
+  refresh: () => void;
   /** Total count of commits */
   totalCount: number | null;
 }
+
+const EMPTY_COMMITS: GitCommitInfo[] = [];
 
 /**
  * Hook to fetch and manage file commit history
@@ -46,69 +48,31 @@ export function useFileHistory({
   onSuccess,
   onError,
 }: UseFileHistoryOptions): UseFileHistoryResult {
-  const [commits, setCommits] = useState<GitCommitInfo[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState<number | null>(null);
-
-  // Callback props are mirrored into refs so `refresh` stays stable. Keeping
-  // them in the dep array meant any caller passing an inline arrow rebuilt
-  // `refresh` every render, and the autoLoad effect below — keyed on
-  // `refresh` — would then re-issue GET /commits on every render.
-  const onSuccessRef = useRef(onSuccess);
-  onSuccessRef.current = onSuccess;
-  const onErrorRef = useRef(onError);
-  onErrorRef.current = onError;
-
-  const refresh = useCallback(async () => {
+  const { data, loading, error, refresh } = useAsyncData<
+    GitCommitsResponse["data"] | undefined,
+    string
+  >({
+    key: `${repoId}\u0000${filePath ?? ""}\u0000${limit}`,
     // Don't fetch if no file is selected
-    if (!filePath) {
-      setCommits([]);
-      setTotalCount(null);
-      return;
-    }
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const result = await getGitCommits({
+    enabled: autoLoad && Boolean(filePath),
+    initialData: undefined,
+    query: () =>
+      getGitCommits({
         repo_id: repoId,
-        file_path: filePath,
+        file_path: filePath ?? undefined,
         limit,
-      });
-
-      if (result) {
-        setCommits(result.commits);
-        setTotalCount(result.total_count);
-        onSuccessRef.current?.(result.commits);
-      } else {
-        setCommits([]);
-        setTotalCount(null);
-      }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      setError(errorMessage);
-      setCommits([]);
-      setTotalCount(null);
-      onErrorRef.current?.(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  }, [repoId, filePath, limit]);
-
-  // Auto-load on mount or when dependencies change
-  useEffect(() => {
-    if (autoLoad) {
-      refresh();
-    }
-  }, [autoLoad, refresh]);
+      }),
+    onSuccess: (result) => {
+      if (result) onSuccess?.(result.commits);
+    },
+    onError: (message) => onError?.(message),
+  });
 
   return {
-    commits,
+    commits: data?.commits ?? EMPTY_COMMITS,
     loading,
     error,
     refresh,
-    totalCount,
+    totalCount: data?.total_count ?? null,
   };
 }

--- a/src/hooks/git/useOrgtrackFileTimeline.test.ts
+++ b/src/hooks/git/useOrgtrackFileTimeline.test.ts
@@ -1,0 +1,164 @@
+/* @vitest-environment jsdom */
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { OrgtrackFileTimeline } from "@src/api/tauri/lineage";
+import { createHookLifecycleHarness } from "@src/test/hookLifecycleHarness";
+
+import {
+  type UseOrgtrackFileTimelineOptions,
+  useOrgtrackFileTimeline,
+} from "./useOrgtrackFileTimeline";
+
+const mocks = vi.hoisted(() => ({
+  getOrgtrackFileTimeline: vi.fn(),
+}));
+
+vi.mock("@src/api/tauri/lineage", () => ({
+  getOrgtrackFileTimeline: mocks.getOrgtrackFileTimeline,
+}));
+
+const TIMELINE = { entries: [] } as unknown as OrgtrackFileTimeline;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function createHarness() {
+  return createHookLifecycleHarness((props: UseOrgtrackFileTimelineOptions) =>
+    useOrgtrackFileTimeline(props)
+  );
+}
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+  vi.clearAllMocks();
+});
+
+describe("useOrgtrackFileTimeline", () => {
+  it("loads the timeline for the given repo and file", async () => {
+    const request = deferred<OrgtrackFileTimeline>();
+    mocks.getOrgtrackFileTimeline.mockReturnValue(request.promise);
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({ repoPath: "/repo", filePath: "src/a.ts" });
+    expect(harness.read()).toMatchObject({
+      timeline: null,
+      loading: true,
+      error: null,
+    });
+
+    request.resolve(TIMELINE);
+    await flushAsync();
+    expect(mocks.getOrgtrackFileTimeline).toHaveBeenCalledWith({
+      repoPath: "/repo",
+      filePath: "src/a.ts",
+    });
+    expect(harness.read()).toMatchObject({
+      timeline: TIMELINE,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it("does not fetch and reports idle state without a file or repo path", async () => {
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({ repoPath: "/repo", filePath: null });
+    await flushAsync();
+    expect(mocks.getOrgtrackFileTimeline).not.toHaveBeenCalled();
+    expect(harness.read()).toMatchObject({
+      timeline: null,
+      loading: false,
+      error: null,
+    });
+
+    await harness.render({ repoPath: "", filePath: "src/a.ts" });
+    await flushAsync();
+    expect(mocks.getOrgtrackFileTimeline).not.toHaveBeenCalled();
+    expect(harness.read()).toMatchObject({ timeline: null, loading: false });
+  });
+
+  it("does not fetch when autoLoad is false", async () => {
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({
+      repoPath: "/repo",
+      filePath: "src/a.ts",
+      autoLoad: false,
+    });
+    await flushAsync();
+    expect(mocks.getOrgtrackFileTimeline).not.toHaveBeenCalled();
+    expect(harness.read()).toMatchObject({ timeline: null, loading: false });
+  });
+
+  it("maps a rejected query to an error message and clears the timeline", async () => {
+    mocks.getOrgtrackFileTimeline.mockRejectedValue(new Error("boom"));
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({ repoPath: "/repo", filePath: "src/a.ts" });
+    await flushAsync();
+    expect(harness.read()).toMatchObject({
+      timeline: null,
+      loading: false,
+      error: "boom",
+    });
+
+    mocks.getOrgtrackFileTimeline.mockRejectedValue("plain failure");
+    await act(async () => harness.read().refresh());
+    await flushAsync();
+    expect(harness.read()).toMatchObject({ error: "plain failure" });
+  });
+
+  it("refreshes the same key and refetches when the file changes", async () => {
+    const first = { entries: [{ id: 1 }] } as unknown as OrgtrackFileTimeline;
+    const second = { entries: [{ id: 2 }] } as unknown as OrgtrackFileTimeline;
+    mocks.getOrgtrackFileTimeline.mockResolvedValue(first);
+    const harness = createHarness();
+    cleanup.push(harness.unmount);
+
+    await harness.render({ repoPath: "/repo", filePath: "src/a.ts" });
+    await flushAsync();
+    expect(harness.read().timeline).toBe(first);
+
+    const callsBeforeRefresh = mocks.getOrgtrackFileTimeline.mock.calls.length;
+    const request = deferred<OrgtrackFileTimeline>();
+    mocks.getOrgtrackFileTimeline.mockReturnValue(request.promise);
+    await act(async () => harness.read().refresh());
+    expect(harness.read()).toMatchObject({
+      timeline: null,
+      loading: true,
+      error: null,
+    });
+    request.resolve(second);
+    await flushAsync();
+    expect(mocks.getOrgtrackFileTimeline.mock.calls.length).toBe(
+      callsBeforeRefresh + 1
+    );
+    expect(harness.read()).toMatchObject({ timeline: second, loading: false });
+
+    mocks.getOrgtrackFileTimeline.mockResolvedValue(first);
+    await harness.render({ repoPath: "/repo", filePath: "src/b.ts" });
+    await flushAsync();
+    expect(mocks.getOrgtrackFileTimeline).toHaveBeenLastCalledWith({
+      repoPath: "/repo",
+      filePath: "src/b.ts",
+    });
+  });
+});

--- a/src/hooks/git/useOrgtrackFileTimeline.ts
+++ b/src/hooks/git/useOrgtrackFileTimeline.ts
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
-
 import {
   type OrgtrackFileTimeline,
   getOrgtrackFileTimeline,
 } from "@src/api/tauri/lineage";
+import { useAsyncData } from "@src/hooks/async/useAsyncData";
 
 export interface UseOrgtrackFileTimelineOptions {
   repoPath: string;
@@ -15,7 +14,7 @@ export interface UseOrgtrackFileTimelineResult {
   timeline: OrgtrackFileTimeline | null;
   loading: boolean;
   error: string | null;
-  refresh: () => Promise<void>;
+  refresh: () => void;
 }
 
 export function useOrgtrackFileTimeline({
@@ -23,33 +22,20 @@ export function useOrgtrackFileTimeline({
   filePath,
   autoLoad = true,
 }: UseOrgtrackFileTimelineOptions): UseOrgtrackFileTimelineResult {
-  const [timeline, setTimeline] = useState<OrgtrackFileTimeline | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const refresh = useCallback(async () => {
-    if (!filePath || !repoPath) {
-      setTimeline(null);
-      return;
-    }
-
-    setLoading(true);
-    setError(null);
-    try {
-      setTimeline(await getOrgtrackFileTimeline({ repoPath, filePath }));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setTimeline(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [filePath, repoPath]);
-
-  useEffect(() => {
-    if (autoLoad) {
-      void refresh();
-    }
-  }, [autoLoad, refresh]);
+  const {
+    data: timeline,
+    loading,
+    error,
+    refresh,
+  } = useAsyncData<OrgtrackFileTimeline | null, string>({
+    key: `${repoPath}\u0000${filePath ?? ""}`,
+    enabled: autoLoad && Boolean(repoPath) && Boolean(filePath),
+    initialData: null,
+    query: () =>
+      filePath
+        ? getOrgtrackFileTimeline({ repoPath, filePath })
+        : Promise.resolve(null),
+  });
 
   return { timeline, loading, error, refresh };
 }

--- a/src/hooks/lifecycle/useMounted.test.ts
+++ b/src/hooks/lifecycle/useMounted.test.ts
@@ -1,0 +1,31 @@
+/* @vitest-environment jsdom */
+import type { RefObject } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createHookLifecycleHarness } from "@src/test/hookLifecycleHarness";
+
+import { useMounted } from "./useMounted";
+
+const cleanup: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0).reverse()) await dispose();
+});
+
+describe("useMounted", () => {
+  it("stays true through StrictMode's simulated remount and flips on unmount", async () => {
+    const harness = createHookLifecycleHarness((_props: object) =>
+      useMounted()
+    );
+    cleanup.push(harness.unmount);
+
+    await harness.render({});
+    const mountedRef: RefObject<boolean> = harness.read();
+    expect(mountedRef.current).toBe(true);
+
+    await harness.render({});
+    expect(mountedRef.current).toBe(true);
+
+    await harness.unmount();
+    expect(mountedRef.current).toBe(false);
+  });
+});

--- a/src/hooks/lifecycle/useMounted.ts
+++ b/src/hooks/lifecycle/useMounted.ts
@@ -34,10 +34,17 @@ import { type MutableRefObject, type RefObject, useEffect } from "react";
  */
 import { useRef } from "react";
 
+function setMounted(mountedRef: RefObject<boolean>, mounted: boolean): void {
+  (mountedRef as MutableRefObject<boolean>).current = mounted;
+}
+
 export function useMountedCleanup(mountedRef: RefObject<boolean>): void {
   useEffect(() => {
+    // Re-arm on every (re)mount so StrictMode's simulated unmount/remount and
+    // Fast Refresh do not leave the ref stuck at `false`.
+    setMounted(mountedRef, true);
     return () => {
-      (mountedRef as MutableRefObject<boolean>).current = false;
+      setMounted(mountedRef, false);
     };
   }, [mountedRef]);
 }


### PR DESCRIPTION
## Problem

`src/hooks/async/useAsyncData.ts` is the canonical keyed async fetch hook (generation-guarded, mounted-guarded, `mapError`, `fallbackData`) but had a single adopter. Two git history hooks re-derived the same `data / loading / error / refresh` shape by hand with `setLoading(true); setError(null); try/catch/finally` plus an autoload effect:

- `src/hooks/git/useOrgtrackFileTimeline.ts` was `useAsyncData` inlined, without any stale-response guard: a slow response for a previous file could overwrite the timeline of the currently selected file.
- `src/hooks/git/useFileHistory.ts` did the same and additionally mirrored `onSuccess`/`onError` into refs so `refresh` stayed stable.

Neither hook had a test. While writing them against `src/test/hookLifecycleHarness.ts` (which renders under `StrictMode`), the adoption surfaced that `useMountedCleanup` never re-arms its ref: StrictMode's simulated unmount/remount left `mountedRef.current === false` for the lifetime of the component, so `useAsyncData` (and the other `useMounted` consumers) silently discard every result under StrictMode.

## Solution

- `useOrgtrackFileTimeline` and `useFileHistory` now delegate to `useAsyncData` with a string key (`repoPath\0filePath`, and `repoId\0filePath\0limit`) and `enabled: autoLoad && <inputs present>`. Exported field names, `refresh` name, and the `string | null` error type are unchanged; the sole consumer (`src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/TimelineContent/index.tsx`) needed no change.
- `useAsyncData` gains optional `onSuccess(data, key)` / `onError(message, error, key)` options, stored in refs like `query`, fired only for the generation that commits (still mounted, latest request). `onError` is skipped when `mapError` returns `null`. The promise chain uses two-argument `then` so a throwing `onSuccess` cannot be misreported as a query failure. `useFileHistory` uses these to keep its `onSuccess(commits)` / `onError(message)` callbacks working, preserving the existing rule that an `undefined` API result yields `[]` without calling `onSuccess`.
- `useMountedCleanup` sets the ref back to `true` in the effect body so StrictMode/Fast Refresh remounts do not leave it stuck at `false`. The write goes through a module-level helper because the React Compiler lint (`react-hooks/immutability`) rejects mutating a hook argument inline.
- `useOrgtrackFileSessionHistory` is intentionally not migrated. Its `loadMore` merges pages into the current `history`, and its backfill poll calls `refresh()` every second while indexing; `useAsyncData` resets `data` to `initialData` during a refresh, which would blank the visible session list on every poll. Modelling "keep previous data while refreshing" is a design change to `useAsyncData`, not a call-site adaptation.

## Potential risks

- Behaviour nuances in the two migrated hooks, all confined to the timeline sidebar:
  - `refresh` is now `() => void` (was `() => Promise<void>` that resolved after the fetch). No consumer calls `refresh` on either hook; `useRefreshSpin` in `src/hooks/ui` already takes `() => void`.
  - While a new key or a refresh is loading, `timeline` / `commits` read as the initial value (`null` / `[]`) instead of the previous file's stale data. `TimelineContent` renders its loading placeholder when there are no entries and `loading` is true, so the visible change is a loading state on file switch instead of briefly showing the previous file's history.
  - `autoLoad: false` now disables the hook entirely (a manual `refresh()` no longer fetches). The only `autoLoad: false` caller (`variant !== "session"`) never reads or refreshes that data.
  - `useFileHistory` callbacks fire only for the committed (latest, still-mounted) result; previously a stale or post-unmount response also invoked them.
- `useMountedCleanup` re-arming affects every `useMounted`/`useMountedCleanup` consumer (10 call sites). In production (no StrictMode) the effect body writes `true` over a value that is already `true`, so there is no behavioural change there; in StrictMode/dev it fixes silently dropped results.
- No screenshot was captured: the app is Tauri-only and cannot be rendered here. The UI diff is a loading placeholder replacing briefly-stale history on file switch.

## Verification

Run from the worktree root (`/private/tmp/orgii-consol-asyncdata`, based on `origin/develop` at `1a0a9166d`):

- `npx prettier --write <8 changed files>` — all unchanged after formatting (EXIT 0).
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <8 changed files>` — EXIT 0.
- `nice -n 10 npx eslint --max-warnings 0 --report-unused-disable-directives <8 changed files>` — first run flagged `react-hooks/immutability` on the inline ref write in `useMounted.ts`; after moving the write into `setMounted()`, `useMounted.ts` re-linted with EXIT 0 (the other 7 files had passed in the first run).
- `npx vitest run --config config/vitest.config.ts src/hooks/async/useAsyncData.test.ts src/hooks/git/useOrgtrackFileTimeline.test.ts src/hooks/git/useFileHistory.test.ts src/hooks/lifecycle/useMounted.test.ts src/test/hookLifecycleHarness.test.ts` — 5 files, 16 tests passed. New coverage: initial load, refresh, error mapping (Error and non-Error rejections), empty key / empty repo no-fetch, `autoLoad: false` no-fetch, key change refetch; `useFileHistory` `onSuccess`/`onError` firing and the undefined-result-no-`onSuccess` rule; `useAsyncData` `onSuccess`/`onError` fire only for the committed generation and `onError` is skipped when `mapError` returns null; `useMounted` stays `true` across StrictMode remount and flips on unmount.
- `npx vitest run --config config/vitest.config.ts useSkillsHub useSkillEditor useAgentDefinitions useAgentOrgs useGitWorktrees useBrowserStatusBar useWorkspaceMemoryData CreatePlanCard NewItemInput MobileRemoteSettingsSection` (other `useMounted`/`useAsyncData` consumers with tests) — 3 files, 11 tests passed.
- `pnpm run check:test-placement` — "Test placement is consistent across 533 directories." (EXIT 0).
- `nice -n 10 npx tsgo --noEmit --pretty false` — EXIT 0.

Not run: the full vitest suite, cargo, e2e, and no manual run of the Tauri app.

Commit was made with git hooks bypassed (worktree has no husky shim), so there is no `Pre-commit hook ran.` trailer; the equivalent prettier/oxlint/eslint/tsgo/vitest checks were run manually and are listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
