### PR TITLE
fix(chat): align context popover controls with session support

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/ContextInfoButton.tsx
+++ b/src/engines/ChatPanel/InputArea/components/ContextInfoButton.tsx
@@ -317,6 +317,7 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
 
     const manualCompactSupported =
       resolveManualCompactSessionId(sessionId, executionBinding) !== null;
+    const manualCompactExpanded = manualCompactSupported && manualCompactOpen;
     const compactDisabled = manualCompacting || !manualCompactSupported;
     const triggerSurfaceClass =
       panelPos !== null
@@ -373,6 +374,8 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
                     <Button
                       variant="tertiary"
                       size="small"
+                      shape="square"
+                      iconOnly
                       aria-label={t("common:actions.refresh")}
                       title={t("common:actions.refresh")}
                       loading={refreshing}
@@ -380,18 +383,22 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
                       onClick={refresh}
                       icon={<HugeiconsIcon icon={Refresh04Icon} size={14} />}
                     />
-                    <button
-                      type="button"
+                    <Button
+                      variant="tertiary"
+                      size="small"
+                      shape="square"
+                      iconOnly
                       onClick={close}
-                      className="flex h-5 w-5 items-center justify-center rounded text-text-3 transition-colors hover:bg-fill-2 hover:text-text-2"
                       aria-label={t("common:actions.close")}
-                    >
-                      <HugeiconsIcon
-                        icon={Cancel01Icon}
-                        data-icon="x"
-                        size={12}
-                      />
-                    </button>
+                      title={t("common:actions.close")}
+                      icon={
+                        <HugeiconsIcon
+                          icon={Cancel01Icon}
+                          data-icon="x"
+                          size={14}
+                        />
+                      }
+                    />
                   </div>
                 </div>
                 {refreshError && (
@@ -402,7 +409,7 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
 
                 <p className="mt-0.5 text-[13px] text-text-3">{tokenLabel}</p>
 
-                {!manualCompactOpen &&
+                {!manualCompactExpanded &&
                   (showCacheHero ? (
                     <div className="mt-2 rounded-lg bg-green-500/10 px-2.5 py-1.5">
                       <p className="text-[12px] font-semibold text-green-600">
@@ -442,7 +449,7 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
                 </div>
               </div>
 
-              {!manualCompactOpen && categories.length > 0 && (
+              {!manualCompactExpanded && categories.length > 0 && (
                 <div className="px-4 py-2">
                   <div className="flex flex-col">
                     {categories.map((cat) => (
@@ -462,85 +469,92 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
                 </div>
               )}
 
-              <div className="border-t border-border-2 bg-fill-1/30 px-3.5 py-2">
-                <button
-                  type="button"
-                  data-testid="context-info-manual-compact-toggle"
-                  onClick={() => setManualCompactOpen((open) => !open)}
-                  aria-expanded={manualCompactOpen}
-                  className="group flex w-full items-center justify-between rounded px-1 py-1 text-left"
-                >
-                  <span className="text-[13px] font-semibold text-text-1">
-                    {t("contextInfo.manualCompactSectionTitle")}
-                  </span>
-                  <span className="flex h-5 w-5 items-center justify-center rounded text-text-3 transition-colors group-hover:bg-fill-2 group-hover:text-text-2">
-                    {manualCompactOpen ? (
-                      <HugeiconsIcon
-                        icon={ChevronsDownUpIcon}
-                        data-icon="chevrons-down-up"
-                        size={12}
-                      />
-                    ) : (
-                      <HugeiconsIcon
-                        icon={UnfoldMoreIcon}
-                        data-icon="chevrons-up-down"
-                        size={12}
-                      />
-                    )}
-                  </span>
-                </button>
-
-                {manualCompactOpen && (
-                  <div className="mt-2">
-                    {!manualCompactSupported && (
-                      <p className="mb-2 text-xs text-text-3">
-                        {t("contextInfo.manualCompactNativeProvider", {
-                          defaultValue:
-                            "Manual compaction here supports built-in Agent sessions. Compact native CLI history in its provider app.",
-                        })}
-                      </p>
-                    )}
-                    <Textarea
-                      size="small"
-                      autoSize={{ minRows: 2, maxRows: 5 }}
-                      data-testid="context-info-compact-instructions-input"
-                      value={compactInstructions}
-                      onChange={(value) => setCompactInstructions(value)}
-                      onKeyDown={handleInstructionsKeyDown}
-                      placeholder={t(
-                        "contextInfo.manualCompactInstructionsPlaceholder"
-                      )}
-                    />
+              {manualCompactSupported && (
+                <div className="border-t border-border-2 bg-fill-1/30 px-3.5 py-2">
+                  <div className="flex items-center justify-between px-1 py-1">
+                    <button
+                      type="button"
+                      onClick={() => setManualCompactOpen((open) => !open)}
+                      aria-expanded={manualCompactOpen}
+                      className="flex-1 self-stretch text-left text-[13px] font-semibold text-text-1"
+                    >
+                      {t("contextInfo.manualCompactSectionTitle")}
+                    </button>
                     <Button
-                      long
-                      variant="secondary"
+                      variant="tertiary"
                       size="small"
-                      className="mt-2"
-                      data-testid="context-info-manual-compact-button"
+                      shape="square"
+                      iconOnly
+                      data-testid="context-info-manual-compact-toggle"
+                      onClick={() => setManualCompactOpen((open) => !open)}
+                      aria-expanded={manualCompactOpen}
+                      aria-label={t(
+                        manualCompactOpen
+                          ? "common:actions.collapse"
+                          : "common:actions.expand"
+                      )}
                       icon={
                         <HugeiconsIcon
-                          icon={ArchiveIcon}
-                          data-icon="archive"
+                          icon={
+                            manualCompactOpen
+                              ? ChevronsDownUpIcon
+                              : UnfoldMoreIcon
+                          }
+                          data-icon={
+                            manualCompactOpen
+                              ? "chevrons-down-up"
+                              : "chevrons-up-down"
+                          }
                           size={14}
                         />
                       }
-                      loading={manualCompacting}
-                      disabled={compactDisabled}
-                      onClick={runManualCompact}
-                    >
-                      {manualCompacting
-                        ? t("contextInfo.manualCompactRunning")
-                        : t("contextInfo.manualCompactAction")}
-                    </Button>
-
-                    {housekeeperEnabled &&
-                      contextCompactEnabled &&
-                      sessionId && (
-                        <ConfiguredMiniCpmCompactCard sessionId={sessionId} />
-                      )}
+                    />
                   </div>
-                )}
-              </div>
+
+                  {manualCompactOpen && (
+                    <div className="mt-2">
+                      <Textarea
+                        size="small"
+                        autoSize={{ minRows: 2, maxRows: 5 }}
+                        data-testid="context-info-compact-instructions-input"
+                        value={compactInstructions}
+                        onChange={(value) => setCompactInstructions(value)}
+                        onKeyDown={handleInstructionsKeyDown}
+                        placeholder={t(
+                          "contextInfo.manualCompactInstructionsPlaceholder"
+                        )}
+                      />
+                      <Button
+                        long
+                        variant="secondary"
+                        size="small"
+                        className="mt-2"
+                        data-testid="context-info-manual-compact-button"
+                        icon={
+                          <HugeiconsIcon
+                            icon={ArchiveIcon}
+                            data-icon="archive"
+                            size={14}
+                          />
+                        }
+                        loading={manualCompacting}
+                        disabled={compactDisabled}
+                        onClick={runManualCompact}
+                      >
+                        {manualCompacting
+                          ? t("contextInfo.manualCompactRunning")
+                          : t("contextInfo.manualCompactAction")}
+                      </Button>
+
+                      {housekeeperEnabled &&
+                        contextCompactEnabled &&
+                        sessionId && (
+                          <ConfiguredMiniCpmCompactCard sessionId={sessionId} />
+                        )}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>,
             document.body
           )}


### PR DESCRIPTION
## Problem

The context popover uses inconsistent action controls and shows a manual compaction form for sessions that cannot use it, including native CLI sessions.

## Solution

Use small tertiary square icon-only Buttons for refresh, close, and expand/collapse, matching workstation trailing controls. Keep the compaction heading clickable and show the entire manual compaction section only when the existing session-support resolver permits it. Context details remain visible when compaction is unsupported, even if the expansion state was previously open.

## Potential risks

Button geometry and keyboard focus order change in the popover. Updated appearance, themes, constrained viewports, loading states, and session switching have not been verified in the running app. No persistence, dependency, API, or backend compaction behavior changes. Rollback is a revert of this single-file commit.

## Verification

- `pnpm exec eslint src/engines/ChatPanel/InputArea/components/ContextInfoButton.tsx` — passed.
- `pnpm exec prettier --check src/engines/ChatPanel/InputArea/components/ContextInfoButton.tsx` — passed.
- `pnpm test -- src/engines/ChatPanel/hooks/useManualCompact.test.ts` — 5 tests passed; these cover existing compaction behavior, not the rendered popover.
- `git diff --check` and `git diff origin/develop...HEAD --check` — passed.
- Commit hook ran lint-staged (oxlint, ESLint, Prettier) successfully. Its `npx tsgo --noEmit --pretty false` check reported errors outside the staged file; no errors in the changed file. Full project typecheck is therefore not clean.
- Reviewed the final diff: only the context popover file changes; no secrets, private configuration, build artifacts, or unrelated edits.
- No new screenshots or real-app checks: desktop control was not authorized. Visual and rendered-interaction verification remain outstanding.
