### PR TITLE
fix(chat): use default alerts in the session body

### DIFF
--- a/docs/frontend-ui-audit-2026-09-09/ChatErrorAlerts.md
+++ b/docs/frontend-ui-audit-2026-09-09/ChatErrorAlerts.md
@@ -1,0 +1,11 @@
+# Chat error alerts UI audit
+
+| Line                   | Element                      | Verdict          | Reason                                                       | Suggested change                                                       |
+| ---------------------- | ---------------------------- | ---------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| UserChatItem.tsx       | Delivery failure and retry   | fix              | Custom red text was embedded in the message toolbar          | Moved to session body with default PageNotice and action configuration |
+| AgentErrorChatItem.tsx | Account recovery alert       | fix              | User requested default alert props                           | Uses default full-width PageNotice with recovery action                |
+| AgentErrorChatItem.tsx | Technical details disclosure | keep with reason | Native button supports keyboard activation and aria-expanded | None                                                                   |
+
+Verdict totals: **2 fix**, **1 keep with reason**, **0 abstract**.
+
+Scope: both screenshot error surfaces; shared alert defaults are unchanged.

--- a/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useGroupHeaderRenderer.truncation.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useGroupHeaderRenderer.truncation.test.ts
@@ -195,7 +195,7 @@ describe("continuous chat user-message previews", () => {
     );
 
     const retryButton = container.querySelector<HTMLButtonElement>(
-      '[data-testid="chat-message-delivery-retry"]'
+      '[data-testid="chat-message-delivery-failed"] button'
     );
     const editButton = container.querySelector<HTMLButtonElement>(
       '[data-testid="chat-message-user-edit-button"]'
@@ -221,7 +221,9 @@ describe("continuous chat user-message previews", () => {
     );
 
     expect(
-      container.querySelector('[data-testid="chat-message-delivery-retry"]')
+      container.querySelector(
+        '[data-testid="chat-message-delivery-failed"] button'
+      )
     ).toBeNull();
     expect(
       container.querySelector('[data-testid="chat-message-user-edit-button"]')

--- a/src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx
+++ b/src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx
@@ -1,9 +1,7 @@
 /**
  * AgentErrorChatItem — Displays LLM/agent errors inline in the chat panel.
  *
- * Rendered as a single PageNotice, so the error reads as one bordered card
- * instead of the split header / body / footer layout the previous block-style
- * render produced. PageNotice has one neutral style for every type.
+ * Rendered as a full-width PageNotice in the session body.
  *
  * IMPORTANT: This component must NOT subscribe to chatEventsAtom. It is
  * rendered inside the chat list which is itself driven by chatEventsAtom.
@@ -62,7 +60,7 @@ const AgentErrorChatItem: React.FC<AgentErrorChatItemProps> = memo(
 
     return (
       <div className="animate-fade-in">
-        <PageNotice type="danger" title={title} action={action}>
+        <PageNotice title={title} action={action}>
           {needsCodexReauthentication ? (
             <>
               <div>{t("errors.codexLoginExpiredDescription")}</div>

--- a/src/engines/ChatPanel/ChatItems/UserChatItem.tsx
+++ b/src/engines/ChatPanel/ChatItems/UserChatItem.tsx
@@ -15,6 +15,7 @@ import ClampedContent from "@src/components/ClampedContent";
 import type { ComposerSnapshot } from "@src/components/ComposerInput";
 import ExpandOverlay from "@src/components/ExpandOverlay";
 import Message from "@src/components/Message";
+import PageNotice from "@src/components/PageNotice";
 import PersonAvatar from "@src/components/PersonAvatar";
 import { REPO_SETUP_PROMPT_MARKER } from "@src/config/repoSetupMarker";
 import type { OptimizedChatItem } from "@src/engines/ChatPanel/ChatHistory/chatItemPipeline/types";
@@ -569,8 +570,7 @@ const UserChatItem = ({
       {(rawPrompt.trim() ||
         isEditableDisplay ||
         toolbarActions ||
-        deliveryStatus === "pending" ||
-        deliveryStatus === "failed") && (
+        deliveryStatus === "pending") && (
         <div className="relative mt-1 flex min-h-6 items-center px-1 text-[11px] leading-none text-text-3">
           {(rawPrompt.trim() ||
             isEditableDisplay ||
@@ -655,41 +655,9 @@ const UserChatItem = ({
               {toolbarActions}
             </div>
           )}
-          {(deliveryStatus === "pending" || deliveryStatus === "failed") && (
-            <span className="flex items-center gap-1.5">
-              {deliveryStatus === "pending" && (
-                <span data-testid="chat-message-delivery-pending">
-                  {t("common:status.sending")}
-                </span>
-              )}
-              {deliveryStatus === "failed" && (
-                <>
-                  <span
-                    className="text-danger-6"
-                    data-testid="chat-message-delivery-failed"
-                    title={deliveryError ?? undefined}
-                  >
-                    {t("chat.failedToSendMessage")}
-                    {deliveryError &&
-                    deliveryError !== t("chat.failedToSendMessage")
-                      ? `: ${deliveryError}`
-                      : null}
-                  </span>
-                  {retryDelivery && (
-                    <button
-                      type="button"
-                      className="font-medium text-danger-6 hover:underline"
-                      data-testid="chat-message-delivery-retry"
-                      onClick={(clickEvent) => {
-                        clickEvent.stopPropagation();
-                        retryDelivery();
-                      }}
-                    >
-                      {t("common:actions.retry", "Retry")}
-                    </button>
-                  )}
-                </>
-              )}
+          {deliveryStatus === "pending" && (
+            <span data-testid="chat-message-delivery-pending">
+              {t("common:status.sending")}
             </span>
           )}
         </div>
@@ -698,53 +666,75 @@ const UserChatItem = ({
   );
 
   return (
-    <div
-      className={`group/msg flex w-full flex-col ${
-        isRemoteSharedMessage ? "items-start pr-24" : "items-end pl-24"
-      }`}
-      data-message-side={messageSide}
-    >
-      {isRemoteSharedMessage && senderName ? (
-        <div className="flex max-w-full items-start gap-2.5">
-          <span
-            className="mt-0.5 shrink-0"
-            title={senderName}
-            aria-label={senderName}
-            data-testid={
-              isParentAgentMessage
-                ? "parent-agent-sender-avatar"
-                : "shared-message-sender-avatar"
-            }
-          >
-            {isParentAgentMessage ? (
-              <span
-                className="flex h-6 w-6 items-center justify-center rounded-full"
-                style={{ backgroundColor: "var(--color-fill-2)" }}
-              >
-                <SessionIdentityIcon
-                  session={parentAgentSender?.parentSession}
-                  sessionId={parentAgentSender?.parentSessionId ?? ""}
+    <>
+      <div
+        className={`group/msg flex w-full flex-col ${
+          isRemoteSharedMessage ? "items-start pr-24" : "items-end pl-24"
+        }`}
+        data-message-side={messageSide}
+      >
+        {isRemoteSharedMessage && senderName ? (
+          <div className="flex max-w-full items-start gap-2.5">
+            <span
+              className="mt-0.5 shrink-0"
+              title={senderName}
+              aria-label={senderName}
+              data-testid={
+                isParentAgentMessage
+                  ? "parent-agent-sender-avatar"
+                  : "shared-message-sender-avatar"
+              }
+            >
+              {isParentAgentMessage ? (
+                <span
+                  className="flex h-6 w-6 items-center justify-center rounded-full"
+                  style={{ backgroundColor: "var(--color-fill-2)" }}
+                >
+                  <SessionIdentityIcon
+                    session={parentAgentSender?.parentSession}
+                    sessionId={parentAgentSender?.parentSessionId ?? ""}
+                  />
+                </span>
+              ) : (
+                <PersonAvatar
+                  size={24}
+                  name={senderName}
+                  src={senderResolution.identity?.avatarUrl}
                 />
-              </span>
-            ) : (
-              <PersonAvatar
-                size={24}
-                name={senderName}
-                src={senderResolution.identity?.avatarUrl}
-              />
-            )}
-          </span>
-          <div className="flex min-w-0 flex-col items-start">
-            <span className="mb-0.5 text-xs font-medium text-text-3">
-              {senderName}
+              )}
             </span>
-            {display}
+            <div className="flex min-w-0 flex-col items-start">
+              <span className="mb-0.5 text-xs font-medium text-text-3">
+                {senderName}
+              </span>
+              {display}
+            </div>
           </div>
-        </div>
-      ) : (
-        display
+        ) : (
+          display
+        )}
+      </div>
+      {deliveryStatus === "failed" && (
+        <PageNotice
+          title={t("chat.failedToSendMessage")}
+          dataTestId="chat-message-delivery-failed"
+          action={
+            retryDelivery
+              ? {
+                  label: t("common:actions.retry", "Retry"),
+                  onClick: retryDelivery,
+                }
+              : undefined
+          }
+        >
+          {deliveryError && (
+            <div className="wrap-anywhere whitespace-pre-wrap">
+              {deliveryError}
+            </div>
+          )}
+        </PageNotice>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/engines/ChatPanel/ChatItems/__tests__/UserChatItem.test.ts
+++ b/src/engines/ChatPanel/ChatItems/__tests__/UserChatItem.test.ts
@@ -337,7 +337,7 @@ describe("UserChatItem raw prompt affordance", () => {
 });
 
 describe("UserChatItem delivery failure", () => {
-  it("renders the underlying provider error beside the failed message", () => {
+  it("renders provider details in a default session-body alert", () => {
     const event = makeSessionEvent({
       id: "user-message-failed",
       sessionId: "agentsession-local",


### PR DESCRIPTION
## Problem

Chat delivery failures rendered long provider errors and a custom retry link inside the message toolbar, constraining the error to the message layout. The agent error notice also supplied a type override instead of using the requested default alert props.

## Solution

Render delivery failures as full-width default PageNotice alerts in the session body, outside the message alignment wrapper. Use the default action configuration for Retry and default props for the agent recovery notice, retaining Reconnect and its technical-details disclosure. Include the focused UI audit and update the delivery test description to match the placement.

## Potential risks

The placement and default icon treatment change visually. Narrow viewports, themes, and live Retry/Reconnect interactions have not been visually verified; computer control was not authorized. No persistence, dependencies, IPC, or recovery behavior changes are included. Reverting this commit restores the previous presentation.

## Verification

Run on a separate worktree based on the latest fetched origin/develop:

- `pnpm test src/engines/ChatPanel/ChatItems/__tests__/UserChatItem.test.ts src/engines/ChatPanel/ChatItems/__tests__/sanitizeAgentErrorMessage.test.ts src/components/PageNotice/PageNotice.test.ts` — 39 tests passed across 3 files.
- `pnpm exec eslint src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx src/engines/ChatPanel/ChatItems/UserChatItem.tsx` — passed.
- `pnpm typecheck:fast` — blocked by missing jsqr declarations in scanCameraQr.ts and scanCameraQr.decoder.test.ts, outside this change.
- `git diff --check` — passed.
- Inspected the scoped diff for unrelated changes, secrets, personal paths, debug output, and generated artifacts; none included.
- No live UI checks or new screenshots were captured because computer control requires explicit opt-in.

CI follow-up: the full suite found a stale custom Retry test ID in the group-header interaction test. The test now locates the default action button inside the failure alert and still verifies the retry callback arguments.

- `pnpm test src/engines/ChatPanel/ChatHistory/hooks/__tests__/useGroupHeaderRenderer.truncation.test.ts src/engines/ChatPanel/ChatItems/__tests__/UserChatItem.test.ts src/components/PageNotice/PageNotice.test.ts` — 32 tests passed, including Retry interaction.
- Commit hooks: `oxlint`, `eslint --fix`, and `prettier --write` passed on the updated test.
- Latest origin/develop fetched; no merge conflicts reported. Full CI rerun pending after this test correction.

## Audit

Frontend UI audit: 2 fixes, 1 retained with reason, 0 abstractions. Report: docs/frontend-ui-audit-2026-09-09/ChatErrorAlerts.md.


## Shared CI repair

Updated this branch from develop to include b02e3a505, which corrects the shared TeamInboxList test after inbox timestamps intentionally changed from `5h ago` to `5h`. No PR-specific product scope was added.

Verification: `pnpm test src/modules/MainApp/TeamInbox/__tests__/TeamInboxList.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts` — all 17 tests passed on this updated branch. Full GitHub CI rerun is pending.
