### PR TITLE
fix(shortcuts): use native text while preserving Spotlight rendering

### DIFF
--- a/src/components/KeyboardShortcut/index.test.ts
+++ b/src/components/KeyboardShortcut/index.test.ts
@@ -41,14 +41,54 @@ describe("KeyboardShortcut", () => {
     expect(markup).toContain("rounded-full");
     expect(markup).toContain("font-normal");
     expect(markup).not.toContain("font-semibold");
-    for (const character of ["⌘", "⇧", "⌥", "⌃", "⌫", "esc", "⇥"]) {
+    for (const character of [
+      "⌘",
+      "⇧",
+      "⌥",
+      "⌃",
+      "↑",
+      "↓",
+      "↩",
+      "⌫",
+      "esc",
+      "⇥",
+    ]) {
       expect(markup).toContain(character);
     }
-    expect(markup).toContain('data-icon="arrow-up"');
-    expect(markup).toContain('data-icon="arrow-down"');
-    expect(markup).toContain('data-icon="corner-down-left"');
+    expect(markup).toContain("↑");
+    expect(markup).toContain("↓");
+    expect(markup).not.toContain("<svg");
+    expect(markup).toContain("font-family:system-ui");
+    expect(markup).not.toContain("text-[12px]");
     expect(markup).not.toContain("↵");
     expect(markup).toContain(">2</span>");
+  });
+
+  it.each(["spotlightFooter", "default"] as const)(
+    "preserves original rendering for Spotlight %s shortcuts",
+    async (variant) => {
+      const { KeyboardShortcut } = await import("./index");
+      const markup = renderToStaticMarkup(
+        createElement(KeyboardShortcut, {
+          shortcut: "Up+Down+Enter+Esc",
+          variant,
+          ...(variant === "default" ? { rendering: "original" as const } : {}),
+        })
+      );
+      expect(markup).toContain('data-icon="arrow-up"');
+      expect(markup).toContain('data-icon="arrow-down"');
+      expect(markup).toContain('data-icon="corner-down-left"');
+      expect(markup).toContain("text-[12px]");
+      expect(markup).not.toContain("font-family:system-ui");
+    }
+  );
+
+  it("sets the native font on Shift itself despite the global span reset", async () => {
+    const { KeyboardShortcut } = await import("./index");
+    const markup = renderToStaticMarkup(
+      createElement(KeyboardShortcut, { shortcut: "Shift+M" })
+    );
+    expect(markup).toMatch(/<span style="font-family:system-ui[^>]+>⇧<\/span>/);
   });
 
   it("supports a compact size for dense menus", async () => {
@@ -72,7 +112,7 @@ describe("KeyboardShortcut", () => {
     expect(markup).not.toContain("data-icon=");
   });
 
-  it("keeps the up and down icons close together", async () => {
+  it("keeps the up and down text symbols close together", async () => {
     const { KeyboardShortcut } = await import("./index");
 
     const markup = renderToStaticMarkup(
@@ -80,8 +120,8 @@ describe("KeyboardShortcut", () => {
     );
 
     expect(markup).toContain("gap-0");
-    expect(markup).toContain('data-icon="arrow-up"');
-    expect(markup).toContain('data-icon="arrow-down"');
+    expect(markup).toContain("↑");
+    expect(markup).toContain("↓");
   });
 });
 

--- a/src/components/KeyboardShortcut/index.tsx
+++ b/src/components/KeyboardShortcut/index.tsx
@@ -26,6 +26,7 @@ export interface KeyboardShortcutProps {
   className?: string;
   variant?: KeyboardShortcutVariant;
   size?: KeyboardShortcutSize;
+  rendering?: "native" | "original";
 }
 
 interface KeyboardShortcutTooltipRow {
@@ -35,6 +36,7 @@ interface KeyboardShortcutTooltipRow {
 }
 
 interface KeyboardShortcutTooltipContentProps {
+  rendering?: KeyboardShortcutProps["rendering"];
   label?: ReactNode;
   shortcutId?: string;
   shortcut?: string;
@@ -179,10 +181,10 @@ function ModifierKey({ modifier }: { modifier: ModifierType }) {
     ctrl: IS_MAC ? "⌃" : "Ctrl",
   }[modifier];
 
-  return <span className="leading-none">{character}</span>;
+  return character;
 }
 
-function SpecialKey({
+function OriginalSpecialKey({
   special,
   iconSize,
 }: {
@@ -217,7 +219,20 @@ function SpecialKey({
     tab: "⇥",
   }[special];
 
-  return <span className="leading-none">{character}</span>;
+  return character;
+}
+
+function SpecialKey({ special }: { special: SpecialKeyType }) {
+  const character = {
+    arrowUp: "↑",
+    arrowDown: "↓",
+    enter: "↩",
+    backspace: "⌫",
+    esc: "esc",
+    tab: "⇥",
+  }[special];
+
+  return character;
 }
 
 // A shortcut chord is one joined pill, matching the compact presentation used
@@ -271,6 +286,9 @@ export const KeyboardShortcut = memo<KeyboardShortcutProps>(
     className = "",
     variant = KEYBOARD_SHORTCUT_VARIANT.default,
     size = "default",
+    rendering = variant === KEYBOARD_SHORTCUT_VARIANT.spotlightFooter
+      ? "original"
+      : "native",
   }) => {
     const resolvedShortcut = useShortcutKeys(shortcutId ?? "");
     const tokens = parseShortcut(shortcutId ? resolvedShortcut : shortcut);
@@ -302,19 +320,28 @@ export const KeyboardShortcut = memo<KeyboardShortcutProps>(
             return (
               <span
                 key={index}
-                className={`${KEY_TOKEN_BASE} ${
-                  isTextToken ? capSize.text : capSize.glyph
-                }`}
+                style={
+                  rendering === "native"
+                    ? {
+                        fontFamily:
+                          "system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+                      }
+                    : undefined
+                }
+                className={`${KEY_TOKEN_BASE} ${rendering === "original" && isTextToken ? capSize.text : capSize.glyph}`}
               >
                 {token.type === "modifier" && (
                   <ModifierKey modifier={token.modifier} />
                 )}
-                {token.type === "special" && (
-                  <SpecialKey
-                    special={token.special}
-                    iconSize={capSize.iconSize}
-                  />
-                )}
+                {token.type === "special" &&
+                  (rendering === "original" ? (
+                    <OriginalSpecialKey
+                      special={token.special}
+                      iconSize={capSize.iconSize}
+                    />
+                  ) : (
+                    <SpecialKey special={token.special} />
+                  ))}
                 {token.type === "key" && token.label}
               </span>
             );
@@ -335,6 +362,7 @@ export const KeyboardShortcutTooltipContent =
       shortcutId,
       rows,
       noShortcut = false,
+      rendering,
       className = "",
     }) => {
       const resolvedShortcut = useShortcutKeys(shortcutId ?? "");
@@ -353,6 +381,7 @@ export const KeyboardShortcutTooltipContent =
               shortcut={row.shortcut}
               shortcutId={row.shortcutId}
               variant={KEYBOARD_SHORTCUT_VARIANT.dropdown}
+              rendering={rendering}
             />
           </div>
         );
@@ -373,6 +402,7 @@ export const KeyboardShortcutTooltipContent =
                   shortcut={row.shortcut}
                   shortcutId={row.shortcutId}
                   variant={KEYBOARD_SHORTCUT_VARIANT.dropdown}
+                  rendering={rendering}
                 />
               </div>
             ))}

--- a/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx
@@ -529,7 +529,9 @@ export const SpotlightItemRow = memo<SpotlightItemRowProps>(
           {(item.type === "action" ||
             item.type === "command" ||
             item.type === "hint") &&
-            item.shortcut && <KeyboardShortcut shortcut={item.shortcut} />}
+            item.shortcut && (
+              <KeyboardShortcut shortcut={item.shortcut} rendering="original" />
+            )}
 
           {hasDisclosureChevron && (
             <span className="spotlight-disclosure-chevron pointer-events-none inline-flex h-5 shrink-0 items-center justify-center overflow-hidden text-primary-6">

--- a/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/AgentControlSubmitButton.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/AgentControlSubmitButton.tsx
@@ -51,6 +51,7 @@ export const AgentControlSubmitButton: React.FC<
     <Tooltip
       content={
         <KeyboardShortcutTooltipContent
+          rendering="original"
           label={t("adeManager.submit")}
           shortcut={sendShortcut}
         />


### PR DESCRIPTION
## Problem

Shortcut badges mix font glyphs with SVG arrows and Return icons, giving keys inconsistent visual weight. The global CSS font reset also applies directly to spans, so setting a system font only on the enclosing badge does not change the actual modifier glyph font.

## Solution

Render regular shortcut badges entirely as text (including ↑, ↓, and ↩), use one font size per badge, and apply the system font directly to each key span. Preserve Spotlight’s original SVG arrows/Return and text sizing in its footer, result rows, and agent submit tooltip through an explicit original-rendering option.

## Potential risks

System-font glyph proportions and fallback fonts vary across macOS, Windows, and Linux; exact optical alignment is not guaranteed. Native app appearance, themes, and viewport layouts have not been visually verified. Text labels such as Esc and Ctrl now share the glyph size outside Spotlight and can occupy slightly more width. This is presentation-only, with no changes to shortcut bindings, persistence, dependencies, or background work; reverting the commit restores the previous rendering.

## Verification

- `pnpm test src/components/KeyboardShortcut/index.test.ts src/components/KeyboardShortcut/index.bindings.test.ts` — 9 tests passed on the latest fetched `origin/develop` base, covering text-only rendering, direct Shift font assignment, preserved Spotlight rendering, and custom bindings.
- `pnpm exec eslint src/components/KeyboardShortcut/index.tsx src/components/KeyboardShortcut/index.test.ts src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/AgentControlSubmitButton.tsx` — passed.
- Commit hooks ran `oxlint -c .oxlintrc.json --max-warnings 0`, `eslint --fix`, and `prettier --write` on staged files — passed. The hook’s TypeScript check reported errors outside the staged files; none in the changed files.
- `git diff --check origin/develop...HEAD` — passed. Inspected the four-file diff for scope, secrets, personal paths, logs, and generated artifacts.
- Full test suite and native visual checks were not run. Screenshots remain outstanding because desktop control was not authorized; automated markup checks do not establish optical consistency.


## Shared CI repair

Updated this branch from develop to include b02e3a505, which corrects the shared TeamInboxList test after inbox timestamps intentionally changed from `5h ago` to `5h`. No PR-specific product scope was added.

Verification: `pnpm test src/modules/MainApp/TeamInbox/__tests__/TeamInboxList.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts` — all 17 tests passed on this updated branch. Full GitHub CI rerun is pending.
