### PR TITLE
refactor(session-replay): remove unused replay atoms

### DIFF
--- a/src/engines/SessionCore/core/atoms/actions.snapshotLifecycle.ts
+++ b/src/engines/SessionCore/core/atoms/actions.snapshotLifecycle.ts
@@ -9,7 +9,6 @@ import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
 
 import { resetChatEventsMemoCaches } from "../../derived/chatEvents";
 import { eventStoreProxy } from "../store/EventStoreProxy";
-import { resetContextAtomMemoCaches } from "./context";
 import { resetEventAtomMemoCaches } from "./events";
 
 export function releaseDepartingSessionSnapshot(sessionId: string): void {
@@ -18,7 +17,6 @@ export function releaseDepartingSessionSnapshot(sessionId: string): void {
   // leaves the session. Clear it synchronously even for live sessions whose
   // Rust/bridge snapshot keeps the normal warm-switch grace period.
   resetEventAtomMemoCaches();
-  resetContextAtomMemoCaches();
   resetChatEventsMemoCaches(sessionId);
 
   if (isImportedHistorySession(sessionId)) {

--- a/src/engines/SessionCore/core/atoms/context.ts
+++ b/src/engines/SessionCore/core/atoms/context.ts
@@ -6,17 +6,9 @@
  */
 import { atom } from "jotai";
 
-import { REPLAY_CONFIG } from "@src/config/workspace/replayConfig";
 import { selectedExecutionThreadAtom } from "@src/store/ui/sessionPaginationAtom";
 
-import type { ReplayMode } from "../types";
-import { eventIndexAtom, sortedEventsAtom } from "./events";
-import {
-  currentEventIdAtom,
-  replayBarValueAtom,
-  replayModeAtom,
-  replayTimeRangeAtom,
-} from "./replay";
+import { sortedEventsAtom } from "./events";
 
 // ============================================
 // Effective Replay Context (Thread Aware)
@@ -44,94 +36,3 @@ export const effectiveEventsAtom = atom((get) => {
   return get(threadFilteredEventsAtom);
 });
 effectiveEventsAtom.debugLabel = "session/effectiveEvents";
-
-/**
- * Effective time range based on current filter.
- * Automatically adjusts when a thread is selected.
- */
-export const effectiveTimeRangeAtom = atom((get) => {
-  const events = get(effectiveEventsAtom);
-  const globalRange = get(replayTimeRangeAtom);
-
-  // No events - use global range
-  if (events.length === 0) {
-    return globalRange;
-  }
-
-  const firstEvent = events[0];
-  const lastEvent = events[events.length - 1];
-
-  const start = firstEvent.createdAt;
-  let end = lastEvent.createdAt;
-
-  // Add buffer if same timestamp
-  if (start === end) {
-    end = new Date(new Date(end).getTime() + 60000).toISOString();
-  }
-
-  return { start, end };
-});
-effectiveTimeRangeAtom.debugLabel = "session/effectiveTimeRange";
-
-/**
- * O(1) index lookup within effectiveEventsAtom.
- * Maps event ID → index in the context-filtered array.
- * Uses module-level caching to avoid rebuilding when the array reference is stable.
- */
-let _prevEffectiveEvents: ReadonlyArray<unknown> = [];
-let _prevEffectiveIndexMap = new Map<string, number>();
-
-/** Release the previous session's replay-index inputs on session departure. */
-export function resetContextAtomMemoCaches(): void {
-  _prevEffectiveEvents = [];
-  _prevEffectiveIndexMap = new Map<string, number>();
-}
-
-const effectiveEventIndexMapAtom = atom((get) => {
-  const events = get(effectiveEventsAtom);
-  if (events === _prevEffectiveEvents) return _prevEffectiveIndexMap;
-  _prevEffectiveEvents = events;
-  const map = new Map<string, number>();
-  for (let i = 0; i < events.length; i++) {
-    map.set(events[i].id, i);
-  }
-  _prevEffectiveIndexMap = map;
-  return map;
-});
-effectiveEventIndexMapAtom.debugLabel = "session/effectiveEventIndexMap";
-
-/**
- * Navigate to event with thread-aware slider calculation.
- * Uses effectiveTimeRange for correct slider position.
- */
-export const navigateToEventInContextAtom = atom(
-  null,
-  (get, set, eventId: string) => {
-    const index = get(eventIndexAtom);
-    const event = index.get(eventId);
-
-    if (!event) return;
-
-    set(currentEventIdAtom, eventId);
-    set(replayModeAtom, "replay" as ReplayMode);
-
-    // Use effective time range for slider calculation
-    const range = get(effectiveTimeRangeAtom);
-    if (range.start && range.end) {
-      const startMs = new Date(range.start).getTime();
-      const endMs = new Date(range.end).getTime();
-      const eventMs = new Date(event.createdAt).getTime();
-      const rangeMs = endMs - startMs;
-
-      if (rangeMs > 0) {
-        // Clamp to 0-200 range
-        const value = ((eventMs - startMs) / rangeMs) * REPLAY_CONFIG.MAX_VALUE;
-        set(
-          replayBarValueAtom,
-          Math.max(0, Math.min(REPLAY_CONFIG.MAX_VALUE, value))
-        );
-      }
-    }
-  }
-);
-navigateToEventInContextAtom.debugLabel = "session/navigateToEventInContext";

--- a/src/engines/SessionCore/core/atoms/events.ts
+++ b/src/engines/SessionCore/core/atoms/events.ts
@@ -389,12 +389,6 @@ export const sortedEventIndexMapAtom = atom((get) => {
 });
 sortedEventIndexMapAtom.debugLabel = "session/sortedEventIndexMap";
 
-// ============================================
-// Last Event (reference-stable)
-// ============================================
-
-let _prevLastEvent: SessionEvent | null = null;
-
 /**
  * Drop module-level memo state when the active session departs.
  *
@@ -422,29 +416,7 @@ export function resetEventAtomMemoCaches(): void {
   };
   _prevSortedForIndex = [];
   _prevSortedIndexMap = new Map<string, number>();
-  _prevLastEvent = null;
 }
-
-export const lastEventAtom = atom<SessionEvent | null>((get) => {
-  const snap = get(derivedSnapshotAtom);
-
-  if (snap) {
-    const last = snap.lastEvent ?? null;
-    if (last === _prevLastEvent) return _prevLastEvent;
-    if (
-      last &&
-      _prevLastEvent &&
-      last.id === _prevLastEvent.id &&
-      last.displayStatus === _prevLastEvent.displayStatus
-    ) {
-      return _prevLastEvent;
-    }
-    _prevLastEvent = last;
-    return last;
-  }
-  return null;
-});
-lastEventAtom.debugLabel = "session/lastEvent";
 
 // ============================================
 // Event Count (present in both snapshot types)

--- a/src/engines/SessionCore/core/atoms/replay.ts
+++ b/src/engines/SessionCore/core/atoms/replay.ts
@@ -96,15 +96,6 @@ export const replayTimeRangeAtom = atom<ReplayTimeRange>({
 replayTimeRangeAtom.debugLabel = "session/replayTimeRange";
 
 /**
- * Whether time range is valid (has both start and end).
- */
-export const replayTimeRangeValidAtom = atom((get) => {
-  const range = get(replayTimeRangeAtom);
-  return Boolean(range.start && range.end && range.start !== range.end);
-});
-replayTimeRangeValidAtom.debugLabel = "session/replayTimeRangeValid";
-
-/**
  * Current replay mode.
  * - "follow": Following latest events (auto-scroll to new events)
  * - "replay": Viewing historical event (no auto-scroll)


### PR DESCRIPTION
## Problem

The replay atom graph retained selectors and a navigation action with no consumers: lastEventAtom, replayTimeRangeValidAtom, effectiveTimeRangeAtom, effectiveEventIndexMapAtom and navigateToEventInContextAtom. Their dedicated memo state also left unnecessary lifecycle cleanup wiring.

## Solution

Delete the unused atoms, their dedicated last-event/index caches and resetContextAtomMemoCaches, including its session-departure call. Keep the live thread-filtered event projections, other event memo resets, persisted replay state and current replay/navigation behavior.

## Potential risks

Removal depends on the repository-wide consumer trace and full TypeScript checking; external code that imported these internal symbols would need updating. Native replay interaction and CPU/RSS were not measured. No persistence keys, wire payloads, backend behavior or dependencies change. Rollback is a code revert.

## Verification

- Integrated develop commit `7b8c5ac8d` to resolve the shared CI failure: SplitListFullscreenButton now consumes the existing expand/restore translations. After integration, `pnpm check:i18n-keys` and `pnpm test -- src/modules/shared/layouts/SplitListFullscreenButton.test.ts` pass. The fix lives on develop; this PR diff retains its original scope.

- `pnpm test -- src/engines/SessionCore/core/atoms/__tests__/actions.test.ts src/engines/SessionCore/derived/__tests__` — passed (11 files / 90 tests).
- `pnpm typecheck:fast` — passed. The first agent-definition check found missing local jsqr; the already-declared version 1.4.0 was restored only in isolated worktree dependencies before the successful checks. No tracked dependency changes.
- `node_modules/.bin/eslint --max-warnings 0 src/engines/SessionCore/core/atoms/actions.snapshotLifecycle.ts src/engines/SessionCore/core/atoms/context.ts src/engines/SessionCore/core/atoms/events.ts src/engines/SessionCore/core/atoms/replay.ts` — passed.
- `pnpm check:test-placement` — passed.
- `git diff --check` — passed.
- Repository-wide removed-symbol/writer search and final diff inspection: no dangling references or unrelated changes.
- Native Tauri/UI, full test suite, and CPU/RSS profiling were not run. Computer control is not authorized. Screenshots are not useful for these state/control-flow changes, which do not change visual design. Rust checks are not applicable; no Rust code changes.

## Audit

Architecture layers 1–7 covered through full typecheck, consumer/writer tracing, naming, state ownership, filters/defaults, dependency boundaries and readability. Layer 9 reviewed for initialization/lifecycle parity. Layers 8 and 10 have no changed wire or resolver contracts; live payload/resolver verification was not performed. UI-consistency audit is inapplicable to this control-flow-only change.

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | No timers, requests or listeners added | Preserve session departure and live replay flow | Session action tests |
| Memory | fix | Unused selector-specific memo state | Delete caches and their reset plumbing | No removed-symbol references; typecheck |
| Scope/isolation | keep | Other session memo cleanup remains | Keep live-session and imported-history departure handling | Session action and retained-event tests |
| Rendering/hot path | keep | Live projections remain | Remove only unreachable derived nodes | Derived-event tests |

Performance verdict: blocked for native runtime measurement (visible/hidden idle CPU/RSS and native open/close paths were not exercised). The source-level cleanup and listed correctness checks pass; no measured performance improvement is claimed.
