### PR TITLE
fix(sidebar): wait for pointer movement before highlighting org selector

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
@@ -46,6 +46,8 @@ const SidebarOrgSelector: React.FC<SidebarOrgSelectorProps> = React.memo(
   }) => {
     const { t } = useTranslation("navigation");
     const [menuOpen, setMenuOpen] = useState(false);
+    // A route change can mount this row beneath a stationary pointer.
+    const [pointerMoved, setPointerMoved] = useState(false);
 
     const handleChange = useCallback(
       (nextValue: string | number | (string | number)[]) => {
@@ -143,12 +145,13 @@ const SidebarOrgSelector: React.FC<SidebarOrgSelectorProps> = React.memo(
         className="w-full min-w-0 [&>span]:w-full"
         data-testid="sidebar-org-selector-scope"
         data-org-id={value}
+        onPointerMove={pointerMoved ? undefined : () => setPointerMoved(true)}
       >
         <ToolbarTooltip
           label={t("collaboration.switchOrg")}
           position="bottom"
           mouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}
-          disabled={menuOpen}
+          disabled={menuOpen || !pointerMoved}
         >
           <div className="w-full min-w-0">
             <Select
@@ -173,8 +176,8 @@ const SidebarOrgSelector: React.FC<SidebarOrgSelectorProps> = React.memo(
               selectorClassName={`h-8 px-2! [&_.select-arrow]:text-text-2! ${
                 menuOpen
                   ? "[&_.select-arrow]:opacity-100 bg-sidebar-selected!"
-                  : "[&_.select-arrow]:opacity-0 group-hover/sidebar:[&_.select-arrow]:opacity-100 hover:[&_.select-arrow]:opacity-100 hover:bg-sidebar-selected!"
-              } [&_.select-suffix]:ml-2 [&_.select-value]:flex-initial! [&_.select-value]:gap-3 [&_.select-value]:text-[13px] [&_.select-value]:font-semibold`}
+                  : "[&_.select-arrow]:opacity-0 group-hover/sidebar:[&_.select-arrow]:opacity-100 hover:[&_.select-arrow]:opacity-100"
+              } ${pointerMoved ? "hover:bg-sidebar-selected!" : ""} [&_.select-suffix]:ml-2 [&_.select-value]:flex-initial! [&_.select-value]:gap-3 [&_.select-value]:text-[13px] [&_.select-value]:font-semibold`}
               dataTestId="sidebar-org-selector"
             />
           </div>

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts
@@ -1,4 +1,6 @@
-import React from "react";
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -66,7 +68,7 @@ describe("SidebarOrgSelector", () => {
 
     expect(markup).toContain("select-bare");
     expect(markup).not.toContain("select-ghost");
-    expect(markup).toContain("hover:bg-sidebar-selected!");
+    expect(markup).not.toContain("hover:bg-sidebar-selected!");
   });
 
   it("keeps its chevron hidden until the sidebar or selector is active", () => {
@@ -101,4 +103,75 @@ describe("SidebarOrgSelector", () => {
     expect(markup).not.toContain("cloud.signedInAs");
     expect(markup).not.toContain("sidebar-cloud-sign-in");
   });
+});
+
+it("waits for pointer movement after remount while allowing keyboard activation", () => {
+  const env = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  const previous = env.IS_REACT_ACT_ENVIRONMENT;
+  env.IS_REACT_ACT_ENVIRONMENT = true;
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const render = () =>
+    act(() =>
+      root.render(
+        React.createElement(SidebarOrgSelector, {
+          ...baseProps,
+          value: "personal",
+          options: [{ value: "personal", label: "Local profile" }],
+          loading: false,
+        })
+      )
+    );
+  const selector = () =>
+    container.querySelector('[role="combobox"]') as HTMLElement;
+  try {
+    render();
+    expect(
+      selector()
+        .querySelector(".select-selector")!
+        .classList.contains("hover:bg-sidebar-selected!")
+    ).toBe(false);
+    act(() =>
+      selector().dispatchEvent(new MouseEvent("pointerover", { bubbles: true }))
+    );
+    expect(
+      selector()
+        .querySelector(".select-selector")!
+        .classList.contains("hover:bg-sidebar-selected!")
+    ).toBe(false);
+    act(() =>
+      selector().dispatchEvent(new MouseEvent("pointermove", { bubbles: true }))
+    );
+    expect(
+      selector()
+        .querySelector(".select-selector")!
+        .classList.contains("hover:bg-sidebar-selected!")
+    ).toBe(true);
+
+    act(() => root.render(null));
+    render();
+    expect(
+      selector()
+        .querySelector(".select-selector")!
+        .classList.contains("hover:bg-sidebar-selected!")
+    ).toBe(false);
+    act(() =>
+      selector().dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+      )
+    );
+    expect(selector().getAttribute("aria-expanded")).toBe("true");
+    expect(
+      selector()
+        .querySelector(".select-selector")!
+        .classList.contains("bg-sidebar-selected!")
+    ).toBe(true);
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+    env.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
 });


### PR DESCRIPTION
## Problem

Leaving Settings remounts the organization selector beneath the pointer. Its CSS hover background and tooltip could activate immediately even when the pointer had not moved; this is presentation state, not an organization selection change.

## Solution

Enable the selector's hover background and tooltip only after pointer movement within the newly mounted selector. An explicitly opened menu still receives its active background, and click/keyboard activation remain available immediately. Keep the existing passive sidebar chevron visibility.

The gate is local component state with an event handler removed after the first movement; there are no new global listeners, timers, or subscriptions.

## Potential risks

Hover feedback and the tooltip now wait for pointer movement on every mount, including the first visit. Native stationary-pointer route transitions have not been visually verified across platforms; jsdom validates event/state behavior but cannot validate native CSS hit testing. No persisted selection, API, dependency, or data format changes. Reverting this commit restores the prior hover behavior.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts` — 6 tests passed, including initial mount, pointer enter without movement, pointer movement, remount reset, and keyboard activation.
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx src/scaffold/NavigationSidebar/connectors/__tests__/SidebarOrgSelector.test.ts --max-warnings 0` — passed.
- Commit hooks ran lint-staged (oxlint, ESLint, Prettier) and `npx tsgo --noEmit --pretty false`. No staged-file TypeScript errors; errors outside the changed files were reported, so a clean whole-project typecheck is not claimed. No Rust files changed.
- `git diff --check origin/develop...HEAD` passed; final diff inspected for unrelated changes, secrets, personal paths, and generated artifacts.
- No after-change screenshots, native UI control, or rendered E2E: the user's computer-use preference requires explicit opt-in.
