### PR TITLE
fix(cli): reconcile native history after terminal events

### DIFF
--- a/src/engines/SessionCore/sync/adapters/cli/__tests__/createCliEventHandler.test.ts
+++ b/src/engines/SessionCore/sync/adapters/cli/__tests__/createCliEventHandler.test.ts
@@ -1389,6 +1389,40 @@ describe("createCliEventHandler ingestion boundary", () => {
   // -------------------------------------------------------------------------
 
   describe("status transitions", () => {
+    it.each(["completed", "failed", "cancelled"])(
+      "forwards %s to the shared lifecycle with its dispatch identity",
+      async (status) => {
+        const onStatusChange = vi.fn();
+        callbacks.onStatusChange = onStatusChange;
+        handler.handleEvent({
+          type: "code_session.status_changed",
+          session_id: SESSION_ID,
+          status,
+          turn_intent_id: "intent-first-turn",
+        });
+        await flush();
+        expect(onStatusChange).toHaveBeenCalledTimes(1);
+        expect(onStatusChange).toHaveBeenCalledWith(status, undefined, {
+          turnIntentId: "intent-first-turn",
+        });
+      }
+    );
+
+    it("does not notify a disposed view after terminal persistence settles", async () => {
+      const onStatusChange = vi.fn();
+      callbacks.onStatusChange = onStatusChange;
+      handler.handleEvent({
+        type: "code_session.status_changed",
+        session_id: SESSION_ID,
+        status: "completed",
+        turn_intent_id: "intent-disposed",
+      });
+      handler.dispose();
+      await flush();
+      expect(onStatusChange).not.toHaveBeenCalled();
+      expect(callbacks.agentCompletes).toBe(0);
+    });
+
     it("closes the turn on a terminal status and mirrors it into the runtime atom", async () => {
       handler.handleEvent(
         activityEvent(
@@ -1520,6 +1554,8 @@ describe("createCliEventHandler ingestion boundary", () => {
     });
 
     it("does not expose the terminal runtime state before partial rows close", async () => {
+      const onStatusChange = vi.fn();
+      callbacks.onStatusChange = onStatusChange;
       await store.api.upsert(
         {
           id: "slow-partial",
@@ -1542,10 +1578,13 @@ describe("createCliEventHandler ingestion boundary", () => {
         type: "code_session.status_changed",
         session_id: SESSION_ID,
         status: "cancelled",
+        turn_intent_id: "intent-terminal-history",
+        error_message: "cancelled by user",
       });
       await vi.waitFor(() => expect(store.api.upsert).toHaveBeenCalledTimes(2));
 
       expect(getInstrumentedStore().get(sessionRuntimeStatusAtom)).toBe("idle");
+      expect(onStatusChange).not.toHaveBeenCalled();
       releaseBarrier?.();
       await flush();
 
@@ -1553,6 +1592,12 @@ describe("createCliEventHandler ingestion boundary", () => {
         "cancelled"
       );
       expect(callbacks.agentCompletes).toBe(1);
+      expect(onStatusChange).toHaveBeenCalledTimes(1);
+      expect(onStatusChange).toHaveBeenCalledWith(
+        "cancelled",
+        "cancelled by user",
+        { turnIntentId: "intent-terminal-history" }
+      );
     });
 
     it("waits for an in-flight streamed row before publishing terminal state", async () => {

--- a/src/engines/SessionCore/sync/adapters/cli/createCliEventHandler.ts
+++ b/src/engines/SessionCore/sync/adapters/cli/createCliEventHandler.ts
@@ -533,7 +533,8 @@ export function createCliEventHandler(
     }
   }
 
-  function handleStatusChange(status: string): void {
+  function handleStatusChange(raw: RawSessionEvent): void {
+    const status = raw.status as string;
     const terminalStatus = isCliTerminalStatus(status as CliSessionStatus)
       ? (status as CliSessionStatus)
       : undefined;
@@ -549,7 +550,21 @@ export function createCliEventHandler(
       // Otherwise a fast Stop -> runtime switch can read the old native fork
       // before EventStore owns the interrupted suffix.
       void markObservedCliTerminalStatus(sessionId, observedTerminalStatus)
-        .then(() => callbacks.onAgentComplete?.())
+        .then(() => {
+          if (disposed) return;
+          // The shared lifecycle callback owns native transcript reconciliation.
+          // Notify it after streamed writes settle, preserving the turn identity
+          // so a late terminal cannot reconcile a newer dispatch.
+          callbacks.onStatusChange?.(
+            status,
+            asString(raw.error_message) ?? asString(raw.errorMessage),
+            {
+              turnIntentId:
+                asString(raw.turn_intent_id) ?? asString(raw.turnIntentId),
+            }
+          );
+          callbacks.onAgentComplete?.();
+        })
         .catch((error: unknown) => {
           log.error("CLI terminal completion failed", error);
         });
@@ -607,7 +622,7 @@ export function createCliEventHandler(
       } else if (raw.type === "agent:streaming_complete") {
         handleStreamingComplete(raw);
       } else if (raw.type === "code_session.status_changed") {
-        handleStatusChange(raw.status as string);
+        handleStatusChange(raw);
       } else if (raw.type === "code_session.token_usage_updated") {
         const total = raw.total_tokens;
         // Billing events invalidate telemetry; their cumulative total is not context.


### PR DESCRIPTION
## Problem

The CLI event adapter consumed terminal status broadcasts and closed streamed rows, but never forwarded the terminal to the shared Session lifecycle callback. That callback schedules authoritative provider-native transcript reconciliation. During live Fable 5.1 testing, the workstation showed replies while the main chat stayed empty or retained only the prior turn until Reload.

## Solution

Forward CLI terminal status and error through `onStatusChange` after the existing streaming persistence barrier. Preserve the originating turn-intent ID so the shared lifecycle can reject stale dispatches. Do not call view callbacks after disposal. The existing reconciliation owner still performs and coalesces native-history reads; this adds no alternate history writer or UI fallback.

## Potential risks

All CLI providers share this adapter, so terminal callbacks now perform the already-defined native reconciliation path. Existing dispatch-generation checks and the streaming write barrier remain in place. There is no schema migration, historical cleanup, new timer, or polling loop. Reverting restores the previous adapter behavior. Packaged UI verification passed for a fresh Fable first turn and a subsequent turn while the chat stayed visible; this does not solve native App sidebar project mapping or Claude effort metadata.

## Verification

- `pnpm test src/engines/SessionCore/sync/adapters/cli/__tests__/createCliEventHandler.test.ts`: regression failed before the change because the lifecycle callback was invoked zero times instead of once.
- `pnpm test src/engines/SessionCore/sync/adapters/cli/__tests__/createCliEventHandler.test.ts src/engines/SessionCore/sync/__tests__/nativeTranscriptReconcile.test.ts src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.sessionListStatus.test.ts`: 107 passed. Covers completed/failed/cancelled dispatch identity, persistence ordering, disposed views and existing canonical reconciliation behavior.
- Commit hooks: oxlint, ESLint, Prettier and `tsgo --noEmit --pretty false` passed.
- `git diff --check origin/develop...HEAD`: passed. Only the owning adapter and its ingestion-boundary tests changed.
- Architecture review covered wire ingestion, callback ownership and native persistence ordering. Performance review: reuse the existing coalesced reconciliation, no added background loop or retained state; runtime UI timing remains unverified.
- Combined verification build: `pnpm run tauri:build:fast -- --skip-frontend /tmp/ORG2-native-integration-final.app` passed (393.8 seconds); frontend built using `pnpm run tauri:build:fast -- --frontend-only` (40.8 seconds).
- Fresh Fable 5.1 High session: first reply appeared in the main chat without Reload. Second turn initially waited for Cloud family metadata, then completed in the same provider session. A third turn, with the chat continuously visible, automatically appeared in the main chat alongside the prior two turns, without Reload or switching views. The native UUID remained unchanged.
- Fresh Astra Medium session: first reply appeared in the main chat without Reload. Its unrelated Codex App sidebar assignment issue still reproduces and is tracked in #1442.
- Observed transient Cloud queue recovery (`Cloud conversation family metadata is not ready`) before the second Fable turn; this change does not address that separate dispatch prerequisite. No UI presentation code or historical records were manually patched.
