### PR TITLE
fix(notifications): expire completion toasts

### DIFF
--- a/src/hooks/session/__tests__/sessionTerminalNotifications.test.ts
+++ b/src/hooks/session/__tests__/sessionTerminalNotifications.test.ts
@@ -10,7 +10,13 @@ import {
 } from "../sessionTerminalNotifications";
 
 vi.mock("@src/components/Message", () => ({
-  default: { warning: vi.fn() },
+  default: { warning: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@src/api/services/notification", () => ({
+  TASK_FAILURE_NOTIFICATION_BODY: "Task failed",
+  notifyError: vi.fn(),
+  notifyTaskCompletion: vi.fn().mockResolvedValue({ disposition: "delivered" }),
 }));
 
 describe("shouldDeliverSessionTerminalNotification", () => {
@@ -31,29 +37,57 @@ describe("shouldDeliverSessionTerminalNotification", () => {
 });
 
 describe("deliverSessionTerminalNotification", () => {
+  const settings: NotificationSettings = {
+    enabled: true,
+    systemNotificationEnabled: false,
+    dockBadgeEnabled: false,
+    soundEnabled: false,
+    soundPreset: "classic",
+    soundVolume: 70,
+    criticalOnly: false,
+    quietHours: {
+      enabled: false,
+      start: "23:00",
+      end: "08:00",
+      allowCritical: true,
+    },
+    backgroundCompletionSummary: true,
+    categories: {
+      taskCompletion: true,
+      agentApproval: true,
+      errors: true,
+      teamInbox: true,
+    },
+  };
+  it.each(["completed", "idle"])(
+    "expires a delivered %s toast after six seconds while keeping its action",
+    async (status) => {
+      vi.mocked(Message.success).mockClear();
+      deliverSessionTerminalNotification(
+        {
+          sessionId: "session-a",
+          sessionName: "Session A",
+          status,
+          attentionRequired: true,
+        },
+        settings,
+        ((key: string) => key) as TFunction
+      );
+      await Promise.resolve();
+      expect(Message.success).toHaveBeenCalledOnce();
+      expect(Message.success).toHaveBeenCalledWith({
+        content: "notifications.taskCompletedToast",
+        duration: 6000,
+        closable: true,
+        action: {
+          label: "notifications.openSessionAction",
+          onClick: expect.any(Function),
+        },
+      });
+    }
+  );
+
   it("ignores removed mute preferences for cancellation while honoring the master toggle", () => {
-    const settings: NotificationSettings = {
-      enabled: true,
-      systemNotificationEnabled: false,
-      dockBadgeEnabled: false,
-      soundEnabled: false,
-      soundPreset: "classic",
-      soundVolume: 70,
-      criticalOnly: false,
-      quietHours: {
-        enabled: false,
-        start: "23:00",
-        end: "08:00",
-        allowCritical: true,
-      },
-      backgroundCompletionSummary: true,
-      categories: {
-        taskCompletion: true,
-        agentApproval: true,
-        errors: true,
-        teamInbox: true,
-      },
-    };
     const obsoleteSettings = { ...settings, mutedSessionIds: ["session-a"] };
     const event = {
       sessionId: "session-a",

--- a/src/hooks/session/sessionTerminalNotifications.ts
+++ b/src/hooks/session/sessionTerminalNotifications.ts
@@ -44,41 +44,44 @@ export function deliverSessionTerminalNotification(
     const body = t("notifications.taskCompletedBody", {
       name: event.sessionName,
     });
-    void notifyTaskCompletion(body, settings, {
+    notifyTaskCompletion(body, settings, {
       title: t("notifications.taskCompletedTitle"),
       context,
       summaryLabel: event.sessionName,
-    }).then((result) => {
-      if (result.disposition !== "delivered" || !event.attentionRequired)
-        return;
-      Message.success({
-        content: t("notifications.taskCompletedToast", {
-          name: event.sessionName,
-        }),
-        // Actionable completion notices still expire; duration is milliseconds.
-        duration: 6000,
-        closable: true,
-        // The copy says "open the Session" — give it an actual door.
-        action: {
-          label: t("notifications.openSessionAction", {
-            defaultValue: "Open Session",
+    })
+      .then((result) => {
+        if (result.disposition !== "delivered" || !event.attentionRequired)
+          return;
+        Message.success({
+          content: t("notifications.taskCompletedToast", {
+            name: event.sessionName,
           }),
-          onClick: () => {
-            void Promise.all([
-              import("@src/util/core/state/instrumentedStore"),
-              import("@src/store/chatPanel/chatPanelTabsAtom"),
-            ]).then(([storeModule, tabsModule]) => {
-              storeModule
-                .getInstrumentedStore()
-                .set(tabsModule.openOrFocusSessionInChatPanelTabAtom, {
-                  sessionId: event.sessionId,
-                  sessionName: event.sessionName,
-                });
-            });
+          // Actionable completion notices still expire; duration is milliseconds.
+          duration: 6000,
+          closable: true,
+          // The copy says "open the Session" — give it an actual door.
+          action: {
+            label: t("notifications.openSessionAction", {
+              defaultValue: "Open Session",
+            }),
+            onClick: () => {
+              void Promise.all([
+                import("@src/util/core/state/instrumentedStore"),
+                import("@src/store/chatPanel/chatPanelTabsAtom"),
+              ]).then(([storeModule, tabsModule]) => {
+                storeModule
+                  .getInstrumentedStore()
+                  .set(tabsModule.openOrFocusSessionInChatPanelTabAtom, {
+                    sessionId: event.sessionId,
+                    sessionName: event.sessionName,
+                  });
+              });
+            },
           },
-        },
-      });
-    });
+        });
+      })
+      // Notification delivery is best effort and this public boundary is void.
+      .catch(() => undefined);
     return;
   }
 

--- a/src/hooks/session/sessionTerminalNotifications.ts
+++ b/src/hooks/session/sessionTerminalNotifications.ts
@@ -55,7 +55,8 @@ export function deliverSessionTerminalNotification(
         content: t("notifications.taskCompletedToast", {
           name: event.sessionName,
         }),
-        duration: 0,
+        // Actionable completion notices still expire; duration is milliseconds.
+        duration: 6000,
         closable: true,
         // The copy says "open the Session" — give it an actual door.
         action: {


### PR DESCRIPTION
## Problem

Successful session-completion toasts with an Open Session action used `duration: 0`, so every completion remained on screen indefinitely until manually closed. The changed completion chain also exposed an existing best-effort notification Promise that was not explicitly rejection-handled.

## Solution

Keep the existing action and close control, but expire delivered completion and idle terminal toasts after 6,000 ms. Explicitly consume best-effort delivery rejection so the void public boundary cannot create an unhandled Promise. Failure handling, system notification settings, and terminal deduplication remain unchanged.

## Potential risks

Users now have six seconds to use the inline Open Session action before the toast disappears; the session itself remains available through normal navigation. A rejected system-notification delivery remains silent, matching prior user-visible behavior, but is now explicitly handled. Only successful completion/idle toasts change. Rollback is a commit revert with no data or compatibility impact.

## Audit

`frontend-ui-audit` was intentionally skipped because this is a single-file timing bug fix with no component, styling, token, or design-system change.

A screenshot is not useful for a time-expiry-only change; the existing toast appearance is unchanged and contract assertions verify the configured duration and retained action.

## Verification

- `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/hooks/session/__tests__/sessionTerminalNotifications.test.ts`: passed, 4 tests
- `node_modules/@typescript/native-preview/bin/tsgo --noEmit --pretty false`: passed
- `node scripts/quality/typed-lint/check.mjs`: passed, 1,179 existing findings and 0 new or increased findings
- Targeted ESLint over the changed source and test: passed with zero warnings
- Prettier check: passed
- `node scripts/quality/check-test-placement.mjs`: passed
- Pre-commit staged-file checks: passed
- `git diff --check`: passed