### PR TITLE
fix(agent-defs): derive agent lists from canonical definitions

### DIFF
--- a/src/app/root/E2EBootstrap.tsx
+++ b/src/app/root/E2EBootstrap.tsx
@@ -39,13 +39,10 @@
 import { useStore } from "jotai";
 import { type FC, useEffect } from "react";
 
-import { INTERNAL_AGENT_IDS } from "@src/modules/MainApp/AgentOrgs/config/agentConstants";
 import {
   agentDefsLoadErrorAtom,
   agentDefsLoadedAtom,
   allAgentDefsAtom,
-  builtInAgentsAtom,
-  customAgentsAtom,
 } from "@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom";
 import type { AgentDefinition } from "@src/modules/MainApp/AgentOrgs/types";
 
@@ -125,16 +122,6 @@ export const E2EBootstrap: FC = () => {
         if (!result.ok) return result;
         const defs = result.defs as unknown as AgentDefinition[];
         store.set(allAgentDefsAtom, defs);
-        store.set(
-          builtInAgentsAtom,
-          defs.filter(
-            (agent) => agent.builtIn && !INTERNAL_AGENT_IDS.has(agent.id)
-          )
-        );
-        store.set(
-          customAgentsAtom,
-          defs.filter((agent) => !agent.builtIn)
-        );
         store.set(agentDefsLoadedAtom, true);
         store.set(agentDefsLoadErrorAtom, null);
         return result;

--- a/src/modules/MainApp/AgentOrgs/hooks/useAgentDefinitions.ts
+++ b/src/modules/MainApp/AgentOrgs/hooks/useAgentDefinitions.ts
@@ -18,14 +18,13 @@
  * without manual refresh calls.
  */
 import { useAtomValue, useSetAtom } from "jotai";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { rpc } from "@src/api/tauri/rpc";
 import { useMounted } from "@src/hooks/lifecycle/useMounted";
 import { createLogger } from "@src/hooks/logger";
 import { useTauriListen } from "@src/hooks/platform/useTauriListen";
 
-import { INTERNAL_AGENT_IDS } from "../config/agentConstants";
 import {
   agentDefsLoadErrorAtom,
   agentDefsLoadedAtom,
@@ -55,10 +54,9 @@ async function fetchAllDefs(forceFresh = false): Promise<AgentDefinition[]> {
 }
 
 export function useAgentDefinitions() {
-  const allDefs = useAtomValue(allAgentDefsAtom);
+  const builtInAgents = useAtomValue(builtInAgentsAtom);
+  const agents = useAtomValue(customAgentsAtom);
   const setAllDefs = useSetAtom(allAgentDefsAtom);
-  const setBuiltInAgents = useSetAtom(builtInAgentsAtom);
-  const setCustomAgents = useSetAtom(customAgentsAtom);
   const setAgentDefsLoaded = useSetAtom(agentDefsLoadedAtom);
   const loaded = useAtomValue(agentDefsLoadedAtom);
   const loadError = useAtomValue(agentDefsLoadErrorAtom);
@@ -70,22 +68,10 @@ export function useAgentDefinitions() {
   const applyResult = useCallback(
     (result: AgentDefinition[]) => {
       setAllDefs(result);
-      setBuiltInAgents(
-        result.filter(
-          (agent) => agent.builtIn && !INTERNAL_AGENT_IDS.has(agent.id)
-        )
-      );
-      setCustomAgents(result.filter((agent) => !agent.builtIn));
       setAgentDefsLoaded(true);
       setLoadError(null);
     },
-    [
-      setAllDefs,
-      setBuiltInAgents,
-      setCustomAgents,
-      setAgentDefsLoaded,
-      setLoadError,
-    ]
+    [setAllDefs, setAgentDefsLoaded, setLoadError]
   );
 
   const refresh = useCallback(
@@ -146,19 +132,6 @@ export function useAgentDefinitions() {
     { enabled: ownsChangeListener }
   );
 
-  const builtInAgents = useMemo(
-    () =>
-      allDefs.filter(
-        (agent) => agent.builtIn && !INTERNAL_AGENT_IDS.has(agent.id)
-      ),
-    [allDefs]
-  );
-
-  const agents = useMemo(
-    () => allDefs.filter((agent) => !agent.builtIn),
-    [allDefs]
-  );
-
   const addAgent = useCallback(
     async (agent: AgentDefinition) => {
       setLoading(true);
@@ -186,9 +159,6 @@ export function useAgentDefinitions() {
         setAllDefs((current) =>
           current.filter((agent) => agent.id !== agentId)
         );
-        setCustomAgents((current) =>
-          current.filter((agent) => agent.id !== agentId)
-        );
         setAgentDefsLoaded(true);
         setLoadError(null);
       } catch (error) {
@@ -198,7 +168,7 @@ export function useAgentDefinitions() {
         if (mountedRef.current) setLoading(false);
       }
     },
-    [mountedRef, setAgentDefsLoaded, setAllDefs, setCustomAgents, setLoadError]
+    [mountedRef, setAgentDefsLoaded, setAllDefs, setLoadError]
   );
 
   return {

--- a/src/modules/MainApp/AgentOrgs/hooks/useEnsureAgentDefs.ts
+++ b/src/modules/MainApp/AgentOrgs/hooks/useEnsureAgentDefs.ts
@@ -24,12 +24,9 @@ import { useEffect } from "react";
 import { rpc } from "@src/api/tauri/rpc";
 import { createLogger } from "@src/hooks/logger";
 
-import { INTERNAL_AGENT_IDS } from "../config/agentConstants";
 import {
   agentDefsLoadedAtom,
   allAgentDefsAtom,
-  builtInAgentsAtom,
-  customAgentsAtom,
 } from "../store/builtInAgentsAtom";
 
 const log = createLogger("useEnsureAgentDefs");
@@ -42,8 +39,6 @@ const log = createLogger("useEnsureAgentDefs");
 export function useEnsureAgentDefs(enabled = true): boolean {
   const loaded = useAtomValue(agentDefsLoadedAtom);
   const setAllDefs = useSetAtom(allAgentDefsAtom);
-  const setBuiltInAgents = useSetAtom(builtInAgentsAtom);
-  const setCustomAgents = useSetAtom(customAgentsAtom);
   const setLoaded = useSetAtom(agentDefsLoadedAtom);
 
   useEffect(() => {
@@ -56,12 +51,6 @@ export function useEnsureAgentDefs(enabled = true): boolean {
       .then((result) => {
         if (cancelled) return;
         setAllDefs(result);
-        setBuiltInAgents(
-          result.filter(
-            (agent) => agent.builtIn && !INTERNAL_AGENT_IDS.has(agent.id)
-          )
-        );
-        setCustomAgents(result.filter((agent) => !agent.builtIn));
         setLoaded(true);
       })
       .catch((err) => {
@@ -71,14 +60,7 @@ export function useEnsureAgentDefs(enabled = true): boolean {
     return () => {
       cancelled = true;
     };
-  }, [
-    enabled,
-    loaded,
-    setAllDefs,
-    setBuiltInAgents,
-    setCustomAgents,
-    setLoaded,
-  ]);
+  }, [enabled, loaded, setAllDefs, setLoaded]);
 
   return loaded;
 }

--- a/src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom.test.ts
+++ b/src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom.test.ts
@@ -1,0 +1,52 @@
+import { createStore } from "jotai/vanilla";
+import { describe, expect, it } from "vitest";
+
+import type { AgentDefinition } from "../types";
+import {
+  allAgentDefsAtom,
+  builtInAgentsAtom,
+  customAgentsAtom,
+} from "./builtInAgentsAtom";
+
+const builtin: AgentDefinition = {
+  id: "builtin:sde",
+  name: "SDE",
+  builtIn: true,
+};
+const internal: AgentDefinition = {
+  id: "builtin:base",
+  name: "Base",
+  builtIn: true,
+};
+const custom: AgentDefinition = {
+  id: "custom:reviewer",
+  name: "Reviewer",
+  builtIn: false,
+};
+
+describe("agent definition projections", () => {
+  it("projects canonical loads, replacement and removal without separate writes", () => {
+    const store = createStore();
+    store.set(allAgentDefsAtom, [internal, builtin, custom]);
+    expect(store.get(builtInAgentsAtom)).toEqual([builtin]);
+    expect(store.get(customAgentsAtom)).toEqual([custom]);
+    expect(store.get(allAgentDefsAtom)).toContain(internal);
+
+    const renamed = { ...custom, name: "Updated reviewer" };
+    store.set(allAgentDefsAtom, [internal, builtin, renamed]);
+    expect(store.get(customAgentsAtom)).toEqual([renamed]);
+    store.set(allAgentDefsAtom, [internal, builtin]);
+    expect(store.get(customAgentsAtom)).toEqual([]);
+    expect(store.get(builtInAgentsAtom)).toEqual([builtin]);
+  });
+
+  it("keeps separately mounted stores isolated", () => {
+    const first = createStore();
+    const second = createStore();
+    first.set(allAgentDefsAtom, [builtin]);
+    second.set(allAgentDefsAtom, [custom]);
+    expect(first.get(customAgentsAtom)).toEqual([]);
+    expect(second.get(builtInAgentsAtom)).toEqual([]);
+    expect(second.get(customAgentsAtom)).toEqual([custom]);
+  });
+});

--- a/src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom.ts
+++ b/src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom.ts
@@ -10,6 +10,7 @@
  */
 import { atom } from "jotai";
 
+import { INTERNAL_AGENT_IDS } from "../config/agentConstants";
 import type { AgentDefinition } from "../types";
 
 /**
@@ -32,11 +33,17 @@ export const agentDefsLoadErrorAtom = atom<string | null>(null);
 agentDefsLoadErrorAtom.debugLabel = "agentDefsLoadErrorAtom";
 
 /** User-visible built-in agents (internal subagents filtered out). */
-export const builtInAgentsAtom = atom<AgentDefinition[]>([]);
+export const builtInAgentsAtom = atom((get) =>
+  get(allAgentDefsAtom).filter(
+    (agent) => agent.builtIn && !INTERNAL_AGENT_IDS.has(agent.id)
+  )
+);
 builtInAgentsAtom.debugLabel = "builtInAgentsAtom";
 
 /** User-created custom agents (CRUD-able). */
-export const customAgentsAtom = atom<AgentDefinition[]>([]);
+export const customAgentsAtom = atom((get) =>
+  get(allAgentDefsAtom).filter((agent) => !agent.builtIn)
+);
 customAgentsAtom.debugLabel = "customAgentsAtom";
 
 /**

--- a/src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.test.ts
+++ b/src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.test.ts
@@ -14,6 +14,7 @@ import {
 } from "vitest";
 
 import {
+  allAgentDefsAtom,
   builtInAgentsAtom,
   customAgentsAtom,
 } from "@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom";
@@ -53,18 +54,20 @@ function Probe({
   return null;
 }
 
-describe("useAgentToolMatrix", () => {
+describe.each([true, false])("useAgentToolMatrix (builtIn=%s)", (builtIn) => {
   let container: HTMLDivElement;
   let root: Root;
   let store: ReturnType<typeof createStore>;
   let latest: UseAgentToolMatrixReturn;
 
   const agent: AgentDefinition = {
-    id: "builtin:sde",
+    id: builtIn ? "builtin:sde" : "custom:sde",
     name: "SDE",
-    builtIn: true,
+    builtIn,
     tools: {},
   };
+
+  const selectedAgentsAtom = builtIn ? builtInAgentsAtom : customAgentsAtom;
 
   beforeAll(() => {
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
@@ -72,8 +75,7 @@ describe("useAgentToolMatrix", () => {
 
   beforeEach(() => {
     store = createStore();
-    store.set(builtInAgentsAtom, [agent]);
-    store.set(customAgentsAtom, []);
+    store.set(allAgentDefsAtom, [agent]);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -107,26 +109,32 @@ describe("useAgentToolMatrix", () => {
 
     let request!: Promise<void>;
     act(() => {
-      request = latest.toggle("builtin:sde", "read_file", false);
+      request = latest.toggle(agent.id, "read_file", false);
     });
 
     expect(latest.rowsByTool("read_file")[0]?.enabled).toBe(false);
-    expect(store.get(builtInAgentsAtom)[0]?.tools?.excludedTools).toEqual([
+    expect(store.get(selectedAgentsAtom)[0]?.tools?.excludedTools).toEqual([
+      "read_file",
+    ]);
+
+    expect(store.get(allAgentDefsAtom)[0]?.tools?.excludedTools).toEqual([
       "read_file",
     ]);
 
     await act(async () => request);
-    expect(store.get(builtInAgentsAtom)[0]).toEqual(saved);
+    expect(store.get(selectedAgentsAtom)[0]).toEqual(saved);
+    expect(store.get(allAgentDefsAtom)[0]).toEqual(saved);
   });
 
   it("rolls back the shared atom when persistence fails", async () => {
     mocks.updatePatch.mockRejectedValueOnce(new Error("write failed"));
 
     await act(async () => {
-      await latest.toggle("builtin:sde", "read_file", false);
+      await latest.toggle(agent.id, "read_file", false);
     });
 
     expect(latest.rowsByTool("read_file")[0]?.enabled).toBe(true);
-    expect(store.get(builtInAgentsAtom)[0]).toEqual(agent);
+    expect(store.get(selectedAgentsAtom)[0]).toEqual(agent);
+    expect(store.get(allAgentDefsAtom)[0]).toEqual(agent);
   });
 });

--- a/src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.ts
+++ b/src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.ts
@@ -18,6 +18,7 @@ import { rpc } from "@src/api/tauri/rpc";
 import { createLogger } from "@src/hooks/logger";
 import { useEnsureAgentDefs } from "@src/modules/MainApp/AgentOrgs/hooks/useEnsureAgentDefs";
 import {
+  allAgentDefsAtom,
   builtInAgentsAtom,
   customAgentsAtom,
 } from "@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom";
@@ -93,8 +94,7 @@ export function useAgentToolMatrix() {
   const defsLoaded = useEnsureAgentDefs();
   const builtInAgents = useAtomValue(builtInAgentsAtom);
   const customAgents = useAtomValue(customAgentsAtom);
-  const setBuiltInAgents = useSetAtom(builtInAgentsAtom);
-  const setCustomAgents = useSetAtom(customAgentsAtom);
+  const setAllDefs = useSetAtom(allAgentDefsAtom);
   const records = useMemo(
     () => [...builtInAgents, ...customAgents].map(parseAgent),
     [builtInAgents, customAgents]
@@ -106,13 +106,9 @@ export function useAgentToolMatrix() {
         current.map((entry) =>
           entry.id === definition.id ? definition : entry
         );
-      if (definition.builtIn) {
-        setBuiltInAgents(update);
-      } else {
-        setCustomAgents(update);
-      }
+      setAllDefs(update);
     },
-    [setBuiltInAgents, setCustomAgents]
+    [setAllDefs]
   );
 
   const rowsByTool = useCallback(


### PR DESCRIPTION
## Problem

Agent definitions were stored in three independently writable frontend lists. The tool-matrix save and rollback paths updated only the filtered list, while other consumers read allAgentDefsAtom, so views could disagree until a later refresh.

## Solution

Keep allAgentDefsAtom as the sole writable frontend list and derive the built-in and custom lists from it, preserving internal-agent exclusion. Both loaders, removal, optimistic tool edits, saved results, rollback and E2E refresh now update the same source. Hook consumers reuse the derived lists. Regression tests cover built-in and custom edits before/after persistence and rollback, plus load/replacement/removal and per-store isolation.

The backend agent-definition RPC remains the durable authority. This fixes the frontend producing write path; there is no historical persisted-data cleanup or migration.

## Potential risks

Concurrent backend refresh/save ordering is unchanged; this PR removes divergent frontend copies rather than redesigning request coordination. Native Tauri interactions were not exercised. No dependency, lockfile, IPC, schema or persistence-format changes. Rollback is a code revert.

## Verification

- Integrated develop commit `7b8c5ac8d` to resolve the shared CI failure: SplitListFullscreenButton now consumes the existing expand/restore translations. After integration, `pnpm check:i18n-keys` and `pnpm test -- src/modules/shared/layouts/SplitListFullscreenButton.test.ts` pass. The fix lives on develop; this PR diff retains its original scope.

- `pnpm test -- src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom.test.ts src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.test.ts` — passed (2 files / 6 tests).
- `pnpm typecheck:fast` — passed. The first agent-definition check found missing local jsqr; the already-declared version 1.4.0 was restored only in isolated worktree dependencies before the successful checks. No tracked dependency changes.
- `node_modules/.bin/eslint --max-warnings 0 src/app/root/E2EBootstrap.tsx src/modules/MainApp/AgentOrgs/hooks/useAgentDefinitions.ts src/modules/MainApp/AgentOrgs/hooks/useEnsureAgentDefs.ts src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom.test.ts src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom.ts src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.test.ts src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.ts` — passed.
- `pnpm check:test-placement` — passed.
- `git diff --check` — passed.
- Repository-wide removed-symbol/writer search and final diff inspection: no dangling references or unrelated changes.
- Native Tauri/UI, full test suite, and CPU/RSS profiling were not run. Computer control is not authorized. Screenshots are not useful for these state/control-flow changes, which do not change visual design. Rust checks are not applicable; no Rust code changes.

## Audit

Architecture layers 1–7 covered through full typecheck, consumer/writer tracing, naming, state ownership, filters/defaults, dependency boundaries and readability. Layer 9 reviewed for initialization/lifecycle parity. Layers 8 and 10 have no changed wire or resolver contracts; live payload/resolver verification was not performed. UI-consistency audit is inapplicable to this control-flow-only change.

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Existing loader/listener ownership unchanged | No new timers, requests or subscriptions | Source diff review |
| Memory | fix | Two writable list copies | Derive on demand from one store-owned list | Canonical load/replacement tests |
| Scope/isolation | keep | Values belong to the supplied Jotai store | No module-global data cache added | Two-store test |
| Rendering/hot path | fix | Tool edits previously wrote only filtered copies | Subscribe to projections of the canonical write | Built-in/custom save and rollback tests |

Performance verdict: blocked for native runtime measurement (visible/hidden idle CPU/RSS and native open/close paths were not exercised). The source-level cleanup and listed correctness checks pass; no measured performance improvement is claimed.
