### PR TITLE
style(chat-history): use text-4 for disabled navigation arrows

### DIFF
--- a/src/components/SessionHistoryNav/index.tsx
+++ b/src/components/SessionHistoryNav/index.tsx
@@ -67,6 +67,7 @@ const NavButton: React.FC<NavButtonProps> = ({
         shortcutId={shortcutId}
         tooltipMouseEnterDelay={tooltipMouseEnterDelay}
         disabled={disabled}
+        className="disabled:text-text-4! disabled:opacity-100"
         onClick={onClick}
         data-testid={testId}
       >
@@ -82,6 +83,7 @@ const NavButton: React.FC<NavButtonProps> = ({
       tooltipMouseEnterDelay={tooltipMouseEnterDelay}
       nativeTitle={false}
       disabled={disabled}
+      className="disabled:text-text-4! disabled:opacity-100"
       onClick={onClick}
       data-testid={testId}
     >


### PR DESCRIPTION
## Problem

Disabled back/forward controls inherited generic 50% opacity, rather than the requested text-4 disabled color.

## Solution

Apply text-text-4 at full opacity to disabled session-history arrows in sidebar and chat header variants. Both arrows remain visible even when neither direction is available; navigation behavior is unchanged.

## Potential risks

The disabled appearance changes in both header variants and has not been visually checked across themes or native platforms. No state, persistence, dependency, or API changes are introduced. Reverting the commit restores the prior styling.

## Verification

- `pnpm test src/components/SessionHistoryNav/SessionHistoryNav.test.ts src/scaffold/NavigationSidebar/PinnedSidebarChrome.test.ts` — 7 tests passed on an isolated branch from the latest fetched develop.
- `pnpm exec eslint src/components/SessionHistoryNav/index.tsx --max-warnings 0` — passed.
- Commit hooks ran lint-staged (oxlint, ESLint, Prettier) and `npx tsgo --noEmit --pretty false`. No staged-file TypeScript errors; the hook reported errors outside the changed files, so a clean whole-project typecheck is not claimed. Rust checks were skipped because no Rust files changed.
- Final diff reviewed for scope, credentials, personal paths, and generated artifacts; `git diff --check origin/develop...HEAD` passed.
- No native UI control, screenshots of the result, theme matrix, or rendered E2E was run: the user's computer-use preference requires explicit opt-in. The supplied screenshots describe the pre-change problem and are not after-change evidence.
