### PR TITLE
fix(chat-header): preserve two rows in narrow split panes

### DIFF
--- a/src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts
+++ b/src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts
@@ -76,9 +76,30 @@ describe("transcript top padding under floating chrome", () => {
 });
 
 describe("collapsing the tab row into the published header", () => {
-  it("folds a pane that holds a single tab regardless of maximization", () => {
+  it("folds a single tab on maximized or externally sized surfaces", () => {
     expect(shouldCollapseChatPanelTabRow({ tabCount: 1 })).toBe(true);
   });
+
+  it.each([
+    [420, false],
+    [639, false],
+    [640, true],
+    [800, true],
+  ])(
+    "uses the compact layout at split width %ipx: %s",
+    (splitPaneWidth, collapsed) => {
+      const actual = shouldCollapseChatPanelTabRow({
+        tabCount: 1,
+        splitPaneWidth,
+      });
+      expect(actual).toBe(collapsed);
+      expect(resolveChatPanelChromeTopInsetPx(true, actual)).toBe(
+        collapsed
+          ? CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX
+          : CHAT_PANEL_HEADER_STACK_HEIGHT_PX
+      );
+    }
+  );
 
   it("keeps the row whenever a second tab exists to switch to", () => {
     expect(shouldCollapseChatPanelTabRow({ tabCount: 2 })).toBe(false);

--- a/src/engines/ChatPanel/header/chatPanelHeaderLayout.ts
+++ b/src/engines/ChatPanel/header/chatPanelHeaderLayout.ts
@@ -45,24 +45,29 @@ export function resolveTranscriptTopPaddingPx(
   return floatingChromePx + CHAT_PANEL_TRANSCRIPT_TOP_GAP_PX;
 }
 
+/** Minimum split-pane width for title and controls to share one row. */
+export const CHAT_PANEL_COMPACT_HEADER_MIN_WIDTH_PX = 640;
+
 interface ChatPanelTabRowCollapseState {
   tabCount: number;
+  splitPaneWidth?: number;
 }
 
 /**
- * Whether the 44px tab row folds into the 36px published header.
- *
- * A pane holding a single tab has nothing to switch between, maximized or not: the
- * lone pill only repeats the surface title published one row below it, so the
- * row costs 44px of chrome and buys nothing. Collapsing moves its controls
- * (new tab / maximize or restore) onto the published row, which is why that
- * row is force-rendered while collapsed even for surfaces that publish no
- * slots of their own.
+ * Fold a single tab into the published header only when there is room.
+ * Narrow split panes keep the tab controls above the session heading; the
+ * same decision also drives the shell and transcript's header reservations.
+ * Maximized and externally sized surfaces omit splitPaneWidth.
  */
 export function shouldCollapseChatPanelTabRow({
   tabCount,
+  splitPaneWidth,
 }: ChatPanelTabRowCollapseState): boolean {
-  return tabCount === 1;
+  return (
+    tabCount === 1 &&
+    (splitPaneWidth === undefined ||
+      splitPaneWidth >= CHAT_PANEL_COMPACT_HEADER_MIN_WIDTH_PX)
+  );
 }
 
 /**

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -351,6 +351,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     });
     const tabRowCollapsed = shouldCollapseChatPanelTabRow({
       tabCount,
+      splitPaneWidth: !isChatFocus && !useExternalWidth ? chatWidth : undefined,
     });
     const chromeTopInsetPx = resolveChatPanelChromeTopInsetPx(
       overlayChatHeaders,


### PR DESCRIPTION
## Problem

A single chat tab always folded the tab row into the session header, crowding the title and controls in narrow split panes.

## Solution

Keep the existing two-row header for non-maximized, internally sized split panes under 640px. Panes at or above 640px, maximized panes, and externally sized surfaces retain the compact single-tab behavior. The same collapse decision drives the header and transcript inset so content reserves the correct height.

## Potential risks

640px is a fixed breakpoint, not text-overflow measurement. The layout updates when resizing commits on mouseup, not during the drag. Narrow panes use an additional 36px of header space, and the tab row may repeat the session title. Visual behavior, long localized titles, overlays, and native platform chrome remain unverified. No persistence, dependency, or public API changes; revert the commit to restore tab-count-only folding.

## Verification

- `pnpm test src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts src/engines/ChatPanel/ChatPanelHeader.test.ts` — 27 tests passed on an isolated branch from the latest fetched develop.
- `pnpm exec eslint src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts src/engines/ChatPanel/header/chatPanelHeaderLayout.ts src/engines/ChatPanel/index.tsx --max-warnings 0` — passed.
- Commit hooks ran lint-staged (oxlint, ESLint, Prettier) and `npx tsgo --noEmit --pretty false`. No staged-file TypeScript errors; the hook reported errors outside the changed files, so a clean whole-project typecheck is not claimed. Rust checks were skipped because no Rust files changed.
- Final diff reviewed for scope, credentials, personal paths, and generated artifacts; `git diff --check origin/develop...HEAD` passed.
- No native UI control, screenshots of the result, theme matrix, or rendered E2E was run: the user's computer-use preference requires explicit opt-in. The supplied screenshots describe the pre-change problem and are not after-change evidence.
