### PR TITLE
fix(terminal): align info and stop control styling

### DIFF
--- a/src/components/ProcessStopButton/index.tsx
+++ b/src/components/ProcessStopButton/index.tsx
@@ -29,7 +29,7 @@ export function ProcessStopButton({
       aria-label={label}
       title={label}
       disabled={disabled || loading}
-      className={`hover:text-danger-7 inline-flex shrink-0 items-center justify-center rounded text-danger-6 transition-colors hover:bg-danger-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-6 disabled:cursor-not-allowed disabled:opacity-40 ${BUTTON_SIZE[size]} ${className}`}
+      className={`hover:text-danger-7 inline-flex shrink-0 items-center justify-center rounded-lg text-danger-6 transition-colors hover:bg-danger-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-6 disabled:cursor-not-allowed disabled:opacity-40 ${BUTTON_SIZE[size]} ${className}`}
       onClick={(event) => {
         event.stopPropagation();
         onClick?.(event);

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent Terminal",
     "myStation": "Meine Station",
     "agentStation": "Station des Agent",
-    "myTerminal": "Mein Terminal",
-    "myTerminalInfo": "Mein Terminal-Info"
+    "myTerminal": "Mein Terminal"
   },
   "tooltips": {
     "closeEsc": "Schließen (Esc)",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -605,8 +605,7 @@
     "agentTerminal": "Agent Terminal",
     "myStation": "My Station",
     "agentStation": "Agent's Station",
-    "myTerminal": "My Terminal",
-    "myTerminalInfo": "My Terminal Info"
+    "myTerminal": "My Terminal"
   },
   "tooltips": {
     "closeEsc": "Close (Esc)",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent Terminal",
     "myStation": "Mi estación",
     "agentStation": "Estación del Agent",
-    "myTerminal": "Mi terminal",
-    "myTerminalInfo": "Información de mi terminal"
+    "myTerminal": "Mi terminal"
   },
   "tooltips": {
     "closeEsc": "Cerrar (Esc)",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent Terminal",
     "myStation": "Ma station",
     "agentStation": "Station de l'Agent",
-    "myTerminal": "Mon terminal",
-    "myTerminalInfo": "Infos de mon terminal"
+    "myTerminal": "Mon terminal"
   },
   "tooltips": {
     "closeEsc": "Fermer (Esc)",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent ターミナル",
     "myStation": "自分のステーション",
     "agentStation": "Agent のステーション",
-    "myTerminal": "My Terminal",
-    "myTerminalInfo": "My Terminal 情報"
+    "myTerminal": "My Terminal"
   },
   "tooltips": {
     "closeEsc": "閉じる (Esc)",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent 터미널",
     "myStation": "내 스테이션",
     "agentStation": "Agent 스테이션",
-    "myTerminal": "My Terminal",
-    "myTerminalInfo": "My Terminal 정보"
+    "myTerminal": "My Terminal"
   },
   "tooltips": {
     "closeEsc": "닫기 (Esc)",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Shell Agenta",
     "myStation": "Moja stacja",
     "agentStation": "Stacja Agenta",
-    "myTerminal": "Mój Shell",
-    "myTerminalInfo": "Informacje o moim Shellu"
+    "myTerminal": "Mój Shell"
   },
   "tooltips": {
     "closeEsc": "Zamknij (Esc)",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent Terminal",
     "myStation": "Minha estação",
     "agentStation": "Estação do Agent",
-    "myTerminal": "My Terminal",
-    "myTerminalInfo": "Informações do My Terminal"
+    "myTerminal": "My Terminal"
   },
   "tooltips": {
     "closeEsc": "Fechar (Esc)",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent терминал",
     "myStation": "Моя станция",
     "agentStation": "Станция Agent",
-    "myTerminal": "Мой терминал",
-    "myTerminalInfo": "Информация о моем терминале"
+    "myTerminal": "Мой терминал"
   },
   "tooltips": {
     "closeEsc": "Закрыть (Esc)",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent Terminal",
     "myStation": "İstasyonum",
     "agentStation": "Agent istasyonu",
-    "myTerminal": "Terminalim",
-    "myTerminalInfo": "Terminalim bilgisi"
+    "myTerminal": "Terminalim"
   },
   "tooltips": {
     "closeEsc": "Kapat (Esc)",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent Terminal",
     "myStation": "Trạm của tôi",
     "agentStation": "Trạm của Agent",
-    "myTerminal": "Terminal của tôi",
-    "myTerminalInfo": "Thông tin terminal của tôi"
+    "myTerminal": "Terminal của tôi"
   },
   "tooltips": {
     "closeEsc": "Đóng (Esc)",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -774,8 +774,7 @@
     "agentTerminal": "Agent 終端",
     "myStation": "我的工作站",
     "agentStation": "Agent的工作站",
-    "myTerminal": "我的終端",
-    "myTerminalInfo": "我的終端信息"
+    "myTerminal": "我的終端"
   },
   "tooltips": {
     "closeEsc": "關閉 (Esc)",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -605,8 +605,7 @@
     "agentTerminal": "Agent 终端",
     "myStation": "我的工作站",
     "agentStation": "Agent的工作站",
-    "myTerminal": "我的终端",
-    "myTerminalInfo": "我的终端信息"
+    "myTerminal": "我的终端"
   },
   "tooltips": {
     "closeEsc": "关闭 (Esc)",

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx
@@ -186,12 +186,12 @@ const TerminalMainContent: React.FC<TerminalMainContentProps> = ({
           ) : (
             <ProcessStopButton
               label={t("common:tooltips.killTerminal")}
+              size="lg"
               onClick={handleKillTerminal}
             />
           )}
           {!isAgentTerminal && (
             <TerminalInfoButton
-              title={t("common:terminology.myTerminalInfo")}
               name={displayTitle}
               pid={terminalPid}
               shell={terminalShell}

--- a/src/modules/WorkStation/shared/TerminalInfoButton.tsx
+++ b/src/modules/WorkStation/shared/TerminalInfoButton.tsx
@@ -4,20 +4,20 @@ import { useTranslation } from "react-i18next";
 import Button from "@src/components/Button";
 import {
   DROPDOWN_CLASSES,
+  DROPDOWN_ITEM,
+  DROPDOWN_PANEL,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
 import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import { HugeiconsIcon, InformationCircleIcon } from "@src/icons";
 
 export interface TerminalInfoButtonProps {
-  title: string;
   name: string;
   pid?: number;
   shell?: string;
 }
 
 const TerminalInfoButtonComponent: React.FC<TerminalInfoButtonProps> = ({
-  title,
   name,
   pid,
   shell,
@@ -48,31 +48,30 @@ const TerminalInfoButtonComponent: React.FC<TerminalInfoButtonProps> = ({
 
       {showTerminalInfo ? (
         <div
-          className={`absolute top-full right-0 z-50 mt-2 ${DROPDOWN_CLASSES.panel} p-3 ${DROPDOWN_WIDTHS.panelWidthClass}`}
+          className={`absolute top-full right-0 z-50 mt-2 ${DROPDOWN_CLASSES.panel} ${DROPDOWN_PANEL.paddingClass} ${DROPDOWN_WIDTHS.panelWidthClass}`}
         >
-          <div className="space-y-2 text-[13px]">
-            <div className="mb-2 border-b border-border-2 pb-1.5 font-bold text-text-1">
-              {title}
-            </div>
-            <div className="flex items-center justify-between gap-6">
-              <span className="font-bold text-text-3">
-                {t("common:common.name")}:
-              </span>
-              <span className="truncate font-bold text-text-1">{name}</span>
+          <div
+            className={`flex flex-col ${DROPDOWN_PANEL.itemsGapClass} ${DROPDOWN_ITEM.fontSizeClass}`}
+          >
+            <div
+              className={`flex items-center justify-between gap-6 ${DROPDOWN_ITEM.heightClass} ${DROPDOWN_ITEM.paddingXClass}`}
+            >
+              <span className="text-text-3">{t("common:common.name")}</span>
+              <span className="truncate font-medium text-text-1">{name}</span>
             </div>
             {pid !== undefined ? (
-              <div className="flex items-center justify-between gap-6">
-                <span className="font-bold text-text-3">
-                  {t("common:common.pid")}:
-                </span>
-                <span className="font-bold text-text-1">{pid}</span>
+              <div
+                className={`flex items-center justify-between gap-6 ${DROPDOWN_ITEM.heightClass} ${DROPDOWN_ITEM.paddingXClass}`}
+              >
+                <span className="text-text-3">{t("common:common.pid")}</span>
+                <span className="font-medium text-text-1">{pid}</span>
               </div>
             ) : null}
-            <div className="flex items-center justify-between gap-6">
-              <span className="font-bold text-text-3">
-                {t("common:common.shell")}:
-              </span>
-              <span className="truncate font-bold text-text-1">
+            <div
+              className={`flex items-center justify-between gap-6 ${DROPDOWN_ITEM.heightClass} ${DROPDOWN_ITEM.paddingXClass}`}
+            >
+              <span className="text-text-3">{t("common:common.shell")}</span>
+              <span className="truncate font-medium text-text-1">
                 {shell ?? "zsh"}
               </span>
             </div>

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminalHeader.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminalHeader.tsx
@@ -98,7 +98,6 @@ export function WorkstationTrailTerminalHeader({
         <>
           {!collapsed && activeTab ? (
             <ProcessStopButton
-              className="rounded-lg"
               size="sm"
               label={t("common:tooltips.killTerminal")}
               onClick={() => onStop(activeTab.key)}


### PR DESCRIPTION
## Problem

Terminal controls use inconsistent styling: the info popover adds a bold title, colon-suffixed labels and custom spacing, while the kill control is smaller and has sharper corners than neighboring regular buttons.

## Solution

Align terminal controls with existing shared styles. Remove the info title/divider and label colons, use the ports menu's dropdown typography and spacing tokens, and remove the unused title prop. Set the terminal kill control to the existing 28px size. Use the predefined rounded-lg radius for all ProcessStopButton instances and remove the now-redundant trail caller override. Delete the unused myTerminalInfo title translation from all 13 locales.

## Potential risks

The shared radius change also affects stop buttons in ports menus and sidebar/rail rows; their dimensions and destructive styling remain unchanged. The info popover's spacing and font weight change, so long shell names and localized labels merit visual review. Live UI screenshots, theme checks and viewport checks were not performed because desktop control was not authorized. Existing mouse-only info interaction is unchanged. No dependencies, persistence, IPC or process-termination logic change.

## Verification

On an isolated worktree based on the latest origin/develop:

- `pnpm exec eslint src/components/ProcessStopButton/index.tsx src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx src/modules/WorkStation/shared/TerminalInfoButton.tsx src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminalHeader.tsx` — passed.
- `pnpm test src/components/ProcessStopButton/index.test.ts src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts` — 8 tests passed across 2 files.
- `git diff --check` — passed.
- Inspected the final diff for scope, secrets, debug output and generated artifacts; none included.
- No live visual verification or screenshots; limitations are disclosed above.
- `git commit` hooks — staged oxlint, ESLint, Prettier and commitlint passed. The `npx tsgo --noEmit --pretty false` hook reported errors outside the staged files; its staged-file gate passed. A clean full-project typecheck is not claimed.


## Shared CI repair

Updated this branch from develop to include b02e3a505, which corrects the shared TeamInboxList test after inbox timestamps intentionally changed from `5h ago` to `5h`. No PR-specific product scope was added.

Verification: `pnpm test src/modules/MainApp/TeamInbox/__tests__/TeamInboxList.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxRow.test.ts` — all 17 tests passed on this updated branch. Full GitHub CI rerun is pending.

Removed the obsolete `common:terminology.myTerminalInfo` key from all 13 locales after the title removal made it unused. `pnpm test:i18n-keys` passed all 27 tests; `pnpm check:i18n-keys` passed with zero new findings. `git diff --check` and the formatting commit hook passed. Full CI is rerunning after this correction.
