### PR TITLE
fix(session-finality): persist terminal failures before broadcast

### DIFF
--- a/src-tauri/crates/agent-core/src/core/session/launch/launch_helpers.rs
+++ b/src-tauri/crates/agent-core/src/core/session/launch/launch_helpers.rs
@@ -41,16 +41,37 @@ pub(super) async fn handle_background_launch_failure(
     }
     release_work_item_execution_lock_if_present(project_slug, work_item_id, session_id, app_handle)
         .await;
-    broadcast_launch_send_error(session_id, message);
-    crate::lifecycle::persist_session_error_event(app_handle, session_id, message);
-    if let Err(mark_err) = mark_session_failed(session_id.to_string()).await {
+
+    // First-turn failures happen after `session_launch` has already returned
+    // `first_turn_started`, so every recovery path is asynchronous. Make the
+    // durable event + session row authoritative before publishing transient
+    // notifications; a window that misses both broadcasts can then replay the
+    // same terminal error from SQLite.
+    if let Err(err) =
+        crate::lifecycle::persist_session_error_event(app_handle, session_id, message).await
+    {
         tracing::warn!(
+            session_id = %session_id,
+            error = %err,
+            "[session_launch] failed to persist first-turn error event"
+        );
+    }
+
+    match mark_session_failed(session_id.to_string()).await {
+        Ok(()) => crate::lifecycle::emit_session_status_changed(
+            app_handle,
+            session_id,
+            crate::persistence::db_helpers::AgentSessionStatus::Failed,
+        ),
+        Err(mark_err) => tracing::warn!(
             session_id = %session_id,
             error = %mark_err,
             "{}",
             session_mark_warning
-        );
+        ),
     }
+
+    broadcast_launch_send_error(session_id, message);
 }
 
 pub(super) fn apply_member_launch_overrides_to_snapshot(
@@ -257,7 +278,9 @@ pub(super) async fn mark_session_failed(session_id: String) -> Result<(), String
         let Some(mut record) =
             crate::session::persistence::get_session(&session_id).map_err(|err| err.to_string())?
         else {
-            return Ok(());
+            return Err(format!(
+                "session {session_id} disappeared before first-turn failure could be persisted"
+            ));
         };
         record.status = crate::session::SessionStatus::Failed.as_str().to_string();
         record.updated_at = chrono::Utc::now().to_rfc3339();

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/subagent_handler/persistence.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/subagent_handler/persistence.rs
@@ -72,7 +72,15 @@ impl UnifiedSubagentHandler {
             .collect();
 
         let count = persistable.len();
-        event_pipeline_bridge::persist_events("subagent-child-persist", &sid, &persistable, 5);
+        if let Err(err) =
+            event_pipeline_bridge::persist_events("subagent-child-persist", &sid, &persistable, 5)
+        {
+            warn!(
+                "[subagent:{}] Failed to persist {} child events for session {}: {}",
+                self.config.subagent_type, count, sid, err
+            );
+            return;
+        }
         tracing::info!(
             "[subagent:{}] Persisted {} child events for session {}",
             self.config.subagent_type,

--- a/src-tauri/crates/agent-core/src/foundation/bus/event_pipeline_bridge.rs
+++ b/src-tauri/crates/agent-core/src/foundation/bus/event_pipeline_bridge.rs
@@ -119,9 +119,14 @@ pub type FinalizePlanRevisionEventsFn =
 
 /// Persist a batch of `SessionEvent`s synchronously with retry. The wire
 /// side converts each to its on-disk `CachedEvent` representation. `label`
-/// is used in retry log lines.
-pub type PersistEventsFn =
-    fn(label: &'static str, session_id: &str, events: &[SessionEvent], max_retries: u32);
+/// is used in retry log lines. A successful return is the durability barrier
+/// for lifecycle events that must survive a missed frontend broadcast.
+pub type PersistEventsFn = fn(
+    label: &'static str,
+    session_id: &str,
+    events: &[SessionEvent],
+    max_retries: u32,
+) -> Result<(), String>;
 
 /// Fire-and-forget variant: spawns `persist_events` onto a blocking thread.
 pub type PersistEventsAsyncFn =
@@ -444,16 +449,15 @@ pub fn persist_events(
     session_id: &str,
     events: &[SessionEvent],
     max_retries: u32,
-) {
+) -> Result<(), String> {
     if let Some(f) = PERSIST_EVENTS.get() {
-        f(label, session_id, events, max_retries);
-    } else {
-        tracing::warn!(
-            "[event-pipeline-bridge] persist_events ({}) called before register for {}",
-            label,
-            session_id
-        );
+        return f(label, session_id, events, max_retries);
     }
+    let message = format!(
+        "[event-pipeline-bridge] persist_events ({label}) called before register for {session_id}"
+    );
+    tracing::warn!("{message}");
+    Err(message)
 }
 
 pub fn persist_events_async(

--- a/src-tauri/crates/agent-core/src/lifecycle.rs
+++ b/src-tauri/crates/agent-core/src/lifecycle.rs
@@ -89,7 +89,7 @@ pub struct TerminalTurnSignal {
     pub completed_at: String,
 }
 
-fn emit_session_status_changed(
+pub(crate) fn emit_session_status_changed(
     app_handle: Option<&tauri::AppHandle>,
     session_id: &str,
     status: AgentSessionStatus,
@@ -245,19 +245,34 @@ pub fn build_session_error_event(session_id: &str, message: &str) -> SessionEven
     event
 }
 
-pub fn persist_session_error_event(
+pub async fn persist_session_error_event(
     app_handle: Option<&tauri::AppHandle>,
     session_id: &str,
     message: &str,
-) {
-    let Some(handle) = app_handle else {
-        return;
-    };
-    event_pipeline_bridge::push_events(
-        handle,
-        session_id,
-        vec![build_session_error_event(session_id, message)],
-    );
+) -> Result<(), String> {
+    let event = build_session_error_event(session_id, message);
+
+    // Lifecycle errors are terminal user-visible facts, not high-frequency
+    // streaming updates. Persist synchronously before notifying any UI so a
+    // missed `agent:error`/`es:changed` can always be recovered on reopen. The
+    // retry loop sleeps on SQLite contention, so await it on the blocking pool.
+    let durable_session_id = session_id.to_string();
+    let durable_event = event.clone();
+    tokio::task::spawn_blocking(move || {
+        event_pipeline_bridge::persist_events(
+            "session-error-terminal",
+            &durable_session_id,
+            std::slice::from_ref(&durable_event),
+            8,
+        )
+    })
+    .await
+    .map_err(|err| format!("persist terminal session error worker failed: {err}"))??;
+
+    if let Some(handle) = app_handle {
+        event_pipeline_bridge::push_events(handle, session_id, vec![event]);
+    }
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -559,6 +574,19 @@ pub async fn finalize_session(
         AgentSessionStatus::Failed
     };
 
+    // A terminal error is durable before any status notification leaves this
+    // function. Status broadcasts can be missed; the EventStore row is the
+    // authoritative replay path after a window reload or app restart.
+    if let Err(message) = response {
+        if let Err(err) = persist_session_error_event(app_handle, session_id, message).await {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %err,
+                "[lifecycle] failed to persist terminal session error event"
+            );
+        }
+    }
+
     if let Some(ref terminal_turn) = terminal_turn {
         persist_and_emit_terminal_turn(session_id, terminal_turn, final_status, app_handle);
     } else {
@@ -623,10 +651,6 @@ pub async fn finalize_session(
             app_handle_clone.as_ref(),
         )
         .await;
-    }
-
-    if let Err(message) = response {
-        persist_session_error_event(app_handle, session_id, message);
     }
 
     // Turn-end wake re-check (one of the two triggers feeding the single

--- a/src-tauri/src/agent_sessions/event_pipeline/agent_core_bridge.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/agent_core_bridge.rs
@@ -709,8 +709,13 @@ mod tests {
             session_id,
             "provider rejected the first turn",
         );
-        persist_events_adapter("terminal-error-test", session_id, &[event.clone()], 1)
-            .expect("persistence barrier succeeds");
+        persist_events_adapter(
+            "terminal-error-test",
+            session_id,
+            std::slice::from_ref(&event),
+            1,
+        )
+        .expect("persistence barrier succeeds");
 
         let stored = session_persistence::get_event(session_id, &event.id)
             .expect("read persisted event")

--- a/src-tauri/src/agent_sessions/event_pipeline/agent_core_bridge.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/agent_core_bridge.rs
@@ -444,9 +444,9 @@ fn persist_events_adapter(
     session_id: &str,
     events: &[SessionEvent],
     max_retries: u32,
-) {
+) -> Result<(), String> {
     let cached: Vec<_> = events.iter().map(session_event_to_cached_event).collect();
-    let _ = save_events_retry(label, session_id, &cached, max_retries);
+    save_events_retry(label, session_id, &cached, max_retries)
 }
 
 fn persist_events_async_adapter(
@@ -692,4 +692,31 @@ pub fn register() {
         persist_events_async_adapter,
         persist_user_message_event_adapter,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persist_events_adapter_returns_only_after_the_error_is_readable() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        let conn = database::db::get_connection().expect("test database");
+        session_persistence::init_session_tables(&conn).expect("session event schema");
+
+        let session_id = "terminal-error-durability";
+        let event = agent_core::lifecycle::build_session_error_event(
+            session_id,
+            "provider rejected the first turn",
+        );
+        persist_events_adapter("terminal-error-test", session_id, &[event.clone()], 1)
+            .expect("persistence barrier succeeds");
+
+        let stored = session_persistence::get_event(session_id, &event.id)
+            .expect("read persisted event")
+            .expect("event is durable before the adapter returns");
+        assert_eq!(stored.session_id, session_id);
+        assert_eq!(stored.id, event.id);
+        assert!(stored.content.contains("provider rejected the first turn"));
+    }
 }


### PR DESCRIPTION
## Problem

Terminal Rust-agent failures were published through transient status/error channels before their EventStore row was durable. A window that missed those broadcasts could reopen without the terminal error, and first-turn launch failures silently accepted a missing session row. The synchronous persistence bridge also discarded write failures.

## Solution

Make the persistence bridge return `Result` and await a bounded SQLite write before terminal notifications for both normal finalization and first-turn launch failures. Run the retrying synchronous writer on Tokio's blocking pool, then merge/notify through the existing event pipeline. Treat a missing first-turn session as an error and surface child-session persistence failures instead of logging success.

## Potential risks

A contended terminal write can delay the final notification until the bounded retry finishes, but it does not sleep on an async executor thread. If persistence ultimately fails, the error is logged and existing status/error broadcasts still proceed so teardown is not stranded; that path remains operationally observable rather than falsely reported as durable. The subsequent event-pipeline merge performs an idempotent same-ID async upsert. The bridge signature is internal and every repository caller/registration was updated. Rollback is a commit revert; no schema or stored-event format changes.

## Audit

Architecture audit walked all 10 layers: terminal status producers, first-turn and normal entry paths, lifecycle ordering, bridge ownership, persistence adapters, event identity, replay consumers, internal wire signatures, startup registration, and regression tests were checked. Unconsumed `errorMessage`/`terminalAt` payload expansion and an unrelated incomplete `startedAt` change were intentionally excluded.

Performance-guard verdict: pass. There is no new loop, timer, subscription, cache, scan, or retained background state. Each terminal failure adds one bounded durability barrier; retry sleep runs in `spawn_blocking`, work is scoped to one session/event, and retained memory is released when the await completes. Runtime latency under real SQLite lock contention was not benchmarked, so no speed claim is made.

No screenshot was captured because this changes persistence and replay ordering without changing rendered UI.

## Verification

- `cargo test -p agent_core`: passed, 3,261 tests; 2 ignored
- `cargo test -p org2 persist_events_adapter_returns_only_after_the_error_is_readable`: passed, 1 owning-boundary persistence/read-back test
- Pre-commit hook: scoped `agent_core` and `org2` Clippy passed
- Changed-file rustfmt check: passed
- `node scripts/quality/check-test-placement.mjs`: passed
- `git diff --check`: passed
- Real lock-contention latency and packaged Tauri restart replay were not run; the SQLite read-back test verifies the durability barrier directly