### PR TITLE
feat(sidebar): unify the chrome row across hosts and macOS full screen

### DIFF
--- a/src/app/root/useAppShellEffects.ts
+++ b/src/app/root/useAppShellEffects.ts
@@ -10,7 +10,8 @@
  * - `--app-font-family`                                    (applicationUiFontAtom)
  * - `--app-solid-background`                       (resolvedBackgroundConfigAtom)
  * - Chat typography variables                              (chat appearance settings)
- * - `html.fullscreen` class                                (windowFullscreenAtom)
+ * - `html.fullscreen` class                                (windowFullscreenAtom,
+ *   kept in sync with the native window by `useWindowFullscreenSync`)
  *
  * This hook must run in AppBootstrap (before first render) so the styles are
  * applied before any child component paints, avoiding a flash of unstyled UI.
@@ -20,6 +21,7 @@ import { useEffect, useLayoutEffect } from "react";
 
 import { getApplicationUiFontStack } from "@src/config/appearance/applicationUiFonts";
 import { createLogger } from "@src/hooks/logger";
+import { useWindowFullscreenSync } from "@src/hooks/platform/useWindowFullscreenSync";
 import {
   chatCodeFontSizeAtom,
   chatFontSizeAtom,
@@ -38,6 +40,7 @@ import { resolveNativeFrameScale } from "@src/util/platform/tauri/nativeFrame";
 const logger = createLogger("AppShellEffects");
 
 export function useAppShellEffects(): void {
+  useWindowFullscreenSync();
   const uiScale = useAtomValue(uiScaleAtom);
   const applicationUiFont = useAtomValue(applicationUiFontAtom);
   const isFullscreen = useAtomValue(windowFullscreenAtom);

--- a/src/config/windowChromeRadius.ts
+++ b/src/config/windowChromeRadius.ts
@@ -47,6 +47,15 @@ export function resolveHostDesktop(): HostDesktop {
 }
 
 /**
+ * True only inside a real macOS window, where the overlay traffic lights and
+ * the pinned sidebar chrome exist. Browser mode on a Mac reports `isMacOS()`
+ * but resolves to the Linux host: no traffic lights, in-flow chrome.
+ */
+export function hasMacWindowChrome(): boolean {
+  return resolveHostDesktop() === HOST_DESKTOP.MACOS;
+}
+
+/**
  * Sets --border-radius-window and --radius-page on the document root so html/body/#root,
  * splash, rounded-page, and ModalSystem track the host OS.
  */

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -10,7 +10,7 @@ import Tooltip from "@src/components/Tooltip";
 import { CHROME_TOOLTIP_HOVER_DELAY } from "@src/config/tooltip";
 import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import type { DropdownEnginePosition } from "@src/hooks/dropdown";
-import { getCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
+import { useCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { useWorkbenchRightEdgeReservation } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import {
   ArrowExpand01Icon,
@@ -166,6 +166,7 @@ export function ChatPanelHeader({
   // chat on the left the pinned group is over the workstation, so the
   // header keeps its own toggle right of "+" exactly as before.
   const rightEdge = useWorkbenchRightEdgeReservation();
+  const collapsedSidebarChromeOffset = useCollapsedSidebarChromeOffset();
   const pinnedChromeInThisHeader = rightEdge.owner === "chat";
   const trailingInsetPx = pinnedChromeInThisHeader
     ? rightEdge.reservedRight
@@ -455,7 +456,7 @@ export function ChatPanelHeader({
         trailingInsetPx={trailingInsetPx}
         leadingInsetPx={
           shouldOffsetHeaderForCollapsedSidebar
-            ? getCollapsedSidebarChromeOffset()
+            ? collapsedSidebarChromeOffset
             : undefined
         }
       />
@@ -497,7 +498,7 @@ export function ChatPanelHeader({
           style={
             {
               paddingLeft: shouldOffsetHeaderForCollapsedSidebar
-                ? getCollapsedSidebarChromeOffset()
+                ? collapsedSidebarChromeOffset
                 : undefined,
               paddingRight: trailingInsetPx,
               ...(windowsHost

--- a/src/hooks/platform/useWindowFullscreenSync.test.ts
+++ b/src/hooks/platform/useWindowFullscreenSync.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { windowFullscreenAtom } from "@src/store/ui/uiAtom";
+
+import { useWindowFullscreenSync } from "./useWindowFullscreenSync";
+
+const {
+  hasMacWindowChromeMock,
+  isFullscreenMock,
+  onResizedMock,
+  unlistenMock,
+} = vi.hoisted(() => ({
+  hasMacWindowChromeMock: vi.fn(),
+  isFullscreenMock: vi.fn(),
+  onResizedMock: vi.fn(),
+  unlistenMock: vi.fn(),
+}));
+
+vi.mock("@src/config/windowChromeRadius", () => ({
+  hasMacWindowChrome: hasMacWindowChromeMock,
+}));
+vi.mock("@src/util/platform/tauri/safeUnlisten", () => ({
+  safeUnlisten: (fn: (() => void) | null | undefined) => fn?.(),
+}));
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    isFullscreen: isFullscreenMock,
+    onResized: onResizedMock,
+  }),
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+const Harness = () => {
+  useWindowFullscreenSync();
+  return null;
+};
+
+async function flush(): Promise<void> {
+  // Two hops: dynamic import + isFullscreen, then onResized registration.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("useWindowFullscreenSync", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let store: ReturnType<typeof createStore>;
+  let resizeHandler: (() => void) | null;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    resizeHandler = null;
+    hasMacWindowChromeMock.mockReturnValue(true);
+    isFullscreenMock.mockResolvedValue(false);
+    onResizedMock.mockImplementation(async (handler: () => void) => {
+      resizeHandler = handler;
+      return unlistenMock;
+    });
+    store = createStore();
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  function render(): void {
+    act(() => {
+      root.render(createElement(Provider, { store }, createElement(Harness)));
+    });
+  }
+
+  it("seeds the atom from the window and follows resize-driven changes", async () => {
+    isFullscreenMock.mockResolvedValue(true);
+    render();
+    await flush();
+
+    expect(store.get(windowFullscreenAtom)).toBe(true);
+    expect(onResizedMock).toHaveBeenCalledTimes(1);
+
+    // Leaving native full screen resizes the window; re-read the state.
+    isFullscreenMock.mockResolvedValue(false);
+    resizeHandler?.();
+    await flush();
+    expect(store.get(windowFullscreenAtom)).toBe(false);
+
+    isFullscreenMock.mockResolvedValue(true);
+    resizeHandler?.();
+    await flush();
+    expect(store.get(windowFullscreenAtom)).toBe(true);
+  });
+
+  it("unsubscribes on unmount and ignores late resizes", async () => {
+    render();
+    await flush();
+    expect(onResizedMock).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+    expect(unlistenMock).toHaveBeenCalledTimes(1);
+
+    isFullscreenMock.mockResolvedValue(true);
+    resizeHandler?.();
+    await flush();
+    expect(store.get(windowFullscreenAtom)).toBe(false);
+
+    // Re-create so afterEach's unmount stays a no-op.
+    root = createRoot(container);
+  });
+
+  it("does nothing outside a macOS window (other hosts, browser mode)", async () => {
+    hasMacWindowChromeMock.mockReturnValue(false);
+    render();
+    await flush();
+
+    expect(isFullscreenMock).not.toHaveBeenCalled();
+    expect(onResizedMock).not.toHaveBeenCalled();
+    expect(store.get(windowFullscreenAtom)).toBe(false);
+  });
+});

--- a/src/hooks/platform/useWindowFullscreenSync.ts
+++ b/src/hooks/platform/useWindowFullscreenSync.ts
@@ -1,0 +1,71 @@
+/**
+ * useWindowFullscreenSync
+ *
+ * Mirrors the native window's full-screen state into `windowFullscreenAtom`.
+ *
+ * macOS native full screen hides the traffic lights, so every surface that
+ * reserves room for them (sidebar top row, pinned sidebar chrome, collapsed
+ * sidebar header insets) collapses that reserve while the atom is `true`.
+ *
+ * Tauri emits no dedicated full-screen event, but entering or leaving native
+ * full screen always resizes the window, so `onResized` is the trigger and
+ * `isFullscreen()` is the source of truth re-read on each resize.
+ *
+ * Only a real macOS window reserves traffic-light space, so the subscription
+ * is limited to that host (browser mode has no window to ask).
+ */
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+
+import { hasMacWindowChrome } from "@src/config/windowChromeRadius";
+import { createLogger } from "@src/hooks/logger";
+import { windowFullscreenAtom } from "@src/store/ui/uiAtom";
+import { safeUnlisten } from "@src/util/platform/tauri/safeUnlisten";
+
+const log = createLogger("WindowFullscreenSync");
+
+export function useWindowFullscreenSync(): void {
+  const setFullscreen = useSetAtom(windowFullscreenAtom);
+
+  useEffect(() => {
+    if (!hasMacWindowChrome()) return;
+
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+
+    const subscribe = async () => {
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      const appWindow = getCurrentWindow();
+
+      const sync = async () => {
+        const next = await appWindow.isFullscreen();
+        if (!disposed) setFullscreen(next);
+      };
+
+      await sync();
+      if (disposed) return;
+
+      const fn = await appWindow.onResized(() => {
+        if (disposed) return;
+        void sync().catch((error: unknown) => {
+          log.warn("Failed to read window fullscreen state", error);
+        });
+      });
+      if (disposed) {
+        safeUnlisten(fn);
+        return;
+      }
+      unlisten = fn;
+    };
+
+    subscribe().catch((error: unknown) => {
+      log.warn("Failed to subscribe to window fullscreen state", error);
+    });
+
+    return () => {
+      disposed = true;
+      safeUnlisten(unlisten);
+      unlisten = null;
+    };
+  }, [setFullscreen]);
+}

--- a/src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.test.ts
+++ b/src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.test.ts
@@ -5,30 +5,43 @@ import {
   getCollapsedSidebarChromeOffset,
 } from "./useCollapsedSidebarChromeOffset";
 
-const { isMacOSMock } = vi.hoisted(() => ({
-  isMacOSMock: vi.fn(),
+const { hasMacWindowChromeMock } = vi.hoisted(() => ({
+  hasMacWindowChromeMock: vi.fn(),
 }));
 
-vi.mock("@src/util/platform/tauri", () => ({
-  isMacOS: isMacOSMock,
+vi.mock("@src/config/windowChromeRadius", () => ({
+  hasMacWindowChrome: hasMacWindowChromeMock,
 }));
 
 describe("getCollapsedSidebarChromeOffset", () => {
   beforeEach(() => {
-    isMacOSMock.mockReset();
+    hasMacWindowChromeMock.mockReset();
   });
 
   it("reserves native traffic-light space, Back / Forward, and the toggle on macOS", () => {
-    isMacOSMock.mockReturnValue(true);
+    hasMacWindowChromeMock.mockReturnValue(true);
 
     expect(getCollapsedSidebarButtonLeft()).toBe(88);
     expect(getCollapsedSidebarChromeOffset()).toBe(176);
   });
 
-  it("reserves Back / Forward and the standalone sidebar toggle on Windows or Linux", () => {
-    isMacOSMock.mockReturnValue(false);
+  it("swaps the traffic-light reserve for a small edge inset in macOS native full screen", () => {
+    hasMacWindowChromeMock.mockReturnValue(true);
+
+    // Native full screen hides the traffic lights; the group keeps 8px more
+    // than the bare 8px inset so it does not hug the screen edge.
+    expect(getCollapsedSidebarButtonLeft({ fullscreen: true })).toBe(16);
+    expect(getCollapsedSidebarChromeOffset({ fullscreen: true })).toBe(104);
+    expect(getCollapsedSidebarButtonLeft({ fullscreen: false })).toBe(88);
+    expect(getCollapsedSidebarChromeOffset({ fullscreen: false })).toBe(176);
+  });
+
+  it("reserves Back / Forward and the standalone sidebar toggle on Windows, Linux, or the browser", () => {
+    hasMacWindowChromeMock.mockReturnValue(false);
 
     expect(getCollapsedSidebarButtonLeft()).toBe(8);
     expect(getCollapsedSidebarChromeOffset()).toBe(96);
+    expect(getCollapsedSidebarButtonLeft({ fullscreen: true })).toBe(8);
+    expect(getCollapsedSidebarChromeOffset({ fullscreen: true })).toBe(96);
   });
 });

--- a/src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.ts
+++ b/src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.ts
@@ -4,14 +4,15 @@ import {
   SESSION_HISTORY_NAV_GAP,
   SESSION_HISTORY_NAV_WIDTH,
 } from "@src/components/SessionHistoryNav";
+import { hasMacWindowChrome } from "@src/config/windowChromeRadius";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
 import { chatWidthAtom } from "@src/store/ui/chatPanel/widthAtoms";
 import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
+import { windowFullscreenAtom } from "@src/store/ui/uiAtom";
 import {
   type ChatPanelPosition,
   chatPanelPositionAtom,
 } from "@src/store/ui/workStationLayout/chatPositionAtoms";
-import { isMacOS } from "@src/util/platform/tauri";
 
 const COLLAPSED_SIDEBAR_BUTTON_LEFT_INSET = 8;
 const COLLAPSED_SIDEBAR_BUTTON_RESERVED_WIDTH = 30;
@@ -20,26 +21,64 @@ const COLLAPSED_SIDEBAR_HISTORY_NAV_RESERVED_WIDTH =
   SESSION_HISTORY_NAV_WIDTH + SESSION_HISTORY_NAV_GAP;
 const MACOS_TRAFFIC_LIGHTS_RESERVED_WIDTH = 80;
 /**
+ * Native full screen hides the traffic lights, but the group reads better a
+ * touch further in from the bare screen edge than the 8px inset alone gives.
+ */
+const MACOS_FULLSCREEN_EXTRA_LEFT_INSET = 8;
+/**
  * Vertical center of the 36px title-bar row every host places its chrome in
  * (8px top breathing room + half the row). The pinned macOS group and each
  * host's own collapsed toggle share it so nothing shifts between states.
  */
 export const COLLAPSED_SIDEBAR_CHROME_CENTER_TOP = 26;
 
-export function getCollapsedSidebarChromeOffset(): number {
+export interface CollapsedSidebarChromeOptions {
+  /**
+   * Native macOS full screen hides the traffic lights, so their reserve gives
+   * way to a small extra edge inset. Components read this from
+   * `windowFullscreenAtom` via the hook variants below; the plain functions
+   * default to the windowed layout.
+   */
+  fullscreen?: boolean;
+}
+
+function getMacLeadingReservedWidth(fullscreen: boolean): number {
+  if (!hasMacWindowChrome()) return 0;
+  return fullscreen
+    ? MACOS_FULLSCREEN_EXTRA_LEFT_INSET
+    : MACOS_TRAFFIC_LIGHTS_RESERVED_WIDTH;
+}
+
+export function getCollapsedSidebarChromeOffset(
+  options?: CollapsedSidebarChromeOptions
+): number {
   return (
-    (isMacOS() ? MACOS_TRAFFIC_LIGHTS_RESERVED_WIDTH : 0) +
+    getMacLeadingReservedWidth(options?.fullscreen ?? false) +
     COLLAPSED_SIDEBAR_BUTTON_LEFT_INSET +
     COLLAPSED_SIDEBAR_HISTORY_NAV_RESERVED_WIDTH +
     COLLAPSED_SIDEBAR_BUTTON_RESERVED_WIDTH
   );
 }
 
-export function getCollapsedSidebarButtonLeft(): number {
+export function getCollapsedSidebarButtonLeft(
+  options?: CollapsedSidebarChromeOptions
+): number {
   return (
-    (isMacOS() ? MACOS_TRAFFIC_LIGHTS_RESERVED_WIDTH : 0) +
+    getMacLeadingReservedWidth(options?.fullscreen ?? false) +
     COLLAPSED_SIDEBAR_BUTTON_LEFT_INSET
   );
+}
+
+/** `getCollapsedSidebarChromeOffset` tracking the live full-screen state. */
+export function useCollapsedSidebarChromeOffset(): number {
+  const fullscreen = useAtomValue(windowFullscreenAtom);
+  return getCollapsedSidebarChromeOffset({ fullscreen });
+}
+
+/** `getCollapsedSidebarButtonLeft` tracking the live full-screen state. */
+export function useCollapsedSidebarButtonLeft(): number {
+  const fullscreen = useAtomValue(windowFullscreenAtom);
+  return getCollapsedSidebarButtonLeft({ fullscreen });
 }
 
 export function useShouldOffsetWorkStationTopBar(): boolean {

--- a/src/modules/MainApp/shared/MainAppPageHeader.tsx
+++ b/src/modules/MainApp/shared/MainAppPageHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import {
-  getCollapsedSidebarChromeOffset,
+  useCollapsedSidebarChromeOffset,
   useShouldOffsetMainAppHeader,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { PageBreadcrumb } from "@src/modules/shared/layouts/blocks";
@@ -27,6 +27,7 @@ const MainAppPageHeader: React.FC<MainAppPageHeaderProps> = ({
   offsetForCollapsedSidebar,
 }) => {
   const defaultOffsetForCollapsedSidebar = useShouldOffsetMainAppHeader();
+  const collapsedSidebarChromeOffset = useCollapsedSidebarChromeOffset();
   const shouldOffsetHeaderForCollapsedSidebar =
     offsetForCollapsedSidebar ?? defaultOffsetForCollapsedSidebar;
 
@@ -38,7 +39,7 @@ const MainAppPageHeader: React.FC<MainAppPageHeaderProps> = ({
         {
           ...style,
           paddingLeft: shouldOffsetHeaderForCollapsedSidebar
-            ? getCollapsedSidebarChromeOffset()
+            ? collapsedSidebarChromeOffset
             : undefined,
           ...DRAG_STYLE,
         } as React.CSSProperties

--- a/src/modules/SessionWindow/index.tsx
+++ b/src/modules/SessionWindow/index.tsx
@@ -26,6 +26,7 @@ import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { hasMacWindowChrome } from "@src/config/windowChromeRadius";
 import { ChatProvider } from "@src/contexts/workspace/ChatContext";
 import { DataProvider } from "@src/contexts/workspace/DataContext";
 import { useReloadSession } from "@src/engines/ChatPanel/ChatHistory/hooks/useReloadSession";
@@ -56,7 +57,8 @@ import { getPrimaryPaneBackgroundStyle } from "@src/modules/shared/layouts/viewC
 import { sessionByIdAtom } from "@src/store/session";
 import type { SessionContinuation } from "@src/store/session/sessionTabPlacementAtom";
 import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";
-import { isMacOS, isWindows } from "@src/util/platform/tauri";
+import { windowFullscreenAtom } from "@src/store/ui/uiAtom";
+import { isWindows } from "@src/util/platform/tauri";
 import { isHumanSession } from "@src/util/session/sessionDispatch";
 
 /** Path the detached window navigates to for one session. Must stay in sync
@@ -145,6 +147,8 @@ const SessionWindowContent: React.FC<{ sessionId: string }> = memo(
     }, [sessionName]);
 
     const windowsHost = isWindows();
+    // Native full screen hides the macOS traffic lights; drop their reserve.
+    const isFullscreen = useAtomValue(windowFullscreenAtom);
 
     // The `data-tauri-drag-region` attribute only reacts to mousedowns whose
     // TARGET carries the attribute — child elements swallow most of the row.
@@ -180,7 +184,10 @@ const SessionWindowContent: React.FC<{ sessionId: string }> = memo(
           data-tauri-drag-region={windowsHost ? undefined : true}
           onMouseDown={handleHeaderMouseDown}
           style={{
-            paddingLeft: isMacOS() ? MACOS_TRAFFIC_LIGHTS_INSET_PX : 12,
+            paddingLeft:
+              hasMacWindowChrome() && !isFullscreen
+                ? MACOS_TRAFFIC_LIGHTS_INSET_PX
+                : 12,
             ...(windowsHost
               ? CHAT_PANEL_HEADER_NO_DRAG_STYLE
               : CHAT_PANEL_HEADER_DRAG_STYLE),

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts
@@ -38,7 +38,7 @@ vi.mock("@src/engines/Simulator/hooks/useCurrentTurnLastAgentMessage", () => ({
   useCurrentTurnLastAgentMessage: () => null,
 }));
 vi.mock("@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset", () => ({
-  getCollapsedSidebarChromeOffset: () => 0,
+  useCollapsedSidebarChromeOffset: () => 0,
   useShouldOffsetWorkStationTopBar: () => false,
 }));
 vi.mock("@src/services/workStation/WorkStationViewService", () => ({

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
@@ -20,7 +20,7 @@ import CaptionBar from "@src/engines/Simulator/components/CaptionBar";
 import { useCurrentTurnLastAgentMessage } from "@src/engines/Simulator/hooks/useCurrentTurnLastAgentMessage";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 import {
-  getCollapsedSidebarChromeOffset,
+  useCollapsedSidebarChromeOffset,
   useShouldOffsetWorkStationTopBar,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import {
@@ -58,6 +58,7 @@ import { SimulatorAgentChip, StationModeChip } from "../shared";
 const AgentStationTopHeader: React.FC = memo(() => {
   const { t } = useTranslation("sessions");
   const shouldOffsetLeftChrome = useShouldOffsetWorkStationTopBar();
+  const collapsedSidebarChromeOffset = useCollapsedSidebarChromeOffset();
   const pinnedChrome = usePinnedWorkbenchChromeVisible();
   const rightEdge = useWorkbenchRightEdgeReservation();
   const getStationChatVisible = useAtomValue(activeStationChatVisibleAtom);
@@ -150,7 +151,7 @@ const AgentStationTopHeader: React.FC = memo(() => {
         style={
           {
             paddingLeft: shouldOffsetLeftChrome
-              ? getCollapsedSidebarChromeOffset()
+              ? collapsedSidebarChromeOffset
               : undefined,
             // The trailing group keeps its own `pr-2`; only the remainder of
             // the pinned-chrome reservation goes here.

--- a/src/modules/WorkStation/shared/TabBar/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/index.tsx
@@ -44,7 +44,7 @@ import { NoDragRegion } from "@src/components/WindowChrome";
 import { TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX } from "@src/config/workstation/tokens";
 import SessionRawTranscriptDialog from "@src/engines/ChatPanel/components/SessionRawTranscriptDialog";
 import {
-  getCollapsedSidebarChromeOffset,
+  useCollapsedSidebarChromeOffset,
   useShouldOffsetWorkStationTopBar,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { useWorkbenchRightEdgeReservation } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
@@ -224,6 +224,7 @@ export const TabBar: React.FC<TabBarProps> = memo(
     const actionSystem = useActionSystemOptional();
     const dispatch = actionSystem?.dispatch;
     const shouldOffsetLeftChrome = useShouldOffsetWorkStationTopBar();
+    const collapsedSidebarChromeOffset = useCollapsedSidebarChromeOffset();
     // macOS pins the right-edge collapse toggles in window space; make room
     // whenever the workstation is the pane touching that edge.
     const rightEdge = useWorkbenchRightEdgeReservation();
@@ -390,7 +391,7 @@ export const TabBar: React.FC<TabBarProps> = memo(
           {
             height: `${TAB_BAR_HEIGHT + 8}px`,
             paddingLeft: shouldOffsetLeftChrome
-              ? getCollapsedSidebarChromeOffset()
+              ? collapsedSidebarChromeOffset
               : undefined,
             // The controls row keeps its own `pr-2`; only the remainder of
             // the pinned-chrome reservation goes here.

--- a/src/scaffold/NavigationSidebar/CollapsedSidebarButton.tsx
+++ b/src/scaffold/NavigationSidebar/CollapsedSidebarButton.tsx
@@ -7,13 +7,13 @@ import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut
 import SessionHistoryNav from "@src/components/SessionHistoryNav";
 import Tooltip from "@src/components/Tooltip";
 import { useShortcutKeys } from "@src/config/keyboard/useShortcutBindings";
+import { hasMacWindowChrome } from "@src/config/windowChromeRadius";
 import {
   COLLAPSED_SIDEBAR_CHROME_CENTER_TOP,
-  getCollapsedSidebarButtonLeft,
+  useCollapsedSidebarButtonLeft,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { HugeiconsIcon, LayoutAlignLeftIcon, PanelLeftIcon } from "@src/icons";
 import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
-import { isMacOS } from "@src/util/platform/tauri";
 
 import { SIDEBAR_TOOLTIP_HOVER_DELAY } from "./config";
 
@@ -23,6 +23,7 @@ const CollapsedSidebarButtonComponent: React.FC = () => {
   const setSidebarCollapsed = useSetAtom(sidebarCollapsedAtom);
   const label = t("common:tooltips.showSidebar");
   const shortcut = useShortcutKeys("toggle_sidebar");
+  const left = useCollapsedSidebarButtonLeft();
   const tooltipContent = (
     <KeyboardShortcutTooltipContent label={label} shortcut={shortcut} />
   );
@@ -33,7 +34,7 @@ const CollapsedSidebarButtonComponent: React.FC = () => {
 
   // On macOS the group is drawn once, pinned in window space by
   // `PinnedSidebarChrome`; hosts only reserve the space under it.
-  if (!collapsed || isMacOS()) return null;
+  if (!collapsed || hasMacWindowChrome()) return null;
 
   // Back / Forward ride along so they hold the spot they had in the sidebar
   // header; `getCollapsedSidebarChromeOffset` reserves room for both.
@@ -43,7 +44,7 @@ const CollapsedSidebarButtonComponent: React.FC = () => {
       data-collapsed-sidebar-button
       style={
         {
-          left: getCollapsedSidebarButtonLeft(),
+          left,
           top: COLLAPSED_SIDEBAR_CHROME_CENTER_TOP,
           WebkitAppRegion: "no-drag",
         } as React.CSSProperties & { WebkitAppRegion: string }

--- a/src/scaffold/NavigationSidebar/PinnedSidebarChrome.test.ts
+++ b/src/scaffold/NavigationSidebar/PinnedSidebarChrome.test.ts
@@ -15,6 +15,7 @@ import {
 
 import { hoverSidebarOpenAtom } from "@src/store/ui/hoverSidebarAtom";
 import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
+import { windowFullscreenAtom } from "@src/store/ui/uiAtom";
 import {
   createInstrumentedStore,
   resetInstrumentedStore,
@@ -22,11 +23,13 @@ import {
 
 import { PinnedSidebarChrome } from "./PinnedSidebarChrome";
 
-const { isMacOSMock } = vi.hoisted(() => ({ isMacOSMock: vi.fn() }));
+const { hasMacWindowChromeMock } = vi.hoisted(() => ({
+  hasMacWindowChromeMock: vi.fn(),
+}));
 
-vi.mock("@src/util/platform/tauri", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@src/util/platform/tauri")>()),
-  isMacOS: isMacOSMock,
+vi.mock("@src/config/windowChromeRadius", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@src/config/windowChromeRadius")>()),
+  hasMacWindowChrome: hasMacWindowChromeMock,
 }));
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -46,7 +49,7 @@ describe("PinnedSidebarChrome", () => {
   });
 
   beforeEach(() => {
-    isMacOSMock.mockReturnValue(true);
+    hasMacWindowChromeMock.mockReturnValue(true);
     resetInstrumentedStore();
     localStorage.clear();
     store = createInstrumentedStore();
@@ -59,7 +62,7 @@ describe("PinnedSidebarChrome", () => {
     act(() => root.unmount());
     container.remove();
     resetInstrumentedStore();
-    isMacOSMock.mockReset();
+    hasMacWindowChromeMock.mockReset();
   });
 
   afterAll(() => {
@@ -86,8 +89,8 @@ describe("PinnedSidebarChrome", () => {
     act(() => element.click());
   }
 
-  it("renders nothing off macOS", () => {
-    isMacOSMock.mockReturnValue(false);
+  it("renders nothing outside a macOS window (other hosts, browser mode)", () => {
+    hasMacWindowChromeMock.mockReturnValue(false);
     render();
     expect(query("pinned-sidebar-chrome")).toBeNull();
   });
@@ -101,7 +104,7 @@ describe("PinnedSidebarChrome", () => {
     expect(group?.style.left).toBe("88px");
     expect(group?.style.top).toBe("26px");
     expect(query("session-history-nav")).not.toBeNull();
-    expect(query("pinned-sidebar-chrome-hide")).not.toBeNull();
+    expect(query("sidebar-chrome-hide")).not.toBeNull();
 
     // Sidebar open: sidebar tokens, toggle first, then Back / Forward, 1px apart.
     expect(group?.getAttribute("data-variant")).toBe("sidebar");
@@ -110,17 +113,32 @@ describe("PinnedSidebarChrome", () => {
       group?.querySelectorAll("button[data-testid]") ?? []
     ).map((element) => element.getAttribute("data-testid"));
     expect(order).toEqual([
-      "pinned-sidebar-chrome-hide",
+      "sidebar-chrome-hide",
       "session-history-nav-back",
       "session-history-nav-forward",
     ]);
 
-    click("pinned-sidebar-chrome-hide");
+    click("sidebar-chrome-hide");
     expect(store.get(sidebarCollapsedAtom)).toBe(true);
-    expect(query("pinned-sidebar-chrome-show")).not.toBeNull();
+    expect(query("sidebar-chrome-show")).not.toBeNull();
     expect(group?.style.left).toBe("88px");
     // Collapsed: the chat pane is underneath, so its tokens take over.
     expect(group?.getAttribute("data-variant")).toBe("chat");
+  });
+
+  it("slides to the window edge in native full screen, where no traffic lights are drawn", () => {
+    act(() => store.set(sidebarCollapsedAtom, false));
+    render();
+
+    const group = query("pinned-sidebar-chrome");
+    expect(group?.style.left).toBe("88px");
+
+    act(() => store.set(windowFullscreenAtom, true));
+    expect(group?.style.left).toBe("16px");
+    expect(group?.style.top).toBe("26px");
+
+    act(() => store.set(windowFullscreenAtom, false));
+    expect(group?.style.left).toBe("88px");
   });
 
   it("offers expand and close while the hover sidebar is open", () => {
@@ -130,16 +148,16 @@ describe("PinnedSidebarChrome", () => {
     });
     render();
 
-    expect(query("pinned-sidebar-chrome-expand")).not.toBeNull();
+    expect(query("sidebar-chrome-expand")).not.toBeNull();
     expect(query("pinned-sidebar-chrome")?.getAttribute("data-variant")).toBe(
       "sidebar"
     );
-    click("pinned-sidebar-chrome-close-hover");
+    click("sidebar-chrome-close-hover");
     expect(store.get(hoverSidebarOpenAtom)).toBe(false);
     expect(store.get(sidebarCollapsedAtom)).toBe(true);
 
     act(() => store.set(hoverSidebarOpenAtom, true));
-    click("pinned-sidebar-chrome-expand");
+    click("sidebar-chrome-expand");
     expect(store.get(hoverSidebarOpenAtom)).toBe(false);
     expect(store.get(sidebarCollapsedAtom)).toBe(false);
   });

--- a/src/scaffold/NavigationSidebar/PinnedSidebarChrome.tsx
+++ b/src/scaffold/NavigationSidebar/PinnedSidebarChrome.tsx
@@ -7,179 +7,31 @@
  * (which slides as the sidebar resizes) owns the group, so it holds still
  * while everything around it moves — the sidebar header and every
  * collapsed-sidebar host merely reserve the space underneath it.
+ *
+ * Other hosts draw the same group in flow: `SidebarBase` leads its chrome
+ * row with it, and `CollapsedSidebarButton` takes over once it collapses.
  */
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import React, { memo, useCallback } from "react";
-import { useTranslation } from "react-i18next";
+import React, { memo } from "react";
 
-import SessionHistoryNav, {
-  type SessionHistoryNavVariant,
-} from "@src/components/SessionHistoryNav";
-import SidebarChromeIconButton from "@src/components/SidebarChromeIconButton";
-import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
+import SessionHistoryNav from "@src/components/SessionHistoryNav";
+import { hasMacWindowChrome } from "@src/config/windowChromeRadius";
 import {
   COLLAPSED_SIDEBAR_CHROME_CENTER_TOP,
-  getCollapsedSidebarButtonLeft,
+  useCollapsedSidebarButtonLeft,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
-import {
-  Cancel01Icon,
-  HugeiconsIcon,
-  type IconSvgElement,
-  LayoutAlignLeftIcon,
-  PanelLeftIcon,
-} from "@src/icons";
 import { SIDEBAR_TOOLTIP_HOVER_DELAY } from "@src/scaffold/NavigationSidebar/config";
-import { hoverSidebarOpenAtom } from "@src/store/ui/hoverSidebarAtom";
-import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
-import { isMacOS } from "@src/util/platform/tauri";
 
-interface ChromeButtonProps {
-  variant: SessionHistoryNavVariant;
-  label: string;
-  shortcutId?: string;
-  onClick: () => void;
-  testId: string;
-  icon: IconSvgElement;
-  dataIcon: string;
-  /** Second glyph swapped in on hover, without a cross-fade. */
-  hoverIcon?: IconSvgElement;
-  hoverDataIcon?: string;
-}
-
-const ChromeButton: React.FC<ChromeButtonProps> = ({
-  variant,
-  label,
-  shortcutId,
-  onClick,
-  testId,
-  icon,
-  dataIcon,
-  hoverIcon,
-  hoverDataIcon,
-}) => {
-  const glyphs = (
-    <span className="flex h-4 w-4 items-center justify-center">
-      <HugeiconsIcon
-        icon={icon}
-        data-icon={dataIcon}
-        size={16}
-        strokeWidth={2}
-        className={hoverIcon ? "group-hover/toggle:hidden" : undefined}
-      />
-      {hoverIcon ? (
-        <HugeiconsIcon
-          icon={hoverIcon}
-          data-icon={hoverDataIcon}
-          size={16}
-          strokeWidth={2}
-          className="hidden group-hover/toggle:block"
-        />
-      ) : null}
-    </span>
-  );
-  if (variant === "sidebar") {
-    return (
-      <SidebarChromeIconButton
-        title={label}
-        shortcutId={shortcutId}
-        tooltipMouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}
-        onClick={onClick}
-        className="group/toggle"
-        data-testid={testId}
-      >
-        {glyphs}
-      </SidebarChromeIconButton>
-    );
-  }
-  return (
-    <TabBarTrailingIconButton
-      title={label}
-      shortcutId={shortcutId}
-      tooltipPosition="bottom"
-      tooltipMouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}
-      nativeTitle={false}
-      onClick={onClick}
-      className="group/toggle"
-      data-testid={testId}
-    >
-      {glyphs}
-    </TabBarTrailingIconButton>
-  );
-};
+import {
+  SidebarChromeToggle,
+  useSidebarChromeVariant,
+} from "./SidebarChromeToggle";
 
 const PinnedSidebarChromeComponent: React.FC = () => {
-  const { t } = useTranslation("sessions");
-  const [collapsed, setCollapsed] = useAtom(sidebarCollapsedAtom);
-  const hoverOpen = useAtomValue(hoverSidebarOpenAtom);
-  const setHoverOpen = useSetAtom(hoverSidebarOpenAtom);
+  const variant = useSidebarChromeVariant();
+  // Native full screen hides the traffic lights; the group slides to the edge.
+  const left = useCollapsedSidebarButtonLeft();
 
-  const hide = useCallback(() => setCollapsed(true), [setCollapsed]);
-  const show = useCallback(() => setCollapsed(false), [setCollapsed]);
-  const expandFromHover = useCallback(() => {
-    setHoverOpen(false);
-    setCollapsed(false);
-  }, [setCollapsed, setHoverOpen]);
-  const closeHover = useCallback(() => setHoverOpen(false), [setHoverOpen]);
-
-  if (!isMacOS()) return null;
-
-  // Whichever surface is under the group lends its tokens: the sidebar while
-  // it is open (or peeking in as the hover sidebar), the chat pane otherwise.
-  const variant: SessionHistoryNavVariant =
-    !collapsed || hoverOpen ? "sidebar" : "chat";
-
-  let toggle: React.ReactNode;
-  if (collapsed && hoverOpen) {
-    toggle = (
-      <>
-        <ChromeButton
-          variant={variant}
-          label={t("common:tooltips.showSidebar")}
-          shortcutId="toggle_sidebar"
-          onClick={expandFromHover}
-          testId="pinned-sidebar-chrome-expand"
-          icon={PanelLeftIcon}
-          dataIcon="panel-left"
-        />
-        <ChromeButton
-          variant={variant}
-          label={t("common:actions.close")}
-          onClick={closeHover}
-          testId="pinned-sidebar-chrome-close-hover"
-          icon={Cancel01Icon}
-          dataIcon="x"
-        />
-      </>
-    );
-  } else if (collapsed) {
-    toggle = (
-      <ChromeButton
-        variant={variant}
-        label={t("common:tooltips.showSidebar")}
-        shortcutId="toggle_sidebar"
-        onClick={show}
-        testId="pinned-sidebar-chrome-show"
-        icon={LayoutAlignLeftIcon}
-        dataIcon="layout-align-left"
-        hoverIcon={PanelLeftIcon}
-        hoverDataIcon="panel-left"
-      />
-    );
-  } else {
-    toggle = (
-      <ChromeButton
-        variant={variant}
-        label={t("common:tooltips.hideSidebar")}
-        shortcutId="toggle_sidebar"
-        onClick={hide}
-        testId="pinned-sidebar-chrome-hide"
-        icon={PanelLeftIcon}
-        dataIcon="panel-left"
-        hoverIcon={LayoutAlignLeftIcon}
-        hoverDataIcon="layout-align-left"
-      />
-    );
-  }
+  if (!hasMacWindowChrome()) return null;
 
   return (
     <div
@@ -188,13 +40,13 @@ const PinnedSidebarChromeComponent: React.FC = () => {
       data-variant={variant}
       style={
         {
-          left: getCollapsedSidebarButtonLeft(),
+          left,
           top: COLLAPSED_SIDEBAR_CHROME_CENTER_TOP,
           WebkitAppRegion: "no-drag",
         } as React.CSSProperties
       }
     >
-      {toggle}
+      <SidebarChromeToggle variant={variant} />
       <SessionHistoryNav
         variant={variant}
         tooltipMouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}

--- a/src/scaffold/NavigationSidebar/SidebarBase.hostChrome.test.ts
+++ b/src/scaffold/NavigationSidebar/SidebarBase.hostChrome.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { SidebarBaseProps } from "./types";
+
+const { resolveHostDesktopMock } = vi.hoisted(() => ({
+  resolveHostDesktopMock: vi.fn<() => "macos" | "windows" | "linux">(),
+}));
+
+vi.mock("@src/config/windowChromeRadius", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@src/config/windowChromeRadius")>();
+  return {
+    ...actual,
+    resolveHostDesktop: resolveHostDesktopMock,
+    hasMacWindowChrome: () => resolveHostDesktopMock() === "macos",
+  };
+});
+vi.mock("@src/hooks/settings/useSettings", () => ({
+  useSettingValue: (key: string) => {
+    if (key === "layout.sidebarSelectedRowOpacity") return 100;
+    if (key === "layout.sidebarEdgeDepthEnabled") return false;
+    if (key === "general.translucentSidebar") return true;
+    return undefined;
+  },
+}));
+vi.mock("@src/hooks/ui/sidebar/useSidebarState", () => ({
+  useSidebarState: () => ({
+    width: 260,
+    expandedWidth: 260,
+    isCollapsed: false,
+    isDragging: false,
+    handleMouseDown: () => undefined,
+    toggleCollapse: () => undefined,
+    expand: () => undefined,
+    collapse: () => undefined,
+    setWidth: () => undefined,
+  }),
+}));
+vi.mock("@src/scaffold/Resize", () => ({
+  VerticalResizeHandle: () => null,
+}));
+vi.mock("@src/util/platform/tauri/nativeMenuPopup", () => ({
+  popupNativeMenu: async () => undefined,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+type SidebarBaseModule = typeof import("./SidebarBase");
+type UiAtomModule = typeof import("@src/store/ui/uiAtom");
+
+describe("SidebarBase host chrome row", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let store: ReturnType<typeof createStore>;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    // `SidebarBase` resolves the host once at module scope.
+    vi.resetModules();
+    store = createStore();
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    resolveHostDesktopMock.mockReset();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  async function renderHost(
+    host: "macos" | "windows" | "linux"
+  ): Promise<UiAtomModule> {
+    resolveHostDesktopMock.mockReturnValue(host);
+    const [{ default: SidebarBase }, uiAtoms] = await Promise.all([
+      import("./SidebarBase") as Promise<SidebarBaseModule>,
+      import("@src/store/ui/uiAtom") as Promise<UiAtomModule>,
+    ]);
+    // `SidebarBaseProps` requires `children`, so it rides in the props object.
+    const props: SidebarBaseProps = {
+      onAddNew: () => undefined,
+      addLabel: "Add",
+      topBarFollowingContent: createElement("div", {
+        "data-testid": "follow-content",
+      }),
+      children: createElement("div", { "data-testid": "sidebar-body" }),
+    };
+    await act(async () => {
+      root.render(
+        createElement(Provider, { store }, createElement(SidebarBase, props))
+      );
+    });
+    return uiAtoms;
+  }
+
+  function query(testId: string): HTMLElement | null {
+    return container.querySelector(`[data-testid="${testId}"]`);
+  }
+
+  it.each(["windows", "linux"] as const)(
+    "%s: leads the chrome row with the toggle group and gives the follow content its own row",
+    async (host) => {
+      await renderHost(host);
+
+      const row = query("sidebar-chrome-row");
+      expect(row).not.toBeNull();
+      // No traffic lights to reserve: the class inset (8px, matching the
+      // collapsed-sidebar hosts) wins, and nothing inline overrides it.
+      expect(row?.style.paddingLeft).toBe("");
+      expect(row?.className).toContain("pl-2");
+
+      const leading = query("sidebar-chrome-leading-group");
+      expect(leading).not.toBeNull();
+      expect(row?.firstElementChild).toBe(leading);
+      const order = Array.from(
+        leading?.querySelectorAll("button[data-testid]") ?? []
+      ).map((element) => element.getAttribute("data-testid"));
+      expect(order).toEqual([
+        "sidebar-chrome-hide",
+        "session-history-nav-back",
+        "session-history-nav-forward",
+      ]);
+      expect(
+        leading?.querySelector("[data-variant]")?.getAttribute("data-variant")
+      ).toBe("sidebar");
+
+      // Add-new stays at the right edge of the same row.
+      expect(row?.querySelector('button[aria-label="Add"]')).not.toBeNull();
+      expect(row?.textContent).not.toContain("ORG2");
+
+      // The org selector / settings return item is the next row, not a
+      // co-tenant of the chrome row.
+      const follow = query("follow-content");
+      expect(follow).not.toBeNull();
+      expect(row?.contains(follow)).toBe(false);
+      expect(row?.nextElementSibling).toBe(follow);
+    }
+  );
+
+  it("macos: reserves the pinned group and traffic lights instead of drawing the group in flow", async () => {
+    const { windowFullscreenAtom } = await renderHost("macos");
+
+    const row = query("sidebar-chrome-row");
+    expect(row).not.toBeNull();
+    expect(query("sidebar-chrome-leading-group")).toBeNull();
+    expect(query("sidebar-chrome-hide")).toBeNull();
+    // 80px traffic lights + 8px inset + 57px Back / Forward + 30px toggle.
+    expect(row?.style.paddingLeft).toBe("176px");
+    expect(row?.nextElementSibling).toBe(query("follow-content"));
+
+    // Native full screen hides the traffic lights: an 8px edge inset plus
+    // the pinned group's footprint remains reserved.
+    act(() => store.set(windowFullscreenAtom, true));
+    expect(row?.style.paddingLeft).toBe("104px");
+  });
+});

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -2,7 +2,8 @@
  * SidebarBase
  *
  * The foundational wrapper for all sidebar components.
- * Handles: transparent sidebar surface, resize, collapse, traffic lights spacing.
+ * Handles: transparent sidebar surface, resize, collapse, and the chrome row
+ * (traffic-light spacing on macOS, the in-flow toggle group elsewhere).
  *
  * @example
  * ```tsx
@@ -20,6 +21,7 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react";
 
 import AnyIcon from "@src/components/AnyIcon";
 import Button from "@src/components/Button";
+import SessionHistoryNav from "@src/components/SessionHistoryNav";
 import { SIDEBAR_CHROME_BUTTON_HOVER_CLASS } from "@src/components/SidebarChromeIconButton";
 import Tooltip from "@src/components/Tooltip";
 import { useShortcutKeys } from "@src/config/keyboard/useShortcutBindings";
@@ -29,7 +31,7 @@ import {
 } from "@src/config/windowChromeRadius";
 import { createLogger } from "@src/hooks/logger";
 import { useSettingValue } from "@src/hooks/settings/useSettings";
-import { getCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
+import { useCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { useSidebarState } from "@src/hooks/ui/sidebar/useSidebarState";
 import { Add01Icon } from "@src/icons";
 import {
@@ -42,9 +44,9 @@ import {
   DEFAULT_SIDEBAR_WIDTH,
   MIN_SIDEBAR_WIDTH,
 } from "@src/store/ui/sidebarAtom";
-import { windowFullscreenAtom } from "@src/store/ui/uiAtom";
 import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
 
+import { SidebarChromeToggle } from "./SidebarChromeToggle";
 import { SIDEBAR_STYLE, SIDEBAR_TOOLTIP_HOVER_DELAY } from "./config";
 import { useForceVisibleSidebar } from "./contexts/ForceVisibleContext";
 import type { SidebarBaseProps } from "./types";
@@ -53,9 +55,6 @@ const log = createLogger("SidebarBase");
 
 const HOST_DESKTOP_KIND = resolveHostDesktop();
 const IS_MACOS_HOST = HOST_DESKTOP_KIND === HOST_DESKTOP.MACOS;
-/** Footprint of `PinnedSidebarChrome` past the traffic lights (inset + arrows + toggle). */
-const PINNED_CHROME_RESERVED_WIDTH =
-  getCollapsedSidebarChromeOffset() - SIDEBAR_STYLE.trafficLightsPadding;
 const IS_WINDOWS_HOST = HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS;
 const IS_WINDOWS_OR_LINUX_HOST =
   HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS ||
@@ -88,8 +87,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     addTooltipContent,
     beforeAddNewActions,
     headerActions,
-    hostTopBarLeadingContent,
-    macTopBarFollowingContent,
+    topBarFollowingContent,
   }) => {
     const sidebarContainerRef = useRef<HTMLDivElement>(null);
     const {
@@ -115,7 +113,9 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
       );
     }, [sidebarSelectedRowOpacity]);
     const hideSidebarShortcut = useShortcutKeys("toggle_sidebar");
-    const isFullscreen = useAtomValue(windowFullscreenAtom);
+    // macOS: traffic lights (or the full-screen edge inset) plus the pinned
+    // toggle + Back / Forward group the row only reserves space under.
+    const pinnedChromeOffset = useCollapsedSidebarChromeOffset();
     const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
     const sidebarOpacityStyle = useMemo(
       () => getSidebarSurfaceBackgroundStyle(backgroundConfig.sidebarOpacity),
@@ -238,53 +238,51 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
 
     const sidebarTopChromeClassName = SIDEBAR_TOP_CHROME_CLASS_NAME;
 
-    // Traffic lights section
-    const renderTrafficLightsSpace = () => {
+    // Chrome row: the 36px title-bar row every host places its sidebar chrome
+    // in. macOS keeps the traffic lights and the pinned toggle group on the
+    // left in window space and only reserves the space under them; every
+    // other host draws the same toggle + Back / Forward group in flow at the
+    // 8px inset the collapsed-sidebar hosts use, so it holds its spot across
+    // both states. Add-new and the extra actions sit at the right edge.
+    const renderChromeRow = () => {
       if (!includeTrafficLightSpace) return null;
 
-      // In fullscreen mode, traffic lights are hidden, so no padding needed
-      const trafficLightPadding =
-        IS_WINDOWS_OR_LINUX_HOST || isFullscreen
-          ? 0
-          : SIDEBAR_STYLE.trafficLightsPadding;
       const alignmentClassName = IS_WINDOWS_OR_LINUX_HOST
-        ? hostTopBarLeadingContent
-          ? "justify-between pl-3 pr-2"
-          : "justify-between pl-5 pr-2"
+        ? "justify-between pl-2 pr-2"
         : "justify-end pr-2";
 
       return (
         <div
           className={`flex flex-nowrap items-center gap-1 ${alignmentClassName}`}
           data-tauri-drag-region
+          data-testid="sidebar-chrome-row"
           style={
             {
               height: `${SIDEBAR_STYLE.topBarHeight}px`,
               // Only macOS needs an inline reserve for the traffic lights.
               // Windows/Linux (and browser mode, which resolves to Linux) must
               // fall through to the alignment class above — an inline `0px`
-              // would beat `pl-3` and pull the top bar flush to the sidebar
-              // edge, out of line with the list rows below it.
+              // would beat `pl-2` and pull the group flush to the sidebar
+              // edge, out of line with the collapsed-sidebar hosts.
               paddingLeft: IS_WINDOWS_OR_LINUX_HOST
                 ? undefined
-                : `${trafficLightPadding + PINNED_CHROME_RESERVED_WIDTH}px`,
+                : `${pinnedChromeOffset}px`,
               WebkitAppRegion: IS_WINDOWS_HOST ? "no-drag" : "drag",
             } as React.CSSProperties
           }
         >
           {IS_WINDOWS_OR_LINUX_HOST ? (
-            hostTopBarLeadingContent ? (
-              <div
-                className="min-w-0 flex-1"
-                style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-              >
-                {hostTopBarLeadingContent}
-              </div>
-            ) : (
-              <span className="text-[13px] font-semibold tracking-wide text-text-2 select-none">
-                ORG2
-              </span>
-            )
+            <div
+              className="flex shrink-0 items-center gap-px"
+              data-testid="sidebar-chrome-leading-group"
+              style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+            >
+              <SidebarChromeToggle variant="sidebar" />
+              <SessionHistoryNav
+                variant="sidebar"
+                tooltipMouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}
+              />
+            </div>
           ) : null}
           <div
             className={`flex shrink-0 items-center gap-px ${sidebarTopChromeClassName}`}
@@ -348,11 +346,6 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
                 {headerActions}
               </div>
             ) : null}
-
-            {/* macOS: the toggle lives in `PinnedSidebarChrome`, pinned in
-                window space after the traffic lights; this row only keeps
-                the space under it clear. */}
-            {IS_MACOS_HOST ? null : <div className="h-[28px] w-[28px]" />}
           </div>
         </div>
       );
@@ -392,8 +385,8 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
             aria-hidden
           />
         )}
-        {renderTrafficLightsSpace()}
-        {IS_MACOS_HOST ? macTopBarFollowingContent : null}
+        {renderChromeRow()}
+        {topBarFollowingContent}
         {header}
         <div className="flex flex-1 flex-col overflow-hidden">
           {resolvedChildren}

--- a/src/scaffold/NavigationSidebar/SidebarChromeToggle.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarChromeToggle.tsx
@@ -1,0 +1,189 @@
+/**
+ * SidebarChromeToggle
+ *
+ * The sidebar show / hide control, in whichever state the sidebar is in:
+ * hide while it is open, show while it is collapsed, and expand + close while
+ * the hover sidebar is peeking in over a collapsed one.
+ *
+ * macOS draws it inside `PinnedSidebarChrome`, pinned in window space after
+ * the traffic lights. Every other host draws it in flow at the head of the
+ * sidebar's own chrome row, where the collapsed-sidebar hosts place the same
+ * group, so it never moves between the two states there either.
+ */
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import React, { memo, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { SessionHistoryNavVariant } from "@src/components/SessionHistoryNav";
+import SidebarChromeIconButton from "@src/components/SidebarChromeIconButton";
+import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
+import {
+  Cancel01Icon,
+  HugeiconsIcon,
+  type IconSvgElement,
+  LayoutAlignLeftIcon,
+  PanelLeftIcon,
+} from "@src/icons";
+import { SIDEBAR_TOOLTIP_HOVER_DELAY } from "@src/scaffold/NavigationSidebar/config";
+import { hoverSidebarOpenAtom } from "@src/store/ui/hoverSidebarAtom";
+import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
+
+interface ChromeButtonProps {
+  variant: SessionHistoryNavVariant;
+  label: string;
+  shortcutId?: string;
+  onClick: () => void;
+  testId: string;
+  icon: IconSvgElement;
+  dataIcon: string;
+  /** Second glyph swapped in on hover, without a cross-fade. */
+  hoverIcon?: IconSvgElement;
+  hoverDataIcon?: string;
+}
+
+const ChromeButton: React.FC<ChromeButtonProps> = ({
+  variant,
+  label,
+  shortcutId,
+  onClick,
+  testId,
+  icon,
+  dataIcon,
+  hoverIcon,
+  hoverDataIcon,
+}) => {
+  const glyphs = (
+    <span className="flex h-4 w-4 items-center justify-center">
+      <HugeiconsIcon
+        icon={icon}
+        data-icon={dataIcon}
+        size={16}
+        strokeWidth={2}
+        className={hoverIcon ? "group-hover/toggle:hidden" : undefined}
+      />
+      {hoverIcon ? (
+        <HugeiconsIcon
+          icon={hoverIcon}
+          data-icon={hoverDataIcon}
+          size={16}
+          strokeWidth={2}
+          className="hidden group-hover/toggle:block"
+        />
+      ) : null}
+    </span>
+  );
+  if (variant === "sidebar") {
+    return (
+      <SidebarChromeIconButton
+        title={label}
+        shortcutId={shortcutId}
+        tooltipMouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}
+        onClick={onClick}
+        className="group/toggle"
+        data-testid={testId}
+      >
+        {glyphs}
+      </SidebarChromeIconButton>
+    );
+  }
+  return (
+    <TabBarTrailingIconButton
+      title={label}
+      shortcutId={shortcutId}
+      tooltipPosition="bottom"
+      tooltipMouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}
+      nativeTitle={false}
+      onClick={onClick}
+      className="group/toggle"
+      data-testid={testId}
+    >
+      {glyphs}
+    </TabBarTrailingIconButton>
+  );
+};
+
+/**
+ * Which surface's tokens the group borrows: the sidebar while it is open (or
+ * peeking in as the hover sidebar), the chat pane otherwise.
+ */
+export function useSidebarChromeVariant(): SessionHistoryNavVariant {
+  const collapsed = useAtomValue(sidebarCollapsedAtom);
+  const hoverOpen = useAtomValue(hoverSidebarOpenAtom);
+  return !collapsed || hoverOpen ? "sidebar" : "chat";
+}
+
+interface SidebarChromeToggleProps {
+  variant: SessionHistoryNavVariant;
+}
+
+const SidebarChromeToggleComponent: React.FC<SidebarChromeToggleProps> = ({
+  variant,
+}) => {
+  const { t } = useTranslation("sessions");
+  const [collapsed, setCollapsed] = useAtom(sidebarCollapsedAtom);
+  const hoverOpen = useAtomValue(hoverSidebarOpenAtom);
+  const setHoverOpen = useSetAtom(hoverSidebarOpenAtom);
+
+  const hide = useCallback(() => setCollapsed(true), [setCollapsed]);
+  const show = useCallback(() => setCollapsed(false), [setCollapsed]);
+  const expandFromHover = useCallback(() => {
+    setHoverOpen(false);
+    setCollapsed(false);
+  }, [setCollapsed, setHoverOpen]);
+  const closeHover = useCallback(() => setHoverOpen(false), [setHoverOpen]);
+
+  if (collapsed && hoverOpen) {
+    return (
+      <>
+        <ChromeButton
+          variant={variant}
+          label={t("common:tooltips.showSidebar")}
+          shortcutId="toggle_sidebar"
+          onClick={expandFromHover}
+          testId="sidebar-chrome-expand"
+          icon={PanelLeftIcon}
+          dataIcon="panel-left"
+        />
+        <ChromeButton
+          variant={variant}
+          label={t("common:actions.close")}
+          onClick={closeHover}
+          testId="sidebar-chrome-close-hover"
+          icon={Cancel01Icon}
+          dataIcon="x"
+        />
+      </>
+    );
+  }
+  if (collapsed) {
+    return (
+      <ChromeButton
+        variant={variant}
+        label={t("common:tooltips.showSidebar")}
+        shortcutId="toggle_sidebar"
+        onClick={show}
+        testId="sidebar-chrome-show"
+        icon={LayoutAlignLeftIcon}
+        dataIcon="layout-align-left"
+        hoverIcon={PanelLeftIcon}
+        hoverDataIcon="panel-left"
+      />
+    );
+  }
+  return (
+    <ChromeButton
+      variant={variant}
+      label={t("common:tooltips.hideSidebar")}
+      shortcutId="toggle_sidebar"
+      onClick={hide}
+      testId="sidebar-chrome-hide"
+      icon={PanelLeftIcon}
+      dataIcon="panel-left"
+      hoverIcon={LayoutAlignLeftIcon}
+      hoverDataIcon="layout-align-left"
+    />
+  );
+};
+
+export const SidebarChromeToggle = memo(SidebarChromeToggleComponent);
+SidebarChromeToggle.displayName = "SidebarChromeToggle";

--- a/src/scaffold/NavigationSidebar/config.ts
+++ b/src/scaffold/NavigationSidebar/config.ts
@@ -14,8 +14,6 @@ export const SIDEBAR_TOOLTIP_HOVER_DELAY = CHROME_TOOLTIP_HOVER_DELAY;
 // ============================================
 
 export const SIDEBAR_STYLE = {
-  /** Traffic lights reserved space */
-  trafficLightsPadding: 80,
   /** Top bar height */
   topBarHeight: WINDOW_CHROME_TOKENS.titleBarHeight,
   /** Search input height */

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import Message from "@src/components/Message";
-import SessionHistoryNav from "@src/components/SessionHistoryNav";
 import { ROUTES } from "@src/config/routes";
 import { useAppNavigation } from "@src/hooks/navigation/useAppNavigation";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
@@ -28,7 +27,6 @@ import {
   sidebarCollapsedAtom,
 } from "@src/store/ui/sidebarAtom";
 import { CHAT_PANEL_SURFACE_KIND } from "@src/types/ui/chatPanel";
-import { isMacOS } from "@src/util/platform/tauri";
 
 import { SidebarBottomBar } from "../../blocks";
 import SidebarSettingsMenuButton from "../../blocks/SidebarSettingsMenuButton";
@@ -654,8 +652,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
         onMenuItemClick={resolvedMenuItemClick}
         onMenuItemContextMenu={resolvedMenuItemContextMenu}
         renderMenuItemWrapper={renderOrderedMenuItem}
-        hostTopBarLeadingContent={sidebarOrgSelector}
-        macTopBarFollowingContent={
+        topBarFollowingContent={
           <div className="shrink-0 px-3 pt-1">{sidebarOrgSelector}</div>
         }
         preListContent={
@@ -663,9 +660,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
             activeKey={activeViewKey}
             onChange={handleViewChange}
           />
-        }
-        headerActions={
-          isMacOS() ? undefined : <SessionHistoryNav variant="sidebar" />
         }
         listTopPadding
         bottomContent={

--- a/src/scaffold/NavigationSidebar/types.ts
+++ b/src/scaffold/NavigationSidebar/types.ts
@@ -148,10 +148,8 @@ export interface SidebarBaseProps {
   beforeAddNewActions?: ReactNode;
   /** Extra controls to the right of the add button (e.g. session group-by filter) */
   headerActions?: ReactNode;
-  /** Leading content in the Windows/Linux sidebar chrome row. */
-  hostTopBarLeadingContent?: ReactNode;
-  /** Equivalent content rendered below the traffic-light row on macOS. */
-  macTopBarFollowingContent?: ReactNode;
+  /** Content rendered in its own row directly below the chrome row. */
+  topBarFollowingContent?: ReactNode;
 }
 
 /** SidebarHeader props */

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -70,10 +70,8 @@ export interface NavigationSidebarProps {
   beforeAddNewActions?: React.ReactNode;
   /** Extra controls next to add-new (passed to SidebarBase) */
   headerActions?: React.ReactNode;
-  /** Leading content in the Windows/Linux sidebar chrome row. */
-  hostTopBarLeadingContent?: React.ReactNode;
-  /** Equivalent content rendered below the traffic-light row on macOS. */
-  macTopBarFollowingContent?: React.ReactNode;
+  /** Content rendered in its own row directly below the chrome row. */
+  topBarFollowingContent?: React.ReactNode;
   /** Preserve top padding for the scrollable menu list. */
   listTopPadding?: boolean;
   /** Optional control row rendered before pinned/list content. */
@@ -197,8 +195,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
     addTooltipContent,
     beforeAddNewActions,
     headerActions,
-    hostTopBarLeadingContent,
-    macTopBarFollowingContent,
+    topBarFollowingContent,
     listTopPadding = false,
     preListContent,
     isLoading = false,
@@ -337,8 +334,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
         addTooltipContent={addTooltipContent}
         beforeAddNewActions={beforeAddNewActions}
         headerActions={headerActions}
-        hostTopBarLeadingContent={hostTopBarLeadingContent}
-        macTopBarFollowingContent={macTopBarFollowingContent}
+        topBarFollowingContent={topBarFollowingContent}
         solidSurface={solidSurface}
       >
         {preListContent}

--- a/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
@@ -186,8 +186,7 @@ const SettingsSidebar: React.FC = () => {
 
   return (
     <SidebarBase
-      hostTopBarLeadingContent={settingsReturnItem}
-      macTopBarFollowingContent={
+      topBarFollowingContent={
         <div className="shrink-0 px-3">{settingsReturnItem}</div>
       }
     >


### PR DESCRIPTION
## Problem

The sidebar's top chrome row was wrong on every host except a windowed macOS window:

- **macOS native full screen** kept the 80px traffic-light reserve even though the lights are hidden, so the sidebar toggle, Back / Forward, and every collapsed-sidebar header inset sat 80px from the screen edge with nothing there. Root cause: `windowFullscreenAtom` has existed since the initial commit but nothing ever wrote it, so the existing full-screen branches in `SidebarBase` and `useAppShellEffects` were dead.
- **Windows, Linux, and browser mode** put the org selector / "‹ Settings" return item inside the chrome row next to the add button and Back / Forward, with an `ORG2` filler label and an empty 28px spacer, and no hide toggle in the open sidebar. The arrows also jumped from the right of that row (open) to the left of the content header (collapsed).
- **Browser mode on a Mac** reports `isMacOS()` true, so it got the pinned macOS group at 88px and the 80px reserve everywhere despite resolving to the Linux host with no window chrome.

## Solution

- `useWindowFullscreenSync` mirrors the Tauri window into `windowFullscreenAtom`: seeds from `isFullscreen()` and re-reads it on every `onResized`, which native full screen always triggers. Mounted from `useAppShellEffects`, so the main window and detached session windows both get it. macOS-window only.
- `getCollapsedSidebarChromeOffset` / `getCollapsedSidebarButtonLeft` take a `fullscreen` option, with hook variants that read the atom. In full screen the traffic-light reserve becomes a 16px edge inset instead of 0, so the group does not hug the bare screen edge. Every consumer (chat header, workstation tab bar, agent-station header, main-app header, pinned group, sidebar row, detached session window) reads the hook.
- `hasMacWindowChrome()` next to `resolveHostDesktop()` keys macOS chrome decisions off the resolved host instead of raw `isMacOS()`, so browser mode gets the in-flow layout.
- `SidebarBase` gives every host the macOS two-row top: the chrome row leads with `SidebarChromeToggle` + `SessionHistoryNav` at the same 8px inset `CollapsedSidebarButton` uses, add-new and extra actions stay at the right edge, and the new single `topBarFollowingContent` prop renders in its own row below. The two host-specific props (`hostTopBarLeadingContent`, `macTopBarFollowingContent`) are gone, and the workstation connector no longer routes Back / Forward through `headerActions`.
- The show / hide / expand / close-hover logic moved out of `PinnedSidebarChrome` into `SidebarChromeToggle`, shared by the pinned macOS group and the in-flow row. Test ids dropped the `pinned-` prefix.

Invariant: on every host, the toggle + Back / Forward group renders at the same x whether the sidebar is open or collapsed (88px windowed macOS, 16px full-screen macOS, 8px elsewhere), and the row under it reserves exactly that footprint.

## Potential risks

- **Windows / Linux visual change.** The open sidebar now has a hide toggle and the org selector drops to a second row, so the list starts ~36px lower than before on those hosts. Not rendered live on either platform; only unit-tested in jsdom.
- **Full-screen transition timing.** The atom updates after the resize event's `isFullscreen()` round trip, so the reserve collapses a frame or two after the native transition ends, animated by the existing chrome-inset transition classes. Not watched live; no dev app was running. The 36px title-bar row itself stays in full screen by design, so the group keeps its vertical spot.
- **Prop rename** is a compile-time break for any out-of-tree `SidebarBase` / `NavigationSidebar` caller. In-tree callers are all updated; typecheck is clean.
- **Browser-mode behavior change** is deliberate: web on a Mac now looks like Linux at the top of the sidebar.
- Commit was built with a temp index from a live dirty checkout (plumbing, no hooks), so the `Pre-commit hook ran.` trailer is absent and does not indicate `--no-verify`.

## Verification

Ran on the branch commit alone in a detached worktree of `origin/develop` (`25e9c3f5c`), not the dirty checkout:

- `npx vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar src/hooks/ui/sidebar src/hooks/platform/useWindowFullscreenSync.test.ts src/engines/ChatPanel/ChatPanelHeader.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/components/SessionHistoryNav` → 70 files, 333 tests, all passing.
- `npx tsgo --noEmit --pretty false` → the only errors were two `Cannot find module 'jsqr'` in `src/modules/MobileRemote/platform/scanCameraQr*.ts`. `jsqr@1.4.0` was added to `package.json` by the iOS PRs merged upstream after this checkout's last install and is not in the local `node_modules`; this branch does not touch `MobileRemote`. No errors in any touched file.

Ran on the dirty live checkout at `35b9a38a5` (one merge behind the branch base, no overlap with the touched files):

- `npx tsgo --noEmit --pretty false` → clean.
- `npx eslint --max-warnings 0` and `prettier --check` on every touched file → clean.

New coverage:
- `useWindowFullscreenSync.test.ts`: seeds from the window, follows resize-driven changes, unsubscribes on unmount, inert outside a macOS window.
- `useCollapsedSidebarChromeOffset.test.ts`: 88/176 windowed macOS, 16/104 full-screen macOS, 8/96 elsewhere.
- `PinnedSidebarChrome.test.ts`: slides 88px → 16px → 88px as the atom flips.
- `SidebarBase.hostChrome.test.ts`: Windows and Linux lead the row with hide + Back + Forward, no inline padding, no `ORG2`, follow content as the next sibling row; macOS draws no in-flow group, reserves 176px, 104px in full screen.
