### PR TITLE
fix(imported-history): ignore SQLite reader state in fingerprints

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history_tests.rs
@@ -564,3 +564,88 @@ fn decodes_file_uris_with_percent_escapes() {
     );
     assert_eq!(file_uri_to_path("not-a-uri"), None);
 }
+
+#[test]
+fn wal_store_read_does_not_dirty_the_persisted_discovery_signature() {
+    let dir = std::env::temp_dir().join(format!(
+        "orgii-cursor-wal-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let writer_path = dir.join("writer.db");
+    fixture_conn()
+        .execute("VACUUM INTO ?1", [writer_path.to_str().unwrap()])
+        .unwrap();
+    let writer = Connection::open(&writer_path).unwrap();
+    writer
+        .execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; UPDATE meta SET value=value;",
+        )
+        .unwrap();
+    let path = dir.join("store.db");
+    std::fs::copy(&writer_path, &path).unwrap();
+    std::fs::copy(dir.join("writer.db-wal"), dir.join("store.db-wal")).unwrap();
+    let discover = || {
+        let (mtime, size) = imported_paths::file_metadata_signature(&path, "Cursor CLI").unwrap();
+        ImportedHistoryDiscoveredRecord {
+            source_path: path.clone(),
+            source_mtime_ms: mtime,
+            source_size_bytes: size,
+            source_fingerprint: imported_paths::sqlite_sidecar_signature(&path),
+            ..fixture_record()
+        }
+    };
+    let record = discover();
+    let mut cache = Connection::open_in_memory().unwrap();
+    crate::store::sqlite::SqliteRecordStore::init_tables(&cache).unwrap();
+    crate::store::sqlite::SqliteRecordStore::init_source_cache_tables(&cache).unwrap();
+    let reader = open_store_readonly(&path).unwrap();
+    let input = session_meta_to_cache_input(
+        session_meta_from_store_conn(&reader, &record, 10)
+            .unwrap()
+            .unwrap(),
+    );
+    assert_eq!(input.name, "Fix the login bug");
+    imported_cache::upsert_imported_session_cache_from_conn(&mut cache, &[input]).unwrap();
+    drop(reader);
+    for _ in 0..4 {
+        let reader = open_store_readonly(&path).unwrap();
+        assert!(read_store_meta(&reader).unwrap().is_some());
+        drop(reader);
+        let records = [discover()];
+        let changed = imported_cache::changed_records_with_generated_name_repairs_from_conn(
+            &cache,
+            SOURCE_CURSOR_CLI,
+            &records,
+            |record| record.signature(),
+        )
+        .unwrap();
+        assert!(
+            changed.is_empty(),
+            "our own metadata read must not cause a reparse/cache write"
+        );
+    }
+    // A real provider commit in the WAL still invalidates the persisted row.
+    let provider = Connection::open(&path).unwrap();
+    provider
+        .execute_batch(
+            "PRAGMA wal_autocheckpoint=0; INSERT INTO blobs VALUES ('new-message', X'7B7D');",
+        )
+        .unwrap();
+    let records = [discover()];
+    let changed = imported_cache::changed_records_with_generated_name_repairs_from_conn(
+        &cache,
+        SOURCE_CURSOR_CLI,
+        &records,
+        |record| record.signature(),
+    )
+    .unwrap();
+    assert_eq!(changed.len(), 1);
+    drop(provider);
+    drop(writer);
+    std::fs::remove_dir_all(dir).unwrap();
+}

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/paths.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/paths.rs
@@ -32,34 +32,25 @@ pub fn file_metadata_signature(path: &Path, source_name: &str) -> Result<(i64, i
     Ok((modified_at_ns, metadata.len() as i64))
 }
 
-/// Build a change-signature component from a SQLite database's WAL/`-shm`
-/// sidecar files.
+/// Track SQLite content still in the WAL, alongside the caller's main-file
+/// metadata. Checkpoint/truncation/removal also invalidates the signature.
 ///
-/// Writes to a SQLite database in WAL mode land in the `-wal` sidecar and are
-/// only folded back into the main file at checkpoint time. Reading only the
-/// main file's mtime/size therefore misses not-yet-checkpointed sessions. This
-/// folds each sidecar's size and nanosecond mtime into a compact string so a
-/// pending write invalidates dependent caches. Missing sidecars contribute a
-/// stable placeholder so checkpoint (which deletes `-wal`) also changes it.
+/// Do not include `-shm`: it is a coordination index that read-only connections
+/// can create or rewrite without any change to the transcript. Including it
+/// makes our own history reads invalidate the next scan's cache.
 pub fn sqlite_sidecar_signature(db_path: &Path) -> String {
-    ["-wal", "-shm"]
-        .iter()
-        .map(
-            |suffix| match sqlite_sidecar_path(db_path, suffix).metadata() {
-                Ok(metadata) => {
-                    let mtime_ns = metadata
-                        .modified()
-                        .ok()
-                        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-                        .map(|since| since.as_nanos() as i64)
-                        .unwrap_or_default();
-                    format!("{suffix}:{}:{mtime_ns}", metadata.len())
-                }
-                Err(_) => format!("{suffix}:-"),
-            },
-        )
-        .collect::<Vec<_>>()
-        .join("|")
+    match sqlite_sidecar_path(db_path, "-wal").metadata() {
+        Ok(metadata) => {
+            let mtime_ns = metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|since| since.as_nanos() as i64)
+                .unwrap_or_default();
+            format!("-wal:{}:{mtime_ns}", metadata.len())
+        }
+        Err(_) => "-wal:-".to_owned(),
+    }
 }
 
 /// Fold independent per-session count/size components into the `u64` half of
@@ -245,6 +236,62 @@ mod tests {
         )
         .expect("seed fixture");
         (path, conn)
+    }
+
+    #[test]
+    fn sqlite_content_signature_ignores_readers_but_detects_writes_and_checkpoint() {
+        let (writer_path, writer) = fixture_db("wal-writer");
+        writer.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; INSERT INTO part VALUES ('wal', 'a', 30, '{}');").unwrap();
+        let reader_path = writer_path.with_extension("reader.sqlite");
+        std::fs::copy(&writer_path, &reader_path).unwrap();
+        std::fs::copy(
+            sqlite_sidecar_path(&writer_path, "-wal"),
+            sqlite_sidecar_path(&reader_path, "-wal"),
+        )
+        .unwrap();
+        let signature = |path: &Path| {
+            (
+                file_metadata_signature(path, "test").unwrap(),
+                sqlite_sidecar_signature(path),
+            )
+        };
+        let before = signature(&reader_path);
+        assert!(!sqlite_sidecar_path(&reader_path, "-shm").exists());
+        for _ in 0..4 {
+            let reader = Connection::open_with_flags(
+                &reader_path,
+                rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+            )
+            .unwrap();
+            let count: i64 = reader
+                .query_row("SELECT count(*) FROM part", [], |row| row.get(0))
+                .unwrap();
+            assert_eq!(count, 3);
+            drop(reader);
+            assert!(sqlite_sidecar_path(&reader_path, "-shm").exists());
+            assert_eq!(
+                signature(&reader_path),
+                before,
+                "read-only WAL recovery must not invalidate history"
+            );
+        }
+        let before_write = signature(&writer_path);
+        writer
+            .execute("INSERT INTO part VALUES ('new', 'a', 40, '{}')", [])
+            .unwrap();
+        let after_write = signature(&writer_path);
+        assert_eq!(before_write.0, after_write.0, "write is still in WAL");
+        assert_ne!(before_write.1, after_write.1);
+        writer
+            .execute_batch("PRAGMA wal_checkpoint(TRUNCATE)")
+            .unwrap();
+        assert_ne!(signature(&writer_path), after_write);
+        drop(writer);
+        for path in [&writer_path, &reader_path] {
+            std::fs::remove_file(path).ok();
+            std::fs::remove_file(sqlite_sidecar_path(path, "-wal")).ok();
+            std::fs::remove_file(sqlite_sidecar_path(path, "-shm")).ok();
+        }
     }
 
     #[test]

--- a/src-tauri/crates/orgtrack-core/src/sources/windsurf/history/sync.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/windsurf/history/sync.rs
@@ -40,8 +40,8 @@ pub(super) fn list_windsurf_composer_meta_from_conn(
         .query_map([], |row| row.get::<_, Option<String>>(0))
         .map_err(|err| format!("Failed to query Windsurf composers: {err}"))?;
 
-    // A single `state.vscdb` backs every composer, so fold its WAL/`-shm`
-    // sidecars into each composer's fingerprint once.
+    // A single `state.vscdb` backs every composer, so fold its WAL
+    // sidecar into each composer's fingerprint once.
     let sidecar_signature = imported_paths::sqlite_sidecar_signature(db_path);
     let mut metas = Vec::new();
     for row in rows {
@@ -88,7 +88,7 @@ pub(super) fn list_windsurf_composer_meta_from_conn(
 ///
 /// The `state.vscdb` mtime alone can stay flat across a same-mtime rewrite, so
 /// this folds the composer's own identity/status/timestamp/token/turn-count
-/// fields together with the shared WAL/`-shm` sidecar signature.
+/// fields together with the shared WAL sidecar signature.
 fn windsurf_source_fingerprint(composer: &RawComposerData, sidecar_signature: &str) -> String {
     [
         composer.composer_id.as_str(),

--- a/src-tauri/crates/orgtrack-core/src/sources/windsurf/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/windsurf/history_tests.rs
@@ -370,3 +370,43 @@ fn maps_windsurf_subagent_parent_and_child_impact() {
     assert_eq!(child.impact.lines_removed, 1);
     assert!(!child.listable);
 }
+
+#[test]
+fn wal_composer_fingerprint_is_stable_across_read_only_reopens() {
+    let (writer_path, writer) = signature_fixture_db("wal-reader");
+    writer.execute_batch("PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; UPDATE cursorDiskKV SET value=value;").unwrap();
+    let path = writer_path.with_extension("reader.sqlite");
+    let sidecar = |path: &std::path::Path, suffix: &str| {
+        std::path::PathBuf::from(format!("{}{suffix}", path.display()))
+    };
+    std::fs::copy(&writer_path, &path).unwrap();
+    std::fs::copy(sidecar(&writer_path, "-wal"), sidecar(&path, "-wal")).unwrap();
+    let read = || {
+        let conn = Connection::open_with_flags(
+            &path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+        )
+        .unwrap();
+        let (mtime, size) = imported_paths::file_metadata_signature(&path, "Windsurf").unwrap();
+        let metas = list_windsurf_composer_meta_from_conn(&conn, &path, mtime, size).unwrap();
+        assert_eq!(metas.len(), 2);
+        metas
+            .into_iter()
+            .map(|meta| (meta.source_session_id, meta.source_fingerprint))
+            .collect::<Vec<_>>()
+    };
+    let before = read();
+    for _ in 0..4 {
+        assert_eq!(read(), before);
+    }
+    let provider = Connection::open(&path).unwrap();
+    provider.execute_batch(r#"PRAGMA wal_autocheckpoint=0; UPDATE cursorDiskKV SET value='{"type":1,"bubbleId":"u1","text":"new native message"}' WHERE key='bubbleId:a:u1';"#).unwrap();
+    assert_ne!(read(), before);
+    drop(provider);
+    drop(writer);
+    for path in [&writer_path, &path] {
+        std::fs::remove_file(path).ok();
+        std::fs::remove_file(sidecar(path, "-wal")).ok();
+        std::fs::remove_file(sidecar(path, "-shm")).ok();
+    }
+}


### PR DESCRIPTION
## Problem

Cursor CLI discovery persists the SQLite sidecar fingerprint before opening the provider database. The fingerprint included `-shm`, which read-only SQLite connections can create or rewrite. The next scan therefore reparsed unchanged history and wrote its cache again. A local read-only inventory found 487 Cursor rows stale solely because of SHM metadata. Windsurf uses the same helper.

## Solution

Track main-database metadata plus WAL metadata, excluding the transient SHM coordination index. WAL commits and checkpoint/truncation still invalidate history. Add real WAL fixtures at the shared helper and the Cursor/Windsurf parser boundaries; the Cursor regression also verifies the persisted cache no longer requests a reparse after read-only opens.

## Potential risks

Existing signatures refresh once naturally on the next scan; no schema migration, raw-history writes, or destructive cleanup is needed. Rolling back similarly refreshes the cache once. This retains the existing metadata-based invalidation tradeoffs and does not redesign concurrent scans, database pooling, or polling cadence. Full live-app CPU/RAM improvement is not established by these tests; combined short runtime verification with #1465 is recorded below; it is not full pressure acceptance. No visual UI change is introduced, so screenshots would not verify this source-level behavior.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml -p orgtrack_core sqlite_content_signature -- --nocapture`: new regression failed on the old helper after the first read-only WAL recovery, then passed after the fix; covers repeated reads, WAL commit, and checkpoint.
- `cargo test --manifest-path src-tauri/Cargo.toml -p orgtrack_core wal_ -- --nocapture`: 3 passed, including faithful Cursor and Windsurf raw SQLite fixtures and actual metadata parsing.
- `cargo test --manifest-path src-tauri/Cargo.toml -p orgtrack_core --lib`: 630 passed, 8 existing ignored tests.
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p orgtrack_core --all-targets -- -D warnings`: passed.
- `git diff --check`: passed.

## Performance review

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | fix | Reader-created SHM dirties the saved signature | Exclude SHM; preserve main/WAL invalidation | Red-to-green SQLite and persisted Cursor-cache regression |
| Memory | keep | No new retained state | Existing caches unchanged | Source diff |
| Scope/isolation | keep | Per-file signatures and provider-owned raw databases | No identity/path changes | Isolated temporary SQLite fixtures |
| Rendering/hot path | keep | Cache invalidation is the producing boundary | No UI filtering or renderer changes | Adapter/cache regression |

| Provider | Raw transition | App/UI state | Topology/boundary | Expected invariant | Observed evidence |
| --- | --- | --- | --- | --- | --- |
| Cursor CLI | WAL recovery/read-only reopen, WAL write | Fixture scan/read/rescan | Raw store to persisted discovery cache | Reads stay cached, writes invalidate | Passed |
| Windsurf | WAL recovery/read-only reopen, bubble write | Fixture read/reopen | Raw composer database to metadata fingerprint | Reads stable, writes invalidate | Passed |
| Shared SQLite | WAL write, truncate/checkpoint | Fixture | Main file plus sidecar signature | Actual data transitions invalidate | Passed |
| Cursor CLI | First scan and subsequent unchanged scans | Real app, existing Codex chat open | Raw store to local cache | One-time fingerprint update, then stable | 487 rows migrated once; all 487 matched on subsequent checks |
| Windsurf | Live UI and sustained scans | Real app | Whole-process CPU/RAM | Provider lifecycle behavior | Not run; raw adapter fixtures passed |

Performance verdict: blocked pending full live-app measurement; source-level regressions and compilation pass. No claim that this explains every earlier CPU/RAM sample.


### Combined live verification of the fixes — 2026-09-09

Diagnostic package contained #1465 `f42f2462e` and #1475 `ccc8b8a81`, plus temporary visibility/revision logging that was removed from the worktree afterwards. `pnpm run build`, `cargo rustc --manifest-path src-tauri/Cargo.toml --bin org2 --profile dev-build --features tauri/custom-protocol -- -C strip=none`, and bundle signature verification passed.

- The 487 real Cursor cache rows transitioned from 487 old SHM fingerprints to zero old fingerprints after the first scan. All 487 main DB/WAL signatures matched, including repeat checks after visible and hidden observation. No history cleanup was needed.
- Opened the existing Codex/Astra native test conversation in Chat. Actual WebView traces showed visible/focused and three 30-second probes with **zero full reconciliations** after the cold load. A focus-return probe ran immediately; hidden intervals had no native revision probes.
- Calibrated four-process CPU (main/GPU/Networking/WebContent; one core = 100%): visible/focused 89.41 s averaged 4.10%, footprint 746.64→768.86 MiB, peak 908.75 MiB; final continuous hidden interval 106.44 s averaged 4.89%, footprint 805.19→806.33 MiB. A short fullscreen/focus transition peaked at 997.85 MiB and then fell. Existing cloud/background work remained enabled, so this is not a clean A/B attribution or a zero-CPU claim.
- Normal UI quit, with no running native sessions, released all four attributed processes. The independent second instance stayed running. The ordinary window state and an accidental pin action were restored.

The diagnosed fingerprint loop and redundant initial parse are fixed and verified. **Performance verdict remains blocked for comprehensive acceptance**: whole-app background CPU persists; large mounted histories, compaction/rotation, repeated-open recovery and physical dual-machine pressure have not been fully revalidated. No merge was performed.
