### PR TITLE
fix(agent-org): recover interrupted task execution safely

### DIFF
--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/mod.rs
@@ -393,6 +393,33 @@ pub struct AgentOrgRunRecord {
     pub archive_receipt_id: Option<String>,
 }
 
+/// One-shot persisted work produced before AgentAppState is installed.
+/// Only the exact receipt IDs in this plan may ring a post-init doorbell.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentOrgStartupRecoveryPlan {
+    pub inspected_runs: usize,
+    pub inspected_terminal_members: usize,
+    pub skipped_without_unique_execution: usize,
+    pub recovered_tasks: Vec<crate::coordination::agent_org_tasks::TaskExecutionRecovery>,
+    pub failures: Vec<AgentOrgStartupRecoveryFailure>,
+}
+
+impl AgentOrgStartupRecoveryPlan {
+    pub fn recovered_task_count(&self) -> usize {
+        self.recovered_tasks.len()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentOrgStartupRecoveryFailure {
+    pub org_run_id: String,
+    pub session_id: String,
+    pub member_id: Option<String>,
+    pub error: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct CreateAgentOrgRunParams {
     pub org_id: String,

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store/lifecycle.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store/lifecycle.rs
@@ -7,7 +7,8 @@ use database::db::{get_connection, with_sessions_writer};
 use super::super::helpers::{insert_run, validate_entry_mode, validate_status};
 use super::super::progress::ensure_progress_in_conn;
 use super::super::{
-    AgentOrgRunRecord, AgentOrgRunStatus, CreateAgentOrgRunParams, COORDINATOR_MEMBER_ID,
+    AgentOrgRunRecord, AgentOrgRunStatus, AgentOrgStartupRecoveryFailure,
+    AgentOrgStartupRecoveryPlan, CreateAgentOrgRunParams, COORDINATOR_MEMBER_ID,
 };
 use super::AgentOrgRunStore;
 
@@ -64,42 +65,118 @@ impl AgentOrgRunStore {
     /// Member session terminal. Recovery proceeds only when one persisted
     /// running TaskExecution identifies the exact Task; a missing or ambiguous
     /// binding fails closed instead of mutating every Task owned by the Member.
-    pub fn requeue_abandoned_member_tasks_on_startup() -> Result<usize, String> {
-        let mut changed = 0usize;
-        for run in Self::list_running_runs(100)? {
-            for worker in Self::list_descendant_worker_sessions(&run.id)? {
-                if !worker.status.is_terminal() || worker.status == SessionStatus::Archived {
-                    continue;
-                }
-                let Some(member_id) = worker.member_id.as_deref() else {
-                    continue;
+    pub fn requeue_abandoned_member_tasks_on_startup() -> Result<AgentOrgStartupRecoveryPlan, String>
+    {
+        const PAGE_SIZE: usize = 100;
+
+        let mut plan = AgentOrgStartupRecoveryPlan::default();
+        let mut after_id: Option<String> = None;
+        loop {
+            let runs = Self::list_running_runs_after_id(after_id.as_deref(), PAGE_SIZE)?;
+            if runs.is_empty() {
+                break;
+            }
+            after_id = runs.last().map(|run| run.id.clone());
+            plan.inspected_runs = plan.inspected_runs.saturating_add(runs.len());
+
+            for run in runs {
+                let context = match super::super::helpers::context_for_run_record(&run) {
+                    Ok(context) => context,
+                    Err(error) => {
+                        plan.failures.push(AgentOrgStartupRecoveryFailure {
+                            org_run_id: run.id,
+                            session_id: String::new(),
+                            member_id: None,
+                            error,
+                        });
+                        continue;
+                    }
                 };
-                let failed_turn_intent_id = {
-                    let conn = get_connection().map_err(|error| error.to_string())?;
-                    crate::coordination::agent_org_turn_contexts::unique_running_task_execution_turn_for_recovery(
+                let workers = match Self::list_descendant_worker_sessions(&run.id) {
+                    Ok(workers) => workers,
+                    Err(error) => {
+                        plan.failures.push(AgentOrgStartupRecoveryFailure {
+                            org_run_id: run.id,
+                            session_id: String::new(),
+                            member_id: None,
+                            error,
+                        });
+                        continue;
+                    }
+                };
+                for worker in workers {
+                    if !worker.status.is_terminal() || worker.status == SessionStatus::Archived {
+                        continue;
+                    }
+                    plan.inspected_terminal_members =
+                        plan.inspected_terminal_members.saturating_add(1);
+                    let Some(member_id) = worker.member_id.as_deref() else {
+                        continue;
+                    };
+                    let failed_turn_lookup = {
+                        let conn = get_connection().map_err(|error| error.to_string())?;
+                        crate::coordination::agent_org_turn_contexts::unique_running_task_execution_turn_for_recovery(
                         &conn,
                         &run.id,
                         &worker.session_id,
                         member_id,
-                    )?
-                };
-                let Some(failed_turn_intent_id) = failed_turn_intent_id else {
-                    tracing::warn!(
-                        run_id = %run.id,
-                        session_id = %worker.session_id,
-                        member_id,
-                        "abandoned Agent Org Member has no unique persisted TaskExecution; refusing Task recovery"
-                    );
-                    continue;
-                };
-                changed += AgentOrgTaskStore::recover_task_execution_failure(
-                    &worker.session_id,
-                    &failed_turn_intent_id,
-                )?
-                .len();
+                    )
+                    };
+                    let failed_turn_intent_id = match failed_turn_lookup {
+                        Ok(Some(turn_intent_id)) => turn_intent_id,
+                        Ok(None) => {
+                            plan.skipped_without_unique_execution =
+                                plan.skipped_without_unique_execution.saturating_add(1);
+                            tracing::warn!(
+                                run_id = %run.id,
+                                session_id = %worker.session_id,
+                                member_id,
+                                "abandoned Agent Org Member has no unique persisted TaskExecution; refusing Task recovery"
+                            );
+                            continue;
+                        }
+                        Err(error) => {
+                            plan.failures.push(AgentOrgStartupRecoveryFailure {
+                                org_run_id: run.id.clone(),
+                                session_id: worker.session_id.clone(),
+                                member_id: Some(member_id.to_string()),
+                                error,
+                            });
+                            continue;
+                        }
+                    };
+                    let Some(member) = context
+                        .members
+                        .iter()
+                        .find(|candidate| candidate.member_id == member_id)
+                    else {
+                        plan.failures.push(AgentOrgStartupRecoveryFailure {
+                        org_run_id: run.id.clone(),
+                        session_id: worker.session_id.clone(),
+                        member_id: Some(member_id.to_string()),
+                        error: "startup recovery member is absent from the immutable launch snapshot"
+                            .to_string(),
+                    });
+                        continue;
+                    };
+                    match AgentOrgTaskStore::recover_task_execution_failure_on_startup(
+                        &worker.session_id,
+                        &failed_turn_intent_id,
+                        &run.coordinator_agent_id,
+                        &member.name,
+                    ) {
+                        Ok(recovered) => plan.recovered_tasks.extend(recovered),
+                        Err(error) => plan.failures.push(AgentOrgStartupRecoveryFailure {
+                            org_run_id: run.id.clone(),
+                            session_id: worker.session_id.clone(),
+                            member_id: Some(member_id.to_string()),
+                            error,
+                        }),
+                    }
+                }
             }
         }
-        Ok(changed)
+        Ok(plan)
     }
 
     /// Promote the canonical Root Coordinator's current Idle Turn only when

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store/queries.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store/queries.rs
@@ -114,6 +114,56 @@ impl AgentOrgRunStore {
         Self::list_runs_by_status(AgentOrgRunStatus::Running, limit)
     }
 
+    /// Stable keyset page used by one-shot startup recovery. Run mutations may
+    /// update timestamps while the scan is in progress, so the immutable run
+    /// id—not `updated_at`—owns the cursor.
+    pub fn list_running_runs_after_id(
+        after_id: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<AgentOrgRunRecord>, String> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let bounded_limit = i64::try_from(limit)
+            .map_err(|_| format!("Agent Org run list limit is too large: {limit}"))?;
+        let conn = get_connection().map_err(|err| err.to_string())?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id,
+                        org_id,
+                        coordinator_agent_id,
+                        root_session_id,
+                        org_snapshot_json,
+                        entry_mode,
+                        status,
+                        activation_generation,
+                        has_initial_work,
+                        work_item_id,
+                        project_slug,
+                        routine_fire_id,
+                        summary,
+                        last_error,
+                        failure_json,
+                        last_activity_outcome,
+                        created_at,
+                        updated_at,
+                        idled_at,
+                        archived_at,
+                        archive_receipt_id
+                 FROM agent_org_runtime_runs
+                 WHERE root_session_id IS NOT NULL
+                   AND status='running'
+                   AND (?1 IS NULL OR id>?1)
+                 ORDER BY id ASC
+                 LIMIT ?2",
+            )
+            .map_err(|err| err.to_string())?;
+        let rows = stmt
+            .query_map(params![after_id, bounded_limit], row_to_run)
+            .map_err(|err| err.to_string())?;
+        rows.map(|row| row.map_err(|err| err.to_string())).collect()
+    }
+
     pub(super) fn list_runs_by_status(
         status: AgentOrgRunStatus,
         limit: usize,

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/mod.rs
@@ -24,6 +24,31 @@ pub use actor::{TaskGraphWriterAdmin, TaskOwnerExecution, UserTaskHandoffAdmin};
 pub use graph::TaskGraphIndex;
 pub use store::AgentOrgTaskStore;
 
+/// Exact durable output of one failed TaskExecution recovery.
+///
+/// `receipt_id` is present only for startup recovery, where the Task mutation
+/// and the Coordinator-facing recovery doorbell are committed atomically.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskExecutionRecovery {
+    pub task: Task,
+    pub previous_owner_member_id: String,
+    pub failed_session_id: String,
+    pub failed_turn_intent_id: String,
+    pub receipt_id: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskAssignmentDoorbellRepair {
+    pub org_run_id: String,
+    pub task_id: String,
+    pub owner_member_id: String,
+    pub assignment_event_id: String,
+    pub owner_inbox_id: i64,
+    pub coordinator_receipt_id: String,
+}
+
 #[cfg(test)]
 mod task_store_contract_tests;
 #[cfg(test)]

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store/mod.rs
@@ -29,6 +29,7 @@ mod dependencies;
 mod fsm;
 mod plan_completion;
 mod read;
+mod repair;
 mod requeue;
 mod update;
 mod validation;

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store/repair.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store/repair.rs
@@ -1,0 +1,222 @@
+//! Narrow repair for an already-authorized Task assignment whose original
+//! runtime doorbell was lost.
+//!
+//! This path never chooses an owner and never creates or mutates a Task. It
+//! requires a ready, assigned Pending Task, no active/queued TaskExecution,
+//! and no unread TaskAssigned envelope. One durable marker per latest Task
+//! assignment event makes the replacement envelope idempotent.
+
+use std::collections::HashMap;
+
+use database::db::{get_connection, with_sessions_writer};
+use rusqlite::{params, OptionalExtension};
+
+use crate::coordination::agent_inbox::SYSTEM_SENDER_ID;
+
+use super::super::helpers::list_tasks_with_conn;
+use super::super::TaskAssignmentDoorbellRepair;
+use super::AgentOrgTaskStore;
+
+const REPAIR_ACTION_KIND: &str = "task_assignment_doorbell_repair_event";
+
+#[derive(Debug)]
+struct RepairCandidate {
+    org_run_id: String,
+    task_id: String,
+    owner_member_id: String,
+    assignment_event_id: String,
+    owner_agent_id: String,
+}
+
+impl AgentOrgTaskStore {
+    pub(crate) fn repair_lost_assignment_doorbells(
+        limit: usize,
+    ) -> Result<Vec<TaskAssignmentDoorbellRepair>, String> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let limit = i64::try_from(limit.min(100))
+            .map_err(|_| "assignment repair limit is too large".to_string())?;
+        with_sessions_writer(|| {
+            let mut conn = get_connection().map_err(|error| error.to_string())?;
+            let tx = conn
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .map_err(|error| error.to_string())?;
+            let candidates = {
+                let mut statement = tx
+                    .prepare(
+                        "SELECT task.org_run_id,task.id,task.owner,
+                                latest.id,materialization.agent_id
+                         FROM agent_org_runtime_tasks task
+                         JOIN agent_org_runtime_runs run
+                           ON run.id=task.org_run_id AND run.status='running'
+                         JOIN agent_org_runtime_task_events latest
+                           ON latest.rowid=(
+                               SELECT MAX(event.rowid)
+                               FROM agent_org_runtime_task_events event
+                               WHERE event.org_run_id=task.org_run_id
+                                 AND event.task_id=task.id
+                           )
+                         JOIN agent_org_runtime_member_materializations materialization
+                           ON materialization.rowid=(
+                               SELECT MAX(candidate.rowid)
+                               FROM agent_org_runtime_member_materializations candidate
+                               WHERE candidate.org_run_id=task.org_run_id
+                                 AND candidate.member_id=task.owner
+                                 AND candidate.status='succeeded'
+                           )
+                         WHERE task.status='pending' AND task.owner IS NOT NULL
+                           AND NOT EXISTS (
+                               SELECT 1 FROM json_each(task.blocked_by_json) dependency
+                               LEFT JOIN agent_org_runtime_tasks blocker
+                                 ON blocker.org_run_id=task.org_run_id
+                                AND blocker.id=dependency.value
+                               WHERE blocker.id IS NULL OR blocker.status<>'completed'
+                           )
+                           AND NOT EXISTS (
+                               SELECT 1 FROM agent_org_task_execution_leases lease
+                               WHERE lease.org_run_id=task.org_run_id
+                                 AND lease.task_id=task.id AND lease.state='active'
+                           )
+                           AND NOT EXISTS (
+                               SELECT 1
+                               FROM agent_org_runtime_turn_contexts context
+                               JOIN session_turn_intents intent
+                                 ON intent.session_id=context.session_id
+                                AND intent.turn_intent_id=context.turn_intent_id
+                               WHERE context.org_run_id=task.org_run_id
+                                 AND context.task_id=task.id
+                                 AND context.turn_kind='task_execution'
+                                 AND intent.status IN ('optimistic','queued','running')
+                           )
+                           AND NOT EXISTS (
+                               SELECT 1 FROM agent_org_runtime_inbox inbox
+                               WHERE inbox.org_run_id=task.org_run_id
+                                 AND inbox.recipient_member_id=task.owner
+                                 AND inbox.payload_kind='task_assigned'
+                                 AND inbox.read_at IS NULL
+                                 AND json_valid(inbox.payload_json)
+                                 AND json_extract(inbox.payload_json,'$.task_id')=task.id
+                                 AND NOT EXISTS (
+                                     SELECT 1
+                                     FROM agent_org_runtime_inbox_delivery_resolutions resolution
+                                     WHERE resolution.inbox_id=inbox.id
+                                 )
+                           )
+                           AND NOT EXISTS (
+                               SELECT 1 FROM agent_org_runtime_recovery_attempts repaired
+                               WHERE repaired.org_run_id=task.org_run_id
+                                 AND repaired.action_kind=?1
+                                 AND repaired.target_key=task.id
+                                 AND repaired.reason_fingerprint=latest.id
+                           )
+                         ORDER BY task.org_run_id,task.created_at,task.id
+                         LIMIT ?2",
+                    )
+                    .map_err(|error| error.to_string())?;
+                let rows = statement
+                    .query_map(params![REPAIR_ACTION_KIND, limit], |row| {
+                        Ok(RepairCandidate {
+                            org_run_id: row.get(0)?,
+                            task_id: row.get(1)?,
+                            owner_member_id: row.get(2)?,
+                            assignment_event_id: row.get(3)?,
+                            owner_agent_id: row.get(4)?,
+                        })
+                    })
+                    .map_err(|error| error.to_string())?;
+                rows.collect::<rusqlite::Result<Vec<_>>>()
+                    .map_err(|error| error.to_string())?
+            };
+
+            let mut boards = HashMap::new();
+            let mut repairs = Vec::with_capacity(candidates.len());
+            for candidate in candidates {
+                if !boards.contains_key(&candidate.org_run_id) {
+                    boards.insert(
+                        candidate.org_run_id.clone(),
+                        list_tasks_with_conn(&tx, &candidate.org_run_id)?,
+                    );
+                }
+                let board = boards
+                    .get(&candidate.org_run_id)
+                    .expect("board inserted for repair candidate");
+                let task = board
+                    .iter()
+                    .find(|task| task.id == candidate.task_id)
+                    .ok_or_else(|| {
+                        format!(
+                            "assignment repair Task disappeared: {}/{}",
+                            candidate.org_run_id, candidate.task_id
+                        )
+                    })?;
+                let owner_inbox_id = super::super::enqueue_task_assigned_to_with_tasks_in_tx(
+                    &tx,
+                    task,
+                    board,
+                    &candidate.owner_agent_id,
+                    &candidate.owner_member_id,
+                    SYSTEM_SENDER_ID,
+                    None,
+                    "System recovery",
+                    None,
+                )?;
+                let coordinator_receipt_id = tx
+                    .query_row(
+                        "SELECT receipt.receipt_id
+                         FROM agent_org_runtime_inbox observer
+                         JOIN agent_org_runtime_formal_trigger_receipts receipt
+                           ON receipt.inbox_id=observer.id
+                         WHERE observer.causation_inbox_id=?1
+                           AND observer.org_run_id=?2
+                           AND receipt.source_kind='task_assignment'
+                           AND receipt.task_id=?3
+                           AND receipt.owner_member_id=?4
+                         LIMIT 1",
+                        params![
+                            owner_inbox_id,
+                            &candidate.org_run_id,
+                            &candidate.task_id,
+                            &candidate.owner_member_id,
+                        ],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()
+                    .map_err(|error| error.to_string())?
+                    .ok_or_else(|| {
+                        "assignment repair committed no Coordinator receipt".to_string()
+                    })?;
+                let now = chrono::Utc::now().to_rfc3339();
+                tx.execute(
+                    "INSERT INTO agent_org_runtime_recovery_attempts(
+                         org_run_id,action_kind,target_key,reason_fingerprint,
+                         attempts,next_allowed_at,updated_at,reservation_token
+                     ) VALUES (?1,?2,?3,?4,1,?5,?5,NULL)
+                     ON CONFLICT(org_run_id,action_kind,target_key) DO UPDATE SET
+                         reason_fingerprint=excluded.reason_fingerprint,
+                         attempts=1,next_allowed_at=excluded.next_allowed_at,
+                         updated_at=excluded.updated_at,reservation_token=NULL
+                     WHERE reason_fingerprint<>excluded.reason_fingerprint",
+                    params![
+                        &candidate.org_run_id,
+                        REPAIR_ACTION_KIND,
+                        &candidate.task_id,
+                        &candidate.assignment_event_id,
+                        &now,
+                    ],
+                )
+                .map_err(|error| error.to_string())?;
+                repairs.push(TaskAssignmentDoorbellRepair {
+                    org_run_id: candidate.org_run_id,
+                    task_id: candidate.task_id,
+                    owner_member_id: candidate.owner_member_id,
+                    assignment_event_id: candidate.assignment_event_id,
+                    owner_inbox_id,
+                    coordinator_receipt_id,
+                });
+            }
+            tx.commit().map_err(|error| error.to_string())?;
+            Ok(repairs)
+        })
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store/requeue.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store/requeue.rs
@@ -10,8 +10,8 @@ use super::super::helpers::{
 };
 use super::super::SystemTaskOperation;
 use super::super::{
-    SystemArchiveOrRecovery, Task, TaskAnnotationKind, TaskStatus, TaskTerminalReason,
-    TASK_EVENT_RELEASED,
+    SystemArchiveOrRecovery, Task, TaskAnnotationKind, TaskExecutionRecovery, TaskStatus,
+    TaskTerminalReason, TASK_EVENT_RELEASED,
 };
 use super::validation::{ensure_run_allows_task_mutation, validate_task_model_invariants};
 use super::AgentOrgTaskStore;
@@ -21,35 +21,98 @@ impl AgentOrgTaskStore {
         session_id: &str,
         failed_turn_intent_id: &str,
     ) -> Result<Vec<Task>, String> {
-        let updated = with_sessions_writer(|| -> Result<Vec<Task>, String> {
-            let mut conn = get_connection().map_err(|error| error.to_string())?;
-            let tx = conn
-                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-                .map_err(|error| error.to_string())?;
-            let context = crate::coordination::agent_org_turn_contexts::require_task_failure_recovery_context_with_connection(
+        recover_task_execution_failure_inner(session_id, failed_turn_intent_id, None).map(
+            |recoveries| {
+                recoveries
+                    .into_iter()
+                    .map(|recovery| recovery.task)
+                    .collect()
+            },
+        )
+    }
+
+    pub(crate) fn recover_task_execution_failure_on_startup(
+        session_id: &str,
+        failed_turn_intent_id: &str,
+        coordinator_agent_id: &str,
+        member_name: &str,
+    ) -> Result<Vec<TaskExecutionRecovery>, String> {
+        recover_task_execution_failure_inner(
+            session_id,
+            failed_turn_intent_id,
+            Some(StartupRecoveryNotification {
+                coordinator_agent_id,
+                member_name,
+            }),
+        )
+    }
+
+    pub(crate) fn release_owner_for_shutdown(
+        actor: SystemArchiveOrRecovery,
+        org_run_id: &str,
+        owner_member_id: &str,
+    ) -> Result<Vec<Task>, String> {
+        release_owned_tasks_for_shutdown(actor, org_run_id, owner_member_id)
+    }
+
+    #[cfg(test)]
+    pub fn dispose_open_tasks_for_shutdown(
+        org_run_id: &str,
+        owner_member_id: &str,
+    ) -> Result<Vec<Task>, String> {
+        let reservation = crate::coordination::agent_org_watchdog::reserve_task_shutdown_release(
+            org_run_id,
+            owner_member_id,
+        )?;
+        let actor = SystemArchiveOrRecovery::new(
+            reservation.token,
+            reservation.generation,
+            SystemTaskOperation::ShutdownRelease,
+        )?;
+        Self::release_owner_for_shutdown(actor, org_run_id, owner_member_id)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StartupRecoveryNotification<'a> {
+    coordinator_agent_id: &'a str,
+    member_name: &'a str,
+}
+
+fn recover_task_execution_failure_inner(
+    session_id: &str,
+    failed_turn_intent_id: &str,
+    startup_notification: Option<StartupRecoveryNotification<'_>>,
+) -> Result<Vec<TaskExecutionRecovery>, String> {
+    let updated = with_sessions_writer(|| -> Result<Vec<TaskExecutionRecovery>, String> {
+        let mut conn = get_connection().map_err(|error| error.to_string())?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|error| error.to_string())?;
+        let context = crate::coordination::agent_org_turn_contexts::require_task_failure_recovery_context_with_connection(
                 &tx,
                 session_id,
                 failed_turn_intent_id,
             )?;
-            ensure_run_allows_task_mutation(&tx, &context.org_run_id)?;
-            let task_id = context
-                .task_id
-                .as_deref()
-                .ok_or_else(|| "task_failure_recovery_context_missing_task".to_string())?;
-            let owner_member_id = context
-                .owner_member_id
-                .as_deref()
-                .ok_or_else(|| "task_failure_recovery_context_missing_owner".to_string())?;
-            let activation_generation = context
-                .activation_generation
-                .ok_or_else(|| "task_failure_recovery_context_missing_generation".to_string())?;
-            let fingerprint =
-                crate::coordination::agent_org_watchdog::task_failure_recovery_fingerprint(
-                    task_id,
-                    failed_turn_intent_id,
-                    activation_generation,
-                );
-            if crate::coordination::agent_org_watchdog::task_failure_recovery_already_processed_with_connection(
+        ensure_run_allows_task_mutation(&tx, &context.org_run_id)?;
+        let task_id = context
+            .task_id
+            .as_deref()
+            .ok_or_else(|| "task_failure_recovery_context_missing_task".to_string())?;
+        let owner_member_id = context
+            .owner_member_id
+            .as_deref()
+            .ok_or_else(|| "task_failure_recovery_context_missing_owner".to_string())?;
+        let activation_generation = context
+            .activation_generation
+            .ok_or_else(|| "task_failure_recovery_context_missing_generation".to_string())?;
+        let fingerprint =
+            crate::coordination::agent_org_watchdog::task_failure_recovery_fingerprint(
+                task_id,
+                failed_turn_intent_id,
+                activation_generation,
+            );
+        if crate::coordination::agent_org_watchdog::task_failure_recovery_already_processed_with_connection(
                 &tx,
                 &context.org_run_id,
                 &fingerprint,
@@ -57,16 +120,16 @@ impl AgentOrgTaskStore {
                 return Ok(Vec::new());
             }
 
-            // Revalidate after the idempotency probe so a replay of an already
-            // committed failure is a no-op, while an unprocessed late callback
-            // still fails closed on Task/Owner/run/snapshot/generation drift.
-            crate::coordination::agent_org_turn_contexts::revalidate_context_with_connection(
-                &tx,
-                session_id,
-                failed_turn_intent_id,
-            )?;
-            let sql = format!(
-                "SELECT {SELECT_COLUMNS} FROM agent_org_runtime_tasks task
+        // Revalidate after the idempotency probe so a replay of an already
+        // committed failure is a no-op, while an unprocessed late callback
+        // still fails closed on Task/Owner/run/snapshot/generation drift.
+        crate::coordination::agent_org_turn_contexts::revalidate_context_with_connection(
+            &tx,
+            session_id,
+            failed_turn_intent_id,
+        )?;
+        let sql = format!(
+            "SELECT {SELECT_COLUMNS} FROM agent_org_runtime_tasks task
                  WHERE task.org_run_id=?1 AND task.id=?2 AND task.owner=?3
                    AND task.status='in_progress'
                    AND NOT EXISTS (
@@ -96,106 +159,176 @@ impl AgentOrgTaskStore {
                                AND latest.task_id=task.id
                          )
                    )"
-            );
-            let previous = tx
-                .query_row(
-                    &sql,
-                    params![
-                        &context.org_run_id,
-                        task_id,
-                        owner_member_id,
-                        failed_turn_intent_id,
-                        session_id,
-                    ],
-                    row_to_task,
+        );
+        let previous = tx
+            .query_row(
+                &sql,
+                params![
+                    &context.org_run_id,
+                    task_id,
+                    owner_member_id,
+                    failed_turn_intent_id,
+                    session_id,
+                ],
+                row_to_task,
+            )
+            .optional()
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| {
+                format!(
+                    "task_failure_recovery_turn_or_target_changed: {}/{}",
+                    context.org_run_id, task_id
                 )
-                .optional()
-                .map_err(|error| error.to_string())?
-                .ok_or_else(|| {
-                    format!(
-                        "task_failure_recovery_turn_or_target_changed: {}/{}",
-                        context.org_run_id, task_id
-                    )
-                })?;
-            let reservation = crate::coordination::agent_org_watchdog::reserve_task_failure_recovery_with_connection(
+            })?;
+        let reservation =
+            crate::coordination::agent_org_watchdog::reserve_task_failure_recovery_with_connection(
                 &tx,
                 &context.org_run_id,
                 task_id,
                 &fingerprint,
                 activation_generation,
             )?;
-            let operation = if reservation.exhausted {
-                SystemTaskOperation::RecoveryFail
-            } else {
-                SystemTaskOperation::RecoveryRequeue
-            };
-            let actor =
-                SystemArchiveOrRecovery::new(reservation.token, reservation.generation, operation)?;
-            let mut audit = actor.validate(&tx, &context.org_run_id, task_id)?;
-            audit.turn_intent_id = Some(failed_turn_intent_id.to_string());
-            let updated = recover_task_in_tx(
-                &tx,
-                previous,
-                owner_member_id,
-                RecoveryMode::Failure {
-                    exhausted: reservation.exhausted,
-                },
-                &audit,
-            )?;
-            release_reservation_in_tx(&tx, &context.org_run_id, &actor, task_id)?;
-            crate::coordination::agent_org_finality::record_task_mutation_in_tx(
-                &tx,
-                &context.org_run_id,
-                &audit,
-            )?;
-            crate::foundation::session_bridge::update_turn_intent_status_with_connection(
-                &tx,
-                session_id,
-                failed_turn_intent_id,
-                crate::foundation::session_bridge::TurnIntentBridgeStatus::Failed,
-            )?;
-            crate::coordination::agent_org_finality::release_turn_lease_in_tx(
-                &tx,
-                session_id,
-                failed_turn_intent_id,
-                "released",
-                "task_execution_recovered",
-            )?;
-            tx.commit().map_err(|error| error.to_string())?;
-            Ok(vec![updated])
-        })?;
-        if let Some(task) = updated.first() {
-            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(
-                &task.org_run_id,
-            );
-        }
-        Ok(updated)
-    }
-
-    pub(crate) fn release_owner_for_shutdown(
-        actor: SystemArchiveOrRecovery,
-        org_run_id: &str,
-        owner_member_id: &str,
-    ) -> Result<Vec<Task>, String> {
-        release_owned_tasks_for_shutdown(actor, org_run_id, owner_member_id)
-    }
-
-    #[cfg(test)]
-    pub fn dispose_open_tasks_for_shutdown(
-        org_run_id: &str,
-        owner_member_id: &str,
-    ) -> Result<Vec<Task>, String> {
-        let reservation = crate::coordination::agent_org_watchdog::reserve_task_shutdown_release(
-            org_run_id,
+        let operation = if reservation.exhausted {
+            SystemTaskOperation::RecoveryFail
+        } else {
+            SystemTaskOperation::RecoveryRequeue
+        };
+        let actor =
+            SystemArchiveOrRecovery::new(reservation.token, reservation.generation, operation)?;
+        let mut audit = actor.validate(&tx, &context.org_run_id, task_id)?;
+        audit.turn_intent_id = Some(failed_turn_intent_id.to_string());
+        let updated = recover_task_in_tx(
+            &tx,
+            previous,
             owner_member_id,
+            RecoveryMode::Failure {
+                exhausted: reservation.exhausted,
+            },
+            &audit,
         )?;
-        let actor = SystemArchiveOrRecovery::new(
-            reservation.token,
-            reservation.generation,
-            SystemTaskOperation::ShutdownRelease,
+        release_reservation_in_tx(&tx, &context.org_run_id, &actor, task_id)?;
+        crate::coordination::agent_org_finality::record_task_mutation_in_tx(
+            &tx,
+            &context.org_run_id,
+            &audit,
         )?;
-        Self::release_owner_for_shutdown(actor, org_run_id, owner_member_id)
+        crate::foundation::session_bridge::update_turn_intent_status_with_connection(
+            &tx,
+            session_id,
+            failed_turn_intent_id,
+            crate::foundation::session_bridge::TurnIntentBridgeStatus::Failed,
+        )?;
+        crate::coordination::agent_org_finality::release_turn_lease_in_tx(
+            &tx,
+            session_id,
+            failed_turn_intent_id,
+            "released",
+            "task_execution_recovered",
+        )?;
+        let receipt_id = if let Some(notification) = startup_notification {
+            Some(persist_startup_recovery_notification_in_tx(
+                &tx,
+                &updated,
+                owner_member_id,
+                session_id,
+                failed_turn_intent_id,
+                notification,
+            )?)
+        } else {
+            None
+        };
+        tx.commit().map_err(|error| error.to_string())?;
+        Ok(vec![TaskExecutionRecovery {
+            task: updated,
+            previous_owner_member_id: owner_member_id.to_string(),
+            failed_session_id: session_id.to_string(),
+            failed_turn_intent_id: failed_turn_intent_id.to_string(),
+            receipt_id,
+        }])
+    })?;
+    if let Some(recovery) = updated.first() {
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(
+            &recovery.task.org_run_id,
+        );
     }
+    Ok(updated)
+}
+
+fn persist_startup_recovery_notification_in_tx(
+    tx: &rusqlite::Transaction<'_>,
+    task: &Task,
+    previous_owner_member_id: &str,
+    failed_session_id: &str,
+    failed_turn_intent_id: &str,
+    notification: StartupRecoveryNotification<'_>,
+) -> Result<String, String> {
+    use crate::coordination::agent_inbox::{
+        AgentInboxStore, AgentMessage, InsertInboxParams, MemberIdleReason, SYSTEM_SENDER_ID,
+    };
+
+    let eligible_member_ids = super::super::eligible_member_ids(task);
+    let eligible = if eligible_member_ids.is_empty() {
+        "none".to_string()
+    } else {
+        let truncated = eligible_member_ids.len() > 16;
+        let mut value = eligible_member_ids
+            .iter()
+            .take(16)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        if truncated {
+            value.push_str(", …");
+        }
+        value
+    };
+    let failure_reason = crate::utils::safe_truncate_chars_to_string(
+        &format!(
+        "The app stopped while TaskExecution {failed_turn_intent_id} was running in session {failed_session_id}. Task {} is now {} and has no automatic replacement owner. Previous owner: {previous_owner_member_id}. Eligible replacement member IDs: [{eligible}]. Inspect any external side effects before explicitly assigning a new owner; startup recovery will not replay the interrupted execution.",
+        task.id,
+        task.status.as_wire(),
+        ),
+        crate::coordination::agent_org_payload_limits::MEMBER_FAILURE_REASON_MAX_CHARS,
+    );
+    let record = AgentInboxStore::insert_in_tx_without_formal_trigger(
+        tx,
+        InsertInboxParams {
+            recipient_agent_id: notification.coordinator_agent_id.to_string(),
+            recipient_member_id: Some(
+                crate::coordination::agent_org_runs::COORDINATOR_MEMBER_ID.to_string(),
+            ),
+            sender_agent_id: SYSTEM_SENDER_ID.to_string(),
+            sender_member_id: None,
+            org_run_id: Some(task.org_run_id.clone()),
+            message: AgentMessage::MemberIdle {
+                member_id: previous_owner_member_id.to_string(),
+                member_name: notification.member_name.to_string(),
+                reason: MemberIdleReason::Failed,
+                current_mode: None,
+                summary: Some(
+                    "A TaskExecution was interrupted by app shutdown; review and explicitly reassign its Task."
+                        .to_string(),
+                ),
+                failure_reason: Some(failure_reason),
+                unfinished_task_ids: vec![task.id.clone()],
+            },
+        },
+    )?;
+    let receipt = crate::coordination::agent_org_formal_triggers::record_inbox_trigger_in_tx(
+        tx,
+        &task.org_run_id,
+        record.id,
+        crate::coordination::agent_org_formal_triggers::InboxFormalTriggerSource {
+            source_kind: "task_execution_recovery_required",
+            task_id: Some(&task.id),
+            owner_member_id: Some(previous_owner_member_id),
+            source_turn_intent_id: Some(failed_turn_intent_id),
+            task_output_digest: None,
+            plan_revision_id: None,
+            suppress_self_wake: false,
+        },
+    )?;
+    Ok(receipt.receipt_id)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/task_store_contract_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/task_store_contract_tests.rs
@@ -3184,6 +3184,98 @@ fn an_unprocessed_old_turn_cannot_recover_a_new_execution_of_the_same_task() {
 }
 
 #[test]
+fn crash_recovery_reassignment_uses_a_new_execution_epoch_for_same_or_new_member() {
+    let _fixture = fixture();
+    let conn = get_connection().unwrap();
+
+    for (task_id, replacement_member, replacement_session) in [
+        ("retry-same-owner", MEMBER_A, MEMBER_A_SESSION),
+        ("retry-new-owner", MEMBER_B, MEMBER_B_SESSION),
+    ] {
+        create(pending(task_id, None, vec![]));
+        assign_pending(task_id, MEMBER_A);
+        let old_turn = format!("turn-{task_id}-old");
+        bind_and_start(&conn, MEMBER_A, MEMBER_A_SESSION, task_id, &old_turn, 1);
+        let old_context =
+            crate::coordination::agent_org_turn_contexts::require_context_with_connection(
+                &conn,
+                MEMBER_A_SESSION,
+                &old_turn,
+            )
+            .unwrap();
+        crate::coordination::agent_org_finality::claim_task_execution_in_tx(
+            &conn,
+            &old_context,
+            &crate::coordination::agent_org_finality::TaskExecutionAuthoritySource::receipt(
+                crate::coordination::agent_org_finality::TaskExecutionAuthoritySourceKind::Assignment,
+                format!("authority-{task_id}-old"),
+            ),
+        )
+        .expect("old execution owns epoch one");
+        assert_eq!(fail_turn(MEMBER_A_SESSION, &old_turn).len(), 1);
+
+        assign_pending(task_id, replacement_member);
+        let new_turn = format!("turn-{task_id}-new");
+        bind_and_start(
+            &conn,
+            replacement_member,
+            replacement_session,
+            task_id,
+            &new_turn,
+            1,
+        );
+        let new_context =
+            crate::coordination::agent_org_turn_contexts::require_context_with_connection(
+                &conn,
+                replacement_session,
+                &new_turn,
+            )
+            .unwrap();
+        crate::coordination::agent_org_finality::claim_task_execution_in_tx(
+            &conn,
+            &new_context,
+            &crate::coordination::agent_org_finality::TaskExecutionAuthoritySource::receipt(
+                crate::coordination::agent_org_finality::TaskExecutionAuthoritySourceKind::Assignment,
+                format!("authority-{task_id}-new"),
+            ),
+        )
+        .expect("replacement execution owns a fresh epoch");
+
+        let leases = conn
+            .prepare(
+                "SELECT execution_epoch,owner_member_id,state,prior_lease_id IS NOT NULL
+                 FROM agent_org_task_execution_leases
+                 WHERE org_run_id=?1 AND task_id=?2
+                 ORDER BY execution_epoch",
+            )
+            .unwrap()
+            .query_map(params![RUN_ID, task_id], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, bool>(3)?,
+                ))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            leases,
+            vec![
+                (1, MEMBER_A.to_string(), "released".to_string(), false),
+                (
+                    2,
+                    replacement_member.to_string(),
+                    "active".to_string(),
+                    true,
+                ),
+            ]
+        );
+    }
+}
+
+#[test]
 fn recovery_mutation_failure_rolls_back_budget_and_concurrent_replay_counts_once() {
     let _fixture = fixture();
     let conn = get_connection().unwrap();
@@ -3245,4 +3337,58 @@ fn recovery_mutation_failure_rolls_back_budget_and_concurrent_replay_counts_once
     assert_eq!(mutation_counts, vec![0, 1]);
     assert_eq!(recovery_attempts("concurrent"), 1);
     assert_eq!(recovery_event_count(), 1);
+}
+
+#[test]
+fn startup_recovery_receipt_failure_rolls_back_task_turn_and_inbox_together() {
+    let _fixture = fixture();
+    let conn = get_connection().unwrap();
+    create(pending("atomic-startup-recovery", Some(MEMBER_A), vec![]));
+    bind_and_start(
+        &conn,
+        MEMBER_A,
+        MEMBER_A_SESSION,
+        "atomic-startup-recovery",
+        "turn-atomic-startup-recovery",
+        1,
+    );
+    conn.execute_batch("DROP TABLE agent_org_runtime_formal_trigger_receipts")
+        .expect("inject failure at formal receipt boundary");
+
+    let error = AgentOrgTaskStore::recover_task_execution_failure_on_startup(
+        MEMBER_A_SESSION,
+        "turn-atomic-startup-recovery",
+        "agent-coordinator",
+        "A",
+    )
+    .expect_err("receipt failure must abort the whole recovery transaction");
+    assert!(
+        error.contains("agent_org_runtime_formal_trigger_receipts"),
+        "{error}"
+    );
+    let task = AgentOrgTaskStore::get(RUN_ID, "atomic-startup-recovery")
+        .unwrap()
+        .unwrap();
+    assert_eq!(task.status, TaskStatus::InProgress);
+    assert_eq!(task.owner.as_deref(), Some(MEMBER_A));
+    let turn_status: String = conn
+        .query_row(
+            "SELECT status FROM session_turn_intents
+             WHERE session_id=?1 AND turn_intent_id='turn-atomic-startup-recovery'",
+            [MEMBER_A_SESSION],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(turn_status, "running");
+    let recovery_inbox_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM agent_org_runtime_inbox
+             WHERE org_run_id=?1 AND payload_kind='member_idle'",
+            [RUN_ID],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(recovery_inbox_rows, 0);
+    assert_eq!(recovery_attempts("atomic-startup-recovery"), 0);
+    assert_eq!(recovery_event_count(), 0);
 }

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_watchdog/recover.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_watchdog/recover.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
 
 use serde::Serialize;
@@ -14,6 +14,8 @@ use super::{WATCHDOG_INTERVAL_SECS, WATCHDOG_MAX_RECEIPTS, WATCHDOG_TEAM_BUDGET}
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DoorbellRepairReport {
+    pub scanned_assignments: usize,
+    pub repaired_assignments: usize,
     pub scanned_receipts: usize,
     pub affected_runs: usize,
     pub repaired_receipts: usize,
@@ -59,32 +61,44 @@ pub fn repair_missing_doorbells(app_handle: AppHandle) -> Result<DoorbellRepairR
 pub(super) fn repair_missing_doorbells_with_hook(
     wake_hook: &dyn InboxWakeHook,
 ) -> Result<DoorbellRepairReport, String> {
+    let assignment_repairs =
+        crate::coordination::agent_org_tasks::AgentOrgTaskStore::repair_lost_assignment_doorbells(
+            WATCHDOG_MAX_RECEIPTS,
+        )?;
     let receipts = {
         let conn = database::db::get_connection().map_err(|error| error.to_string())?;
         list_missing_doorbells_with_connection(&conn, WATCHDOG_MAX_RECEIPTS)?
     };
-    if receipts.is_empty() {
+    if receipts.is_empty() && assignment_repairs.is_empty() {
         return Ok(DoorbellRepairReport::default());
     }
 
-    let mut by_run = BTreeMap::<String, Vec<_>>::new();
-    for receipt in receipts {
-        by_run
-            .entry(receipt.org_run_id.clone())
-            .or_default()
-            .push(receipt);
-    }
+    let mut by_run = BTreeMap::<String, BTreeSet<String>>::new();
     let mut report = DoorbellRepairReport {
-        scanned_receipts: by_run.values().map(Vec::len).sum(),
-        affected_runs: by_run.len(),
+        scanned_assignments: assignment_repairs.len(),
+        repaired_assignments: assignment_repairs.len(),
+        scanned_receipts: receipts.len(),
         ..DoorbellRepairReport::default()
     };
-    for (run_id, receipts) in by_run {
+    for repair in assignment_repairs {
+        wake_hook.wake_member(&repair.owner_member_id, &repair.org_run_id);
+        by_run
+            .entry(repair.org_run_id)
+            .or_default()
+            .insert(repair.coordinator_receipt_id);
+    }
+    for receipt in receipts {
+        by_run
+            .entry(receipt.org_run_id)
+            .or_default()
+            .insert(receipt.receipt_id);
+    }
+    report.affected_runs = by_run.len();
+    for (run_id, receipt_ids) in by_run {
         let deadline = Instant::now() + WATCHDOG_TEAM_BUDGET;
-        let receipt_ids = receipts
-            .iter()
+        let receipt_ids = receipt_ids
+            .into_iter()
             .take_while(|_| Instant::now() < deadline)
-            .map(|receipt| receipt.receipt_id.clone())
             .collect::<Vec<_>>();
         if receipt_ids.is_empty() {
             continue;

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_watchdog/tests/doorbell_repair_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_watchdog/tests/doorbell_repair_tests.rs
@@ -1,5 +1,6 @@
 use super::super::{WATCHDOG_INTERVAL_SECS, WATCHDOG_MAX_RECEIPTS, WATCHDOG_TEAM_BUDGET};
 use super::fixture::{RecordingWake, UnacceptedWake, WatchdogFixture};
+use crate::coordination::agent_org_runs::AgentOrgRunStatus;
 
 #[test]
 fn watchdog_budget_is_fixed_and_bounded() {
@@ -58,6 +59,95 @@ fn five_ticks_repair_only_the_original_receipt_once() {
         )
         .unwrap();
     assert_eq!(state, ("pending".into(), "delivered".into(), 0, 0));
+}
+
+#[test]
+fn ready_assigned_task_gets_one_replacement_doorbell_without_owner_or_task_mutation() {
+    let fixture = WatchdogFixture::new();
+    fixture.seed_lost_assignment_doorbell("assigned-with-lost-doorbell");
+    let wake = RecordingWake::default();
+
+    let first = super::super::recover::repair_missing_doorbells_with_hook(&wake).unwrap();
+    assert_eq!(first.repaired_assignments, 1);
+    assert_eq!(first.repaired_receipts, 1);
+    assert_eq!(
+        wake.calls(),
+        vec![
+            ("worker".to_string(), fixture.run_id.clone()),
+            ("coordinator".to_string(), fixture.run_id.clone()),
+        ]
+    );
+
+    for _ in 0..3 {
+        assert_eq!(
+            super::super::recover::repair_missing_doorbells_with_hook(&wake).unwrap(),
+            Default::default(),
+            "the same assignment event must never get another replacement envelope"
+        );
+    }
+    assert_eq!(wake.calls().len(), 2);
+
+    let conn = database::db::get_connection().unwrap();
+    let state: (String, String, i64, i64, i64) = conn
+        .query_row(
+            "SELECT task.status,task.owner,
+                    (SELECT COUNT(*) FROM agent_org_runtime_tasks
+                     WHERE org_run_id=task.org_run_id),
+                    (SELECT COUNT(*) FROM agent_org_runtime_inbox
+                     WHERE org_run_id=task.org_run_id
+                       AND recipient_member_id='worker'
+                       AND payload_kind='task_assigned'),
+                    (SELECT COUNT(*) FROM agent_org_runtime_recovery_attempts
+                     WHERE org_run_id=task.org_run_id
+                       AND action_kind='task_assignment_doorbell_repair_event')
+             FROM agent_org_runtime_tasks task
+             WHERE task.org_run_id=?1 AND task.id='assigned-with-lost-doorbell'",
+            [&fixture.run_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(state, ("pending".into(), "worker".into(), 1, 1, 1));
+}
+
+#[test]
+fn paused_idle_and_archived_teams_never_receive_assignment_repairs() {
+    let fixture = WatchdogFixture::new();
+    fixture.seed_lost_assignment_doorbell("inactive-team-assignment");
+    let wake = RecordingWake::default();
+
+    for status in [
+        AgentOrgRunStatus::Paused,
+        AgentOrgRunStatus::Idle,
+        AgentOrgRunStatus::Archived,
+    ] {
+        fixture.set_run_status(status);
+        assert_eq!(
+            super::super::recover::repair_missing_doorbells_with_hook(&wake).unwrap(),
+            Default::default(),
+            "inactive Team state must be a read-only watchdog no-op"
+        );
+    }
+
+    assert!(wake.calls().is_empty());
+    let conn = database::db::get_connection().unwrap();
+    let side_effects: (i64, i64) = conn
+        .query_row(
+            "SELECT
+                 (SELECT COUNT(*) FROM agent_org_runtime_inbox WHERE org_run_id=?1),
+                 (SELECT COUNT(*) FROM agent_org_runtime_recovery_attempts WHERE org_run_id=?1)",
+            [&fixture.run_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(side_effects, (0, 0));
 }
 
 #[test]

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_watchdog/tests/fixture.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_watchdog/tests/fixture.rs
@@ -8,6 +8,9 @@ use crate::coordination::agent_org_formal_triggers::{
 use crate::coordination::agent_org_runs::{
     AgentOrgRunEntryMode, AgentOrgRunStatus, AgentOrgRunStore, CreateAgentOrgRunParams,
 };
+use crate::coordination::agent_org_tasks::{
+    AgentOrgTaskStore, CreateTaskParams, TaskStatus, TASK_METADATA_ELIGIBLE_MEMBER_IDS,
+};
 use crate::definitions::orgs::{FlatOrgMember, OrgDefinition, PlanApprovalPolicy};
 use crate::tools::impls::orchestration::org_send_message::InboxWakeHook;
 
@@ -21,6 +24,20 @@ impl WatchdogFixture {
         let sandbox = test_helpers::test_env::sandbox();
         let conn = get_connection().expect("watchdog fixture database");
         crate::persistence::test_schema::ensure_agent_sessions_schema(&conn);
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS session_turn_intents (
+                 session_id TEXT NOT NULL,
+                 turn_intent_id TEXT NOT NULL,
+                 client_message_id TEXT,
+                 org_run_id TEXT,
+                 source TEXT NOT NULL,
+                 status TEXT NOT NULL,
+                 created_at TEXT NOT NULL,
+                 updated_at TEXT NOT NULL,
+                 PRIMARY KEY(session_id,turn_intent_id)
+             );",
+        )
+        .expect("Turn-intent fixture schema");
         crate::coordination::init_agent_org_schemas(&conn).expect("Agent Org schemas");
         let org = OrgDefinition {
             id: "watchdog-org".into(),
@@ -79,6 +96,48 @@ impl WatchdogFixture {
         )
         .expect("missing formal doorbell")
         .receipt_id
+    }
+
+    pub(super) fn seed_lost_assignment_doorbell(&self, task_id: &str) {
+        let conn = get_connection().expect("watchdog fixture database");
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO agent_org_runtime_member_materializations(
+                 org_run_id,member_id,agent_id,generation,session_id,
+                 authority_class,status,created_at,updated_at
+             ) VALUES (?1,'worker','worker-agent',1,'watchdog-worker-session',
+                       'formal','succeeded',?2,?2)",
+            rusqlite::params![&self.run_id, &now],
+        )
+        .expect("worker materialization");
+        AgentOrgTaskStore::create(CreateTaskParams {
+            id: task_id.to_string(),
+            org_run_id: self.run_id.clone(),
+            subject: "Repair existing assignment".to_string(),
+            description: "The original TaskAssigned envelope was lost".to_string(),
+            active_form: None,
+            owner: Some("worker".to_string()),
+            status: TaskStatus::Pending,
+            blocks: Vec::new(),
+            blocked_by: Vec::new(),
+            metadata: Some(serde_json::json!({
+                TASK_METADATA_ELIGIBLE_MEMBER_IDS: ["worker"],
+            })),
+        })
+        .expect("assigned pending Task without its doorbell");
+    }
+
+    pub(super) fn set_run_status(&self, status: AgentOrgRunStatus) {
+        let conn = get_connection().expect("watchdog fixture database");
+        conn.execute(
+            "UPDATE agent_org_runtime_runs
+             SET status=?2,
+                 archived_at=CASE WHEN ?2='archived' THEN ?3 ELSE NULL END,
+                 archive_receipt_id=CASE WHEN ?2='archived' THEN 'watchdog-archive-receipt' ELSE NULL END
+             WHERE id=?1",
+            rusqlite::params![&self.run_id, status.as_str(), chrono::Utc::now().to_rfc3339()],
+        )
+        .expect("change watchdog fixture lifecycle state");
     }
 }
 

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/inbox_wake.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/inbox_wake.rs
@@ -39,8 +39,9 @@ use crate::tools::impls::orchestration::org_send_message::{InboxWakeHook, UserDi
 
 /// Production [`InboxWakeHook`] that resolves the recipient session by
 /// canonical `member_id` and, when the session is idle or terminal, fires
-/// `send_message_impl(session_id, "", is_resume=true)` on a detached Tokio
-/// task.
+/// `send_message_impl(session_id, "", is_resume=true)` on Tauri's detached
+/// application runtime. The hook is synchronous and may be called from the
+/// macOS setup thread, where no Tokio reactor is entered yet.
 ///
 /// Failures (DB lookup errors, missing app handle, in-flight session)
 /// are logged at `info!`/`warn!` and swallowed — the persisted inbox
@@ -85,7 +86,7 @@ impl InboxWakeHook for AppHandleInboxWakeHook {
 
     fn wake_user_directed_member(&self, wake: UserDirectedWake) {
         let app_handle = self.app_handle.clone();
-        tokio::spawn(async move {
+        tauri::async_runtime::spawn(async move {
             let Some(state) = app_handle.try_state::<AgentAppState>() else {
                 warn!(
                     run_id = %wake.org_run_id,
@@ -116,7 +117,7 @@ impl AppHandleInboxWakeHook {
         let member = member_id.to_string();
         let run_id = org_run_id.to_string();
         let app_handle = self.app_handle.clone();
-        tokio::spawn(async move {
+        tauri::async_runtime::spawn(async move {
             let is_repair = formal_receipt_ids.is_some();
             let formal_receipt_ids = if member
                 == crate::coordination::agent_org_runs::COORDINATOR_MEMBER_ID
@@ -180,6 +181,23 @@ impl AppHandleInboxWakeHook {
             }
             info!(run_id = %run_id, member_id = %member, ?outcome, "[inbox_wake] wake request finished");
         });
+    }
+}
+
+#[cfg(test)]
+mod runtime_boundary_tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn tauri_runtime_spawn_is_safe_without_an_entered_tokio_reactor() {
+        let (sender, receiver) = mpsc::channel();
+        tauri::async_runtime::spawn(async move {
+            sender.send(()).expect("test receiver remains alive");
+        });
+        receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("Tauri runtime should execute work from a synchronous startup thread");
     }
 }
 

--- a/src-tauri/crates/agent-core/src/init/mod.rs
+++ b/src-tauri/crates/agent-core/src/init/mod.rs
@@ -199,6 +199,9 @@ pub async fn init_session(
     state: &AgentAppState,
     spec: AgentLaunchSpec,
 ) -> Result<Arc<SessionRuntime>, String> {
+    if state.is_shutting_down() {
+        return Err("app_shutdown_in_progress: refusing to initialize a new Agent session".into());
+    }
     let AgentLaunchSpec {
         session_id,
         definition,

--- a/src-tauri/crates/agent-core/src/state/commands/session/message/send.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message/send.rs
@@ -272,6 +272,9 @@ pub(crate) async fn send_message_impl(
     intent_org_run_id: Option<String>,
     source: TurnIntentBridgeSource,
 ) -> Result<AgentResponse, String> {
+    if state.is_shutting_down() {
+        return Err("app_shutdown_in_progress: refusing to enqueue a new Agent turn".into());
+    }
     // Canonical user-intent id: callers that already mint one at the
     // submit boundary pass it through; legacy / internal callers that
     // don't (mobile remote, wake hook, plan-approval re-entry) get a

--- a/src-tauri/crates/agent-core/src/state/unified.rs
+++ b/src-tauri/crates/agent-core/src/state/unified.rs
@@ -103,6 +103,21 @@ pub struct AgentAppState {
 
     /// Whether the global agent (OS/Gateway) is initialized and running.
     pub running: Arc<AtomicBool>,
+
+    /// Process lifecycle admission fence. Once set, no new Agent turn may be
+    /// initialized or enqueued while shutdown waits for accepted work to
+    /// persist its terminal boundary.
+    shutting_down: Arc<AtomicBool>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentShutdownReport {
+    pub already_started: bool,
+    pub sessions_signalled: usize,
+    pub sessions_drained: usize,
+    pub sessions_still_processing: Vec<String>,
+    pub elapsed_ms: u128,
 }
 
 impl AgentAppState {
@@ -122,51 +137,10 @@ impl AgentAppState {
         // Clean up stale session registry files from a previous crash
         crate::session::file_registry::cleanup_stale_sessions(&[]);
 
-        // First repair rows whose latest turn already wrote a durable terminal
-        // marker but whose session-level status is still in-flight. This is a
-        // stronger signal than startup crash cleanup: the backend observed a
-        // terminal turn, so don't downgrade it to `abandoned` below.
-        match crate::session::persistence::reconcile_sessions_with_terminal_turn_markers() {
-            Ok(0) => {}
-            Ok(n) => info!(
-                "[agent-state] Reconciled {} session(s) from terminal turn markers on startup",
-                n
-            ),
-            Err(err) => warn!(
-                "[agent-state] Failed to reconcile terminal turn markers on startup: {}",
-                err
-            ),
-        }
-
-        // Mark any remaining DB sessions stuck in "running" (from a prior crash) as abandoned
-        // so the frontend doesn't show phantom active sessions on reload.
-        match crate::session::persistence::mark_stale_running_sessions_abandoned() {
-            Ok(0) => {}
-            Ok(n) => info!(
-                "[agent-state] Marked {} stale running session(s) as abandoned on startup",
-                n
-            ),
-            Err(err) => warn!(
-                "[agent-state] Failed to clean stale sessions on startup: {}",
-                err
-            ),
-        }
-
-        match crate::coordination::agent_org_runs::AgentOrgRunStore::requeue_abandoned_member_tasks_on_startup() {
-            Ok(0) => {}
-            Ok(n) => info!(
-                "[agent-state] Applied failure disposition to {} abandoned Agent Org task(s) on startup",
-                n
-            ),
-            Err(err) => warn!(
-                "[agent-state] Failed to recover abandoned Agent Org tasks on startup: {}",
-                err
-            ),
-        }
-
-        // Direct-user intervention receipts are durable. Startup recovery
-        // leaves active chains intact and classifies their queued/running
-        // Turns from persisted evidence; it never implies Return to Work.
+        // Persistence reconciliation is owned by the app startup boundary.
+        // Keeping this constructor side-effect-free prevents tests, debug
+        // endpoints, or a second state value from silently rerunning crash
+        // recovery without being able to dispatch its exact durable receipts.
 
         let bus = Arc::new(Mutex::new(AgentMessageBus::new()));
         let sessions: Arc<Mutex<HashMap<String, Arc<AgentSession>>>> =
@@ -188,6 +162,7 @@ impl AgentAppState {
             sessions: Arc::clone(&sessions),
             current_account_id: Arc::new(Mutex::new(None)),
             running: Arc::new(AtomicBool::new(false)),
+            shutting_down: Arc::new(AtomicBool::new(false)),
         };
 
         state.spawn_cleanup_task(sessions);
@@ -198,10 +173,14 @@ impl AgentAppState {
     /// `SESSION_IDLE_EVICTION_TIMEOUT`.  Singleton (OS) sessions are never
     /// evicted — they must be explicitly removed.
     fn spawn_cleanup_task(&self, sessions: Arc<Mutex<HashMap<String, Arc<AgentSession>>>>) {
+        let shutting_down = Arc::clone(&self.shutting_down);
         tauri::async_runtime::spawn(async move {
             let mut ticker = tokio::time::interval(SESSION_CLEANUP_INTERVAL);
             loop {
                 ticker.tick().await;
+                if shutting_down.load(Ordering::Acquire) {
+                    break;
+                }
 
                 let candidates: Vec<(String, Arc<AgentSession>)> = {
                     let guard = sessions.lock().await;
@@ -273,6 +252,64 @@ impl AgentAppState {
     /// Set the Tauri app handle (called during Tauri setup).
     pub fn set_app_handle(&mut self, handle: tauri::AppHandle) {
         self.app_handle = Some(handle);
+    }
+
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::Acquire)
+    }
+
+    /// Stop Agent admission, cancel every accepted turn and queued message,
+    /// then wait within a fixed budget for scheduler-owned finalization. The
+    /// database pool fence intentionally runs after this method so terminal
+    /// Turn/Task writes still have a chance to commit.
+    pub async fn begin_shutdown(&self, timeout: Duration) -> AgentShutdownReport {
+        let started = std::time::Instant::now();
+        let already_started = self.shutting_down.swap(true, Ordering::AcqRel);
+        self.running.store(false, Ordering::Release);
+        let sessions = {
+            let sessions = self.sessions.lock().await;
+            sessions.values().cloned().collect::<Vec<_>>()
+        };
+        if !already_started {
+            for session in &sessions {
+                session
+                    .cancel_active_turn(
+                        crate::state::control_flow::CancelReason::ProgrammaticShutdown,
+                    )
+                    .await;
+            }
+        }
+
+        let deadline = started + timeout;
+        loop {
+            let all_drained = sessions.iter().all(|session| {
+                !session.scheduler.is_processing() && session.scheduler.pending_count() == 0
+            });
+            if all_drained || std::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        let sessions_still_processing = sessions
+            .iter()
+            .filter(|session| {
+                session.scheduler.is_processing() || session.scheduler.pending_count() > 0
+            })
+            .map(|session| session.id.clone())
+            .collect::<Vec<_>>();
+        for session in &sessions {
+            session.invalidate_runtime().await;
+        }
+        AgentShutdownReport {
+            already_started,
+            sessions_signalled: sessions.len(),
+            sessions_drained: sessions
+                .len()
+                .saturating_sub(sessions_still_processing.len()),
+            sessions_still_processing,
+            elapsed_ms: started.elapsed().as_millis(),
+        }
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -490,5 +527,28 @@ impl AgentAppState {
 impl Default for AgentAppState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod shutdown_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shutdown_admission_fence_is_immediate_and_idempotent() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        let state = AgentAppState::new();
+        assert!(!state.is_shutting_down());
+
+        let first = state.begin_shutdown(Duration::ZERO).await;
+        assert!(state.is_shutting_down());
+        assert!(!first.already_started);
+        assert_eq!(first.sessions_signalled, 0);
+        assert_eq!(first.sessions_drained, 0);
+        assert!(first.sessions_still_processing.is_empty());
+
+        let second = state.begin_shutdown(Duration::ZERO).await;
+        assert!(second.already_started);
+        assert_eq!(second.sessions_signalled, 0);
     }
 }

--- a/src-tauri/crates/agent-core/src/tests/lifecycle_tests.rs
+++ b/src-tauri/crates/agent-core/src/tests/lifecycle_tests.rs
@@ -797,11 +797,54 @@ fn startup_recovery_requeues_only_the_uniquely_bound_task_and_is_idempotent() {
     )
     .expect("reproduce historical Session-failed / Turn-running split");
 
+    let first = AgentOrgRunStore::requeue_abandoned_member_tasks_on_startup()
+        .expect("recover exact abandoned TaskExecution");
+    assert_eq!(first.recovered_task_count(), 1);
+    assert!(first.failures.is_empty());
+    let recovery = &first.recovered_tasks[0];
+    let receipt_id = recovery
+        .receipt_id
+        .as_deref()
+        .expect("startup recovery must commit an exact formal receipt");
+    assert_eq!(recovery.task.id, "crashed-task");
+    assert_eq!(recovery.previous_owner_member_id, "member-worker");
+
+    let conn = database::db::get_connection().expect("inspect startup recovery receipt");
+    let receipt: (String, String, String, String, String) = conn
+        .query_row(
+            "SELECT source_kind,task_id,owner_member_id,source_turn_intent_id,doorbell_status
+             FROM agent_org_runtime_formal_trigger_receipts WHERE receipt_id=?1",
+            [receipt_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .expect("exact startup recovery receipt");
     assert_eq!(
-        AgentOrgRunStore::requeue_abandoned_member_tasks_on_startup()
-            .expect("recover exact abandoned TaskExecution"),
-        1
+        receipt,
+        (
+            "task_execution_recovery_required".to_string(),
+            "crashed-task".to_string(),
+            "member-worker".to_string(),
+            "turn-crashed-task".to_string(),
+            "missing".to_string(),
+        )
     );
+    let recovery_inbox_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM agent_org_runtime_inbox
+             WHERE org_run_id=?1 AND payload_kind='member_idle'",
+            [&run_id],
+            |row| row.get(0),
+        )
+        .expect("count recovery inbox rows");
+    assert_eq!(recovery_inbox_count, 1);
     assert_eq!(
         AgentOrgTaskStore::get(&run_id, "crashed-task")
             .unwrap()
@@ -817,9 +860,60 @@ fn startup_recovery_requeues_only_the_uniquely_bound_task_and_is_idempotent() {
         TaskStatus::InProgress,
         "startup must not batch-recover every Task owned by the Member"
     );
+    for restart in 2..=3 {
+        let replay = AgentOrgRunStore::requeue_abandoned_member_tasks_on_startup()
+            .expect("startup replay is a no-op");
+        assert_eq!(
+            replay.recovered_task_count(),
+            0,
+            "restart {restart} must not duplicate recovery"
+        );
+    }
+    let receipt_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM agent_org_runtime_formal_trigger_receipts
+             WHERE org_run_id=?1 AND source_kind='task_execution_recovery_required'",
+            [&run_id],
+            |row| row.get(0),
+        )
+        .expect("count exact recovery receipts");
     assert_eq!(
-        AgentOrgRunStore::requeue_abandoned_member_tasks_on_startup()
-            .expect("startup replay is a no-op"),
-        0
+        receipt_count, 1,
+        "restarts must not duplicate recovery facts"
     );
+}
+
+#[test]
+fn startup_recovery_keyset_scan_is_not_capped_at_first_hundred_runs() {
+    let _serial = test_serial_guard();
+    let _sandbox = test_helpers::test_env::sandbox();
+    ensure_runtime_schemas();
+    let snapshot = serde_json::to_string(&crate::definitions::orgs::AgentOrgLaunchSnapshot::from(
+        &org_definition("builtin:sde"),
+    ))
+    .expect("launch snapshot");
+    let mut conn = database::db::get_connection().expect("seed paginated run set");
+    let tx = conn.transaction().expect("run-set transaction");
+    for index in 0..105 {
+        let id = format!("agent-org-run-page-{index:03}");
+        let root = format!("root-page-{index:03}");
+        let now = chrono::Utc::now().to_rfc3339();
+        tx.execute(
+            "INSERT INTO agent_org_runtime_runs(
+                 id,org_id,coordinator_agent_id,root_session_id,org_snapshot_json,
+                 entry_mode,status,activation_generation,created_at,updated_at
+             ) VALUES (?1,'org-lifecycle','builtin:coord',?2,?3,
+                       'standalone_session','running',1,?4,?4)",
+            rusqlite::params![id, root, &snapshot, now],
+        )
+        .expect("running paginated Team");
+    }
+    tx.commit().expect("commit paginated run set");
+    drop(conn);
+
+    let plan = AgentOrgRunStore::requeue_abandoned_member_tasks_on_startup()
+        .expect("scan every keyset page");
+    assert_eq!(plan.inspected_runs, 105);
+    assert_eq!(plan.recovered_task_count(), 0);
+    assert!(plan.failures.is_empty());
 }

--- a/src-tauri/crates/database/src/db/checkpoint.rs
+++ b/src-tauri/crates/database/src/db/checkpoint.rs
@@ -1,0 +1,287 @@
+//! Observable, protocol-safe SQLite WAL maintenance.
+//!
+//! WAL files are never deleted directly. Maintenance uses SQLite's checkpoint
+//! protocol on a dedicated non-pooled connection after excluding in-process
+//! writers. A busy reader is a normal, reported result: the WAL remains intact
+//! and a later global tick or next startup can retry.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use rusqlite::Connection;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalCheckpointMode {
+    Passive,
+    Restart,
+    Truncate,
+}
+
+impl WalCheckpointMode {
+    fn pragma(self) -> &'static str {
+        match self {
+            Self::Passive => "PRAGMA wal_checkpoint(PASSIVE)",
+            Self::Restart => "PRAGMA wal_checkpoint(RESTART)",
+            Self::Truncate => "PRAGMA wal_checkpoint(TRUNCATE)",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalCheckpointReport {
+    pub database_path: PathBuf,
+    pub mode: WalCheckpointMode,
+    pub busy: i64,
+    pub log_frames: i64,
+    pub checkpointed_frames: i64,
+    pub wal_bytes_before: u64,
+    pub wal_bytes_after: u64,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WalMaintenanceOutcome {
+    BelowHighWater { wal_bytes: u64 },
+    AlreadyRunning { wal_bytes: u64 },
+    WriterBusy { wal_bytes: u64 },
+    Checkpointed(WalCheckpointReport),
+}
+
+static SESSIONS_CHECKPOINT_RUNNING: AtomicBool = AtomicBool::new(false);
+
+struct CheckpointSingleFlight;
+
+impl Drop for CheckpointSingleFlight {
+    fn drop(&mut self) {
+        SESSIONS_CHECKPOINT_RUNNING.store(false, Ordering::Release);
+    }
+}
+
+pub fn wal_path(database_path: &Path) -> PathBuf {
+    let mut value = database_path.as_os_str().to_os_string();
+    value.push("-wal");
+    PathBuf::from(value)
+}
+
+pub fn wal_bytes(database_path: &Path) -> u64 {
+    std::fs::metadata(wal_path(database_path))
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
+}
+
+pub fn checkpoint_database(
+    database_path: &Path,
+    mode: WalCheckpointMode,
+    busy_timeout: Duration,
+) -> Result<WalCheckpointReport, String> {
+    let started = Instant::now();
+    if !database_path.exists() {
+        return Err(format!(
+            "refusing to create missing database during checkpoint: {}",
+            database_path.display()
+        ));
+    }
+    let wal_bytes_before = wal_bytes(database_path);
+    let conn = Connection::open(database_path).map_err(|error| {
+        format!(
+            "open dedicated checkpoint connection for {} failed: {error}",
+            database_path.display()
+        )
+    })?;
+    conn.busy_timeout(busy_timeout)
+        .map_err(|error| format!("set checkpoint busy timeout failed: {error}"))?;
+    let (busy, log_frames, checkpointed_frames) = conn
+        .query_row(mode.pragma(), [], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
+        .map_err(|error| {
+            format!(
+                "{} checkpoint for {} failed: {error}",
+                mode.pragma(),
+                database_path.display()
+            )
+        })?;
+    drop(conn);
+    Ok(WalCheckpointReport {
+        database_path: database_path.to_path_buf(),
+        mode,
+        busy,
+        log_frames,
+        checkpointed_frames,
+        wal_bytes_before,
+        wal_bytes_after: wal_bytes(database_path),
+        elapsed_ms: started.elapsed().as_millis(),
+    })
+}
+
+/// One global high-water owner for sessions.db. Callers may invoke this from a
+/// low-frequency process timer, but concurrent calls coalesce and a busy
+/// writer causes an immediate skip rather than foreground contention.
+pub fn checkpoint_sessions_if_wal_exceeds(
+    high_water_bytes: u64,
+    writer_wait: Duration,
+    sqlite_busy_timeout: Duration,
+) -> Result<WalMaintenanceOutcome, String> {
+    let path = super::connection::get_db_path();
+    let bytes = wal_bytes(&path);
+    if bytes < high_water_bytes {
+        return Ok(WalMaintenanceOutcome::BelowHighWater { wal_bytes: bytes });
+    }
+    if SESSIONS_CHECKPOINT_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Ok(WalMaintenanceOutcome::AlreadyRunning { wal_bytes: bytes });
+    }
+    let _single_flight = CheckpointSingleFlight;
+    let Some(result) = super::writer::try_with_sessions_writer(writer_wait, || {
+        checkpoint_database(&path, WalCheckpointMode::Restart, sqlite_busy_timeout)
+    }) else {
+        return Ok(WalMaintenanceOutcome::WriterBusy { wal_bytes: bytes });
+    };
+    result.map(WalMaintenanceOutcome::Checkpointed)
+}
+
+pub fn checkpoint_sessions_for_shutdown(
+    writer_wait: Duration,
+    sqlite_busy_timeout: Duration,
+) -> Result<WalMaintenanceOutcome, String> {
+    let path = super::connection::get_db_path();
+    let bytes = wal_bytes(&path);
+    if SESSIONS_CHECKPOINT_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Ok(WalMaintenanceOutcome::AlreadyRunning { wal_bytes: bytes });
+    }
+    let _single_flight = CheckpointSingleFlight;
+    let Some(result) = super::writer::try_with_sessions_writer(writer_wait, || {
+        checkpoint_database(&path, WalCheckpointMode::Truncate, sqlite_busy_timeout)
+    }) else {
+        return Ok(WalMaintenanceOutcome::WriterBusy { wal_bytes: bytes });
+    };
+    result.map(WalMaintenanceOutcome::Checkpointed)
+}
+
+pub fn checkpoint_projects_for_shutdown(
+    sqlite_busy_timeout: Duration,
+) -> Result<WalCheckpointReport, String> {
+    checkpoint_database(
+        &app_paths::projects_db(),
+        WalCheckpointMode::Truncate,
+        sqlite_busy_timeout,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_db_path(label: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "orgii-checkpoint-{label}-{}-{nonce}.db",
+            std::process::id()
+        ))
+    }
+
+    fn remove_sqlite_files(path: &Path) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(wal_path(path));
+        let mut shm = path.as_os_str().to_os_string();
+        shm.push("-shm");
+        let _ = std::fs::remove_file(PathBuf::from(shm));
+    }
+
+    fn seed_large_wal(path: &Path) -> Connection {
+        let mut conn = Connection::open(path).expect("writer connection");
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA synchronous=NORMAL;
+             PRAGMA wal_autocheckpoint=0;
+             CREATE TABLE payloads(id INTEGER PRIMARY KEY, body BLOB NOT NULL);",
+        )
+        .expect("WAL schema");
+        let tx = conn.transaction().expect("payload transaction");
+        let payload = vec![0x5a_u8; 8 * 1024];
+        for id in 0..512_i64 {
+            tx.execute(
+                "INSERT INTO payloads(id,body) VALUES(?1,?2)",
+                rusqlite::params![id, &payload],
+            )
+            .expect("payload row");
+        }
+        tx.commit().expect("payload commit");
+        assert!(wal_bytes(path) > 1024 * 1024, "fixture needs a real WAL");
+        conn
+    }
+
+    #[test]
+    fn truncate_checkpoint_reclaims_wal_without_losing_data() {
+        let path = temp_db_path("truncate");
+        let writer = seed_large_wal(&path);
+        let report = checkpoint_database(
+            &path,
+            WalCheckpointMode::Truncate,
+            Duration::from_millis(250),
+        )
+        .expect("truncate checkpoint");
+        assert_eq!(report.busy, 0);
+        assert_eq!(report.wal_bytes_after, 0);
+        assert!(report.wal_bytes_before > 1024 * 1024);
+        let rows: i64 = writer
+            .query_row("SELECT COUNT(*) FROM payloads", [], |row| row.get(0))
+            .expect("read checkpointed data");
+        assert_eq!(rows, 512);
+        let integrity: String = writer
+            .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+            .expect("integrity check");
+        assert_eq!(integrity, "ok");
+        drop(writer);
+        remove_sqlite_files(&path);
+    }
+
+    #[test]
+    fn busy_reader_preserves_wal_until_a_later_safe_retry() {
+        let path = temp_db_path("busy-reader");
+        let writer = seed_large_wal(&path);
+        let reader = Connection::open(&path).expect("reader connection");
+        reader.execute_batch("BEGIN").expect("reader transaction");
+        let _: i64 = reader
+            .query_row("SELECT COUNT(*) FROM payloads", [], |row| row.get(0))
+            .expect("hold read snapshot");
+        writer
+            .execute("INSERT INTO payloads(body) VALUES(zeroblob(8192))", [])
+            .expect("newer WAL frame");
+
+        let busy = checkpoint_database(
+            &path,
+            WalCheckpointMode::Truncate,
+            Duration::from_millis(25),
+        )
+        .expect("busy is a checkpoint result, not an error");
+        assert_eq!(busy.busy, 1);
+        assert!(busy.wal_bytes_after > 0, "busy WAL must never be deleted");
+
+        reader.execute_batch("COMMIT").expect("release reader");
+        drop(reader);
+        let recovered = checkpoint_database(
+            &path,
+            WalCheckpointMode::Truncate,
+            Duration::from_millis(250),
+        )
+        .expect("retry after reader release");
+        assert_eq!(recovered.busy, 0);
+        assert_eq!(recovered.wal_bytes_after, 0);
+        let integrity: String = writer
+            .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+            .expect("integrity check");
+        assert_eq!(integrity, "ok");
+        drop(writer);
+        remove_sqlite_files(&path);
+    }
+}

--- a/src-tauri/crates/database/src/db/connection.rs
+++ b/src-tauri/crates/database/src/db/connection.rs
@@ -32,6 +32,7 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::{Condvar, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 /// Per-connection PRAGMA settings (must run on every new connection).
 ///
@@ -202,6 +203,19 @@ struct IdleConnection {
     identity: Option<FileIdentity>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum PoolPhase {
+    #[default]
+    Running,
+    Draining,
+}
+
+#[derive(Debug)]
+struct CheckedOutConnection {
+    path: PathBuf,
+    borrowed_at: Instant,
+}
+
 #[derive(Default)]
 struct ConnectionPool {
     /// Bumped whenever pooled connections must not be reused (an init
@@ -209,12 +223,44 @@ struct ConnectionPool {
     /// or an explicit reset). A guard whose generation is older closes its
     /// connection instead of returning it.
     generation: u64,
+    phase: PoolPhase,
+    next_checkout_id: u64,
     idle: HashMap<PathBuf, Vec<IdleConnection>>,
+    checked_out: HashMap<u64, CheckedOutConnection>,
 }
 
-fn connection_pool() -> &'static Mutex<ConnectionPool> {
-    static POOL: OnceLock<Mutex<ConnectionPool>> = OnceLock::new();
-    POOL.get_or_init(|| Mutex::new(ConnectionPool::default()))
+#[derive(Default)]
+struct ConnectionPoolState {
+    pool: Mutex<ConnectionPool>,
+    returned: Condvar,
+}
+
+fn connection_pool() -> &'static ConnectionPoolState {
+    static POOL: OnceLock<ConnectionPoolState> = OnceLock::new();
+    POOL.get_or_init(ConnectionPoolState::default)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionPoolPathMetrics {
+    pub path: PathBuf,
+    pub idle: usize,
+    pub checked_out: usize,
+    pub oldest_checkout_ms: Option<u128>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionPoolMetrics {
+    pub accepting_new_connections: bool,
+    pub paths: Vec<ConnectionPoolPathMetrics>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectionPoolDrainReport {
+    pub drained: bool,
+    pub elapsed_ms: u128,
+    pub idle_connections_closed: usize,
+    pub remaining_checked_out: usize,
+    pub metrics: ConnectionPoolMetrics,
 }
 
 /// Serializes tests that assert on the *contents* of the process-global
@@ -243,11 +289,127 @@ fn pool_test_guard() -> std::sync::MutexGuard<'static, ()> {
 /// already have been opened without it, and by tests that rotate the
 /// database path.
 pub fn reset_connection_pool() {
-    let mut pool = connection_pool()
+    let state = connection_pool();
+    let idle = {
+        let mut pool = state
+            .pool
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        pool.generation = pool.generation.saturating_add(1);
+        std::mem::take(&mut pool.idle)
+    };
+    drop(idle);
+}
+
+pub fn connection_pool_metrics() -> ConnectionPoolMetrics {
+    let pool = connection_pool()
+        .pool
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    pool.generation += 1;
-    pool.idle.clear();
+    pool_metrics_locked(&pool, Instant::now())
+}
+
+/// Fence new checkouts, close every idle connection, and wait up to `timeout`
+/// for borrowed guards to return. A timed-out connection is never force-closed
+/// underneath its owner; it is reported and will close naturally on drop.
+pub fn begin_connection_pool_shutdown(timeout: Duration) -> ConnectionPoolDrainReport {
+    let started = Instant::now();
+    let state = connection_pool();
+    let (idle, idle_connections_closed) = {
+        let mut pool = state
+            .pool
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        pool.phase = PoolPhase::Draining;
+        pool.generation = pool.generation.saturating_add(1);
+        let idle = std::mem::take(&mut pool.idle);
+        let count = idle.values().map(Vec::len).sum();
+        (idle, count)
+    };
+    // SQLite connection destructors may do filesystem work. Never run them
+    // while holding the pool mutex needed by checked-out guard destructors.
+    drop(idle);
+
+    let deadline = started + timeout;
+    let mut pool = state
+        .pool
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    while !pool.checked_out.is_empty() {
+        let now = Instant::now();
+        if now >= deadline {
+            break;
+        }
+        let wait = deadline.saturating_duration_since(now);
+        let (next, timed_out) = state
+            .returned
+            .wait_timeout(pool, wait)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        pool = next;
+        if timed_out.timed_out() {
+            break;
+        }
+    }
+    let remaining_checked_out = pool.checked_out.len();
+    let metrics = pool_metrics_locked(&pool, Instant::now());
+    ConnectionPoolDrainReport {
+        drained: remaining_checked_out == 0,
+        elapsed_ms: started.elapsed().as_millis(),
+        idle_connections_closed,
+        remaining_checked_out,
+        metrics,
+    }
+}
+
+#[cfg(test)]
+fn resume_connection_pool_for_test() {
+    let state = connection_pool();
+    let idle = {
+        let mut pool = state
+            .pool
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(
+            pool.checked_out.is_empty(),
+            "test may not reopen the pool while a connection is borrowed"
+        );
+        pool.phase = PoolPhase::Running;
+        pool.generation = pool.generation.saturating_add(1);
+        std::mem::take(&mut pool.idle)
+    };
+    drop(idle);
+}
+
+fn pool_metrics_locked(pool: &ConnectionPool, now: Instant) -> ConnectionPoolMetrics {
+    let mut by_path = HashMap::<PathBuf, (usize, usize, Option<Instant>)>::new();
+    for (path, connections) in &pool.idle {
+        by_path.entry(path.clone()).or_default().0 = connections.len();
+    }
+    for checkout in pool.checked_out.values() {
+        let entry = by_path.entry(checkout.path.clone()).or_default();
+        entry.1 = entry.1.saturating_add(1);
+        entry.2 = Some(match entry.2 {
+            Some(previous) => previous.min(checkout.borrowed_at),
+            None => checkout.borrowed_at,
+        });
+    }
+    let mut paths = by_path
+        .into_iter()
+        .map(
+            |(path, (idle, checked_out, oldest))| ConnectionPoolPathMetrics {
+                path,
+                idle,
+                checked_out,
+                oldest_checkout_ms: oldest
+                    .map(|instant| now.saturating_duration_since(instant).as_millis()),
+            },
+        )
+        .collect::<Vec<_>>();
+    paths.sort_by(|left, right| left.path.cmp(&right.path));
+    ConnectionPoolMetrics {
+        accepting_new_connections: pool.phase == PoolPhase::Running,
+        paths,
+    }
 }
 
 /// A pooled SQLite connection. Derefs to [`rusqlite::Connection`]; on drop
@@ -258,6 +420,7 @@ pub struct PooledConnection {
     path: PathBuf,
     identity: Option<FileIdentity>,
     generation: u64,
+    checkout_id: u64,
 }
 
 impl PooledConnection {
@@ -266,12 +429,14 @@ impl PooledConnection {
         path: PathBuf,
         identity: Option<FileIdentity>,
         generation: u64,
+        checkout_id: u64,
     ) -> Self {
         Self {
             conn: Some(conn),
             path,
             identity,
             generation,
+            checkout_id,
         }
     }
 }
@@ -302,46 +467,81 @@ impl Drop for PooledConnection {
         // A connection left inside a transaction (a caller that began one
         // and never committed, or unwound mid-write) must not be reused:
         // the next caller would silently inherit its open write lock.
-        if !conn.is_autocommit() {
-            return;
-        }
-        let mut pool = connection_pool()
+        let reusable = conn.is_autocommit();
+        let state = connection_pool();
+        let mut pool = state
+            .pool
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if pool.generation != self.generation {
-            return;
+        pool.checked_out.remove(&self.checkout_id);
+        if reusable && pool.phase == PoolPhase::Running && pool.generation == self.generation {
+            let idle = pool.idle.entry(self.path.clone()).or_default();
+            if idle.len() < MAX_IDLE_CONNECTIONS_PER_PATH {
+                idle.push(IdleConnection {
+                    conn,
+                    identity: self.identity,
+                });
+                state.returned.notify_all();
+                return;
+            }
         }
-        let idle = pool.idle.entry(self.path.clone()).or_default();
-        if idle.len() < MAX_IDLE_CONNECTIONS_PER_PATH {
-            idle.push(IdleConnection {
-                conn,
-                identity: self.identity,
-            });
-        }
+        state.returned.notify_all();
+        drop(pool);
+        drop(conn);
     }
 }
 
-/// Pop an idle connection for `path` whose file identity still matches the
-/// file currently at that path; stale ones (file replaced) are closed.
-fn take_idle_connection(path: &Path, current: Option<FileIdentity>) -> Option<(Connection, u64)> {
-    let mut pool = connection_pool()
+fn pool_draining_error() -> rusqlite::Error {
+    rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+        Some("database connection pool is draining for app shutdown".to_string()),
+    )
+}
+
+/// Reserve a checkout before opening a physical connection. This closes the
+/// race where shutdown fences the pool while a caller is between its phase
+/// check and `Connection::open`.
+fn reserve_checkout(
+    path: &Path,
+    current: Option<FileIdentity>,
+) -> SqliteResult<(Option<Connection>, u64, u64)> {
+    let state = connection_pool();
+    let mut pool = state
+        .pool
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let generation = pool.generation;
-    let idle = pool.idle.get_mut(path)?;
-    while let Some(candidate) = idle.pop() {
-        if candidate.identity == current {
-            return Some((candidate.conn, generation));
-        }
+    if pool.phase == PoolPhase::Draining {
+        return Err(pool_draining_error());
     }
-    None
+    let idle_connection = pool.idle.get_mut(path).and_then(|idle| {
+        while let Some(candidate) = idle.pop() {
+            if candidate.identity == current {
+                return Some(candidate.conn);
+            }
+        }
+        None
+    });
+    let generation = pool.generation;
+    let checkout_id = pool.next_checkout_id;
+    pool.next_checkout_id = pool.next_checkout_id.saturating_add(1);
+    pool.checked_out.insert(
+        checkout_id,
+        CheckedOutConnection {
+            path: path.to_path_buf(),
+            borrowed_at: Instant::now(),
+        },
+    );
+    Ok((idle_connection, generation, checkout_id))
 }
 
-fn current_pool_generation() -> u64 {
-    connection_pool()
+fn abandon_checkout(checkout_id: u64) {
+    let state = connection_pool();
+    let mut pool = state
+        .pool
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .generation
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    pool.checked_out.remove(&checkout_id);
+    state.returned.notify_all();
 }
 
 /// Pooled variant of [`open_with_init`]: reuse an idle connection for
@@ -355,23 +555,34 @@ fn open_pooled(
     configure_new: fn(&Connection) -> SqliteResult<()>,
 ) -> SqliteResult<PooledConnection> {
     let current = file_identity(db_path);
-    if let Some((conn, generation)) = take_idle_connection(db_path, current) {
+    let (idle_connection, generation, checkout_id) = reserve_checkout(db_path, current)?;
+    if let Some(conn) = idle_connection {
         return Ok(PooledConnection::new(
             conn,
             db_path.to_path_buf(),
             current,
             generation,
+            checkout_id,
         ));
     }
-    let generation = current_pool_generation();
-    let conn = open_with_init(db_path, init_fn)?;
-    configure_new(&conn)?;
+    let conn = match open_with_init(db_path, init_fn) {
+        Ok(conn) => conn,
+        Err(error) => {
+            abandon_checkout(checkout_id);
+            return Err(error);
+        }
+    };
+    if let Err(error) = configure_new(&conn) {
+        abandon_checkout(checkout_id);
+        return Err(error);
+    }
     let identity = file_identity(db_path);
     Ok(PooledConnection::new(
         conn,
         db_path.to_path_buf(),
         identity,
         generation,
+        checkout_id,
     ))
 }
 
@@ -679,6 +890,56 @@ mod tests {
         assert!(!has_temp_table(&conn, "held_marker"));
         assert!(!has_temp_table(&conn, "idle_marker"));
         drop(conn);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn shutdown_fences_new_checkouts_and_waits_for_return() {
+        let _pool_guard = pool_test_guard();
+        resume_connection_pool_for_test();
+        let path = temp_db_path("pool-shutdown-drain");
+        let held = open_pooled(&path, None, configure_nothing).expect("held checkout");
+
+        let shutdown =
+            std::thread::spawn(|| begin_connection_pool_shutdown(Duration::from_millis(500)));
+        while connection_pool_metrics().accepting_new_connections {
+            std::thread::yield_now();
+        }
+        let rejected = match open_pooled(&path, None, configure_nothing) {
+            Ok(_) => panic!("new checkout must be fenced during shutdown"),
+            Err(error) => error,
+        };
+        assert!(rejected.to_string().contains("draining for app shutdown"));
+        drop(held);
+
+        let report = shutdown.join().expect("shutdown waiter");
+        assert!(report.drained, "returned checkout must unblock drain");
+        assert_eq!(report.remaining_checked_out, 0);
+        resume_connection_pool_for_test();
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn shutdown_timeout_reports_oldest_borrowed_connection() {
+        let _pool_guard = pool_test_guard();
+        resume_connection_pool_for_test();
+        let path = temp_db_path("pool-shutdown-timeout");
+        let held = open_pooled(&path, None, configure_nothing).expect("held checkout");
+
+        let report = begin_connection_pool_shutdown(Duration::from_millis(10));
+        assert!(!report.drained);
+        assert_eq!(report.remaining_checked_out, 1);
+        let path_metrics = report
+            .metrics
+            .paths
+            .iter()
+            .find(|metrics| metrics.path == path)
+            .expect("borrowed path metrics");
+        assert_eq!(path_metrics.checked_out, 1);
+        assert!(path_metrics.oldest_checkout_ms.is_some());
+
+        drop(held);
+        resume_connection_pool_for_test();
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/src-tauri/crates/database/src/db/mod.rs
+++ b/src-tauri/crates/database/src/db/mod.rs
@@ -37,15 +37,24 @@
 //! proj.execute("SELECT * FROM projects", [])?;
 //! ```
 
+mod checkpoint;
 mod connection;
 mod shell_replay_schema;
 mod writer;
 
+pub use checkpoint::{
+    checkpoint_database, checkpoint_projects_for_shutdown, checkpoint_sessions_for_shutdown,
+    checkpoint_sessions_if_wal_exceeds, wal_bytes, wal_path, WalCheckpointMode,
+    WalCheckpointReport, WalMaintenanceOutcome,
+};
 pub use connection::{
-    configure_connection, get_connection, get_db_path, get_projects_connection,
-    register_projects_init, register_sessions_init, reset_connection_pool, PooledConnection,
+    begin_connection_pool_shutdown, configure_connection, connection_pool_metrics, get_connection,
+    get_db_path, get_projects_connection, register_projects_init, register_sessions_init,
+    reset_connection_pool, ConnectionPoolDrainReport, ConnectionPoolMetrics,
+    ConnectionPoolPathMetrics, PooledConnection,
 };
 pub use shell_replay_schema::init_shell_replay_tables;
 pub use writer::{
-    begin_immediate, sessions_writer_guard, with_sessions_writer, SessionsWriterGuard,
+    begin_immediate, sessions_writer_guard, try_with_sessions_writer, with_sessions_writer,
+    SessionsWriterGuard,
 };

--- a/src-tauri/crates/database/src/db/writer.rs
+++ b/src-tauri/crates/database/src/db/writer.rs
@@ -58,6 +58,7 @@
 //! contention is limited to manual `sqlite3` inspection.
 
 use std::cell::Cell;
+use std::time::Duration;
 
 use parking_lot::Mutex;
 use rusqlite::{Connection, Result as SqliteResult, Transaction, TransactionBehavior};
@@ -112,6 +113,17 @@ impl SessionsWriterGuard {
         };
         Self { _outer: outer }
     }
+
+    fn try_acquire_for(timeout: Duration) -> Option<Self> {
+        let depth = SESSIONS_WRITER_DEPTH.with(Cell::get);
+        let outer = if depth == 0 {
+            Some(sessions_writer_mutex().try_lock_for(timeout)?)
+        } else {
+            None
+        };
+        SESSIONS_WRITER_DEPTH.with(|cell| cell.set(depth.saturating_add(1)));
+        Some(Self { _outer: outer })
+    }
 }
 
 impl Drop for SessionsWriterGuard {
@@ -145,6 +157,17 @@ where
 {
     let _guard = SessionsWriterGuard::acquire();
     func()
+}
+
+/// Run a write-excluding maintenance closure only when the writer lock can be
+/// acquired inside a small explicit budget. Runtime WAL maintenance uses this
+/// to remain invisible to foreground Agent writes.
+pub fn try_with_sessions_writer<F, T>(timeout: Duration, func: F) -> Option<T>
+where
+    F: FnOnce() -> T,
+{
+    let _guard = SessionsWriterGuard::try_acquire_for(timeout)?;
+    Some(func())
 }
 
 /// Begin an IMMEDIATE-mode transaction on `conn`.

--- a/src-tauri/crates/database/src/lib.rs
+++ b/src-tauri/crates/database/src/lib.rs
@@ -30,7 +30,11 @@
 pub mod db;
 
 pub use db::{
-    begin_immediate, configure_connection, get_db_path, init_shell_replay_tables,
-    register_projects_init, register_sessions_init, sessions_writer_guard, with_sessions_writer,
-    SessionsWriterGuard,
+    begin_connection_pool_shutdown, begin_immediate, checkpoint_database,
+    checkpoint_projects_for_shutdown, checkpoint_sessions_for_shutdown,
+    checkpoint_sessions_if_wal_exceeds, configure_connection, connection_pool_metrics, get_db_path,
+    init_shell_replay_tables, register_projects_init, register_sessions_init,
+    sessions_writer_guard, try_with_sessions_writer, wal_bytes, wal_path, with_sessions_writer,
+    ConnectionPoolDrainReport, ConnectionPoolMetrics, ConnectionPoolPathMetrics,
+    SessionsWriterGuard, WalCheckpointMode, WalCheckpointReport, WalMaintenanceOutcome,
 };

--- a/src-tauri/crates/e2e-test/src/agent_org.rs
+++ b/src-tauri/crates/e2e-test/src/agent_org.rs
@@ -32,6 +32,8 @@ const RUN_VIEW_PATH: &str = "/agent/test/agent-org/run-view";
 const DURABLE_INVARIANTS_PATH: &str = "/agent/test/agent-org/durable-invariants";
 const FIND_WORKER_SESSION_PATH: &str = "/agent/test/agent-org/find-worker-session";
 const SEED_CLI_MEMBER_RUN_PATH: &str = "/agent/test/agent-org/stale-workers/seed-cli-member";
+const SEED_CRASHED_TASK_EXECUTION_PATH: &str =
+    "/agent/test/agent-org/startup-recovery/seed-crashed-task";
 const TASKS_SEED_PATH: &str = "/agent/test/agent-org/tasks/seed";
 const PAUSE_RUN_PATH: &str = "/agent/test/agent-org/run/pause";
 const RESUME_RUN_PATH: &str = "/agent/test/agent-org/run/resume";
@@ -2903,27 +2905,20 @@ pub async fn run_pause_resume_toggles_status(cfg: &Config) -> bool {
     )
 }
 
-/// Verify that `mark_all_running_as_paused_on_startup` transitions all
-/// `running` org runs to `paused` so that the UI can show the overview
-/// panel and Resume button after an app restart.
-///
-/// Invariants checked:
-/// - Before restart: seeded run is `running`
-/// - After simulated restart: run is `paused` (non-terminal, resumable)
-/// - `reconcile_run_finality` is a no-op for `paused` runs (run stays paused)
-/// - After user resumes: run is `running` again (full lifecycle round-trip)
-/// - Active interventions are cleared on startup (no stale intervention banner)
-pub async fn app_restart_transitions_running_runs_to_paused(cfg: &Config) -> bool {
-    let label = "app-restart-transitions-running-runs-to-paused";
+/// Production-caller-path restart pin for one interrupted TaskExecution.
+/// The debug helper establishes only the crash-cut precondition; the restart
+/// endpoint executes the same recovery owner and exact receipt dispatch as
+/// application startup.
+pub async fn app_restart_recovers_exact_task_execution_once(cfg: &Config) -> bool {
+    let label = "app-restart-recovers-exact-task-execution-once";
+    let crashed_task_id = unique_run_id("restart-crashed-task");
 
-    // (1) Seed a fresh running org run.
     let seed_resp = match post_agent_org_json(
         cfg,
-        SEED_CLI_MEMBER_RUN_PATH,
+        SEED_CRASHED_TASK_EXECUTION_PATH,
         serde_json::json!({
-            "cli_agent_type": "claude_code",
             "member_id": "m-restart",
-            "status": "idle"
+            "task_id": crashed_task_id,
         }),
     )
     .await
@@ -2940,20 +2935,17 @@ pub async fn app_restart_transitions_running_runs_to_paused(cfg: &Config) -> boo
         Some(value) if !value.is_empty() => value.to_string(),
         _ => return harness::print_error(label, "seed did not return root_session_id"),
     };
-    if let Err(err) = seed_task(
-        cfg,
-        &org_run_id,
-        &format!("restart-keep-open-{org_run_id}"),
-        "Keep restart fixture open",
-        "m-restart",
-        TASK_STATUS_PENDING,
-    )
-    .await
-    {
-        return harness::print_error(label, &err);
-    }
+    let crashed_session_id = seed_resp
+        .get("crashed_session_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let crashed_turn_intent_id = seed_resp
+        .get("crashed_turn_intent_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
 
-    // (2) Confirm run starts as `running`.
     let inv_before_restart = match post_agent_org_json(
         cfg,
         DURABLE_INVARIANTS_PATH,
@@ -2969,19 +2961,62 @@ pub async fn app_restart_transitions_running_runs_to_paused(cfg: &Config) -> boo
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    // (3) Simulate app restart.
-    let restart_resp =
+    let first_restart =
         match post_agent_org_json(cfg, SIMULATE_APP_RESTART_PATH, serde_json::json!({})).await {
             Err(err) => return harness::print_error(label, &err),
             Ok(json) => json,
         };
-    let restart_ok = restart_resp.get("ok").and_then(|v| v.as_bool()) == Some(true);
-    let runs_paused_count = restart_resp
-        .get("runs_paused")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
+    let recovered = first_restart
+        .get("recovery_plan")
+        .and_then(|value| value.get("recoveredTasks"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|items| {
+            items.iter().find(|item| {
+                item.get("task")
+                    .and_then(|task| task.get("id"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some(crashed_task_id.as_str())
+            })
+        });
+    let exact_recovery_ok = recovered.is_some_and(|recovery| {
+        recovery
+            .get("task")
+            .and_then(|task| task.get("status"))
+            .and_then(serde_json::Value::as_str)
+            == Some("pending")
+            && recovery
+                .get("task")
+                .and_then(|task| task.get("owner"))
+                .is_some_and(serde_json::Value::is_null)
+            && recovery
+                .get("previousOwnerMemberId")
+                .and_then(serde_json::Value::as_str)
+                == Some("m-restart")
+            && recovery
+                .get("failedSessionId")
+                .and_then(serde_json::Value::as_str)
+                == Some(crashed_session_id.as_str())
+            && recovery
+                .get("failedTurnIntentId")
+                .and_then(serde_json::Value::as_str)
+                == Some(crashed_turn_intent_id.as_str())
+            && recovery
+                .get("receiptId")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|value| !value.is_empty())
+    });
 
-    // (4) Confirm run is now `paused` (non-terminal).
+    let second_restart =
+        match post_agent_org_json(cfg, SIMULATE_APP_RESTART_PATH, serde_json::json!({})).await {
+            Err(err) => return harness::print_error(label, &err),
+            Ok(json) => json,
+        };
+    let third_restart =
+        match post_agent_org_json(cfg, SIMULATE_APP_RESTART_PATH, serde_json::json!({})).await {
+            Err(err) => return harness::print_error(label, &err),
+            Ok(json) => json,
+        };
+
     let inv_after_restart = match post_agent_org_json(
         cfg,
         DURABLE_INVARIANTS_PATH,
@@ -2996,88 +3031,98 @@ pub async fn app_restart_transitions_running_runs_to_paused(cfg: &Config) -> boo
         .get("runStatus")
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
-
-    // (5) Reconcile should be a no-op for paused runs (status stays paused,
-    //     run is NOT auto-terminated even though sessions are now abandoned).
-    let run_view_resp = match post_agent_org_json(
-        cfg,
-        RUN_VIEW_PATH,
-        serde_json::json!({ "session_id": root_session_id }),
-    )
-    .await
-    {
+    let inbox = match list_inbox(cfg, &org_run_id).await {
         Err(err) => return harness::print_error(label, &err),
         Ok(json) => json,
     };
-    let run_status_after_view_poll = run_view_resp
-        .get("view")
-        .and_then(|value| value.get("runStatus"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
-
-    // (6) User can resume from UI — full round trip.
-    let resume_resp = match post_agent_org_json(
-        cfg,
-        RESUME_RUN_PATH,
-        serde_json::json!({ "org_run_id": org_run_id }),
-    )
-    .await
-    {
-        Err(err) => return harness::print_error(label, &err),
-        Ok(json) => json,
-    };
-    let resume_ok = resume_resp.get("ok").and_then(|v| v.as_bool()) == Some(true);
-    let resume_transitioned =
-        resume_resp.get("transitioned").and_then(|v| v.as_bool()) == Some(true);
-
-    let inv_after_resume = match post_agent_org_json(
-        cfg,
-        DURABLE_INVARIANTS_PATH,
-        serde_json::json!({ "org_run_id": org_run_id, "root_session_id": root_session_id }),
-    )
-    .await
-    {
-        Err(err) => return harness::print_error(label, &err),
-        Ok(json) => json,
-    };
-    let run_status_after_resume = inv_after_resume
-        .get("runStatus")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
+    let matching_recovery_inbox_count = inbox
+        .get("messages")
+        .and_then(serde_json::Value::as_array)
+        .map(|messages| {
+            messages
+                .iter()
+                .filter(|message| {
+                    message
+                        .get("payload_kind")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("member_idle")
+                        && message
+                            .get("payload_decoded")
+                            .and_then(|payload| payload.get("reason"))
+                            .and_then(serde_json::Value::as_str)
+                            == Some("failed")
+                        && message
+                            .get("payload_decoded")
+                            .and_then(|payload| payload.get("unfinished_task_ids"))
+                            .and_then(serde_json::Value::as_array)
+                            .is_some_and(|ids| {
+                                ids.iter()
+                                    .any(|id| id.as_str() == Some(crashed_task_id.as_str()))
+                            })
+                })
+                .count()
+        })
+        .unwrap_or(0);
 
     harness::print_result(
         label,
         &serde_json::json!({
             "seed": seed_resp,
-            "restart": restart_resp,
+            "first_restart": first_restart,
+            "second_restart": second_restart,
+            "third_restart": third_restart,
             "inv_before_restart": inv_before_restart,
             "inv_after_restart": inv_after_restart,
-            "run_view_after_restart": run_view_resp,
-            "resume": resume_resp,
-            "inv_after_resume": inv_after_resume,
+            "inbox": inbox,
         })
         .to_string(),
         &[
             ("seed ok", seed_ok),
             (
+                "crash fixture has exact session",
+                !crashed_session_id.is_empty(),
+            ),
+            (
+                "crash fixture has exact Turn",
+                !crashed_turn_intent_id.is_empty(),
+            ),
+            (
                 "run status before restart is 'running'",
                 run_status_before == "running",
             ),
-            ("simulate-app-restart endpoint ok", restart_ok),
-            ("at least one run was paused", runs_paused_count >= 1),
             (
-                "run status after restart is 'paused'",
-                run_status_after_restart == "paused",
+                "first restart endpoint ok",
+                first_restart.get("ok").and_then(serde_json::Value::as_bool) == Some(true),
             ),
             (
-                "run view poll does not auto-terminate paused run",
-                run_status_after_view_poll == "paused",
+                "exact TaskExecution became safe ownerless Pending",
+                exact_recovery_ok,
             ),
-            ("resume endpoint ok", resume_ok),
-            ("resume transitioned=true", resume_transitioned),
             (
-                "run status after resume is 'running'",
-                run_status_after_resume == "running",
+                "one typed Coordinator recovery inbox fact exists",
+                matching_recovery_inbox_count == 1,
+            ),
+            (
+                "running Team lifecycle is preserved",
+                run_status_after_restart == "running",
+            ),
+            (
+                "no ownerless in-progress Task remains",
+                inv_after_restart
+                    .get("ownerlessInProgressCount")
+                    .and_then(serde_json::Value::as_u64)
+                    == Some(0),
+            ),
+            (
+                "second and third restart are idempotent",
+                second_restart
+                    .get("tasks_requeued")
+                    .and_then(serde_json::Value::as_u64)
+                    == Some(0)
+                    && third_restart
+                        .get("tasks_requeued")
+                        .and_then(serde_json::Value::as_u64)
+                        == Some(0),
             ),
         ],
     )

--- a/src-tauri/crates/e2e-test/src/main.rs
+++ b/src-tauri/crates/e2e-test/src/main.rs
@@ -707,8 +707,8 @@ fn all_scenarios() -> Vec<ScenarioDef> {
         ),
         scenario!(
             "agent-org",
-            "agent-org-app-restart-transitions-running-runs-to-paused",
-            agent_org::app_restart_transitions_running_runs_to_paused
+            "agent-org-app-restart-recovers-exact-task-execution-once",
+            agent_org::app_restart_recovers_exact_task_execution_once
         ),
         scenario!(
             "agent-org",

--- a/src-tauri/crates/system-services/src/app_menu.rs
+++ b/src-tauri/crates/system-services/src/app_menu.rs
@@ -435,21 +435,17 @@ pub fn initialize_recent_paths(app: &AppHandle) {
     super::system_recents::clear_system_recent_documents();
 
     let paths = load_recent_paths_from_disk(app);
-    if paths.is_empty() {
+    if let Err(err) = rebuild_menu(app) {
+        eprintln!("[AppMenu] Failed to install application menu: {}", err);
         return;
     }
 
-    if let Err(err) = rebuild_menu(app) {
-        eprintln!(
-            "[AppMenu] Failed to rebuild menu after loading recents: {}",
-            err
+    if !paths.is_empty() {
+        println!(
+            "✅ [AppMenu] Restored {} recent path(s) from disk",
+            paths.len()
         );
     }
-
-    println!(
-        "✅ [AppMenu] Restored {} recent path(s) from disk",
-        paths.len()
-    );
 }
 
 /// Add a path to the recent items list and persist to disk.

--- a/src-tauri/crates/terminal/src/pty_commands/pty/state.rs
+++ b/src-tauri/crates/terminal/src/pty_commands/pty/state.rs
@@ -49,17 +49,14 @@ impl PtyState {
     /// [`pending_exit_session_leaders`].
     ///
     /// Must be called from a non-runtime thread (it blocks on the session
-    /// map lock); the Tauri run-loop exit handler qualifies.
+    /// map lock). The app lifecycle owns a dedicated shutdown thread for this
+    /// work.
     ///
     /// Thread-safety: `self.sessions.blocking_lock()` calls
     /// `tokio::future::block_on`, which panics if the current thread is a
-    /// tokio runtime worker. This is safe only because the sole caller is the
-    /// `RunEvent::ExitRequested` callback, which Tauri runs synchronously on
-    /// the main (wry/tao event-loop) thread — NOT a tokio async_runtime
-    /// worker (those live in a separate thread pool). Do NOT call this from
-    /// an `async fn`, a `spawn`/`spawn_blocking` task, or any context where
-    /// a tokio runtime guard is entered; move it to a fresh `std::thread`
-    /// before blocking on the lock.
+    /// tokio runtime worker. Do NOT call this from an `async fn` or any
+    /// context where a tokio runtime guard is entered; move it to a fresh
+    /// `std::thread` before blocking on the lock.
     pub fn shutdown_kill_all(&self) {
         let drained: Vec<PtySession> = {
             let mut map = self.sessions.blocking_lock();
@@ -147,5 +144,18 @@ impl PtyState {
 impl Default for PtyState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PtyState;
+
+    #[test]
+    fn shutdown_sweep_is_safe_on_a_dedicated_thread() {
+        let state = PtyState::new();
+        std::thread::spawn(move || state.shutdown_kill_all())
+            .join()
+            .expect("empty PTY shutdown sweep should not panic");
     }
 }

--- a/src-tauri/src/api/agent/mod.rs
+++ b/src-tauri/src/api/agent/mod.rs
@@ -22,7 +22,6 @@ pub mod test {
         pub async fn debug_work_item_scheduler_run_once() -> Result<serde_json::Value, String> {
             Err("debug_work_item_scheduler_run_once is only available in debug builds".to_string())
         }
-
     }
 }
 
@@ -730,6 +729,14 @@ pub fn create_routes() -> Router {
         .route(
             "/test/agent-org/stale-workers/seed-cli-member",
             post(test::agent_org::test_agent_org_seed_cli_member_run),
+        )
+        .route(
+            "/test/agent-org/startup-recovery/seed-crashed-task",
+            post(test::agent_org::test_agent_org_seed_crashed_task_execution),
+        )
+        .route(
+            "/test/agent-org/startup-recovery/wake-seeded-task",
+            post(test::agent_org::test_agent_org_wake_seeded_task),
         )
         .route(
             "/test/agent-org/find-worker-session",

--- a/src-tauri/src/api/agent/test/agent_org.rs
+++ b/src-tauri/src/api/agent/test/agent_org.rs
@@ -2818,7 +2818,6 @@ pub async fn test_agent_org_seed_cli_member_run(
         .filter(|s| !s.trim().is_empty())
         .unwrap_or("idle")
         .to_string();
-
     let result = tokio::task::spawn_blocking(move || {
         let conn = database::db::get_connection().map_err(|err| err.to_string())?;
         agent_core::foundation::persistence::session_snapshots::ensure_tables_with(&conn)
@@ -2900,7 +2899,6 @@ pub async fn test_agent_org_seed_cli_member_run(
             ],
         )
         .map_err(|err| err.to_string())?;
-
         Ok::<serde_json::Value, String>(serde_json::json!({
             "ok": true,
             "org_run_id": run.id,
@@ -2918,6 +2916,310 @@ pub async fn test_agent_org_seed_cli_member_run(
         Ok(Err(err)) => Json(serde_json::json!({ "ok": false, "error": err })),
         Ok(Ok(value)) => Json(value),
     }
+}
+
+/// `POST /test/agent-org/startup-recovery/seed-crashed-task`
+///
+/// Establishes the durable state left immediately after a canonical Rust
+/// Member TaskExecution starts and immediately before its Provider call
+/// returns. Task creation and Pending -> InProgress both go through the
+/// production Task Store; direct inserts are limited to the two Turn identity
+/// rows that represent the intentional process-crash cut.
+pub async fn test_agent_org_seed_crashed_task_execution(
+    Json(body): Json<serde_json::Value>,
+) -> Json<serde_json::Value> {
+    use agent_core::coordination::agent_org_runs::{
+        AgentOrgRunEntryMode, AgentOrgRunStatus, AgentOrgRunStore, CreateAgentOrgRunParams,
+        COORDINATOR_MEMBER_ID,
+    };
+    use agent_core::coordination::agent_org_tasks::{
+        AgentOrgTaskStore, CreatePendingTaskParams, TaskCreateSchedulingPolicy, TaskExecutionMode,
+        TaskGraphWriterAdmin, TaskOwnerExecution,
+    };
+    use agent_core::core::definitions::orgs::{
+        AgentOrgLaunchSnapshot, FlatOrgMember, OrgDefinition,
+    };
+    use agent_core::core::session::persistence::{
+        session_type, upsert_session, UnifiedSessionRecord,
+    };
+    use agent_core::core::session::SessionStatus;
+
+    let task_id = body
+        .get("task_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("crashed-task-{}", uuid::Uuid::new_v4()));
+    let member_id = body
+        .get("member_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("m-restart")
+        .to_string();
+
+    let result = tokio::task::spawn_blocking(move || -> Result<serde_json::Value, String> {
+        let conn = database::db::get_connection().map_err(|error| error.to_string())?;
+        agent_core::foundation::persistence::session_snapshots::ensure_tables_with(&conn)
+            .map_err(|error| error.to_string())?;
+        agent_core::core::session::persistence::init(&conn).map_err(|error| error.to_string())?;
+        agent_core::coordination::init_agent_org_schemas(&conn)
+            .map_err(|error| error.to_string())?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let root_session_id = format!("agent-org-crash-root-{}", uuid::Uuid::new_v4());
+        let member_session_id = format!("agent-org-crash-member-{}", uuid::Uuid::new_v4());
+        let org_id = format!(
+            "{E2E_RUN_FIXTURE_ORG_PREFIX}startup-recovery-{}",
+            uuid::Uuid::new_v4()
+        );
+        let agent_id = "builtin:sde".to_string();
+
+        upsert_session(&UnifiedSessionRecord {
+            session_id: root_session_id.clone(),
+            name: "startup-recovery-root".to_string(),
+            status: SessionStatus::Running.as_str().to_string(),
+            session_type: session_type::GENERIC.to_string(),
+            agent_definition_id: Some(agent_id.clone()),
+            org_member_id: Some(COORDINATOR_MEMBER_ID.to_string()),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            ..Default::default()
+        })
+        .map_err(|error| error.to_string())?;
+        upsert_session(&UnifiedSessionRecord {
+            session_id: member_session_id.clone(),
+            parent_session_id: Some(root_session_id.clone()),
+            name: "startup-recovery-member".to_string(),
+            status: SessionStatus::Failed.as_str().to_string(),
+            session_type: session_type::GENERIC.to_string(),
+            agent_definition_id: Some(agent_id.clone()),
+            org_member_id: Some(member_id.clone()),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            ..Default::default()
+        })
+        .map_err(|error| error.to_string())?;
+
+        let definition = OrgDefinition {
+            id: org_id.clone(),
+            name: org_id.clone(),
+            role: "coordinator".to_string(),
+            agent_id: agent_id.clone(),
+            description: Some("Deterministic startup-recovery crash fixture".to_string()),
+            plan_approval_policy: Default::default(),
+            members: vec![FlatOrgMember {
+                member_id: member_id.clone(),
+                name: "Recovery Worker".to_string(),
+                role: "worker".to_string(),
+                agent_id: agent_id.clone(),
+                runtime_config: None,
+            }],
+            additional_task_graph_writer_member_ids: Vec::new(),
+            member_communication_links: Vec::new(),
+        };
+        let run = AgentOrgRunStore::create(CreateAgentOrgRunParams {
+            org_id,
+            coordinator_agent_id: agent_id.clone(),
+            root_session_id: Some(root_session_id.clone()),
+            org_snapshot: AgentOrgLaunchSnapshot::from(&definition),
+            entry_mode: AgentOrgRunEntryMode::StandaloneSession,
+            status: AgentOrgRunStatus::Running,
+            work_item_id: None,
+            project_slug: None,
+            routine_fire_id: None,
+        })?;
+        conn.execute(
+            "INSERT INTO agent_org_runtime_member_materializations(
+                 org_run_id,member_id,agent_id,generation,session_id,
+                 authority_class,status,created_at,updated_at
+             ) VALUES (?1,?2,?3,1,?4,'formal','succeeded',?5,?5)",
+            rusqlite::params![&run.id, &member_id, &agent_id, &member_session_id, &now],
+        )
+        .map_err(|error| error.to_string())?;
+
+        let coordinator_turn_id = format!("fixture-coordinator-turn-{}", uuid::Uuid::new_v4());
+        conn.execute(
+            "INSERT INTO session_turn_intents(
+                 session_id,turn_intent_id,org_run_id,source,status,created_at,updated_at
+             ) VALUES (?1,?2,?3,'user_submit','running',?4,?4)",
+            rusqlite::params![&root_session_id, &coordinator_turn_id, &run.id, &now],
+        )
+        .map_err(|error| error.to_string())?;
+        conn.execute(
+            "INSERT INTO agent_org_runtime_turn_contexts(
+                 session_id,turn_intent_id,org_run_id,participant_id,turn_kind,
+                 source_kind,source_id,activation_generation,created_at
+             ) VALUES (?1,?2,?3,'coordinator','coordinator','root_turn',?2,1,?4)",
+            rusqlite::params![&root_session_id, &coordinator_turn_id, &run.id, &now],
+        )
+        .map_err(|error| error.to_string())?;
+        AgentOrgTaskStore::create_pending_with_transactional_effects(
+            TaskGraphWriterAdmin::new(&root_session_id, &coordinator_turn_id)?,
+            CreatePendingTaskParams {
+                id: task_id.clone(),
+                org_run_id: run.id.clone(),
+                subject: "Interrupted provider execution".to_string(),
+                description: "Deterministic startup-recovery precondition".to_string(),
+                active_form: None,
+                owner: Some(member_id.clone()),
+                execution_mode: TaskExecutionMode::Build,
+                blocked_by: Vec::new(),
+                metadata: None,
+                originating_message_id: None,
+                replaces_task_id: None,
+            },
+            TaskCreateSchedulingPolicy {
+                allow_parallel_with_unlisted_open_tasks: true,
+            },
+            |_connection, _task, _tasks| Ok(()),
+        )?;
+
+        let turn_intent_id = format!("crashed-turn-{}", uuid::Uuid::new_v4());
+        conn.execute(
+            "INSERT INTO session_turn_intents(
+                 session_id,turn_intent_id,org_run_id,source,status,created_at,updated_at
+             ) VALUES (?1,?2,?3,'agent_org','running',?4,?4)",
+            rusqlite::params![&member_session_id, &turn_intent_id, &run.id, &now],
+        )
+        .map_err(|error| error.to_string())?;
+        conn.execute(
+            "INSERT INTO agent_org_runtime_turn_contexts(
+                 session_id,turn_intent_id,org_run_id,participant_id,turn_kind,
+                 task_id,owner_member_id,dispatch_member_id,member_dispatch_sequence,
+                 source_kind,source_id,activation_generation,created_at
+             ) VALUES (?1,?2,?3,?4,'task_execution',?5,?4,?4,1,
+                       'task',?5,1,?6)",
+            rusqlite::params![
+                &member_session_id,
+                &turn_intent_id,
+                &run.id,
+                &member_id,
+                &task_id,
+                &now,
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+        AgentOrgTaskStore::owner_start_with_transactional_effects(
+            TaskOwnerExecution::new(&member_session_id, &turn_intent_id)?,
+            &run.id,
+            &task_id,
+            |_connection, _outcome, _tasks| Ok(()),
+        )?;
+
+        Ok(serde_json::json!({
+            "ok": true,
+            "org_run_id": run.id,
+            "root_session_id": root_session_id,
+            "crashed_session_id": member_session_id,
+            "crashed_task_id": task_id,
+            "crashed_turn_intent_id": turn_intent_id,
+        }))
+    })
+    .await;
+
+    match result {
+        Err(join_error) => Json(serde_json::json!({
+            "ok": false,
+            "error": format!("spawn_blocking join error: {join_error}"),
+        })),
+        Ok(Err(error)) => Json(serde_json::json!({ "ok": false, "error": error })),
+        Ok(Ok(value)) => Json(value),
+    }
+}
+
+/// `POST /test/agent-org/startup-recovery/wake-seeded-task`
+///
+/// Delivers one seeded task through the production `TaskAssigned` producer and
+/// production inbox wake hook. This keeps real-provider crash acceptance tests
+/// on the actual member TaskExecution path without spending a separate
+/// Coordinator model turn merely to manufacture the assignment.
+pub async fn test_agent_org_wake_seeded_task(
+    Json(body): Json<serde_json::Value>,
+) -> Json<serde_json::Value> {
+    use agent_core::coordination::agent_org_tasks::{enqueue_task_assigned_to, AgentOrgTaskStore};
+    use agent_core::tools::impls::orchestration::inbox_wake::AppHandleInboxWakeHook;
+    use agent_core::tools::impls::orchestration::org_send_message::InboxWakeHook;
+
+    let Some(obj) = body.as_object() else {
+        return Json(serde_json::json!({ "ok": false, "error": "body must be an object" }));
+    };
+    let required = |key: &str| {
+        obj.get(key)
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| format!("{key} is required (non-empty string)"))
+    };
+    let (org_run_id, task_id, member_id, recipient_agent_id) = match (
+        required("org_run_id"),
+        required("task_id"),
+        required("member_id"),
+        required("recipient_agent_id"),
+    ) {
+        (Ok(run), Ok(task), Ok(member), Ok(agent)) => (run, task, member, agent),
+        values => {
+            let error = [
+                values.0.err(),
+                values.1.err(),
+                values.2.err(),
+                values.3.err(),
+            ]
+            .into_iter()
+            .flatten()
+            .next()
+            .unwrap_or_else(|| "invalid request".to_string());
+            return Json(serde_json::json!({ "ok": false, "error": error }));
+        }
+    };
+
+    let run_for_delivery = org_run_id.clone();
+    let task_for_delivery = task_id.clone();
+    let member_for_delivery = member_id.clone();
+    let agent_for_delivery = recipient_agent_id.clone();
+    let delivered = tokio::task::spawn_blocking(move || -> Result<i64, String> {
+        let task = AgentOrgTaskStore::get(&run_for_delivery, &task_for_delivery)?
+            .ok_or_else(|| "seeded task was not found".to_string())?;
+        enqueue_task_assigned_to(
+            &task,
+            &agent_for_delivery,
+            &member_for_delivery,
+            "builtin:sde",
+            Some(agent_core::coordination::agent_org_runs::COORDINATOR_MEMBER_ID),
+            "Coordinator",
+        )
+    })
+    .await;
+
+    let inbox_id = match delivered {
+        Err(error) => {
+            return Json(serde_json::json!({
+                "ok": false,
+                "error": format!("spawn_blocking join error: {error}")
+            }))
+        }
+        Ok(Err(error)) => {
+            return Json(serde_json::json!({ "ok": false, "error": error }));
+        }
+        Ok(Ok(inbox_id)) => inbox_id,
+    };
+
+    let Some(handle) = crate::api::get_app_handle() else {
+        return Json(serde_json::json!({
+            "ok": false,
+            "error": "AppHandle not initialized",
+            "inbox_id": inbox_id,
+        }));
+    };
+    AppHandleInboxWakeHook::new(handle.clone()).wake_member(&member_id, &org_run_id);
+
+    Json(serde_json::json!({
+        "ok": true,
+        "org_run_id": org_run_id,
+        "task_id": task_id,
+        "member_id": member_id,
+        "recipient_agent_id": recipient_agent_id,
+        "inbox_id": inbox_id,
+    }))
 }
 
 /// `POST /test/agent-org/run/pause`
@@ -2982,32 +3284,13 @@ pub async fn test_agent_org_pause_run(
 /// startup never maps `running` to `paused` and never infers terminality from
 /// abandoned Session rows.
 ///
-/// Caller-path probe: drives the same sequence that `AgentAppState::
-/// with_browser` calls, so this endpoint stays in sync if any of those
-/// functions change their signature or semantics. No body required (`{}`).
+/// Caller-path probe: drives the same production startup owner, then dispatches
+/// only the exact receipts returned by that owner. No body required (`{}`).
 pub async fn test_agent_org_simulate_app_restart() -> Json<serde_json::Value> {
     let result = tokio::task::spawn_blocking(move || {
-        use agent_core::coordination::agent_org_runs::AgentOrgRunStore;
-        use agent_core::session::persistence::{
-            mark_stale_running_sessions_abandoned, reconcile_sessions_with_terminal_turn_markers,
-        };
-
+        let report = crate::app::startup_recovery::run_persistence_startup_recovery()?;
         let conn = database::db::get_connection()
-            .map_err(|err| format!("open sessions DB for intent reconciliation failed: {err}"))?;
-        let intents_reconciled =
-            session_persistence::turn_intents::reconcile_in_flight_after_restart(&conn)
-                .map_err(|err| format!("reconcile_in_flight_after_restart failed: {err}"))?;
-        let agent_org_intents_reconciled =
-            agent_core::coordination::reconcile_agent_org_turns_after_restart(&conn)
-                .map_err(|err| format!("reconcile_agent_org_turns failed: {err}"))?;
-        let terminal_sessions_reconciled = reconcile_sessions_with_terminal_turn_markers()
-            .map_err(|err| {
-                format!("reconcile_sessions_with_terminal_turn_markers failed: {err}")
-            })?;
-        let sessions_abandoned = mark_stale_running_sessions_abandoned()
-            .map_err(|err| format!("mark_stale_running_sessions_abandoned failed: {err}"))?;
-        let tasks_requeued = AgentOrgRunStore::requeue_abandoned_member_tasks_on_startup()
-            .map_err(|err| format!("requeue_abandoned_member_tasks_on_startup failed: {err}"))?;
+            .map_err(|err| format!("open sessions DB for recovery inspection failed: {err}"))?;
         let interventions_preserved: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM agent_org_runtime_member_interventions
@@ -3016,20 +3299,7 @@ pub async fn test_agent_org_simulate_app_restart() -> Json<serde_json::Value> {
                 |row| row.get(0),
             )
             .map_err(|err| format!("read preserved interventions failed: {err}"))?;
-        Ok::<serde_json::Value, String>(serde_json::json!({
-            "ok": true,
-            "intents_reconciled": intents_reconciled,
-            "agent_org_intents_reconciled": agent_org_intents_reconciled,
-            "terminal_sessions_reconciled": terminal_sessions_reconciled,
-            "sessions_abandoned": sessions_abandoned,
-            "tasks_requeued": tasks_requeued,
-            // Kept for old E2E clients; canonical PR1 startup performs neither
-            // transition, so both counters are intentionally always zero.
-            "runs_completed": 0,
-            "runs_paused": 0,
-            "interventions_cleared": 0,
-            "interventions_preserved": interventions_preserved,
-        }))
+        Ok::<_, String>((report, interventions_preserved))
     })
     .await;
 
@@ -3039,7 +3309,33 @@ pub async fn test_agent_org_simulate_app_restart() -> Json<serde_json::Value> {
             "error": format!("spawn_blocking join error: {join_err}"),
         })),
         Ok(Err(err)) => Json(serde_json::json!({ "ok": false, "error": err })),
-        Ok(Ok(value)) => Json(value),
+        Ok(Ok((report, interventions_preserved))) => {
+            let Some(app_handle) = crate::api::get_app_handle() else {
+                return Json(serde_json::json!({
+                    "ok": false,
+                    "error": "production AppHandle is unavailable; refusing to report recovery before exact doorbell dispatch",
+                }));
+            };
+            crate::app::startup_recovery::dispatch_agent_org_recovery_receipts(
+                app_handle.clone(),
+                &report.agent_org,
+            );
+            Json(serde_json::json!({
+                "ok": true,
+                "intents_reconciled": report.ordinary_turn_intents_reconciled,
+                "agent_org_intents_reconciled": report.agent_org_turn_intents_reconciled,
+                "terminal_sessions_reconciled": report.terminal_sessions_reconciled,
+                "sessions_abandoned": report.sessions_abandoned,
+                "tasks_requeued": report.agent_org.recovered_task_count(),
+                "recovery_plan": report.agent_org,
+                // Kept for old E2E clients; canonical production startup performs neither
+                // transition, so both counters are intentionally always zero.
+                "runs_completed": 0,
+                "runs_paused": 0,
+                "interventions_cleared": 0,
+                "interventions_preserved": interventions_preserved,
+            }))
+        }
     }
 }
 

--- a/src-tauri/src/app/bootstrap.rs
+++ b/src-tauri/src/app/bootstrap.rs
@@ -8,6 +8,8 @@
 use crate::runtime_instance;
 use crate::setup::*;
 
+use std::sync::{Mutex, OnceLock};
+
 #[cfg(target_os = "macos")]
 use crate::single_instance_focus;
 
@@ -25,6 +27,25 @@ fn write_panic_report_to_stderr(report: &str) {
 
 pub(crate) fn dev_startup_debug_enabled() -> bool {
     std::env::var("ORGII_DEV_STARTUP_DEBUG").as_deref() == Ok("true")
+}
+
+static TRACING_WORKER_GUARD: OnceLock<Mutex<Option<tracing_appender::non_blocking::WorkerGuard>>> =
+    OnceLock::new();
+
+/// Flush the non-blocking file appender before the process exits.
+///
+/// Keeping the guard in a takeable process-global slot preserves logging for
+/// the whole app lifetime while still allowing the final shutdown metrics to
+/// reach disk before Tauri calls `std::process::exit`.
+pub(crate) fn flush_tracing_for_shutdown() {
+    let Some(slot) = TRACING_WORKER_GUARD.get() else {
+        return;
+    };
+    let guard = slot
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take();
+    drop(guard);
 }
 
 /// Linux-only env guards that cap WebKitGTK CPU during streaming/output (issue
@@ -198,9 +219,7 @@ pub(crate) fn bootstrap(identifier: &str) {
         std::fs::create_dir_all(&log_dir).ok();
 
         let file_appender = tracing_appender::rolling::daily(&log_dir, "orgii.log");
-        let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-        // Leak the guard so it lives for the entire process lifetime
-        std::mem::forget(_guard);
+        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
         let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             EnvFilter::new(
@@ -224,6 +243,7 @@ pub(crate) fn bootstrap(identifier: &str) {
                     .with_writer(non_blocking),
             )
             .init();
+        let _ = TRACING_WORKER_GUARD.set(Mutex::new(Some(guard)));
 
         tracing::info!(
             "Tracing initialized — log file: {}/orgii.log",

--- a/src-tauri/src/app/lifecycle.rs
+++ b/src-tauri/src/app/lifecycle.rs
@@ -1,9 +1,27 @@
 //! Application lifecycle handlers wired into the Tauri builder: window events,
 //! page loads, and the process-level run-event loop (including shutdown).
 
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::time::Duration;
+
 use tauri::Manager;
 
 use crate::app::bootstrap::dev_startup_debug_enabled;
+
+const SHUTDOWN_RUNNING: u8 = 0;
+const SHUTDOWN_DRAINING: u8 = 1;
+const SHUTDOWN_READY_TO_EXIT: u8 = 2;
+static SHUTDOWN_PHASE: AtomicU8 = AtomicU8::new(SHUTDOWN_RUNNING);
+
+const AGENT_DRAIN_BUDGET: Duration = Duration::from_secs(3);
+const DATABASE_POOL_DRAIN_BUDGET: Duration = Duration::from_secs(2);
+const CHECKPOINT_WRITER_BUDGET: Duration = Duration::from_millis(250);
+const CHECKPOINT_SQLITE_BUDGET: Duration = Duration::from_millis(500);
+const PERSISTENCE_SHUTDOWN_BUDGET: Duration = Duration::from_secs(4);
+
+fn exit_request_supports_bounded_shutdown(code: Option<i32>) -> bool {
+    code != Some(tauri::RESTART_EXIT_CODE)
+}
 
 /// Keeps the macOS traffic lights pinned after scale-factor, theme, and focus
 /// changes.
@@ -86,7 +104,11 @@ pub(crate) fn handle_page_load(
         let app = webview.app_handle().clone();
         match browser::inline::close_all_inline_webviews(app) {
             Ok(closed) if !closed.is_empty() => {
-                tracing::info!(count = closed.len(), ?closed, "[PageReload] Closed inline webviews");
+                tracing::info!(
+                    count = closed.len(),
+                    ?closed,
+                    "[PageReload] Closed inline webviews"
+                );
             }
             Err(err) => {
                 tracing::warn!(error = %err, "[PageReload] Failed to close inline webviews");
@@ -122,54 +144,185 @@ pub(crate) fn handle_run_event(app_handle: &tauri::AppHandle, event: tauri::RunE
                 }
             }
         }
-        // Release keeps the process alive when all windows are hidden.
-        // Debug Linux/Windows exits normally when the last window closes.
-        // code.is_none() means it's an automatic exit (last window closed), not an explicit exit(0).
-        tauri::RunEvent::ExitRequested {
-            api: _api,
-            code: _code,
-            ..
-        } => {
-            #[cfg(any(target_os = "macos", not(debug_assertions)))]
-            if _code.is_none() {
-                _api.prevent_exit();
+        tauri::RunEvent::ExitRequested { api, code, .. } => {
+            // Tauri explicitly ignores prevent_exit for request_restart. No
+            // current ORGII call site uses that path; keep the old synchronous
+            // best effort and make the missing bounded drain visible.
+            if !exit_request_supports_bounded_shutdown(code) {
+                tracing::warn!(
+                    "[Shutdown] Tauri restart cannot be deferred; running synchronous best-effort cleanup"
+                );
+                run_pre_database_shutdown(app_handle);
+                crate::app::bootstrap::flush_tracing_for_shutdown();
                 return;
             }
 
-            match agent_cli::managed_config::restore_managed_configs_for_shutdown() {
-                Ok(report) => {
-                    if !report.restored_agents.is_empty() {
-                        tracing::info!(
-                            agents = ?report.restored_agents,
-                            "[CLI Managed Config] restored Default configs before exit"
-                        );
-                    }
-                    for (agent, error) in report.failed_agents {
-                        tracing::warn!(
-                            agent,
-                            error = %error,
-                            "[CLI Managed Config] left config unchanged during exit"
-                        );
-                    }
+            match SHUTDOWN_PHASE.compare_exchange(
+                SHUTDOWN_RUNNING,
+                SHUTDOWN_DRAINING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    api.prevent_exit();
+                    let handle = app_handle.clone();
+                    let exit_code = code.unwrap_or(0);
+                    tauri::async_runtime::spawn(async move {
+                        perform_bounded_shutdown(&handle).await;
+                        SHUTDOWN_PHASE.store(SHUTDOWN_READY_TO_EXIT, Ordering::Release);
+                        handle.exit(exit_code);
+                    });
                 }
-                Err(error) => tracing::warn!(
-                    error = %error,
-                    "[CLI Managed Config] failed to run shutdown restoration"
-                ),
+                Err(SHUTDOWN_DRAINING) => {
+                    api.prevent_exit();
+                    tracing::debug!("[Shutdown] exit already draining");
+                }
+                Err(SHUTDOWN_READY_TO_EXIT) => {
+                    // Second ExitRequested was initiated by `handle.exit`
+                    // after the bounded teardown completed. Let it through.
+                }
+                Err(other) => {
+                    api.prevent_exit();
+                    tracing::warn!(phase = other, "[Shutdown] unknown shutdown phase");
+                }
             }
-            // Explicit exit — mark active orchestrator workflows as interrupted
-            agent_core::coordination::work_item_recovery::mark_all_interrupted_sync();
-            // Release computer-use lock if held
-            integrations::computer_use_lock::force_release_on_exit();
-            // Close the outbound Mobile Remote relay and all per-phone actors.
-            crate::api::mobile_bridge::relay::shutdown();
-            // Kill all PTY shells and (on Unix) their whole process
-            // sessions — HUP-immune descendants would otherwise leak
-            // past app exit.
-            app_handle
-                .state::<::terminal::pty_commands::pty::PtyState>()
-                .shutdown_kill_all();
         }
         _ => {}
+    }
+}
+
+async fn perform_bounded_shutdown(app_handle: &tauri::AppHandle) {
+    let started = std::time::Instant::now();
+    if let Some(state) = app_handle.try_state::<agent_core::state::AgentAppState>() {
+        let report = state.begin_shutdown(AGENT_DRAIN_BUDGET).await;
+        tracing::info!(
+            sessions_signalled = report.sessions_signalled,
+            sessions_drained = report.sessions_drained,
+            sessions_still_processing = ?report.sessions_still_processing,
+            elapsed_ms = report.elapsed_ms,
+            "[Shutdown] Agent admission fenced and accepted work drained"
+        );
+    }
+
+    // PTY teardown deliberately uses `blocking_lock`, so this whole ordered
+    // pre-database + pool + checkpoint sequence must run on a thread that has
+    // not entered the Tokio runtime. A dedicated thread also lets the async
+    // coordinator enforce a hard wait budget; on timeout SQLite keeps the WAL
+    // for the next safe startup instead of risking file-level cleanup.
+    let persistence_handle = app_handle.clone();
+    let (persistence_tx, persistence_rx) = tokio::sync::oneshot::channel();
+    let persistence_thread = std::thread::Builder::new()
+        .name("orgii-shutdown-persistence".to_string())
+        .spawn(move || {
+            run_pre_database_shutdown(&persistence_handle);
+            let pool = database::db::begin_connection_pool_shutdown(DATABASE_POOL_DRAIN_BUDGET);
+            let sessions = database::db::checkpoint_sessions_for_shutdown(
+                CHECKPOINT_WRITER_BUDGET,
+                CHECKPOINT_SQLITE_BUDGET,
+            );
+            let projects = database::db::checkpoint_projects_for_shutdown(CHECKPOINT_SQLITE_BUDGET);
+            let _ = persistence_tx.send((pool, sessions, projects));
+        });
+
+    match persistence_thread {
+        Err(error) => {
+            tracing::warn!(error = %error, "[Shutdown] failed to start persistence drain thread")
+        }
+        Ok(_thread) => {
+            match tokio::time::timeout(PERSISTENCE_SHUTDOWN_BUDGET, persistence_rx).await {
+                Ok(Ok((pool, sessions, projects))) => {
+                    tracing::info!(
+                        drained = pool.drained,
+                        idle_closed = pool.idle_connections_closed,
+                        remaining_checked_out = pool.remaining_checked_out,
+                        elapsed_ms = pool.elapsed_ms,
+                        metrics = ?pool.metrics,
+                        "[Shutdown] SQLite connection pool drain completed"
+                    );
+                    match sessions {
+                        Ok(outcome) => tracing::info!(
+                            outcome = ?outcome,
+                            "[Shutdown] sessions WAL checkpoint finished"
+                        ),
+                        Err(error) => tracing::warn!(
+                            error = %error,
+                            "[Shutdown] sessions WAL checkpoint failed safely"
+                        ),
+                    }
+                    match projects {
+                        Ok(report) => tracing::info!(
+                            report = ?report,
+                            "[Shutdown] projects WAL checkpoint finished"
+                        ),
+                        Err(error) => tracing::warn!(
+                            error = %error,
+                            "[Shutdown] projects WAL checkpoint failed safely"
+                        ),
+                    }
+                }
+                Ok(Err(error)) => tracing::warn!(
+                    error = %error,
+                    "[Shutdown] persistence drain thread stopped before reporting"
+                ),
+                Err(_) => tracing::warn!(
+                    budget_ms = PERSISTENCE_SHUTDOWN_BUDGET.as_millis(),
+                    "[Shutdown] persistence drain exceeded its budget; preserving WAL for next startup"
+                ),
+            }
+        }
+    }
+    tracing::info!(
+        elapsed_ms = started.elapsed().as_millis(),
+        "[Shutdown] bounded teardown complete"
+    );
+    crate::app::bootstrap::flush_tracing_for_shutdown();
+}
+
+fn run_pre_database_shutdown(app_handle: &tauri::AppHandle) {
+    match agent_cli::managed_config::restore_managed_configs_for_shutdown() {
+        Ok(report) => {
+            if !report.restored_agents.is_empty() {
+                tracing::info!(
+                    agents = ?report.restored_agents,
+                    "[CLI Managed Config] restored Default configs before exit"
+                );
+            }
+            for (agent, error) in report.failed_agents {
+                tracing::warn!(
+                    agent,
+                    error = %error,
+                    "[CLI Managed Config] left config unchanged during exit"
+                );
+            }
+        }
+        Err(error) => tracing::warn!(
+            error = %error,
+            "[CLI Managed Config] failed to run shutdown restoration"
+        ),
+    }
+    agent_core::coordination::work_item_recovery::mark_all_interrupted_sync();
+    integrations::computer_use_lock::force_release_on_exit();
+    // Close the outbound Mobile Remote relay and all per-phone actors before
+    // the persistence pool is drained.
+    crate::api::mobile_bridge::relay::shutdown();
+    app_handle
+        .state::<::terminal::pty_commands::pty::PtyState>()
+        .shutdown_kill_all();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::exit_request_supports_bounded_shutdown;
+
+    #[test]
+    fn user_and_programmatic_quit_both_run_bounded_shutdown() {
+        // Tauri 2.x documents `None` as a user-interaction quit. Window-close
+        // hiding is handled earlier by `CloseRequested`; this value must never
+        // be treated as an automatic last-window exit that skips teardown.
+        assert!(exit_request_supports_bounded_shutdown(None));
+        assert!(exit_request_supports_bounded_shutdown(Some(0)));
+        assert!(!exit_request_supports_bounded_shutdown(Some(
+            tauri::RESTART_EXIT_CODE
+        )));
     }
 }

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -14,5 +14,6 @@ pub(crate) mod builder;
 pub(crate) mod lifecycle;
 pub(crate) mod plugins;
 pub(crate) mod setup_hook;
+pub(crate) mod startup_recovery;
 
 pub(crate) use builder::run;

--- a/src-tauri/src/app/setup_hook/background.rs
+++ b/src-tauri/src/app/setup_hook/background.rs
@@ -327,4 +327,53 @@ pub(crate) fn spawn_background_workers(app: &tauri::App) {
             let _ = infrastructure::housekeeping::run_deferred_cleanup();
         });
     });
+
+    // One process-wide WAL high-water owner. The first tick doubles as a
+    // startup retry after a previous busy shutdown; later ticks remain sparse
+    // and skip immediately when the foreground writer is occupied.
+    let wal_maintenance_handle = app.handle().clone();
+    tauri::async_runtime::spawn(async move {
+        const WAL_HIGH_WATER_BYTES: u64 = 64 * 1024 * 1024;
+        const WAL_MAINTENANCE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+        let mut interval = tokio::time::interval(WAL_MAINTENANCE_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            if wal_maintenance_handle
+                .try_state::<agent_core::state::AgentAppState>()
+                .is_some_and(|state| state.is_shutting_down())
+            {
+                break;
+            }
+            let outcome = tokio::task::spawn_blocking(|| {
+                database::db::checkpoint_sessions_if_wal_exceeds(
+                    WAL_HIGH_WATER_BYTES,
+                    std::time::Duration::from_millis(25),
+                    std::time::Duration::from_millis(100),
+                )
+            })
+            .await;
+            match outcome {
+                Ok(Ok(database::db::WalMaintenanceOutcome::Checkpointed(report))) => {
+                    tracing::info!(report = ?report, "[DatabaseWAL] high-water checkpoint finished")
+                }
+                Ok(Ok(database::db::WalMaintenanceOutcome::WriterBusy { wal_bytes })) => {
+                    tracing::debug!(
+                        wal_bytes,
+                        "[DatabaseWAL] foreground writer busy; checkpoint deferred"
+                    )
+                }
+                Ok(Ok(database::db::WalMaintenanceOutcome::AlreadyRunning { wal_bytes })) => {
+                    tracing::debug!(wal_bytes, "[DatabaseWAL] checkpoint already running")
+                }
+                Ok(Ok(database::db::WalMaintenanceOutcome::BelowHighWater { .. })) => {}
+                Ok(Err(error)) => {
+                    tracing::warn!(error = %error, "[DatabaseWAL] high-water checkpoint failed safely")
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "[DatabaseWAL] checkpoint worker failed")
+                }
+            }
+        }
+    });
 }

--- a/src-tauri/src/app/setup_hook/state.rs
+++ b/src-tauri/src/app/setup_hook/state.rs
@@ -17,6 +17,27 @@ pub(crate) fn init_core_state(app: &tauri::App) {
     app.manage(agent_sessions::event_pipeline::commands::EventStoreState::new());
     tracing::info!("[EventStore] Rust event store initialized");
 
+    let persistence_recovery = match crate::app::startup_recovery::run_persistence_startup_recovery(
+    ) {
+        Ok(report) => {
+            tracing::info!(
+                ordinary_turn_intents_reconciled = report.ordinary_turn_intents_reconciled,
+                agent_org_turn_intents_reconciled = report.agent_org_turn_intents_reconciled,
+                terminal_sessions_reconciled = report.terminal_sessions_reconciled,
+                sessions_abandoned = report.sessions_abandoned,
+                inspected_agent_org_runs = report.agent_org.inspected_runs,
+                recovered_agent_org_tasks = report.agent_org.recovered_task_count(),
+                recovery_failures = report.agent_org.failures.len(),
+                "[StartupRecovery] persistence reconciliation completed"
+            );
+            Some(report)
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "[StartupRecovery] persistence reconciliation failed");
+            None
+        }
+    };
+
     // Initialize PTY state for terminal sessions
     let pty_state = ::terminal::pty_commands::pty::PtyState::new();
     let pty_sessions_arc = pty_state.sessions_arc();
@@ -101,13 +122,6 @@ pub(crate) fn init_core_state(app: &tauri::App) {
     );
     tracing::info!("[MemberIdle] Member idle hook installed");
 
-    if agent_core::coordination::agent_org_runs::agent_org_redesign_enabled() {
-        agent_core::coordination::agent_org_watchdog::spawn(app.handle().clone());
-        tracing::info!("[AgentOrgWatchdog] Agent Org watchdog started");
-    } else {
-        tracing::info!("[AgentOrgWatchdog] Agent Org redesign is disabled");
-    }
-
     // Plan artifacts have their own one-shot startup owner. Keep this repair
     // independent from the bounded Working-only watchdog so a global
     // filesystem scan cannot consume its Team scan budget or run repeatedly.
@@ -155,6 +169,29 @@ pub(crate) fn init_core_state(app: &tauri::App) {
     let housekeeper_compaction_state = unified_state.clone();
     app.manage(unified_state);
     tracing::info!("[UnifiedAgent] Unified agent state initialized");
+
+    if let Some(report) = persistence_recovery.as_ref() {
+        crate::app::startup_recovery::dispatch_agent_org_recovery_receipts(
+            app.handle().clone(),
+            &report.agent_org,
+        );
+        tracing::info!(
+            receipts = report
+                .agent_org
+                .recovered_tasks
+                .iter()
+                .filter(|recovery| recovery.receipt_id.is_some())
+                .count(),
+            "[AgentOrgStartup] exact recovery doorbells scheduled"
+        );
+    }
+
+    if agent_core::coordination::agent_org_runs::agent_org_redesign_enabled() {
+        agent_core::coordination::agent_org_watchdog::spawn(app.handle().clone());
+        tracing::info!("[AgentOrgWatchdog] Agent Org watchdog started");
+    } else {
+        tracing::info!("[AgentOrgWatchdog] Agent Org redesign is disabled");
+    }
 
     agent_core::core::session::launch::spawn_agent_org_startup_recovery(agent_org_startup_state);
     tracing::info!("[AgentOrgStartup] one-shot lifecycle recovery scheduled");

--- a/src-tauri/src/app/startup_recovery.rs
+++ b/src-tauri/src/app/startup_recovery.rs
@@ -1,0 +1,80 @@
+//! Single production owner for persistence crash reconciliation.
+//!
+//! Schema initialization is deliberately pure. This module runs once after
+//! the EventStore exists, returns the exact durable Agent Org receipts it
+//! created, and rings only those doorbells after AgentAppState is managed.
+
+use std::collections::BTreeMap;
+
+use agent_core::coordination::agent_org_runs::{
+    AgentOrgRunStore, AgentOrgStartupRecoveryPlan, COORDINATOR_MEMBER_ID,
+};
+use agent_core::tools::impls::orchestration::org_send_message::InboxWakeHook;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct PersistenceStartupRecoveryReport {
+    pub ordinary_turn_intents_reconciled: usize,
+    pub agent_org_turn_intents_reconciled: usize,
+    pub terminal_sessions_reconciled: usize,
+    pub sessions_abandoned: usize,
+    pub agent_org: AgentOrgStartupRecoveryPlan,
+}
+
+pub(crate) fn run_persistence_startup_recovery() -> Result<PersistenceStartupRecoveryReport, String>
+{
+    let conn = database::db::get_connection()
+        .map_err(|error| format!("open sessions database for startup recovery failed: {error}"))?;
+    let ordinary_turn_intents_reconciled =
+        session_persistence::turn_intents::reconcile_in_flight_after_restart(&conn)
+            .map_err(|error| format!("ordinary turn-intent recovery failed: {error}"))?;
+    let agent_org_turn_intents_reconciled =
+        agent_core::coordination::reconcile_agent_org_turns_after_restart(&conn)
+            .map_err(|error| format!("Agent Org turn-intent recovery failed: {error}"))?;
+    drop(conn);
+
+    // A durable terminal marker is stronger evidence than a stale session
+    // status. Preserve it before classifying all remaining in-flight sessions
+    // as abandoned.
+    let terminal_sessions_reconciled =
+        agent_core::session::persistence::reconcile_sessions_with_terminal_turn_markers()
+            .map_err(|error| format!("terminal session-marker recovery failed: {error}"))?;
+    let sessions_abandoned =
+        agent_core::session::persistence::mark_stale_running_sessions_abandoned()
+            .map_err(|error| format!("stale session recovery failed: {error}"))?;
+    let agent_org = AgentOrgRunStore::requeue_abandoned_member_tasks_on_startup()
+        .map_err(|error| format!("Agent Org TaskExecution recovery failed: {error}"))?;
+
+    Ok(PersistenceStartupRecoveryReport {
+        ordinary_turn_intents_reconciled,
+        agent_org_turn_intents_reconciled,
+        terminal_sessions_reconciled,
+        sessions_abandoned,
+        agent_org,
+    })
+}
+
+pub(crate) fn dispatch_agent_org_recovery_receipts(
+    app_handle: tauri::AppHandle,
+    plan: &AgentOrgStartupRecoveryPlan,
+) {
+    let mut receipts_by_run = BTreeMap::<String, Vec<String>>::new();
+    for recovery in &plan.recovered_tasks {
+        let Some(receipt_id) = recovery.receipt_id.as_ref() else {
+            continue;
+        };
+        receipts_by_run
+            .entry(recovery.task.org_run_id.clone())
+            .or_default()
+            .push(receipt_id.clone());
+    }
+
+    let wake_hook =
+        agent_core::tools::impls::orchestration::inbox_wake::AppHandleInboxWakeHook::new(
+            app_handle,
+        );
+    for (org_run_id, receipt_ids) in receipts_by_run {
+        wake_hook.wake_member_for_formal_receipts(COORDINATOR_MEMBER_ID, &org_run_id, &receipt_ids);
+    }
+}

--- a/src-tauri/src/setup/hooks.rs
+++ b/src-tauri/src/setup/hooks.rs
@@ -13,17 +13,6 @@ use crate::{agent_sessions, api};
 pub(crate) fn register_database_schemas() {
     fn init_sessions(conn: &rusqlite::Connection) -> rusqlite::Result<()> {
         session_persistence::init_session_tables(conn)?;
-        match session_persistence::turn_intents::reconcile_in_flight_after_restart(conn) {
-            Ok(0) => {}
-            Ok(count) => tracing::info!(
-                "[startup] Closed {} turn intent(s) left in-flight by the previous process",
-                count
-            ),
-            Err(err) => tracing::warn!(
-                "[startup] Failed to reconcile in-flight turn intents: {}",
-                err
-            ),
-        }
 
         agent_core::persistence::session_snapshots::ensure_tables_with(conn)?;
         agent_core::session::persistence::init(conn)?;
@@ -65,17 +54,6 @@ pub(crate) fn register_database_schemas() {
         }
 
         agent_core::coordination::init_agent_org_schemas(conn)?;
-        match agent_core::coordination::reconcile_agent_org_turns_after_restart(conn) {
-            Ok(0) => {}
-            Ok(count) => tracing::info!(
-                "[startup] Reconciled {} Agent Org turn intent(s) from the previous process",
-                count
-            ),
-            Err(err) => tracing::warn!(
-                "[startup] Failed to reconcile Agent Org turn intents: {}",
-                err
-            ),
-        }
 
         // Pending plan-approval snapshots (one row per session with a Build
         // button still awaiting the user). Persists the pending action so the


### PR DESCRIPTION
## Problem

This is the third stacked Agent Org product-repair change and depends on #1349.

An app crash or quit could leave a member Session, its exact TaskExecution turn, and the Task board in contradictory states. Startup schema initialization performed lifecycle mutations before the application runtime and doorbell hooks existed, interrupted turns could remain running while their tasks stayed owned, and recovery notifications could be missed or replayed. Normal quit also lacked one bounded owner for fencing new database access, draining pooled SQLite connections, and truncating session/project WAL files.

The result was stale or duplicated work after restart, Tasks that could not be safely reassigned, coordinator state that did not explain the interruption, and database handles or WAL files surviving shutdown.

## Solution

- Move persistence crash reconciliation into one production startup owner after the EventStore is available and before Agent Org background workers begin.
- Bind recovery to the exact persisted TaskExecution context. Fail that turn once, release only its matching Task to ownerless `pending`, and never replay provider work automatically.
- Persist a bounded `member_idle` failure notification and formal coordinator receipt in the same transaction, then ring only the exact committed recovery doorbells after runtime hooks exist.
- Repair stranded ownerless-ready work and missing formal doorbells through bounded, idempotent watchdog paths.
- Add a database admission fence, connection-pool drain, bounded shutdown teardown, and explicit TRUNCATE checkpoints for both session and project databases.
- Add a sparse 60-second WAL high-water safety check that skips below 64 MiB, does not wait behind the foreground writer, and stops during shutdown.
- Route both menu quit and programmatic quit through the same shutdown owner.
- Keep deterministic regression fixtures and packaged-app diagnostics behind debug/test boundaries.

The resulting invariant is: an interrupted provider-backed TaskExecution is never silently replayed or reported complete; its exact turn becomes failed, its Task becomes explicitly reassignable, and the coordinator receives one durable recovery fact. Shutdown rejects new database admission before draining and checkpointing.

## Potential risks

- This is a stacked PR. It must be reviewed and merged after #1349; changing the base to `develop` would mix the preceding Agent Org stack into this diff.
- Startup recovery intentionally prefers safety over automatic continuation. An interrupted Task is left ownerless and requires explicit coordinator reassignment after possible external side effects are inspected.
- A connection that does not return before the bounded shutdown deadline is reported rather than waited on forever. A busy WAL checkpoint remains recoverable by the next startup/high-water pass.
- The high-water maintenance task is process-wide and bounded: it checks once per minute, performs no checkpoint below 64 MiB, uses a non-blocking writer permit, and exits when shutdown begins.
- No database schema or public wire-format migration is introduced. Rolling back the commit restores the previous runtime behavior; already-written Task history and recovery receipts remain valid retained audit records.
- The debug wake/capture support is compiled only for debug packaged-app acceptance and does not change release behavior.

## Verification

- `cargo test -p agent_core` — 3,475 passed, 0 failed, 3 repository-marked ignored.
- `cargo test -p database` — 13 passed, 0 failed.
- `cargo test -p org2` — 1,064 library tests and 32 integration tests passed, 0 failed; repository-marked real-CLI/doc tests remained ignored.
- `cargo clippy -p org2 -p agent_core -p database -p e2e-test --all-targets -- -D warnings` — passed with zero warnings.
- `cargo check -p e2e-test` — passed.
- `cargo check -p org2` — passed.
- `git diff --check` — passed.
- BuildFast packaged app, isolated Instance 3 — production TaskAssigned/inbox wake started one `codexharry` GPT 5.6 Luna request; the process was killed about 100 ms after the provider boundary. Before kill, the Task was `in_progress` with one persisted TaskExecution turn. On credential-free restart, the turn was `failed`, the Task was ownerless `pending`, and one recovery notification/receipt was committed without provider replay.
- Repeated the credential-free startup twice — Task, failed-turn, recovery-notification, and receipt counts stayed unchanged.
- Seeded 137 interrupted TaskExecution records, killed and restarted the packaged app — all 137 Tasks became ownerless `pending`, all 137 turns failed, and three further restarts produced no duplicate recovery rows.
- Used the packaged UI to quit with `Cmd+Q` and the confirmation button — connection pools drained with zero checked-out connections, both database integrity checks returned `ok`, both WAL files ended at 0 bytes, and bounded teardown completed in 15–18 ms.
- Temporary OAuth material contained only the access token, was removed immediately after the crash window, and was not added to the repository. The isolated test workspace had no tracked or untracked changes.

`cargo fmt --all -- --check` is not green because the repository currently contains broad pre-existing rustfmt drift across untouched files and old regions of a touched startup module. The newly added lines were not among rustfmt's proposed changes; the existing drift was not reformatted here to avoid unrelated churn.

Visual screenshots are not useful for this change because it introduces no visual UI behavior; acceptance evidence is the packaged process lifecycle, provider-boundary capture, durable SQLite state, shutdown logs, and WAL state.

## Audit

Performance verdict: pass for the changed lifecycle surface. Startup scans are keyset-bounded, recovery is idempotent, the WAL worker has one process owner and bounded cadence, secondary-instance data/auth/ports were isolated, and repeated startup/quit cycles showed stable durable row counts with no retained process.
