### PR TITLE
fix(claude): serialize model and effort in App session metadata

### DIFF
--- a/src-tauri/src/agent_sessions/cli/native_materializer.rs
+++ b/src-tauri/src/agent_sessions/cli/native_materializer.rs
@@ -1312,7 +1312,13 @@ fn publish_claude_desktop_session_at_path(
         .as_deref()
         .filter(|value| !value.trim().is_empty())
     {
-        object.insert("model".to_string(), json!(model));
+        let launch = super::session_runner::command::map_claude_model_variant(model);
+        object.insert("model".to_string(), json!(launch.base_model));
+        // Desktop resumes with separate model/effort fields, just like the CLI
+        // launch flags. An unspecified override preserves its existing choice.
+        if let Some(effort) = launch.effort {
+            object.insert("effort".to_string(), json!(effort));
+        }
     }
     if is_new {
         object.insert("orgiiMaterialization".to_string(), json!(true));
@@ -4004,6 +4010,75 @@ mod tests {
             Some(active_project.join(format!("local_{new_native_id}.json"))),
             "a new row must be placed under the active account"
         );
+    }
+
+    #[test]
+    fn claude_desktop_publication_preserves_selected_model_and_effort() {
+        let sandbox = test_env::sandbox();
+        let cwd = sandbox.path().join("effort-workspace");
+        fs::create_dir_all(&cwd).unwrap();
+        let session_id = "cliagent-desktop-effort";
+        create_native_claude_session(session_id, "effort-account", &cwd);
+        let mut session = persistence::get_session(session_id).unwrap().unwrap();
+        let native_id = "33333333-4444-4555-8666-777777777777";
+        let native_path = cwd.join("transcript.jsonl");
+        fs::write(&native_path, b"{}\n").unwrap();
+
+        for effort in ["low", "medium", "high", "xhigh", "max"] {
+            session.model = Some(format!("claude-fable-5-1-{effort}"));
+            let path = cwd.join(format!("{effort}.json"));
+            publish_claude_desktop_session_at_path(
+                &session,
+                &cwd,
+                native_id,
+                &native_path,
+                &[],
+                path.clone(),
+            )
+            .unwrap();
+            let row: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+            assert_eq!(row["model"], "claude-fable-5-1");
+            assert_eq!(row["effort"], effort);
+        }
+
+        let path = cwd.join("existing.json");
+        fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "model": "claude-fable-5-1-high", "effort": "low",
+                "providerOwnedField": "preserve"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        session.model = Some("claude-fable-5-1-high".to_string());
+        publish_claude_desktop_session_at_path(
+            &session,
+            &cwd,
+            native_id,
+            &native_path,
+            &[],
+            path.clone(),
+        )
+        .unwrap();
+        let row: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(row["model"], "claude-fable-5-1");
+        assert_eq!(row["effort"], "high");
+        assert_eq!(row["providerOwnedField"], "preserve");
+
+        // A selection without an effort override must not erase App-owned effort.
+        session.model = Some("claude-fable-5-1".to_string());
+        publish_claude_desktop_session_at_path(
+            &session,
+            &cwd,
+            native_id,
+            &native_path,
+            &[],
+            path.clone(),
+        )
+        .unwrap();
+        let row: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(row["effort"], "high");
     }
 
     #[test]

--- a/src-tauri/src/agent_sessions/cli/session_runner/command.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/command.rs
@@ -359,7 +359,7 @@ pub(super) fn map_claude_model(model: &str) -> String {
     map_claude_model_variant(model).base_model
 }
 
-pub(super) struct ClaudeModelLaunchConfig {
+pub(in crate::agent_sessions::cli) struct ClaudeModelLaunchConfig {
     pub base_model: String,
     pub effort: Option<String>,
 }
@@ -385,7 +385,9 @@ fn claude_effort_token(token: &str) -> Option<&'static str> {
 /// same way [`map_claude_model`] does (strip date suffix, re-add `claude-`
 /// prefix). Non-effort suffixes (e.g. `thinking`, `fast`) and plain version
 /// numbers are left on the base model untouched.
-pub(super) fn map_claude_model_variant(model: &str) -> ClaudeModelLaunchConfig {
+pub(in crate::agent_sessions::cli) fn map_claude_model_variant(
+    model: &str,
+) -> ClaudeModelLaunchConfig {
     // Try the compound `extra-high` token first (two trailing segments),
     // then a single trailing segment. `rfind` alone would split
     // `...-extra-high` at the last `-`, leaving `extra` on the base model.


### PR DESCRIPTION
## Problem

ORG2's existing Claude App catalog publisher writes the ORG2 model variant (for example `claude-fable-5-1-high`) into the native metadata model field. Claude App stores the base model and effort separately. This is a publication-format defect; ordinary Claude Code execution already passes a separate `--effort` flag and is not repaired by this PR.

## Solution

Reuse the existing Claude CLI model-variant parser at the metadata writer. Publish the base model and explicit effort separately, preserve existing effort when no override is selected, and retain unrelated provider-owned fields. Regression coverage exercises five effort variants and updates to existing records.

This changes the existing catalog publication only. The catalog record carries the native session ID, working directory, title, timestamps and settings so Claude App can load a session whose conversation remains in the native JSONL transcript. It is not a runtime settings API.

## Potential risks

End-to-end first-import effort preservation is still blocked in the installed Claude App. Its resume URL handler forwards only the session UUID to importCliSession. For a session absent from its memory, adoptCliSession rebuilds a record from the transcript; its imported settings include model and permissions but omit effort. The resulting record can overwrite the correctly published metadata. App setEffort updates memory, disk and the active query, but the inspected resume URL does not expose that operation. This PR does not claim to repair that App-owned path and remains Draft for the requested complete handoff behavior.

Two successful High continuations (ORG2 and Claude App) have native transcript effort=high. This disproves the inference that a Low display necessarily means a Low request; it does not establish preservation for every effort level. No automatic App restart, global effort override, private runtime injection or vendor-bundle modification is introduced.

The provider-owned metadata format may change. No schema migration, dependency change, new timer or scan is introduced. Existing records are corrected on ordinary publication, with no bulk history rewrite. Revert the commit and rebuild to restore the previous writer; native conversations remain intact. Cross-process metadata ownership and App discovery cadence are unchanged.

## Verification

- Original regression reproduced the unsplit model defect before the fix.
- Earlier CLI suite: 457 passed, 3 ignored; earlier cargo clippy and PR CI passed. These results preceded the latest develop integration.
- Rebased onto develop after #1442 and #1444 merged, without conflicts; the diff remains limited to the metadata publisher, its regression test and shared parser visibility.
- `git diff --check origin/develop...HEAD` passed after integration; inspected both changed files for unrelated changes and private data.
- After integration: `CARGO_TARGET_DIR=<shared-target> cargo test --manifest-path src-tauri/Cargo.toml --lib claude_desktop_publication_preserves_selected_model_and_effort -- --nocapture` — 1 passed.
- After integration: `CARGO_TARGET_DIR=<shared-target> cargo test --manifest-path src-tauri/Cargo.toml --lib agent_sessions::cli:: -- --nocapture` — 458 passed, 4 ignored, 0 failed. Full workspace tests and a new packaged UI run were not repeated; new-head CI must run after push.
- Current installed `claude --help` advertises --effort. ORG2's ClaudeCode command builder passes --model and --effort for both fresh and resumed turns.
- Read-only inspection of the installed Claude App archive reconfirmed the UUID-only resume handler, effort omission during first adoption, and the separate setEffort runtime operation. No vendor files were modified.
- Read back the retained test transcript: the successful ORG2 continuation at 15:00:03 UTC and Claude App continuation at 15:00:56 UTC on 2026-09-09 both record claude-fable-5-1 and effort=high. No new model turn or App restart was performed for this revalidation.
- No UI layout changes; screenshot evidence would not prove the serialization boundary. Complete first-import effort inheritance remains unverified and previously failed its display check.

Architecture review covered parser reuse and visibility, separate CLI/runtime/catalog meanings, absent-override behavior, provider boundary, serialized fields, and loaded-versus-first-import initialization asymmetry. Compilation validation is recorded below; unrelated structural cleanup was excluded. Performance: no new background owner or retained state; no full lifecycle performance certification is claimed.
