### PR TITLE
feat(skills): show native agent source icons

### DIFF
--- a/src/components/AgentSourceIcon.test.ts
+++ b/src/components/AgentSourceIcon.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { getAgentSourceProvider } from "./AgentSourceIcon";
+
+describe("getAgentSourceProvider", () => {
+  it.each([
+    ["/Users/me/.codex/skills/hatch-pet/SKILL.md", "codex"],
+    ["/Users/me/.claude/skills/review/SKILL.md", "claude"],
+    ["/repo/.cursor/skills-cursor/new-repo/SKILL.md", "cursor"],
+    ["C:\\Users\\me\\.opencode\\skills\\shell\\SKILL.md", "opencode"],
+  ])("resolves %s to %s", (path, provider) => {
+    expect(getAgentSourceProvider(path)).toBe(provider);
+  });
+
+  it("does not classify generic or ORGII paths as an agent source", () => {
+    expect(
+      getAgentSourceProvider("/Users/me/.orgii/skills/hatch-pet/SKILL.md")
+    ).toBe(null);
+    expect(getAgentSourceProvider("/repo/skills/review/SKILL.md")).toBe(null);
+  });
+});

--- a/src/components/AgentSourceIcon.tsx
+++ b/src/components/AgentSourceIcon.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+import ModelIcon, { type IconProvider } from "@src/components/ModelIcon";
+
+/** Agent-native config directories and the brand used to represent them. */
+const AGENT_SOURCE_DIRS: ReadonlyArray<readonly [string, IconProvider]> = [
+  [".codex", "codex"],
+  [".claude", "claude"],
+  [".cursor", "cursor"],
+  [".opencode", "opencode"],
+  [".gemini", "gemini"],
+  [".hermes", "hermes"],
+  [".openclaw", "openclaw"],
+];
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+/** Returns the agent brand implied by a native config path, if recognized. */
+export function getAgentSourceProvider(path: string): IconProvider | null {
+  const normalizedPath = normalizePath(path);
+  return (
+    AGENT_SOURCE_DIRS.find(([directory]) =>
+      normalizedPath.split("/").includes(directory)
+    )?.[1] ?? null
+  );
+}
+
+export interface AgentSourceIconProps {
+  path: string;
+  size?: number;
+  className?: string;
+}
+
+/** Renders a native agent brand icon, or nothing for non-agent sources. */
+const AgentSourceIcon: React.FC<AgentSourceIconProps> = ({
+  path,
+  size = 14,
+  className = "",
+}) => {
+  const provider = getAgentSourceProvider(path);
+  if (!provider) return null;
+  return <ModelIcon provider={provider} size={size} className={className} />;
+};
+
+export default AgentSourceIcon;

--- a/src/modules/MainApp/Integrations/Skills/Table/SkillTableParts.tsx
+++ b/src/modules/MainApp/Integrations/Skills/Table/SkillTableParts.tsx
@@ -1,5 +1,8 @@
 import type { TFunction } from "i18next";
 
+import AgentSourceIcon, {
+  getAgentSourceProvider,
+} from "@src/components/AgentSourceIcon";
 import { SETTINGS_TABLE_CELL } from "@src/components/SettingsTable/tokens";
 import type { CursorRepo } from "@src/hooks/policies";
 import { CodeXmlIcon, Home01Icon, HugeiconsIcon, UserIcon } from "@src/icons";
@@ -45,6 +48,11 @@ function renderSourceIcon<TSkill extends SkillTableRow>(
         className={className}
         aria-hidden
       />
+    );
+  }
+  if (getAgentSourceProvider(skill.path)) {
+    return (
+      <AgentSourceIcon path={skill.path} size={14} className={className} />
     );
   }
   if (isRepoSkill(skill, cursorRepos)) {

--- a/src/modules/MainApp/Integrations/Skills/Table/SkillsTable.tsx
+++ b/src/modules/MainApp/Integrations/Skills/Table/SkillsTable.tsx
@@ -8,6 +8,7 @@ import SettingsTable, {
 } from "@src/components/SettingsTable";
 import Switch from "@src/components/Switch";
 import TabPill, { type TabPillItem } from "@src/components/TabPill";
+import { MODEL_TABLE_SWITCH_SIZE } from "@src/config/modelTable";
 import type { CursorRepo } from "@src/hooks/policies";
 import { getInstalledSkillIdentity } from "@src/hooks/skills/installedSkillsMerge";
 import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
@@ -243,7 +244,7 @@ export const SkillsTable: React.FC<SkillsTableProps> = ({
                   onClick={(event) => event.stopPropagation()}
                 >
                   <Switch
-                    size="small"
+                    size={MODEL_TABLE_SWITCH_SIZE}
                     checked={skill.enabled}
                     onCheckedChange={(checked) =>
                       onToggleSkill(skill.name, checked)


### PR DESCRIPTION
## Problem

Skills imported from agent-native directories currently show generic user or code icons, making `.codex`, `.claude`, and `.cursor` sources difficult to distinguish. The skills table toggle also uses the smaller 28×16 switch variant instead of the requested 36×20 control.

## Solution

Added a shared native-source icon resolver backed by the existing canonical provider artwork. Recognized `.codex`, `.claude`, `.cursor`, `.opencode`, `.gemini`, `.hermes`, and `.openclaw` paths now render their matching brand icons; unknown and ORGII-local paths retain the existing generic icons. Updated the skills toggle to use the shared default 36×20 table switch size and added path-resolution regression tests.

## Potential risks

The new resolver depends on the existing provider icon registry and only changes presentation for recognized native-agent paths. Unrecognized paths keep the prior fallback behavior. No persistence, IPC, schema, dependency, or wire-format changes are included.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/components/AgentSourceIcon.test.ts src/modules/MainApp/Integrations/Skills/Table --reporter=dot` — passed, 2 files / 7 tests.
- `pnpm exec eslint src/components/AgentSourceIcon.tsx src/components/AgentSourceIcon.test.ts src/modules/MainApp/Integrations/Skills/Table/SkillTableParts.tsx src/modules/MainApp/Integrations/Skills/Table/SkillsTable.tsx --max-warnings 0 --report-unused-disable-directives` — passed.
- `pnpm run typecheck` — not clean because the repository currently lacks the `jsqr` module/types required by unrelated `src/modules/MobileRemote/platform/scanCameraQr{,.decoder.test}.ts` files.
- `git diff --cached --check` and final branch diff inspection — passed; only the four intended files are included.
- Visual reference: the user-provided skills-table screenshot was used to target the source column and switch sizing; no live desktop screenshot was captured.