### PR TITLE
style(sidebar): unify 28px rows and tighten section spacing

### DIFF
--- a/src/modules/shared/layouts/blocks/SettingsSearchDropdown/SettingsSearchDropdown.test.ts
+++ b/src/modules/shared/layouts/blocks/SettingsSearchDropdown/SettingsSearchDropdown.test.ts
@@ -302,7 +302,7 @@ describe("SettingsSearchDropdown", () => {
     );
     expect(input).not.toBeNull();
     expect(
-      input?.closest(".input-wrapper")?.classList.contains("input-size-default")
+      input?.closest(".input-wrapper")?.classList.contains("input-size-small")
     ).toBe(true);
     expect(input?.closest(".input-inner")?.classList.contains("bg-bg-2")).toBe(
       true

--- a/src/modules/shared/layouts/blocks/SettingsSearchDropdown/index.tsx
+++ b/src/modules/shared/layouts/blocks/SettingsSearchDropdown/index.tsx
@@ -214,7 +214,7 @@ function SettingsSearchDropdown<TItem extends SettingsSearchDropdownItem>({
         {isPersistentSearch ? (
           <Input
             type="search"
-            size="default"
+            size="small"
             className="input-sidebar-search"
             value={searchQuery}
             onChange={handleSearchChange}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarGroup.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarGroup.tsx
@@ -87,7 +87,7 @@ function SidebarGroupInner<T extends SidebarItemData = SidebarItemData>({
       {/* Group Header - styled like NavigationMenu submenu header */}
       {group.title && group.collapsible !== false && (
         <div
-          className={`group mx-2 flex h-8 cursor-pointer items-center justify-between rounded-lg px-2 transition-colors duration-150 ${
+          className={`group mx-2 flex h-7 cursor-pointer items-center justify-between rounded-lg px-2 transition-colors duration-150 ${
             hasSelectedChild
               ? "bg-sidebar-selected text-text-1"
               : "text-text-1 hover:bg-sidebar-selected"
@@ -137,7 +137,7 @@ function SidebarGroupInner<T extends SidebarItemData = SidebarItemData>({
 
       {/* Non-collapsible header */}
       {group.title && group.collapsible === false && (
-        <div className="mx-2 flex h-8 items-center px-3">
+        <div className="mx-2 flex h-7 items-center px-3">
           <span className="text-[11px] font-medium tracking-wider text-text-3 uppercase">
             {group.title}
           </span>
@@ -148,7 +148,7 @@ function SidebarGroupInner<T extends SidebarItemData = SidebarItemData>({
       {!isCollapsed && (
         <div className={`flex flex-col gap-0 ${group.title ? "mt-1" : ""}`}>
           {group.items.length === 0 ? (
-            <div className="mx-2 flex h-8 items-center justify-center px-3 text-[12px] text-text-3">
+            <div className="mx-2 flex h-7 items-center justify-center px-3 text-[12px] text-text-3">
               {t("sidebar.empty.noItems")}
             </div>
           ) : (

--- a/src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.test.ts
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.test.ts
@@ -7,7 +7,7 @@ import { ArrowLeft01Icon } from "@src/icons";
 import SidebarHeaderNavButton from "./SidebarHeaderNavButton";
 
 describe("SidebarHeaderNavButton", () => {
-  it("uses the shared 32px sidebar row height", () => {
+  it("uses the shared 28px sidebar row height", () => {
     const markup = renderToStaticMarkup(
       createElement(SidebarHeaderNavButton, {
         icon: ArrowLeft01Icon,
@@ -16,7 +16,7 @@ describe("SidebarHeaderNavButton", () => {
       })
     );
 
-    expect(markup).toContain("group mt-1 flex h-8 w-full");
+    expect(markup).toContain("group mt-1 flex h-7 w-full");
     expect(markup).toContain("items-center gap-3");
     expect(markup).toContain("flex min-w-0 flex-1 flex-col gap-0");
     expect(markup).not.toContain("min-h-[36px]");

--- a/src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.tsx
@@ -22,7 +22,7 @@ const SidebarHeaderNavButton: React.FC<SidebarHeaderNavButtonProps> = ({
 }) => {
   return (
     <div
-      className={`group mt-1 flex h-8 w-full cursor-pointer items-center justify-between overflow-hidden rounded-lg px-2 text-text-1 transition-colors duration-150 hover:bg-sidebar-selected ${className}`}
+      className={`group mt-1 flex h-7 w-full cursor-pointer items-center justify-between overflow-hidden rounded-lg px-2 text-text-1 transition-colors duration-150 hover:bg-sidebar-selected ${className}`}
       onClick={onClick}
       role="button"
       tabIndex={0}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarItem.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarItem.tsx
@@ -68,7 +68,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
 
   return (
     <div
-      className={`group flex h-8 min-w-0 cursor-pointer items-center gap-2 overflow-hidden rounded-lg px-2 transition-colors duration-150 ${rowStateClasses} ${className}`}
+      className={`group flex h-7 min-w-0 cursor-pointer items-center gap-2 overflow-hidden rounded-lg px-2 transition-colors duration-150 ${rowStateClasses} ${className}`}
       onClick={onClick}
       onContextMenu={handleContextMenu}
       onAuxClick={handleAuxClick}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarList.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarList.tsx
@@ -57,7 +57,7 @@ const SidebarList: React.FC<SidebarListProps> = React.memo(
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <div
           ref={scrollContainerRef}
-          className={`sidebar-list min-h-0 flex-1 overflow-y-auto px-3 ${topPadding ? "pt-3" : ""} scrollbar-hide ${className}`}
+          className={`sidebar-list min-h-0 flex-1 overflow-y-auto px-3 ${topPadding ? "pt-2" : ""} scrollbar-hide ${className}`}
         >
           <div className="flex flex-col" style={SECTION_GAP_STYLE}>
             {children}

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.test.ts
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.test.ts
@@ -32,7 +32,7 @@ describe("NavigationMenuRow", () => {
     Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
   });
 
-  it("uses one fixed 32px height for parent and leaf rows", () => {
+  it("uses one fixed 28px height for parent and leaf rows", () => {
     const parentMarkup = renderToStaticMarkup(
       createElement(NavigationMenuParentRow, {
         item: {
@@ -65,8 +65,9 @@ describe("NavigationMenuRow", () => {
       })
     );
 
+    expect(parentMarkup).toContain("flex h-7 items-center");
+    expect(leafMarkup).toContain('style="height:28px"');
     for (const markup of [parentMarkup, leafMarkup]) {
-      expect(markup).toContain("flex h-8 items-center");
       expect(markup).not.toContain("min-h-[36px]");
     }
   });

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
@@ -12,6 +12,7 @@ import {
 } from "@src/icons";
 import { ReferenceDragGhost } from "@src/shared/dnd/ReferenceDragGhost";
 
+import { SIDEBAR_STYLE } from "../../../config";
 import type { NavigationMenuItem } from "../config";
 import { NavigationMenuRowAccessorySlot } from "./RowAccessorySlot";
 import { NavigationMenuRowActionButton } from "./RowActionButton";
@@ -126,7 +127,7 @@ export const NavigationMenuParentRow = React.forwardRef<
         tabIndex={item.disabled ? -1 : 0}
         aria-expanded={isOpen}
         aria-disabled={item.disabled || undefined}
-        className={`group/parent flex h-8 items-center ${
+        className={`group/parent flex h-7 items-center ${
           item.disclosureFollowsLabel ? "justify-start" : "justify-between"
         } rounded-lg transition-colors duration-150 ${
           isChild ? "pr-2 pl-5" : "px-2"
@@ -353,6 +354,8 @@ export const NavigationMenuLeafRow = React.forwardRef<
       <div
         data-testid={item.dataTestId}
         data-tour-target={item.tourTarget}
+        // Keep the shared mobile session-row geometry independent of sidebar density.
+        style={{ height: SIDEBAR_STYLE.rowHeight }}
         data-menu-item-id={item.id}
         data-selected={isSelected ? "true" : "false"}
         role="button"

--- a/src/scaffold/NavigationSidebar/config.ts
+++ b/src/scaffold/NavigationSidebar/config.ts
@@ -21,7 +21,7 @@ export const SIDEBAR_STYLE = {
   /** Action button size */
   actionButtonSize: 28,
   /** Shared navigation row height */
-  rowHeight: 32,
+  rowHeight: 28,
   /** Border radius */
   borderRadius: 20,
   /** Item border radius */

--- a/src/scaffold/NavigationSidebar/connectors/SidebarAccountButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarAccountButton.tsx
@@ -21,7 +21,7 @@ const SidebarAccountButton: React.FC<SidebarAccountButtonProps> = React.memo(
     return (
       <button
         type="button"
-        className={`flex h-8 min-w-0 flex-1 items-center rounded-lg border-none px-2 text-left focus-visible:ring-2 focus-visible:ring-primary-6/40 focus-visible:outline-none ${
+        className={`flex h-7 min-w-0 flex-1 items-center rounded-lg border-none px-2 text-left focus-visible:ring-2 focus-visible:ring-primary-6/40 focus-visible:outline-none ${
           menuOpen
             ? "bg-sidebar-selected"
             : "bg-transparent hover:bg-sidebar-selected"

--- a/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
@@ -169,8 +169,8 @@ const SidebarOrgSelector: React.FC<SidebarOrgSelectorProps> = React.memo(
               radius="lg"
               dropdownWidth={250}
               dropdownAlign="left"
-              className="h-8 w-full"
-              selectorClassName={`h-8 px-2! [&_.select-arrow]:text-text-2! ${
+              className="h-7 w-full"
+              selectorClassName={`h-7 px-2! [&_.select-arrow]:text-text-2! ${
                 menuOpen
                   ? "[&_.select-arrow]:opacity-100 bg-sidebar-selected!"
                   : "[&_.select-arrow]:opacity-0 group-hover/sidebar:[&_.select-arrow]:opacity-100 hover:[&_.select-arrow]:opacity-100 hover:bg-sidebar-selected!"

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts
@@ -46,10 +46,10 @@ describe("NavigationSidebar", () => {
     );
 
     expect(markup).toContain(
-      'class="mb-2 flex items-center gap-1.5 px-2 text-[11px] font-medium tracking-wider text-text-2 uppercase"'
+      'class="mb-1 flex items-center gap-1.5 px-2 text-[11px] font-medium tracking-wider text-text-2 uppercase"'
     );
     expect(markup).toContain('<span class="min-w-0 truncate">Browse</span>');
-    expect(markup).toContain('class="flex flex-col gap-3 px-3 pt-1"');
+    expect(markup).toContain('class="flex flex-col gap-2 px-3 pt-1"');
     expect(markup).toContain('data-sidebar-section-id="work-items-browse"');
     expect(markup).not.toContain(
       'data-test-menu-item="separator-work-items-browse"'

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -163,7 +163,7 @@ function NavigationSidebarSectionHeader({
   titleIcon?: ReactNode;
 }) {
   return (
-    <div className="mb-2 flex items-center gap-1.5 px-2 text-[11px] font-medium tracking-wider text-text-2 uppercase">
+    <div className="mb-1 flex items-center gap-1.5 px-2 text-[11px] font-medium tracking-wider text-text-2 uppercase">
       {titleIcon}
       <span className="min-w-0 truncate">{title}</span>
     </div>
@@ -361,7 +361,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
         )}
 
         {pinnedSections.length > 0 && (
-          <div className="flex flex-col gap-3 px-3 pt-1">
+          <div className="flex flex-col gap-2 px-3 pt-1">
             {pinnedSections.map((section) => {
               const isSectionCollapsed =
                 collapsibleSections && collapsedSections.has(section.id);

--- a/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
@@ -424,8 +424,8 @@ export const SettingsRootBody: React.FC<SettingsRootBodyProps> = ({
           onMenuItemClick={handleItemClick}
         />
         {namedSections.map((section) => (
-          <div key={section.id} className="mt-4">
-            <div className="mb-2 px-2 text-[11px] font-medium tracking-wider text-text-1 uppercase">
+          <div key={section.id} className="mt-1">
+            <div className="mb-1 px-2 text-[11px] font-medium tracking-wider text-text-1 uppercase">
               {section.label}
             </div>
             <NavigationMenu


### PR DESCRIPTION
## Problem

Navigation, group, account, and organization rows were 32px while sidebar section titles were 28px. Settings search also used the 32px input preset, and settings sections added excessive vertical margins.

## Solution

Use 28px navigation rows and the small (28px) settings search input. Preserve the shared 4px gap between settings and session rows. Use 8px pinned-section gaps and optional list top padding, a 4px heading bottom margin, and a 4px settings-group top margin (12px total with the list gap). Keep the regular 8px section gap. Override session-row height only in the sidebar so mobile stays unchanged.

## Potential risks

The denser 28px rows leave less room for two-line labels and badges. Spacing and clipping have not been visually verified in light/dark themes, narrow sidebars, or native macOS/Windows/Linux. No dependencies, persistence formats, or public APIs change; revert the commit to restore prior dimensions.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.test.ts src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.test.ts src/scaffold/NavigationSidebar/connectors/__tests__/SidebarAccountButton.test.ts src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts src/scaffold/NavigationSidebar/variants/SettingsSidebar.search.test.ts src/scaffold/NavigationSidebar/variants/SettingsSidebar.chrome.test.ts src/modules/shared/layouts/blocks/SettingsSearchDropdown/SettingsSearchDropdown.test.ts` — 30 tests passed on an isolated branch from the latest fetched develop.
- `pnpm exec eslint src/scaffold/NavigationSidebar/blocks/SidebarGroup.tsx src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.test.ts src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.tsx src/scaffold/NavigationSidebar/blocks/SidebarItem.tsx src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.test.ts src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx src/scaffold/NavigationSidebar/config.ts src/scaffold/NavigationSidebar/connectors/SidebarAccountButton.tsx src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx src/scaffold/NavigationSidebar/blocks/SidebarList.tsx src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx src/modules/shared/layouts/blocks/SettingsSearchDropdown/index.tsx src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts src/modules/shared/layouts/blocks/SettingsSearchDropdown/SettingsSearchDropdown.test.ts --max-warnings 0` — passed.
- Commit hooks ran lint-staged (oxlint, ESLint, Prettier) and `npx tsgo --noEmit --pretty false`. No staged-file TypeScript errors; the hook reported errors outside the changed files, so a clean whole-project typecheck is not claimed. Rust checks were skipped because no Rust files changed.
- Final diff reviewed for scope, credentials, personal paths, and generated artifacts; `git diff --check origin/develop...HEAD` passed.
- No native UI control, screenshots of the result, theme matrix, or rendered E2E was run: the user's computer-use preference requires explicit opt-in. The supplied screenshots describe the pre-change problem and are not after-change evidence.
