### PR TITLE
fix(session-creator): preserve live editor text without a saved draft

### DIFF
--- a/docs/org2-performance-guard-2026-09-09/SessionCreatorDraft.md
+++ b/docs/org2-performance-guard-2026-09-09/SessionCreatorDraft.md
@@ -1,0 +1,47 @@
+# Session creator draft content synchronization
+
+## Finding and fix
+
+The running Tauri creator displayed the user's prompt while its Send button was
+disabled. Triggering a content change enabled the button. Clicking Send then
+reached the existing short-input confirmation; no provider turn was submitted.
+
+The producing boundary is `useDraftManagement`'s no-saved-draft load branch.
+It intentionally preserves the live editor, but previously reset `editorContent`
+to an empty string. That state drives launch validation and the debounced draft
+writer. A rendered regression with the real ComposerInput reproduces visible
+text with a disabled submission control before the fix.
+
+The branch now reads the live editor's text, keeping validation and persistence
+aligned with the content it preserves. Saved-draft restoration, model selection,
+API launch behavior and storage format are unchanged.
+
+The authoritative stored draft is `orgii:sessionCreatorDrafts` in localStorage.
+After restoring the user's exact original text, a read-only inspection confirmed
+the active draft's `editorContent` and structured snapshot contain that text.
+No historical drafts were deleted. The installed app was not rebuilt; its current
+draft was recovered through normal editor input.
+
+## Lifecycle verification
+
+| Area               | Verdict | Evidence                                                          | Change or reason kept                                  | Verification                                                                         |
+| ------------------ | ------- | ----------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Background work    | keep    | Existing 500 ms debounced save and bounded restore timers         | No new timer, listener, retry or polling               | Idle produces no further store writes; unmount cancels pending save                  |
+| Memory             | keep    | Existing component-owned refs and draft store                     | No new retained structure                              | No resource allocation added by source change                                        |
+| Scope/isolation    | keep    | Existing active draft id and component-local editor               | Reads only this creator's live editor                  | Save/remount restores the same prompt; blank draft stays empty                       |
+| Rendering/hot path | fix     | Draft effect cleared validation text while preserving editor text | Seed state from the editor at the owning load boundary | Real ComposerInput, parent submit gate, submitted text and persisted snapshot tested |
+
+## Commands and results
+
+- `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/components/ComposerInput src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.test.ts src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.test.ts`: 15 files, 101 tests passed
+- `node node_modules/eslint/bin/eslint.js src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.ts src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.test.ts --max-warnings 0 --report-unused-disable-directives`: passed
+- `node node_modules/prettier/bin/prettier.cjs --check src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.ts src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.test.ts docs/org2-performance-guard-2026-09-09/SessionCreatorDraft.md`: passed
+- `node scripts/quality/check-test-placement.mjs`: passed
+- `git diff --check -- src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.ts src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.test.ts`: passed
+- `node_modules/@typescript/native-preview/bin/tsgo --noEmit --pretty false`: passed
+
+Performance verdict: pass for the scoped lifecycle invariant. The timer,
+persistence, and repository-wide type checks pass. No CPU/RSS improvement is
+claimed. The rebased branch has not been packaged and run in Tauri; the earlier
+live reproduction covered recovery of the current draft and reaching the
+short-input confirmation, not a provider response.

--- a/src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.test.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, useRef, useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ComposerInput, {
+  type ComposerInputRef,
+} from "@src/components/ComposerInput";
+import type { UploadedFile } from "@src/features/SessionCreator/types";
+import {
+  sessionCreatorDraftAtom,
+  sessionCreatorDraftStoreAtom,
+} from "@src/store/session/creatorDraftAtom";
+import {
+  type SmokeRoot,
+  createSmokeRoot,
+  settle,
+} from "@src/test/reactSmokeHarness";
+
+import { useDraftManagement } from "./useDraftManagement";
+
+vi.mock(
+  "@src/store/session",
+  () => import("@src/store/session/creatorDraftAtom")
+);
+vi.mock("@src/util/ui/theme/themeUtils", () => ({
+  useCurrentTheme: () => ({ isDark: false }),
+}));
+vi.mock("@src/store/skills/installedSkillsAtom", async () => {
+  const { atom } = await import("jotai");
+  return { installedSkillsAtom: atom([]) };
+});
+
+describe("useDraftManagement composer content ownership", () => {
+  let root: SmokeRoot;
+  let store: ReturnType<typeof createStore>;
+  const submit = vi.fn();
+
+  function Harness({ seed = "" }: { seed?: string }) {
+    const composerInputRef = useRef<ComposerInputRef>(null);
+    const [editorContent, setEditorContent] = useState("");
+    const [sessionName, setSessionName] = useState("");
+    const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+    useDraftManagement({
+      composerInputRef,
+      editorContent,
+      setEditorContent,
+      sessionName,
+      setSessionName,
+      uploadedFiles,
+      setUploadedFiles,
+      agentIconId: null,
+      cliAgentType: "codex",
+    });
+    return createElement(
+      "div",
+      null,
+      // eslint-disable-next-line react-hooks/refs -- createElement forwards this ref to the editor; it does not read ref.current during render
+      createElement(ComposerInput, {
+        ref: composerInputRef,
+        initialContent: seed,
+        onContentChange: setEditorContent,
+      }),
+      createElement(
+        "button",
+        {
+          disabled: !editorContent.trim(),
+          onClick: () => submit(editorContent),
+        },
+        "Send"
+      )
+    );
+  }
+
+  const mount = (seed = "") =>
+    root.render(
+      createElement(Provider, { store }, createElement(Harness, { seed }))
+    );
+  const sendButton = () => root.container.querySelector("button")!;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    submit.mockClear();
+    store = createStore();
+    root = createSmokeRoot();
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+    vi.useRealTimers();
+  });
+
+  it("keeps editor-seeded text sendable when the active slot has no saved draft", async () => {
+    const text = "你是什么模\n模型";
+    await mount(text);
+    expect(
+      root.container.querySelector('[contenteditable="true"]')?.textContent
+    ).toContain("你是什么模");
+    expect(sendButton().disabled).toBe(false);
+    act(() => sendButton().click());
+    expect(submit).toHaveBeenCalledWith(text);
+
+    await settle(500);
+    const saved = store.get(sessionCreatorDraftAtom);
+    expect(saved?.editorContent).toBe(text);
+    expect(saved?.editorSnapshot?.parts).toEqual([
+      { kind: "text", text: "你是什么模" },
+      { kind: "newline" },
+      { kind: "text", text: "模型" },
+    ]);
+  });
+
+  it("keeps a blank composer disabled and does not persist an empty draft", async () => {
+    await mount();
+    expect(sendButton().disabled).toBe(true);
+    act(() => sendButton().click());
+    expect(submit).not.toHaveBeenCalled();
+    await settle(1000);
+    expect(store.get(sessionCreatorDraftAtom)).toBeNull();
+  });
+
+  it("restores the persisted text after remount and settles without idle writes", async () => {
+    await mount("saved prompt");
+    await settle(500);
+    await root.unmount();
+    root = createSmokeRoot();
+    await mount();
+    await settle(50);
+    expect(sendButton().disabled).toBe(false);
+    act(() => sendButton().click());
+    expect(submit).toHaveBeenCalledWith("saved prompt");
+    await settle(500);
+    const settled = store.get(sessionCreatorDraftStoreAtom);
+    await settle(5000);
+    expect(store.get(sessionCreatorDraftStoreAtom)).toBe(settled);
+  });
+
+  it("cancels pending persistence when the composer unmounts", async () => {
+    await mount("unsaved prompt");
+    await root.unmount();
+    const before = store.get(sessionCreatorDraftStoreAtom);
+    await settle(1000);
+    expect(store.get(sessionCreatorDraftStoreAtom)).toBe(before);
+  });
+});

--- a/src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.ts
@@ -104,7 +104,10 @@ export function useDraftManagement(options: UseDraftManagementOptions) {
 
     if (!currentDraft) {
       setSessionName("");
-      setEditorContent("");
+      // The child composer may already have restored or accepted text before
+      // this effect runs. Keep launch validation and the next persisted draft
+      // aligned with that live editor instead of resetting only their text.
+      setEditorContent(composerInputRef.current?.getText() ?? "");
       setUploadedFiles([]);
       // Do NOT call setContent("") here. This branch means "no saved draft for
       // this slot", but the editor may already have user-typed content (e.g.


### PR DESCRIPTION
## Problem

When the Session Creator had no saved draft, `useDraftManagement` preserved text already visible in the child composer but reset the parent `editorContent` state to empty. Submission validation and the debounced draft writer therefore treated a visible prompt as blank, leaving Send disabled and risking loss on remount.

## Solution

At the no-saved-draft ownership boundary, seed `editorContent` from the live composer ref while retaining the existing rule that does not clear the child editor. Saved-draft restoration, editor snapshots, model selection, launch preparation, timer durations, and storage format remain unchanged.

## Potential risks

The ref can be unavailable during an unusually early effect, in which case behavior falls back to the existing empty string. Reading the composer once does not add a listener or timer. Existing 500 ms persistence and restore timers remain component-owned and are canceled on unmount. Rollback is a commit revert; no draft migration or destructive cleanup is needed.

## Audit

Performance-guard verdict: pass. The lifecycle matrix, producing boundary, idle behavior, unmount cleanup, memory ownership, account/session isolation, and persistence read-back are documented in `docs/org2-performance-guard-2026-09-09/SessionCreatorDraft.md`. No CPU/RSS improvement is claimed.

`frontend-ui-audit` was intentionally skipped because this is a single-file state bug fix with no styling, design-system, or component-pattern change.

No new screenshot was captured after rebasing. The earlier live reproduction showed visible text with a disabled Send control; the rebased branch is verified by the real ComposerInput regression and broader input/launch tests rather than a provider turn.

## Verification

- `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/components/ComposerInput src/engines/SessionCore/hooks/session/useSessionCreator/useDraftManagement.test.ts src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/inputPreparation.test.ts`: passed, 15 files and 101 tests
- `node_modules/@typescript/native-preview/bin/tsgo --noEmit --pretty false`: passed
- Targeted ESLint over the hook and regression test: passed with zero warnings
- Prettier check over changed code and performance report: passed
- `node scripts/quality/check-test-placement.mjs`: passed
- Pre-commit staged-file checks: passed
- `git diff --check`: passed
- The rebased branch was not packaged into Tauri; provider submission was intentionally outside this state-boundary test