### PR TITLE
fix(codex-models): preserve the OAuth model catalog

### DIFF
--- a/src-tauri/crates/key-vault/src/commands/crud/models.rs
+++ b/src-tauri/crates/key-vault/src/commands/crud/models.rs
@@ -51,21 +51,9 @@ pub const CLAUDE_CODE_OAUTH_DEFAULT_ENABLED_MODELS: &[&str] = &[
     "claude-sonnet-4-6",
 ];
 
-pub const CODEX_OAUTH_MODELS: &[&str] = &[
-    "gpt-6-astra",
-    "gpt-5.6-sol",
-    "gpt-5.6-terra",
-    "gpt-5.6-luna",
-    "gpt-5.5",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.3-codex",
-    "gpt-5.2",
-    "codex-auto-review",
-];
-
+pub const CODEX_OAUTH_MODELS: &[&str] = crate::model_catalog::CODEX_OAUTH_MODELS;
 pub const CODEX_OAUTH_DEFAULT_ENABLED_MODELS: &[&str] =
-    &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
+    crate::model_catalog::CODEX_OAUTH_DEFAULT_ENABLED_MODELS;
 
 /// Claude models whose Messages requests carry `output_config.effort`.
 pub fn model_supports_output_config_effort(model: &str) -> bool {

--- a/src-tauri/crates/key-vault/src/commands/validate/oauth.rs
+++ b/src-tauri/crates/key-vault/src/commands/validate/oauth.rs
@@ -47,8 +47,8 @@ fn oauth_static_catalog(
             crate::commands::crud::CLAUDE_CODE_OAUTH_DEFAULT_ENABLED_MODELS,
         )),
         "codex" => Some((
-            crate::commands::crud::CODEX_OAUTH_MODELS,
-            crate::commands::crud::CODEX_OAUTH_DEFAULT_ENABLED_MODELS,
+            crate::model_catalog::CODEX_OAUTH_MODELS,
+            crate::model_catalog::CODEX_OAUTH_DEFAULT_ENABLED_MODELS,
         )),
         _ => None,
     }

--- a/src-tauri/crates/key-vault/src/key_store/service/keys.rs
+++ b/src-tauri/crates/key-vault/src/key_store/service/keys.rs
@@ -84,12 +84,15 @@ impl KeyService {
         store.get_all(agent_type).into_iter().cloned().collect()
     }
 
-    /// Save or update a key
+    /// Save or update a key after enforcing persisted catalog invariants.
     pub fn save_key(&self, key: ModelKey) -> Result<ModelKey, String> {
+        let key_id = key.id.clone();
         self.update_store(|store| {
-            let entry = key.clone();
             store.set(key);
-            entry
+            store
+                .get_by_id(&key_id)
+                .cloned()
+                .expect("KeyStore::set must retain the inserted key")
         })
     }
 
@@ -236,6 +239,7 @@ impl KeyService {
                 if let Some(enabled) = enabled_models {
                     entry.enabled_models = enabled;
                 }
+                entry.normalize_model_catalog();
                 if let Some(quota) = quota_info {
                     entry.quota_info = Some(quota);
                 }

--- a/src-tauri/crates/key-vault/src/key_store/service/persistence.rs
+++ b/src-tauri/crates/key-vault/src/key_store/service/persistence.rs
@@ -171,7 +171,11 @@ fn deserialize_key_store(contents: &str) -> Result<LoadedKeyStore, serde_json::E
         }
 
         match serde_json::from_value::<ModelKey>(raw.clone()) {
-            Ok(key) => {
+            Ok(mut key) => {
+                // Normalize legacy snapshots as they cross the persistence
+                // boundary. Any subsequent store mutation persists the
+                // repaired in-memory catalog atomically with that mutation.
+                key.normalize_model_catalog();
                 store.keys.insert(storage_id, key);
             }
             Err(error) => invalid_credentials.push(InvalidStoredCredential {

--- a/src-tauri/crates/key-vault/src/key_store/store.rs
+++ b/src-tauri/crates/key-vault/src/key_store/store.rs
@@ -64,8 +64,9 @@ impl KeyStore {
             .collect()
     }
 
-    /// Save or update a key
+    /// Save or update a key after enforcing account-type catalog invariants.
     pub fn set(&mut self, mut key: ModelKey) {
+        key.normalize_model_catalog();
         key.updated_at = Utc::now();
         self.keys.insert(key.id.clone(), key);
         self.updated_at = Utc::now();

--- a/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
+++ b/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
@@ -718,6 +718,122 @@ fn test_proxy_env_anthropic_api() {
 }
 
 #[test]
+fn codex_oauth_catalog_is_completed_at_storage_boundaries() {
+    use crate::model_catalog::CODEX_OAUTH_MODELS;
+
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+
+    let mut oauth_key = ModelKey::new(ModelType::Codex);
+    oauth_key.auth_method = AuthMethod::Oauth;
+    oauth_key.session_token = Some("oauth-access-token".to_string());
+    oauth_key.available_models = vec!["account-visible-model".to_string()];
+    oauth_key.enabled_models = vec!["custom-enabled-model".to_string()];
+    let key_id = oauth_key.id.clone();
+
+    let saved = service.save_key(oauth_key).unwrap();
+    assert_eq!(
+        saved.available_models.first().unwrap(),
+        "account-visible-model"
+    );
+    assert!(CODEX_OAUTH_MODELS.iter().all(|model| saved
+        .available_models
+        .iter()
+        .any(|available| available == model)));
+    assert!(saved
+        .available_models
+        .iter()
+        .any(|model| model == "custom-enabled-model"));
+
+    let refreshed = service
+        .update_key_health(
+            &key_id,
+            HealthStatus::Valid,
+            None,
+            Some(vec!["fresh-live-model".to_string()]),
+            Some(vec!["custom-enabled-model".to_string()]),
+            None,
+            None,
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        refreshed.available_models.first().unwrap(),
+        "fresh-live-model"
+    );
+    assert!(refreshed
+        .available_models
+        .iter()
+        .any(|model| model == "gpt-6-astra"));
+    assert!(refreshed
+        .available_models
+        .iter()
+        .any(|model| model == "custom-enabled-model"));
+}
+
+#[test]
+fn legacy_codex_oauth_catalog_is_repaired_on_load_and_next_write() {
+    use crate::model_catalog::CODEX_OAUTH_MODELS;
+
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+
+    let mut oauth_key = ModelKey::new(ModelType::Codex);
+    oauth_key.auth_method = AuthMethod::Oauth;
+    oauth_key.session_token = Some("oauth-access-token".to_string());
+    let key_id = oauth_key.id.clone();
+    service.save_key(oauth_key).unwrap();
+
+    let storage_file = temp_dir.path().join("credentials.json");
+    let mut stored: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&storage_file).unwrap()).unwrap();
+    stored["credentials"][&key_id]["available_models"] = serde_json::json!(["gpt-5.6-sol"]);
+    stored["credentials"][&key_id]["enabled_models"] = serde_json::json!(["legacy-enabled-model"]);
+    std::fs::write(&storage_file, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();
+
+    let loaded = service.get_key_by_id_checked(&key_id).unwrap().unwrap();
+    assert!(loaded
+        .available_models
+        .iter()
+        .any(|model| model == "gpt-6-astra"));
+    assert!(loaded
+        .available_models
+        .iter()
+        .any(|model| model == "legacy-enabled-model"));
+
+    service
+        .save_key(ModelKey::new(ModelType::AnthropicApi))
+        .unwrap();
+    let persisted: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&storage_file).unwrap()).unwrap();
+    let persisted_models = persisted["credentials"][&key_id]["available_models"]
+        .as_array()
+        .unwrap();
+    assert!(CODEX_OAUTH_MODELS.iter().all(|model| {
+        persisted_models
+            .iter()
+            .any(|available| available.as_str() == Some(*model))
+    }));
+    assert!(persisted_models
+        .iter()
+        .any(|model| model.as_str() == Some("legacy-enabled-model")));
+}
+
+#[test]
+fn codex_api_key_catalog_is_not_completed_with_oauth_models() {
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+
+    let mut api_key = ModelKey::new(ModelType::Codex);
+    api_key.auth_method = AuthMethod::ApiKey;
+    api_key.api_key = Some("sk-api-key".to_string());
+    api_key.available_models = vec!["api-visible-model".to_string()];
+
+    let saved = service.save_key(api_key).unwrap();
+    assert_eq!(saved.available_models, vec!["api-visible-model"]);
+}
+
+#[test]
 fn test_store_get_with_key_id() {
     let mut store = KeyStore::default();
     let mut first = ModelKey::new(ModelType::CursorCli);

--- a/src-tauri/crates/key-vault/src/key_store/types.rs
+++ b/src-tauri/crates/key-vault/src/key_store/types.rs
@@ -548,6 +548,16 @@ impl ModelKey {
         }
     }
 
+    /// Restore catalog invariants owned by this account type.
+    pub(crate) fn normalize_model_catalog(&mut self) {
+        if self.is_native_oauth_for(&ModelType::Codex) {
+            crate::model_catalog::complete_codex_oauth_model_catalog(
+                &mut self.available_models,
+                &self.enabled_models,
+            );
+        }
+    }
+
     /// Whether this credential is a native OAuth account for the target CLI.
     /// Cross-provider keys and native API keys must never enter OAuth retry,
     /// token rotation, or OAuth health bookkeeping.

--- a/src-tauri/crates/key-vault/src/lib.rs
+++ b/src-tauri/crates/key-vault/src/lib.rs
@@ -21,6 +21,7 @@ pub mod e2e_guard;
 pub mod harness_connections;
 pub mod key_extractor;
 pub mod key_store;
+pub(crate) mod model_catalog;
 pub mod provider_config;
 pub mod providers;
 pub mod quota_history;

--- a/src-tauri/crates/key-vault/src/model_catalog.rs
+++ b/src-tauri/crates/key-vault/src/model_catalog.rs
@@ -1,0 +1,42 @@
+//! Canonical product-supported model catalog and completion helpers.
+
+/// Product-supported Codex OAuth bases.
+///
+/// Live Codex discovery can be version-gated by the installed CLI. These
+/// models remain part of ORGII's Codex OAuth surface even when a live response
+/// omits them, so discovery and persisted-account ingestion complete from the
+/// same catalog.
+pub const CODEX_OAUTH_MODELS: &[&str] = &[
+    "gpt-6-astra",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex",
+    "gpt-5.2",
+    "codex-auto-review",
+];
+
+pub const CODEX_OAUTH_DEFAULT_ENABLED_MODELS: &[&str] =
+    &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
+
+/// Complete a Codex OAuth catalog without disturbing provider ordering.
+///
+/// Every product-supported base and every enabled model must also be present
+/// in the available list. The caller owns credential-kind validation.
+pub(crate) fn complete_codex_oauth_model_catalog(
+    available_models: &mut Vec<String>,
+    enabled_models: &[String],
+) {
+    for model in CODEX_OAUTH_MODELS
+        .iter()
+        .copied()
+        .chain(enabled_models.iter().map(String::as_str))
+    {
+        if !available_models.iter().any(|available| available == model) {
+            available_models.push(model.to_string());
+        }
+    }
+}

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.test.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.test.ts
@@ -114,6 +114,14 @@ describe("useApiSetupTokenDetection", () => {
 
     expect(serviceMocks.autoDetectKey).toHaveBeenCalledTimes(1);
     expect(serviceMocks.getOAuthModelCatalog).toHaveBeenCalledTimes(1);
+    expect(serviceMocks.getOAuthModelCatalog).toHaveBeenCalledWith(
+      CLI_AGENT.CODEX,
+      {
+        accessToken: "test-access-token",
+        refreshToken: "test-refresh-token",
+        idToken: "test-id-token",
+      }
+    );
     expect(setDetectingToken).toHaveBeenCalledTimes(1);
 
     await act(async () => {
@@ -128,6 +136,147 @@ describe("useApiSetupTokenDetection", () => {
       true,
       false,
     ]);
+
+    await act(async () => root.unmount());
+  });
+
+  it("prefers a valid Codex OAuth session when direct detection also finds an API key", async () => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    serviceMocks.autoDetectKey.mockResolvedValue({
+      success: true,
+      message: "Found 2 key(s)",
+      keys: [
+        {
+          auth_method: "oauth",
+          validated: true,
+          session_token: "oauth-access-token",
+        },
+        {
+          auth_method: "api_key",
+          validated: true,
+          api_key: "sk-api-key",
+        },
+      ],
+    });
+
+    const setSelectedCredentialIndex = vi.fn();
+    const setShowKeySelection = vi.fn();
+    const options: HookOptions = {
+      data: { agent_type: CLI_AGENT.CODEX } as WizardData,
+      onChange: vi.fn(),
+      t: ((key: string) => key) as TFunction<"integrations">,
+      isCursor: false,
+      isOAuthAgent: true,
+      isClaudeCode: false,
+      isCodex: true,
+      detectedKeys: [],
+      selectedCredentialIndex: 0,
+      setDetectingToken: vi.fn(),
+      setTokenDetected: vi.fn(),
+      setTokenError: vi.fn(),
+      setCursorSessionToken: vi.fn(),
+      setShowKeySelection,
+      setDetectedKeys: vi.fn(),
+      setSelectedCredentialIndex,
+    };
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let hookResult: HookResult | undefined;
+    await act(async () => {
+      root.render(
+        createElement(HookHarness, {
+          options,
+          onResult: (result) => {
+            hookResult = result;
+          },
+        })
+      );
+    });
+
+    await act(async () => {
+      await hookResult?.handleAutoDetectToken();
+    });
+
+    expect(setSelectedCredentialIndex).toHaveBeenLastCalledWith(0);
+    expect(setShowKeySelection).toHaveBeenLastCalledWith(true);
+    expect(serviceMocks.getOAuthModelCatalog).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps a directly detected Codex API key on the API model path", async () => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    serviceMocks.autoDetectKey.mockResolvedValue({
+      success: true,
+      message: "Found 1 key(s)",
+      keys: [
+        {
+          auth_method: "api_key",
+          validated: true,
+          api_key: "sk-api-key",
+          available_models: ["api-visible-model"],
+        },
+      ],
+    });
+
+    const onChange = vi.fn();
+    const options: HookOptions = {
+      data: { agent_type: CLI_AGENT.CODEX } as WizardData,
+      onChange,
+      t: ((key: string) => key) as TFunction<"integrations">,
+      isCursor: false,
+      isOAuthAgent: true,
+      isClaudeCode: false,
+      isCodex: true,
+      detectedKeys: [],
+      selectedCredentialIndex: 0,
+      setDetectingToken: vi.fn(),
+      setTokenDetected: vi.fn(),
+      setTokenError: vi.fn(),
+      setCursorSessionToken: vi.fn(),
+      setShowKeySelection: vi.fn(),
+      setDetectedKeys: vi.fn(),
+      setSelectedCredentialIndex: vi.fn(),
+    };
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let hookResult: HookResult | undefined;
+    await act(async () => {
+      root.render(
+        createElement(HookHarness, {
+          options,
+          onResult: (result) => {
+            hookResult = result;
+          },
+        })
+      );
+    });
+
+    await act(async () => {
+      await hookResult?.handleAutoDetectToken();
+    });
+
+    expect(serviceMocks.getOAuthModelCatalog).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw_key_input: "sk-api-key",
+        available_models: ["api-visible-model"],
+      })
+    );
 
     await act(async () => root.unmount());
   });

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.ts
@@ -122,19 +122,20 @@ export function useApiSetupTokenDetection({
         return;
       }
 
-      const catalog =
-        isClaudeCode || isCodex
-          ? await getOAuthModelCatalog(
-              isClaudeCode ? CLI_AGENT.CLAUDE_CODE : CLI_AGENT.CODEX,
-              {
-                accessToken: cred.session_token ?? cred.api_key ?? undefined,
-                refreshToken: isClaudeCode
-                  ? cred.env_vars?.CLAUDE_CODE_REFRESH_TOKEN
-                  : cred.env_vars?.OPENAI_REFRESH_TOKEN,
-                idToken: cred.env_vars?.OPENAI_ID_TOKEN,
-              }
-            )
-          : undefined;
+      const usesOAuthCatalog =
+        (isClaudeCode || isCodex) && cred.auth_method === "oauth";
+      const catalog = usesOAuthCatalog
+        ? await getOAuthModelCatalog(
+            isClaudeCode ? CLI_AGENT.CLAUDE_CODE : CLI_AGENT.CODEX,
+            {
+              accessToken: cred.session_token ?? undefined,
+              refreshToken: isClaudeCode
+                ? cred.env_vars?.CLAUDE_CODE_REFRESH_TOKEN
+                : cred.env_vars?.OPENAI_REFRESH_TOKEN,
+              idToken: cred.env_vars?.OPENAI_ID_TOKEN,
+            }
+          )
+        : undefined;
       applyKey(cred, {
         onChange,
         setTokenDetected,
@@ -219,7 +220,7 @@ export function useApiSetupTokenDetection({
           (cred) => cred.validated
         );
         setSelectedCredentialIndex(
-          isClaudeCode && validOAuthIndex >= 0
+          (isClaudeCode || isCodex) && validOAuthIndex >= 0
             ? validOAuthIndex
             : validApiKeyIndex >= 0
               ? validApiKeyIndex
@@ -245,6 +246,7 @@ export function useApiSetupTokenDetection({
     openCodeEndpoints,
     applySelectedKey,
     isClaudeCode,
+    isCodex,
     setDetectedKeys,
     setDetectingToken,
     setSelectedCredentialIndex,


### PR DESCRIPTION
## Problem

Codex OAuth model discovery can be narrower than ORGII's supported catalog when the installed CLI omits models. Those omissions were persisted, enabled custom models could be absent from the available list, and auto-detection could send a directly detected API key through the OAuth catalog path. The authoritative model invariant therefore differed between discovery, save, load, and health refresh boundaries.

## Solution

Add one canonical Codex OAuth catalog and complete native OAuth credentials at deserialization, store insertion, service save, and health-update boundaries. Preserve provider ordering and account-visible/custom enabled models while appending missing supported bases. Keep Codex API-key credentials unchanged, and select the OAuth catalog only for detected OAuth credentials.

## Potential risks

Legacy Codex OAuth rows are normalized in memory on load and written back on the next ordinary vault mutation; there is no destructive migration and older snapshots remain readable. The visible catalog may expand for existing OAuth accounts, which is intentional, while API-key accounts are protected by regression coverage. Rollback is a commit revert; no schema or credential recovery is required.

## Audit

Architecture audit walked all 10 layers. Canonical ownership now lives in `model_catalog`; callers, aliases, credential-type classification, store/service boundaries, persistence ingestion, OAuth/API-key resolver symmetry, and tests were checked. The JSON shape and startup path remain backward compatible, and no new registration, feature flag, background task, or platform branch was introduced.

No screenshot was captured because this changes model data and selection invariants without introducing new visual chrome.

## Verification

- `cargo test -p key_vault`: passed, 402 tests
- `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.test.ts`: passed, 3 tests
- `node_modules/@typescript/native-preview/bin/tsgo --noEmit --pretty false`: passed
- Targeted ESLint over the two changed TypeScript files: passed with zero warnings
- Prettier and changed-file rustfmt checks: passed
- `node scripts/quality/check-test-placement.mjs`: passed
- Pre-commit hook: scoped `key_vault` Clippy and staged-file checks passed
- `git diff --check`: passed