### PR TITLE
fix(codex): translate Astra CLI model variants

### DIFF
--- a/src-tauri/src/agent_sessions/cli/session_runner/command.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/command.rs
@@ -281,7 +281,8 @@ pub(super) fn codex_app_server_thread_model(model: Option<&str>) -> Option<Strin
 }
 
 fn map_codex_model_variant(model: &str) -> CodexModelLaunchConfig {
-    const CODEX_VARIANT_BASES: [&str; 8] = [
+    const CODEX_VARIANT_BASES: [&str; 9] = [
+        "gpt-6-astra",
         "gpt-5.6-sol",
         "gpt-5.6-terra",
         "gpt-5.6-luna",
@@ -304,11 +305,14 @@ fn map_codex_model_variant(model: &str) -> CodexModelLaunchConfig {
         let Some(reasoning) = suffix_parts.first().copied() else {
             continue;
         };
-        // GPT-5.6 adds Max above xhigh; do not reinterpret unsupported Max
+        // Astra and GPT-5.6 support Max above xhigh; do not reinterpret unsupported Max
         // suffixes for older families as a launch override.
-        let supports_gpt_5_6_max = reasoning == "max"
-            && matches!(base_model, "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna");
-        if !CODEX_REASONING_LEVELS.contains(&reasoning) && !supports_gpt_5_6_max {
+        let supports_max = reasoning == "max"
+            && matches!(
+                base_model,
+                "gpt-6-astra" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna"
+            );
+        if !CODEX_REASONING_LEVELS.contains(&reasoning) && !supports_max {
             continue;
         }
 

--- a/src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs
+++ b/src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs
@@ -277,6 +277,57 @@ fn build_codex_basic() {
 }
 
 #[test]
+fn build_codex_astra_variants_split_model_and_overrides_for_both_transports() {
+    for effort in ["low", "medium", "high", "xhigh", "max", "ultra"] {
+        for fast in [false, true] {
+            let model = format!("gpt-6-astra-{effort}{}", if fast { "-fast" } else { "" });
+            let reasoning = format!("model_reasoning_effort=\"{effort}\"");
+            let priority = "service_tier=\"priority\"";
+
+            // Both fresh and resumed exec turns must send a real model slug.
+            for resume_id in [None, Some("thread-123")] {
+                let cmd = build_command!(
+                    ModelType::Codex,
+                    task = "write tests",
+                    model = Some(&model),
+                    resume_id = resume_id,
+                );
+                let model_idx = cmd.iter().position(|arg| arg == "-m").unwrap();
+                assert_eq!(cmd[model_idx + 1], "gpt-6-astra", "{model}");
+                assert!(cmd.windows(2).any(|args| args == ["-c", &reasoning]));
+                assert_eq!(cmd.windows(2).any(|args| args == ["-c", priority]), fast);
+                assert!(!cmd.contains(&model));
+            }
+
+            let profile = app_server_profile(&ModelType::Codex, Some("app-server"));
+            let turn = CliTurnEnvelope::new("write tests");
+            let cmd = build_command_with_launch_profile(CliCommandBuildRequest {
+                agent: &ModelType::Codex,
+                launch_profile: &profile,
+                model: Some(&model),
+                turn: &turn,
+                resume_id: None,
+                api_key: None,
+                endpoint: None,
+                mode: None,
+                repo_path: None,
+                additional_dirs: &[],
+                mcp_config_path: None,
+                codex_mcp_profile: None,
+            });
+            assert_eq!(cmd[1], "app-server");
+            assert!(cmd.windows(2).any(|args| args == ["-c", &reasoning]));
+            assert_eq!(cmd.windows(2).any(|args| args == ["-c", priority]), fast);
+            assert!(!cmd.iter().any(|arg| arg == "-m" || arg == &model));
+            assert_eq!(
+                codex_app_server_thread_model(Some(&model)).as_deref(),
+                Some("gpt-6-astra")
+            );
+        }
+    }
+}
+
+#[test]
 fn build_codex_reasoning_variant_maps_to_config_override() {
     let cmd = build_command!(
         ModelType::Codex,


### PR DESCRIPTION
## Problem

Selecting an Astra reasoning variant for a Codex CLI session fails with HTTP 400: ORGII launches `codex exec -m gpt-6-astra-medium`, which the ChatGPT-backed Codex endpoint does not accept as a model slug. Astra was added to the catalog and native API provider, but the CLI mapper retained a separate fixed list without Astra. The same mapper also supplies app-server model parameters.

## Solution

Recognize `gpt-6-astra` at the CLI launch boundary and include it in the families supporting Max effort. Astra variants now emit the base model separately from reasoning and optional priority service-tier configuration. Existing model mappings remain unchanged.

Add a regression matrix for all six Astra efforts with and without fast mode, covering fresh and resumed exec command construction, app-server argv, and the app-server thread model parameter. The new test failed on the original source and passes with the fix.

## Potential risks

Real authenticated requests have not been run, so account entitlement and the installed Codex version's acceptance of each effort/service tier remain unverified. This patch preserves the existing CLI convention for Ultra. Future models still require maintaining the CLI's explicit family list.

No persisted data, schema, dependency, or public IPC format changes are required. Existing saved Astra variants become usable through the corrected launch conversion without rewriting sessions. Rollback is a commit revert and rebuild. The locally installed app bundle has not been rebuilt or replaced.

## Verification

- `cd src-tauri && cargo test --lib build_codex_astra_variants_split_model_and_overrides_for_both_transports` — before the source fix, failed as expected because `gpt-6-astra-low` was passed as the model.
- `cd src-tauri && cargo test --lib agent_sessions::cli::session_runner::command_tests::` — after the fix, all 41 tests passed.
- `rustfmt --edition 2021 --check src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs` — passed.
- `git diff --check` — passed; reviewed the two-file diff for unrelated changes and sensitive data.
- `git fetch origin develop` and `git rev-list --left-right --count HEAD...origin/develop` — confirmed the starting base remained current (0/0 before committing).
- Pre-commit hook: `cd src-tauri && cargo clippy --lib --message-format=short -p org2` — passed; hooks completed without bypass.
- Full workspace tests, authenticated end-to-end requests, and an app bundle rebuild were not run; verification targets the changed CLI argument-producing boundary. Screenshots are not useful for this change because it does not modify UI layout or copy.
