### PR TITLE
fix(settings): keep integration actions in table headers

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/SettingsTableActions.md
+++ b/docs/frontend-ui-audit-2026-09-10/SettingsTableActions.md
@@ -1,0 +1,10 @@
+# SettingsTableActions UI audit
+
+| Line                           | Element        | Verdict          | Reason                                                                                                | Suggested change |
+| ------------------------------ | -------------- | ---------------- | ----------------------------------------------------------------------------------------------------- | ---------------- |
+| MyAccountsTableSection.tsx:390 | Refresh action | keep with reason | Reuses Button, localized labels and the existing refresh animation hook; loading disables the action. | None.            |
+| useRouteToolbarConfig.tsx:96   | Top toolbar    | keep with reason | Removes duplicate integration add/refresh actions while preserving supplementary buttons.             | None.            |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+Reviewed changed controls only. Existing layout constants are outside this change. Desktop hover/focus and theme screenshots were not captured: computer control was not enabled.

--- a/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx
@@ -13,7 +13,14 @@ import SettingsTable, {
 import Switch from "@src/components/Switch";
 import { MODEL_TABLE_SWITCH_SIZE } from "@src/config/modelTable";
 import type { KeyVaultAccount } from "@src/hooks/keyVault";
-import { Add01Icon, Delete02Icon, HugeiconsIcon, Pen01Icon } from "@src/icons";
+import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
+import {
+  Add01Icon,
+  Delete02Icon,
+  HugeiconsIcon,
+  Pen01Icon,
+  Refresh04Icon,
+} from "@src/icons";
 import { KEY_VAULT_STATUS_DOT } from "@src/modules/shared/keyVault/statusColors";
 import { groupModels } from "@src/util/modelGrouping";
 
@@ -132,6 +139,13 @@ export default function MyAccountsTableSection({
   const [editRequestedAccountId, setEditRequestedAccountId] = useState<
     string | null
   >(null);
+
+  const {
+    spinClass: refreshSpinClass,
+    handleClick: handleRefreshAccountsClick,
+  } = useRefreshSpin(() => {
+    void onRefreshAccounts?.();
+  }, loading);
 
   const handleEditAccountInline = useCallback(
     (accountId: string) => {
@@ -373,6 +387,27 @@ export default function MyAccountsTableSection({
     [expandedAccountKeys, renderExpandedAccountCard]
   );
 
+  const refreshAccountsButton = onRefreshAccounts ? (
+    <Button
+      variant="secondary"
+      size="default"
+      icon={
+        <HugeiconsIcon
+          icon={Refresh04Icon}
+          data-icon="refresh-cw"
+          size={14}
+          className={refreshSpinClass}
+        />
+      }
+      iconOnly
+      onClick={handleRefreshAccountsClick}
+      disabled={loading}
+      aria-label={t("common:actions.refresh")}
+      title={t("common:actions.refresh")}
+      data-testid="key-vault-accounts-refresh-button"
+    />
+  ) : null;
+
   const addKeyButton = (
     <Button
       variant="secondary"
@@ -403,7 +438,12 @@ export default function MyAccountsTableSection({
         onSearchChange,
         searchPlaceholder: t("keyVault.searchPlaceholder"),
         allowSearchClear: true,
-        rightContent: addKeyButton,
+        rightContent: (
+          <>
+            {refreshAccountsButton}
+            {addKeyButton}
+          </>
+        ),
       }}
       emptyTitle={t("keyVault.noAccountsFound")}
       emptyAction={{

--- a/src/modules/MainApp/Settings/hooks/useRouteToolbarConfig.tsx
+++ b/src/modules/MainApp/Settings/hooks/useRouteToolbarConfig.tsx
@@ -3,19 +3,14 @@
  *
  * Derives per-route header action configuration synchronously from:
  * - Current pathname (via useLocation)
- * - Integrations category atom (for per-tab + button behavior)
- * - Integrations add action atom (callback to dispatch add actions)
+ * - Settings and integrations toolbar registrations for supplementary actions
+ * Integration add and refresh actions live in the corresponding table headers.
  */
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
-import {
-  type AddAction,
-  CATEGORY_KEYS,
-  type IntegrationCategory,
-} from "@src/api/types/integrations";
 import {
   WIZARD_IDS,
   buildAgentOrgsPath,
@@ -30,27 +25,14 @@ import {
   Refresh04Icon,
   UserAdd01Icon,
 } from "@src/icons";
-import {
-  dispatchIntegrationsAddAtom,
-  integrationsToolbarAtom,
-} from "@src/store/ui/integrationsToolbarAtom";
+import { integrationsToolbarAtom } from "@src/store/ui/integrationsToolbarAtom";
 import type {
   RouteToolbarButton,
   RouteToolbarConfig,
 } from "@src/store/ui/routeToolbarAtom";
 import { settingsToolbarAtom } from "@src/store/ui/settingsToolbarAtom";
 
-import { getPlusConfigForCategory } from "./toolbarPlusConfigs";
 import { useSettingsRegionNoticeButton } from "./useSettingsRegionNoticeButton";
-
-function toIntegrationCategory(
-  category: string | null | undefined
-): IntegrationCategory {
-  if (category && (CATEGORY_KEYS as readonly string[]).includes(category)) {
-    return category as IntegrationCategory;
-  }
-  return "models";
-}
 
 const SETTINGS_PREFIX = ROUTES.app.settings.path;
 
@@ -83,17 +65,7 @@ export function useRouteToolbarConfig(): RouteToolbarConfig | null {
     () => parseCoreSettingsItem(pathname),
     [pathname]
   );
-  const integrationCategory = toIntegrationCategory(coreSettingsItem.category);
-  const dispatchAddAction = useSetAtom(dispatchIntegrationsAddAtom);
   const integrationsToolbar = useAtomValue(integrationsToolbarAtom);
-  const {
-    spinClass: integrationsSpinClass,
-    handleClick: integrationsRefreshClick,
-  } = useRefreshSpin(
-    integrationsToolbar.onRefresh ?? noop,
-    integrationsToolbar.loading ?? false
-  );
-
   return useMemo(() => {
     if (pathname.startsWith(SETTINGS_PREFIX)) {
       const topTab = parseSettingsTopTab(pathname);
@@ -121,35 +93,15 @@ export function useRouteToolbarConfig(): RouteToolbarConfig | null {
       }
 
       if (coreSettingsItem.category) {
-        const dispatch = (action: AddAction) => dispatchAddAction(action);
-
-        const plusConfig = getPlusConfigForCategory(
-          integrationCategory,
-          dispatch,
-          t
-        );
-
         const extraButtons: RouteToolbarButton[] = [];
 
         if (settingsRegionNoticeButton) {
           extraButtons.push(settingsRegionNoticeButton);
         }
 
-        if (integrationsToolbar.onRefresh) {
-          extraButtons.push({
-            id: "integrations-refresh",
-            icon: Refresh04Icon,
-            onClick: integrationsRefreshClick,
-            title: t("common:actions.refresh"),
-            iconClassName: integrationsSpinClass,
-            disabled: !!integrationsSpinClass,
-          });
-        }
-
         extraButtons.push(...(integrationsToolbar.extraButtons ?? []));
 
         return {
-          ...plusConfig,
           extraButtons: extraButtons.length > 0 ? extraButtons : undefined,
         };
       }
@@ -188,11 +140,7 @@ export function useRouteToolbarConfig(): RouteToolbarConfig | null {
     openAgentAdd,
     openOrgAdd,
     coreSettingsItem,
-    integrationCategory,
-    dispatchAddAction,
     integrationsToolbar,
-    integrationsRefreshClick,
-    integrationsSpinClass,
     t,
   ]);
 }


### PR DESCRIPTION
## Problem

Integration refresh and add controls are duplicated in the top Settings toolbar, while My Keys lacks refresh beside the table search.

## Solution

Keep the existing Models table controls and add a localized, loading-disabled refresh button beside the My Keys search. Remove integration-category refresh and plus controls from the top toolbar, preserving supplementary buttons and the separate Agent Orgs menu.

## Potential risks

The top-toolbar removal applies to all integration categories; table actions and alternate add flows remain category-owned. Visual and desktop refresh behavior have not been exercised. The reused animation hook owns and cleans up its one-shot timer/RAF, but hidden-window and repeated-mount runtime measurements were not performed. Performance verdict: blocked for runtime measurement evidence; no measured performance improvement is claimed.

No dependency, schema, IPC or persistence format changes. Revert this commit to roll back the UI behavior.

## Verification

- `pnpm exec eslint src/modules/MainApp/Settings/hooks/useRouteToolbarConfig.tsx src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx --max-warnings 0` — passed in the isolated branch.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/MainApp/Integrations/categoryTableRouting.test.ts ` — 17 tests passed.
- `pnpm typecheck:fast` — passed after rebasing onto updated develop and restoring the shared dependency environment.
- `git diff --check` — passed.
- Desktop visual verification and new screenshots were not run: computer control is not enabled. Provided screenshots describe the original state, not verification of this branch.
