### PR TITLE
fix(chat): use primary colors for session stop button

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/InputActions.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputActions.tsx
@@ -168,7 +168,7 @@ const InputActions: React.FC<InputActionsProps> = memo(
         : activeButtonClass
       : showStop
         ? canStopAgent
-          ? "cursor-pointer border-none bg-text-2 text-white hover:bg-text-1"
+          ? INPUT_AREA_BUTTONS.iconButtonActive
           : "cursor-not-allowed border border-solid border-border-2 bg-transparent text-text-3 opacity-50"
         : showRetry
           ? "cursor-pointer border-none bg-warning-6 text-white hover:bg-warning-5"


### PR DESCRIPTION
## Problem

The session composer pause/stop button uses neutral gray colors while Send uses the primary palette, making the two states visually inconsistent.

## Solution

Reuse `INPUT_AREA_BUTTONS.iconButtonActive` for the enabled stop state: primary-6 background, primary-5 hover, and a white icon. This one-line change preserves click handling and disabled behavior.

## Potential risks

The enabled stop control changes appearance in both themes; rendered light/dark appearance has not been visually verified. There are no dependency, persistence, API, or lifecycle changes.

## Verification

- `pnpm exec eslint src/engines/ChatPanel/InputArea/components/InputActions.tsx --max-warnings 0` — passed on the isolated branch based on latest fetched `origin/develop`.
- `git diff origin/develop...HEAD --check` — passed; reviewed the complete one-line diff for scope and unwanted content.
- Commit hooks: `oxlint -c .oxlintrc.json --max-warnings 0`, `eslint --fix`, and `prettier --write` — passed for the staged file. The tsgo gate passed for the staged file and reported TypeScript errors in unstaged files; this is not a clean full-project typecheck.
- No new tests for this styling-only token reuse. GUI checks and screenshots were not performed because computer control requires explicit opt-in under the workspace instructions.


## Shared CI repair

Updated this branch from develop to include b02e3a505, which corrects the shared TeamInboxList test after inbox timestamps intentionally changed from `5h ago` to `5h`. No PR-specific product scope was added.

Verification: `pnpm test src/modules/MainApp/TeamInbox/__tests__/TeamInboxList.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts` — all 17 tests passed on this updated branch. Full GitHub CI rerun is pending.
