### PR TITLE
fix(settings): reveal path actions on hover

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ImportPathActions.md
+++ b/docs/frontend-ui-audit-2026-09-10/ImportPathActions.md
@@ -1,0 +1,13 @@
+# ImportPathActions UI audit
+
+| Line                           | Element            | Verdict          | Reason                                                                                                                  | Suggested change |
+| ------------------------------ | ------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| useCredentialImport.tsx:321    | Source path button | keep with reason | Native inline button provides a truncated path hit area with accessible name, focus ring and independent reveal action. | None.            |
+| useCredentialImport.tsx:333    | Folder icon        | keep with reason | Direct-child selectors scope visibility to its own link; opacity preserves layout.                                      | None.            |
+| PathCopyOpenRow.tsx:53         | Path actions       | keep with reason | Existing Button controls keep keyboard access; CSS reveals them on hover/focus without JavaScript state.                | None.            |
+| CliRawConfigFileEditor.tsx:190 | Config actions     | keep with reason | Existing action group reveals copy/open on hover or focus.                                                              | None.            |
+| ConfigGeneralSection.tsx:90    | Workspace action   | keep with reason | Existing Button reveals on path-group hover or keyboard focus.                                                          | None.            |
+
+Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.
+
+Reviewed changed controls only. Existing layout constants are outside this change. Desktop hover/focus and theme screenshots were not captured: computer control was not enabled.

--- a/src/modules/MainApp/AgentOrgs/components/CliRawConfigFileEditor.tsx
+++ b/src/modules/MainApp/AgentOrgs/components/CliRawConfigFileEditor.tsx
@@ -149,7 +149,7 @@ const CliRawConfigFileEditor: React.FC<CliRawConfigFileEditorProps> = ({
         description={configPath}
         labelAlign="start"
       >
-        <div className={SECTION_ACTION_GAP_CLASSES}>
+        <div className={`group ${SECTION_ACTION_GAP_CLASSES}`}>
           <span className={SECTION_PATH_TEXT_CLASSES}>
             {t("agentOrgs.cliAgentDetail.tokenCount", {
               count: tokenCount,
@@ -187,6 +187,7 @@ const CliRawConfigFileEditor: React.FC<CliRawConfigFileEditorProps> = ({
               <HugeiconsIcon icon={Copy01Icon} data-icon="copy" size={14} />
             }
             iconOnly
+            className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
             onClick={handleCopy}
             disabled={!value.trim()}
             aria-label={t("common:actions.copy")}
@@ -201,6 +202,7 @@ const CliRawConfigFileEditor: React.FC<CliRawConfigFileEditorProps> = ({
               />
             }
             iconOnly
+            className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
             onClick={handleRevealConfig}
             aria-label={t("agentOrgs.cliAgentDetail.revealConfigFile")}
             title={t("agentOrgs.cliAgentDetail.revealConfigFile")}

--- a/src/modules/MainApp/AgentOrgs/config/osAgent/sections/ConfigGeneralSection.tsx
+++ b/src/modules/MainApp/AgentOrgs/config/osAgent/sections/ConfigGeneralSection.tsx
@@ -84,9 +84,10 @@ const ConfigGeneralSection: React.FC<ConfigGeneralSectionProps> = ({
           label={t("osAgent.workspace")}
           description={t("osAgent.workspaceDesc")}
         >
-          <div className={SECTION_ACTION_GAP_CLASSES}>
+          <div className={`group ${SECTION_ACTION_GAP_CLASSES}`}>
             <span className={SECTION_PATH_TEXT_CLASSES}>{workspace}</span>
             <Button
+              className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
               icon={
                 <HugeiconsIcon
                   icon={FolderOpenIcon}

--- a/src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/useCredentialImport.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/useCredentialImport.tsx
@@ -22,7 +22,6 @@ import {
   listCredentialSuggestions,
 } from "@src/api/services/keyValidation";
 import { rpc } from "@src/api/tauri/rpc";
-import Button from "@src/components/Button";
 import Checkbox from "@src/components/Checkbox";
 import ModelIcon from "@src/components/ModelIcon";
 import type { SettingsTableColumn } from "@src/components/SettingsTable";
@@ -311,33 +310,31 @@ export function useCredentialImport({
             >
               <span className="shrink-0">{authLabel}</span>
               <span className="shrink-0 text-text-4">·</span>
-              <span className="min-w-0 truncate">{detail}</span>
+              {row.sourcePath ? (
+                <button
+                  type="button"
+                  className="flex min-w-0 cursor-pointer items-center gap-1.5 text-left underline-offset-2 hover:underline focus-visible:underline focus-visible:ring-1 focus-visible:ring-primary-6 focus-visible:outline-none [&:focus-visible>svg]:opacity-100 [&:hover>svg]:opacity-100"
+                  aria-label={`${t(getFileManagerRevealLabelKey())}: ${row.sourcePath}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleReveal(row);
+                  }}
+                >
+                  <span className="min-w-0 truncate">{detail}</span>
+                  <HugeiconsIcon
+                    icon={FolderOpenIcon}
+                    data-icon="folder-open"
+                    size={14}
+                    className="shrink-0 opacity-0"
+                    aria-hidden
+                  />
+                </button>
+              ) : (
+                <span className="min-w-0 truncate">{detail}</span>
+              )}
             </span>
           );
         },
-      },
-      {
-        key: "actions",
-        label: "",
-        width: SETTINGS_TABLE_COL.hug,
-        renderCell: (row) =>
-          row.sourcePath ? (
-            <Button
-              variant="secondary"
-              size="small"
-              iconOnly
-              icon={
-                <HugeiconsIcon
-                  icon={FolderOpenIcon}
-                  data-icon="folder-open"
-                  size={14}
-                />
-              }
-              title={t(getFileManagerRevealLabelKey())}
-              aria-label={t(getFileManagerRevealLabelKey())}
-              onClick={() => handleReveal(row)}
-            />
-          ) : null,
       },
     ],
     [t, selected, allSelected, handleToggle, handleSelectAll, handleReveal]

--- a/src/modules/shared/layouts/SectionLayout/PathCopyOpenRow.tsx
+++ b/src/modules/shared/layouts/SectionLayout/PathCopyOpenRow.tsx
@@ -50,10 +50,11 @@ const PathCopyOpenRow: React.FC<PathCopyOpenRowProps> = memo(
   }) => {
     return (
       <SectionRow label={label} description={description}>
-        <div className={SECTION_ACTION_GAP_CLASSES}>
+        <div className={`group ${SECTION_ACTION_GAP_CLASSES}`}>
           <span className={SECTION_PATH_TEXT_CLASSES}>{path}</span>
           <Button
             onClick={onCopy}
+            className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
             icon={
               <HugeiconsIcon icon={Copy01Icon} data-icon="copy" size={14} />
             }
@@ -63,6 +64,7 @@ const PathCopyOpenRow: React.FC<PathCopyOpenRowProps> = memo(
           />
           <Button
             onClick={onOpen}
+            className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
             icon={
               <HugeiconsIcon
                 icon={FolderOpenIcon}


### PR DESCRIPTION
## Problem

Path action icons remain visible at rest, including credential source paths, adding persistent visual clutter.

## Solution

Render credential source paths as clickable reveal controls and show the trailing folder icon only while that link is hovered or keyboard-focused. Remove the former separate reveal-action column. Apply hover/focus reveal to existing Settings path and Agent config/workspace action groups; opacity reserves space.

## Potential risks

Credential paths use selectors scoped to the link; other existing path controls reveal as a group. Pointer hover, touch discoverability, keyboard focus, dark theme and narrow-width behavior lack desktop screenshots. Existing reveal behavior is reused; no credential contents, persistence or filesystem write behavior changes.

No dependency, schema, IPC or persistence format changes. Revert this commit to roll back the UI behavior.

## Verification

- `pnpm exec eslint src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/useCredentialImport.tsx src/modules/shared/layouts/SectionLayout/PathCopyOpenRow.tsx src/modules/MainApp/AgentOrgs/components/CliRawConfigFileEditor.tsx src/modules/MainApp/AgentOrgs/config/osAgent/sections/ConfigGeneralSection.tsx --max-warnings 0` — passed in the isolated branch.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/MainApp/Integrations/KeyVault/CliClients/CredentialImport/__tests__/InlineCredentialImport.test.ts src/components/Table/TableBody.test.ts` — 6 tests passed.
- `pnpm typecheck:fast` — passed on the rebased branch.
- `git diff --check` — passed.
- Desktop visual verification and new screenshots were not run: computer control is not enabled. Provided screenshots describe the original state, not verification of this branch.
