### PR TITLE
fix(models): resolve GLM-5.3 context window

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/mod.rs
@@ -18,6 +18,7 @@ pub mod factory;
 pub mod http_error_body;
 pub mod model_capabilities;
 pub mod model_hints;
+pub(crate) mod model_variant;
 pub mod openai_adaptive;
 pub mod openai_compat;
 pub mod openai_policy;

--- a/src-tauri/crates/agent-core/src/core/providers/model_capabilities.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/model_capabilities.rs
@@ -8,10 +8,11 @@
 //!
 //! # Resolution chain
 //!
-//! 1. **KeyVault** (`KEY_SERVICE`): the user's own model registry. A
-//!    `ModelVariant { reasoning: Some(_) }` row for this model means the
-//!    user (or the behavioral-observation writeback in `side_query.rs`)
-//!    has marked it as a reasoning model.
+//! 1. **KeyVault** (`KEY_SERVICE`): the user's own model registry. An exact
+//!    variant's context window wins; otherwise it inherits the parsed
+//!    base-model row. A `ModelVariant { reasoning: Some(_) }` row for the exact
+//!    model means the user (or the behavioral-observation writeback in
+//!    `side_query.rs`) has marked it as a reasoning model.
 //! 2. **Built-in family table** ([`FAMILY_RULES`]): declarative, one row
 //!    per model family. The ONLY place family substring patterns live.
 //! 3. **Conservative defaults**: unknown models get a 200K window and
@@ -37,6 +38,8 @@ use std::collections::HashSet;
 use std::sync::RwLock;
 
 use key_vault::key_store::{ModelVariant, KEY_SERVICE};
+
+use super::model_variant::parse_model_variant_id;
 
 /// Process-level set of models observed to REJECT the `temperature` request
 /// param outright (Anthropic's newer models — e.g. `claude-opus-4-8` — return
@@ -429,8 +432,15 @@ const FAMILY_RULES: &[FamilyRule] = &[
         context_window: 128_000,
         thinking: ThinkingSupport::No,
     },
-    // glm-5.2: 1M context window — only the 5.2 release reached 1M;
-    // 5 / 5.1 / 5-turbo stay at 200K. Must come BEFORE glm-5.
+    // Known GLM 5.2/5.3 releases have 1M context windows. GLM-5.3 reference:
+    // https://docs.z.ai/guides/llm/glm-5.3
+    // Keep exact release rows before the conservative glm-5 fallback. Future
+    // releases must be added explicitly instead of inheriting an unverified 1M.
+    FamilyRule {
+        pattern: "glm-5.3",
+        context_window: 1_000_000,
+        thinking: ThinkingSupport::Optional,
+    },
     FamilyRule {
         pattern: "glm-5.2",
         context_window: 1_000_000,
@@ -576,14 +586,12 @@ pub(crate) fn is_claude_fable_5_1(model: &str) -> bool {
 /// entry for `account_id`.
 ///
 /// Resolution chain for the context window:
-/// 1. **Static family table** ([`FAMILY_RULES`]) — the model's nominal
-///    capability (e.g. opus-4.6 = 1M).
-/// 2. **KeyVault override** — if the provider's `/v1/models` reported a
-///    `context_length` for this model on this account (stored as
-///    `ModelVariant.context_window`), it overrides the static value. This is
-///    what makes a proxy that caps a 1M model at 256K show the *real* limit
-///    instead of the nominal one. Absent (official OpenAI/Anthropic, which
-///    don't expose `context_length`) → keep the static value.
+/// 1. **Static family table** ([`FAMILY_RULES`]) — the parsed base model's
+///    nominal capability (e.g. `glm-5.3` = 1M).
+/// 2. **KeyVault base-model override** — a provider-reported
+///    `context_length` applies to ORG2's synthetic effort variants too.
+/// 3. **KeyVault exact-variant override** — if present, it wins over the base
+///    row. This lets a proxy publish a variant-specific cap.
 ///
 /// Thinking support is upgraded only (a KeyVault `reasoning` row beats the
 /// family guess); context window can be either raised or lowered by the
@@ -615,15 +623,26 @@ pub fn resolve_effective_context_window(
 }
 
 fn apply_keyvault_overrides(caps: &mut ModelCapabilities, model: &str, variants: &[ModelVariant]) {
-    let Some(variant) = variants.iter().find(|v| v.model == model) else {
-        return;
-    };
+    let exact_variant = variants.iter().find(|variant| variant.model == model);
+    let parsed_id = parse_model_variant_id(model);
+    let base_model = exact_variant
+        .map(|variant| variant.base_model.as_str())
+        .filter(|base_model| !base_model.is_empty() && *base_model != model)
+        .unwrap_or(&parsed_id.base_model);
+    let base_variant = variants
+        .iter()
+        .find(|variant| variant.model == base_model && variant.model != model);
 
-    if let Some(ctx) = variant.context_window.filter(|ctx| *ctx > 0) {
+    if let Some(ctx) = exact_variant
+        .and_then(|variant| variant.context_window.filter(|ctx| *ctx > 0))
+        .or_else(|| base_variant.and_then(|variant| variant.context_window.filter(|ctx| *ctx > 0)))
+    {
         caps.context_window = ctx as usize;
     }
 
-    if let Some(vault_thinking) = resolve_thinking_from_variant(variant) {
+    // Reasoning metadata may be variant-specific, so preserve the existing
+    // exact-only behavior instead of inheriting it from the base row.
+    if let Some(vault_thinking) = exact_variant.and_then(resolve_thinking_from_variant) {
         caps.thinking = vault_thinking;
     }
 }
@@ -636,7 +655,8 @@ fn resolve_with_keyvault_variants(model: &str, variants: &[ModelVariant]) -> Mod
 }
 
 fn resolve_from_family_table(model: &str) -> ModelCapabilities {
-    let normalized = super::model_hints::normalize_claude_shorthand(model);
+    let base_model = parse_model_variant_id(model).base_model;
+    let normalized = super::model_hints::normalize_claude_shorthand(&base_model);
     let model_lower = normalize_claude_release_separators(&normalized.to_lowercase());
     for rule in FAMILY_RULES {
         if model_lower.contains(rule.pattern) {

--- a/src-tauri/crates/agent-core/src/core/providers/model_variant.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/model_variant.rs
@@ -1,0 +1,84 @@
+//! Provider-neutral parsing for model ids with ORG2 variant suffixes.
+//!
+//! The parsed base id is used both for wire-model selection and for inheriting
+//! model capabilities such as a provider-reported context window. The
+//! corresponding frontend grammar lives in `src/util/modelNameGrammar.ts`.
+//! `baseline` remains accepted here for backend compatibility; the frontend
+//! represents baseline as the bare model id rather than a suffix.
+
+/// A model id split into the provider's base id and ORG2's suffix tokens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedModelVariantId {
+    pub base_model: String,
+    pub suffix_tokens: Vec<String>,
+}
+
+/// Tokens that ORG2 may append to a provider model id. Provider-native
+/// suffixes (`mini`, `flash`, date stamps, `20250514`) are deliberately absent
+/// so they are never stripped.
+const SUFFIX_TOKENS: &[&str] = &[
+    "none",
+    "baseline",
+    "low",
+    "medium",
+    "high",
+    "extra",
+    "extra-high",
+    "xhigh",
+    "max",
+    "ultra",
+    "ultracode",
+    "minimal",
+    "thinking",
+    "fast",
+];
+
+fn is_suffix_token(token: &str) -> bool {
+    SUFFIX_TOKENS.contains(&token)
+}
+
+/// Peel only trailing ORG2 variant tokens from `model`.
+///
+/// `extra-high` is encoded as two hyphen-delimited segments, so it is merged
+/// back into one token for downstream reasoning-level parsing.
+pub fn parse_model_variant_id(model: &str) -> ParsedModelVariantId {
+    let lower = model.to_lowercase();
+    let lower_segments: Vec<&str> = lower.split('-').collect();
+
+    let mut split = lower_segments.len();
+    while split > 1 {
+        if !is_suffix_token(lower_segments[split - 1]) {
+            break;
+        }
+        split -= 1;
+    }
+
+    if split == lower_segments.len() {
+        return ParsedModelVariantId {
+            base_model: model.to_string(),
+            suffix_tokens: Vec::new(),
+        };
+    }
+
+    let raw_tokens = &lower_segments[split..];
+    let mut suffix_tokens = Vec::with_capacity(raw_tokens.len());
+    let mut cursor = 0;
+    while cursor < raw_tokens.len() {
+        if raw_tokens[cursor] == "extra"
+            && cursor + 1 < raw_tokens.len()
+            && raw_tokens[cursor + 1] == "high"
+        {
+            suffix_tokens.push("extra-high".to_string());
+            cursor += 2;
+        } else {
+            suffix_tokens.push(raw_tokens[cursor].to_string());
+            cursor += 1;
+        }
+    }
+
+    ParsedModelVariantId {
+        // Preserve the provider model id's original casing.
+        base_model: model.split('-').take(split).collect::<Vec<_>>().join("-"),
+        suffix_tokens,
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/providers/tests/model_capabilities_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/tests/model_capabilities_tests.rs
@@ -195,6 +195,16 @@ fn glm_modern_windows() {
 }
 
 #[test]
+fn glm_5_3_has_a_1m_window_including_effort_variants() {
+    for model in ["glm-5.3", "glm-5.3-high", "zai/glm-5.3-max"] {
+        assert_eq!(resolve(model, None).context_window, 1_000_000, "{model}");
+    }
+
+    assert_eq!(resolve("glm-5.1", None).context_window, 200_000);
+    assert_eq!(resolve("glm-5", None).context_window, 200_000);
+}
+
+#[test]
 fn grok_and_mistral_windows() {
     assert_eq!(resolve("grok-build-0.1", None).context_window, 256_000);
     assert_eq!(resolve("grok-4.3", None).context_window, 1_000_000);
@@ -482,11 +492,35 @@ fn keyvault_empty_variant_list_falls_back_to_family() {
 }
 
 #[test]
-fn keyvault_override_only_matches_exact_model() {
-    // Variant for "claude-opus-4.6" must not override a query for "claude-opus-4".
+fn keyvault_override_does_not_leak_to_another_base_model() {
+    // A row for 4.6 must not override a query for the distinct 4.0 base model.
     let variants = vec![variant_with_context("claude-opus-4.6", Some(300_000))];
     let caps = super::resolve_with_keyvault_variants("claude-opus-4", &variants);
     assert_eq!(caps.context_window, 200_000);
+}
+
+#[test]
+fn keyvault_base_context_window_applies_to_org2_variants() {
+    let variants = vec![variant_with_context("glm-5.3", Some(256_000))];
+    let caps = super::resolve_with_keyvault_variants("glm-5.3-max", &variants);
+    assert_eq!(caps.context_window, 256_000);
+}
+
+#[test]
+fn keyvault_legacy_variant_without_context_inherits_parsed_base_model() {
+    let base = variant_with_context("glm-5.3", Some(256_000));
+    let legacy_exact = variant_with_context("glm-5.3-high", None);
+    let caps = super::resolve_with_keyvault_variants("glm-5.3-high", &[base, legacy_exact]);
+    assert_eq!(caps.context_window, 256_000);
+}
+
+#[test]
+fn keyvault_exact_variant_context_window_beats_base_model() {
+    let base = variant_with_context("glm-5.3", Some(256_000));
+    let mut exact = variant_with_context("glm-5.3-high", Some(128_000));
+    exact.base_model = "glm-5.3".to_string();
+    let caps = super::resolve_with_keyvault_variants("glm-5.3-high", &[base, exact]);
+    assert_eq!(caps.context_window, 128_000);
 }
 
 #[test]

--- a/src-tauri/crates/agent-core/src/core/providers/thinking_mode.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/thinking_mode.rs
@@ -14,15 +14,15 @@
 //!    `budget_tokens` (which they reject with HTTP 400).
 //! 3. **Translating** `(mode, level)` into each provider's wire parameter.
 //!
-//! The suffix token set mirrors the frontend `VARIANT_SUFFIX_TOKENS`
-//! (`src/util/modelVariants.ts`) so front- and back-end agree on what a
-//! "variant suffix" is.
+//! The suffix grammar lives in `model_variant.rs`; its frontend counterpart is
+//! `MODEL_VARIANT_SUFFIX_TOKENS` in `src/util/modelNameGrammar.ts`.
 
 use regex::Regex;
 use serde_json::{json, Value};
 use std::sync::OnceLock;
 
 use crate::providers::model_capabilities::{classify_family, ModelFamily};
+use crate::providers::model_variant::parse_model_variant_id;
 
 /// User-selectable reasoning effort, independent of provider protocol.
 /// Mirrors the frontend `MODEL_REASONING_LEVEL`.
@@ -106,73 +106,22 @@ impl ParsedVariant {
     }
 }
 
-/// Tokens that may appear as ORG2-encoded variant suffixes. Matches the
-/// frontend `VARIANT_SUFFIX_TOKENS` exactly. Provider-native suffixes
-/// (`mini`, `flash`, date stamps, `20250514`) are deliberately absent so they
-/// are never stripped.
-const SUFFIX_TOKENS: &[&str] = &[
-    "none",
-    "baseline",
-    "low",
-    "medium",
-    "high",
-    "extra",
-    "extra-high",
-    "xhigh",
-    "max",
-    "ultra",
-    "ultracode",
-    "minimal",
-    "thinking",
-    "fast",
-];
-
-fn is_suffix_token(tok: &str) -> bool {
-    SUFFIX_TOKENS.contains(&tok)
-}
-
 /// Split a (possibly suffixed) model id into base alias + variant metadata.
 ///
 /// Peels trailing tokens that belong to ORG2's variant vocabulary only;
 /// provider-native suffixes are preserved. `extra` + `high` are merged into
 /// `extra-high` exactly as the frontend (`mergeCompoundTokens`) does.
 pub fn parse_model_variant(model: &str) -> ParsedVariant {
-    let lower = model.to_lowercase();
-    let lower_segments: Vec<&str> = lower.split('-').collect();
-
-    // Walk from the end, peeling recognised suffix tokens off the base.
-    let mut split = lower_segments.len();
-    while split > 1 {
-        if !is_suffix_token(lower_segments[split - 1]) {
-            break;
-        }
-        split -= 1;
-    }
-
-    if split == lower_segments.len() {
+    let parsed_id = parse_model_variant_id(model);
+    if parsed_id.suffix_tokens.is_empty() {
         // No suffix token peeled — id carries no encoded variant.
         return ParsedVariant::bare(model);
-    }
-
-    let raw_tokens: Vec<&str> = lower_segments[split..].to_vec();
-
-    // Merge `extra` + `high` → `extra-high`.
-    let mut merged: Vec<String> = Vec::with_capacity(raw_tokens.len());
-    let mut i = 0;
-    while i < raw_tokens.len() {
-        if raw_tokens[i] == "extra" && i + 1 < raw_tokens.len() && raw_tokens[i + 1] == "high" {
-            merged.push("extra-high".to_string());
-            i += 2;
-        } else {
-            merged.push(raw_tokens[i].to_string());
-            i += 1;
-        }
     }
 
     let mut thinking = false;
     let mut fast = false;
     let mut level: Option<ReasoningLevel> = None;
-    for tok in &merged {
+    for tok in &parsed_id.suffix_tokens {
         match tok.as_str() {
             "thinking" => thinking = true,
             "fast" => fast = true,
@@ -181,11 +130,8 @@ pub fn parse_model_variant(model: &str) -> ParsedVariant {
         }
     }
 
-    // Base model keeps original casing (take the first `split` segments).
-    let base_model: String = model.split('-').take(split).collect::<Vec<_>>().join("-");
-
     ParsedVariant {
-        base_model,
+        base_model: parsed_id.base_model,
         level,
         thinking,
         fast,

--- a/src/engines/ChatPanel/InputArea/components/useContextUsageInfo.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/useContextUsageInfo.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   computeCacheHitRate,
   formatTokenCount,
+  resolveAccountContextWindow,
   resolveContextMaxTokens,
 } from "./useContextUsageInfo";
 
@@ -19,6 +20,47 @@ describe("useContextUsageInfo helpers", () => {
     expect(computeCacheHitRate(0, 100)).toBe(0);
     // Negative noise is clamped, never produces NaN or a value outside [0,1].
     expect(computeCacheHitRate(-5, -5)).toBe(0);
+  });
+
+  it("inherits a provider context window from the base model", () => {
+    const variants = [
+      {
+        model: "glm-5.3",
+        base_model: "glm-5.3",
+        context_window: 256_000,
+      },
+    ];
+
+    expect(resolveAccountContextWindow("glm-5.3-max", variants)).toBe(256_000);
+
+    expect(
+      resolveAccountContextWindow("glm-5.3-high", [
+        ...variants,
+        {
+          model: "glm-5.3-high",
+          // Legacy rows may not have recorded the parsed base correctly.
+          base_model: "glm-5.3-high",
+          context_window: null,
+        },
+      ])
+    ).toBe(256_000);
+  });
+
+  it("prefers an exact variant context window over its base model", () => {
+    const variants = [
+      {
+        model: "glm-5.3",
+        base_model: "glm-5.3",
+        context_window: 256_000,
+      },
+      {
+        model: "glm-5.3-high",
+        base_model: "glm-5.3",
+        context_window: 128_000,
+      },
+    ];
+
+    expect(resolveAccountContextWindow("glm-5.3-high", variants)).toBe(128_000);
   });
 });
 

--- a/src/engines/ChatPanel/InputArea/components/useContextUsageInfo.ts
+++ b/src/engines/ChatPanel/InputArea/components/useContextUsageInfo.ts
@@ -12,7 +12,52 @@ import {
   sessionContextUsageAtom,
 } from "@src/store/session/cliSessionStatusAtom";
 import { getModelInfo } from "@src/types/model/info";
+import {
+  type ResolvedModelVariantFields,
+  getModelVariantBaseModel,
+} from "@src/util/modelVariants";
 import { isCliSession } from "@src/util/session/sessionDispatch";
+
+type ContextWindowVariant = Pick<
+  ResolvedModelVariantFields,
+  "model" | "base_model" | "context_window"
+>;
+
+function positiveContextWindow(
+  variant: ContextWindowVariant | undefined
+): number | null {
+  const contextWindow = variant?.context_window;
+  return typeof contextWindow === "number" && contextWindow > 0
+    ? contextWindow
+    : null;
+}
+
+/**
+ * Resolve provider metadata for an ORG2 model variant. A variant-specific
+ * value wins; otherwise synthetic effort variants inherit the base model's
+ * provider-reported window.
+ */
+export function resolveAccountContextWindow(
+  modelName: string,
+  variants: readonly ContextWindowVariant[] | undefined
+): number | null {
+  if (!modelName || !variants) return null;
+
+  const exactVariant = variants.find((variant) => variant.model === modelName);
+  const exactContextWindow = positiveContextWindow(exactVariant);
+  if (exactContextWindow !== null) return exactContextWindow;
+
+  const metadataBaseModel = exactVariant?.base_model;
+  const baseModel =
+    metadataBaseModel && metadataBaseModel !== modelName
+      ? metadataBaseModel
+      : getModelVariantBaseModel(modelName);
+  if (baseModel === modelName) return null;
+
+  return positiveContextWindow(
+    variants.find((variant) => variant.model === baseModel)
+  );
+}
 
 export interface ContextUsageInfo {
   percentage: number;
@@ -91,12 +136,7 @@ export function useContextUsageInfo(): ContextUsageInfo {
     const accountId = lastModel?.selectedAccountId;
     if (!modelName || !accountId) return null;
     const account = accounts.find((entry) => entry.id === accountId);
-    const contextWindow = account?.modelVariants?.find(
-      (variant) => variant.model === modelName
-    )?.context_window;
-    return typeof contextWindow === "number" && contextWindow > 0
-      ? contextWindow
-      : null;
+    return resolveAccountContextWindow(modelName, account?.modelVariants);
   }, [accounts, lastModel?.selectedAccountId, modelName]);
   const contextWindowK = modelInfo?.contextWindow ?? 200;
   const modelMaxTokens = accountContextWindow ?? contextWindowK * 1000;

--- a/src/types/model/info.zai.test.ts
+++ b/src/types/model/info.zai.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { getModelInfo } from "./info";
+
+describe("Z.AI model info", () => {
+  it("uses the GLM-5.3 window before the conservative GLM-5 fallback", () => {
+    for (const model of ["glm-5.3", "glm-5.3-high", "zai/glm-5.3-max"]) {
+      expect(getModelInfo(model)).toMatchObject({
+        providerKey: "zai",
+        contextWindow: 1000,
+        reasoning: true,
+      });
+    }
+
+    expect(getModelInfo("glm-5.1")?.contextWindow).toBe(200);
+    expect(getModelInfo("glm-5")?.contextWindow).toBe(200);
+  });
+});

--- a/src/types/model/info.zai.ts
+++ b/src/types/model/info.zai.ts
@@ -12,6 +12,18 @@ import type { ModelInfoEntry } from "@src/types/model/info.types";
 export const ZAI_MODEL_INFO_ENTRIES: ModelInfoEntry[] = [
   // ─── Z.AI (GLM) ───────────────────────────────────────────
   {
+    pattern: "glm-5.3",
+    info: {
+      provider: "Z.AI",
+      providerKey: "zai",
+      contextWindow: 1000,
+      vision: false,
+      reasoning: true,
+      strengthKeys: ["coding", "reasoning", "agentic"],
+      pricingTier: "budget",
+    },
+  },
+  {
     pattern: "glm-5.2",
     info: {
       provider: "Z.AI",


### PR DESCRIPTION
## Problem

GLM-5.3 model ids resolved to the wrong context window. `glm-5.3`, `glm-5.3-high` and `zai/glm-5.3-max` fell through the capability family table to the conservative `glm-5` fallback (200K) instead of their real 1M window, so the chat-input context gauge under-reported the budget and context-truncation logic used the wrong limit. Two root causes:

1. No `glm-5.3` row existed in the Rust `FAMILY_RULES` table nor in the frontend model-info registry.
2. Provider-reported context windows (KeyVault `ModelVariant.context_window`, sourced from `/v1/models` `context_length`) matched only the exact model id — ORG2's synthetic effort variants (`glm-5.3-max`) never inherited the base model's row, and family-table matching did not strip effort suffixes before matching.

## Solution

Four mirrored layers (Rust `agent-core` + frontend):

1. **Static tables** — add a `glm-5.3` family rule (1M, `ThinkingSupport::Optional`) ahead of the `glm-5` fallback, mirroring the existing `glm-5.2` row; same for `ZAI_MODEL_INFO_ENTRIES` on the frontend.
2. **Shared suffix grammar** — extract ORG2's variant-suffix parsing into `model_variant.rs::parse_model_variant_id` (a behavior-preserving refactor; `thinking_mode::parse_model_variant` now reuses it) and make `resolve_from_family_table` strip ORG2 effort suffixes before matching, so `glm-5.3-high` hits the 5.3 rule.
3. **KeyVault inheritance** — context-window resolution becomes exact-variant row → base-model row (variant `base_model` metadata, falling back to grammatical parsing for legacy rows) → family table. Thinking metadata stays exact-only since it may be variant-specific.
4. **Frontend mirror** — `resolveAccountContextWindow` applies the same chain for the context-usage gauge.

Resulting invariant: a model's effective context window is the exact-variant provider cap if present, else the base model's provider cap, else the family-table nominal (1M for `glm-5.3`).

## Potential risks

- Any id containing `glm-5.3` now nominally gets 1M. If a provider ships a glm-5.3 variant capped below 1M and never reports `context_length`, the UI shows 1M until a KeyVault override is recorded — the same accepted tradeoff as the existing `glm-5.2` row.
- Suffix stripping before family matching could reclassify ids that genuinely end in an effort token (e.g. a provider model literally named `foo-max`); this is bounded by the closed ORG2 token vocabulary — provider-native suffixes (`mini`, `flash`, date stamps) are never stripped.
- Legacy KeyVault rows with empty/incorrect `base_model` fall back to grammatical parsing; covered by tests.
- `glm-5.1` / `glm-5` / `glm-5-turbo` intentionally remain at 200K.

## Verification

- `vitest run src/types/model/info.zai.test.ts src/engines/ChatPanel/InputArea/components/useContextUsageInfo.test.ts` — 8/8 pass (new + existing suites).
- `tsc --noEmit` — 0 errors.
- `cargo test -p agent_core` — full debug compile + link verified; the new `model_capabilities` tests cover glm-5.3 windows, effort-variant inheritance, exact-beats-base, and no-leak-to-other-base cases.
- Hands-on dev-build check (author): `glm-5.3` and its effort variants show a 1M context scale; `glm-5.1` / `glm-5` still show 200K.
