### PR TITLE
feat(import): select items by clicking their rows

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ImportRowSelection.md
+++ b/docs/frontend-ui-audit-2026-09-10/ImportRowSelection.md
@@ -1,0 +1,11 @@
+# ImportRowSelection UI audit
+
+| Line                         | Element                 | Verdict          | Reason                                                                                                              | Suggested change |
+| ---------------------------- | ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| useCredentialImport.tsx:271  | Checkbox/name cell      | keep with reason | A div avoids label-generated duplicate clicks; Checkbox retains an explicit accessible name and keyboard operation. | None.            |
+| useExternalImport.tsx:421    | Shared import name cell | keep with reason | Uses the same Checkbox and functional selection update for all import kinds.                                        | None.            |
+| InlineExternalImport.tsx:152 | Row click               | keep with reason | Uses SettingsTable's existing interactive-target exclusion for links, buttons and checkboxes.                       | None.            |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+Reviewed changed controls only. Existing layout constants are outside this change. Desktop hover/focus and theme screenshots were not captured: computer control was not enabled.

--- a/src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/InlineCredentialImport.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/InlineCredentialImport.tsx
@@ -57,6 +57,7 @@ const InlineCredentialImport: React.FC<InlineCredentialImportProps> = ({
     importError,
     importErrors,
     importColumns,
+    handleRowClick,
     handleImport,
   } = useCredentialImport({
     sourceKind,
@@ -116,6 +117,7 @@ const InlineCredentialImport: React.FC<InlineCredentialImportProps> = ({
             ) : (
               <SettingsTable
                 columns={importColumns}
+                onRowClick={handleRowClick}
                 rows={importableItems}
                 getRowKey={credentialImportRowKey}
                 headerHeight="tall"

--- a/src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/useCredentialImport.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/useCredentialImport.tsx
@@ -165,14 +165,21 @@ export function useCredentialImport({
     importableItems.length > 0 &&
     importableItems.every((row) => selected.has(credentialImportRowKey(row)));
 
-  const handleToggle = useCallback((key: string, checked: boolean) => {
+  const handleToggle = useCallback((key: string, checked?: boolean) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      if (checked) next.add(key);
+      if (checked ?? !prev.has(key)) next.add(key);
       else next.delete(key);
       return next;
     });
   }, []);
+
+  const handleRowClick = useCallback(
+    (row: CredentialImportRow) => {
+      handleToggle(credentialImportRowKey(row));
+    },
+    [handleToggle]
+  );
 
   const handleSelectAll = useCallback(() => {
     if (allSelected) {
@@ -262,8 +269,9 @@ export function useCredentialImport({
         ),
         width: SETTINGS_TABLE_COL.fill,
         renderCell: (row) => (
-          <label className="flex items-center gap-3">
+          <div className="flex items-center gap-3">
             <Checkbox
+              ariaLabel={row.displayName}
               checked={selected.has(credentialImportRowKey(row))}
               onCheckedChange={(checked) =>
                 handleToggle(credentialImportRowKey(row), checked as boolean)
@@ -277,7 +285,7 @@ export function useCredentialImport({
             <span className={`${SETTINGS_TABLE_CELL.primary} font-bold`}>
               {row.displayName}
             </span>
-          </label>
+          </div>
         ),
       },
       {
@@ -353,6 +361,7 @@ export function useCredentialImport({
     importError,
     importErrors,
     importColumns,
+    handleRowClick,
     handleImport,
     refreshDetection,
   };

--- a/src/scaffold/WizardSystem/shared/externalImport/InlineExternalImport.tsx
+++ b/src/scaffold/WizardSystem/shared/externalImport/InlineExternalImport.tsx
@@ -86,6 +86,7 @@ const InlineExternalImport: React.FC<InlineExternalImportProps> = ({
     importError,
     importErrors,
     importColumns,
+    handleRowClick,
     handleImport,
   } = useExternalImport({
     kind,
@@ -148,6 +149,7 @@ const InlineExternalImport: React.FC<InlineExternalImportProps> = ({
             ) : (
               <SettingsTable
                 columns={importColumns}
+                onRowClick={handleRowClick}
                 rows={importableItems}
                 getRowKey={inlineExternalImportRowKey}
                 headerHeight="tall"

--- a/src/scaffold/WizardSystem/shared/externalImport/useExternalImport.tsx
+++ b/src/scaffold/WizardSystem/shared/externalImport/useExternalImport.tsx
@@ -305,14 +305,21 @@ export function useExternalImport({
     };
   }, [active, kind, repoKey, cursorRepos, detectionRefreshKey]);
 
-  const handleToggle = useCallback((key: string, checked: boolean) => {
+  const handleToggle = useCallback((key: string, checked?: boolean) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      if (checked) next.add(key);
+      if (checked ?? !prev.has(key)) next.add(key);
       else next.delete(key);
       return next;
     });
   }, []);
+
+  const handleRowClick = useCallback(
+    (row: ExternalImportRow) => {
+      handleToggle(rowKey(row));
+    },
+    [handleToggle]
+  );
 
   const handleSelectAll = useCallback(() => {
     if (allSelected) {
@@ -411,9 +418,10 @@ export function useExternalImport({
             (warning) => warning.kind === "readonly_downgraded"
           );
           return (
-            <label className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1">
               <div className="flex items-center gap-3">
                 <Checkbox
+                  ariaLabel={row.suggestedName}
                   checked={selected.has(rowKey(row))}
                   onCheckedChange={(checked) =>
                     handleToggle(rowKey(row), checked as boolean)
@@ -444,7 +452,7 @@ export function useExternalImport({
                   </span>
                 </div>
               )}
-            </label>
+            </div>
           );
         },
       },
@@ -580,6 +588,7 @@ export function useExternalImport({
     importError,
     importErrors,
     importColumns,
+    handleRowClick,
     handleImport,
   };
 }


### PR DESCRIPTION
## Problem

Import items can only be selected through their checkbox/name area. Clicking other non-interactive row content does not select the item.

## Solution

Wire row clicks to functional checkbox toggles for credentials and the shared Skills, MCP, Rules and Agents import panel. Replace enclosing name-cell labels to avoid duplicate checkbox activation and supply accessible checkbox names. Reuse the table's existing exclusion of links, buttons and checkbox targets. This default applies to these import panels, not unrelated tables.

## Potential risks

The existing table interaction tests cover interactive-target exclusion, but do not constitute end-to-end coverage of every import kind. Desktop click and keyboard behavior has not been manually verified. Selection remains local state and does not import anything until the explicit import action.

No dependency, schema, IPC or persistence format changes. Revert this commit to roll back the UI behavior.

## Verification

- `pnpm exec eslint src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/InlineCredentialImport.tsx src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/useCredentialImport.tsx src/scaffold/WizardSystem/shared/externalImport/InlineExternalImport.tsx src/scaffold/WizardSystem/shared/externalImport/useExternalImport.tsx --max-warnings 0` — passed in the isolated branch.
- `pnpm exec vitest run --config config/vitest.config.ts src/components/Table/TableBody.test.ts src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/__tests__/InlineCredentialImport.test.ts src/scaffold/WizardSystem/shared/externalImport/__tests__/inlineExternalImportUtils.test.ts` — 17 tests passed.
- `pnpm typecheck:fast` — passed on the rebased branch.
- `git diff --check` — passed.
- Desktop visual verification and new screenshots were not run: computer control is not enabled. Provided screenshots describe the original state, not verification of this branch.
