### PR TITLE
refactor(workstation): remove unused navigation and cache APIs

### DIFF
--- a/src/services/workStation/WorkStationViewService.ts
+++ b/src/services/workStation/WorkStationViewService.ts
@@ -259,16 +259,6 @@ export const WorkStationViewService = {
     return true;
   },
 
-  async openCodeEditorTabOrToggleChatPanelMaximized(
-    tabId: string,
-    options?: NavigationOptions
-  ): Promise<boolean> {
-    if (await shouldToggleMaximizedForActiveTab(tabId, options)) {
-      return this.toggleChatPanelMaximized();
-    }
-    return this.openCodeEditorTab(tabId);
-  },
-
   async openFileFolderTab(options?: NavigationOptions): Promise<boolean> {
     const { EditorTabService } =
       await import("@src/services/workStation/EditorTabService");

--- a/src/store/workstation/tabs/editorCache.ts
+++ b/src/store/workstation/tabs/editorCache.ts
@@ -218,12 +218,6 @@ export const activeEditorRepoAtom = atom(
 );
 activeEditorRepoAtom.debugLabel = "activeEditorRepoAtom";
 
-export const getRepoCacheAtom = atom((get) => {
-  const cache = get(editorCacheAtom);
-  return (repoPath: string): EditorRepoCache | undefined => cache[repoPath];
-});
-getRepoCacheAtom.debugLabel = "getRepoCacheAtom";
-
 export const activeRepoCacheAtom = atom((get) => {
   const cache = get(editorCacheAtom);
   const activeRepo = get(activeEditorRepoAtom);

--- a/src/store/workstation/tabs/index.ts
+++ b/src/store/workstation/tabs/index.ts
@@ -179,7 +179,6 @@ export {
   editorCacheAtom,
   activeEditorRepoAtom,
   // Derived atoms
-  getRepoCacheAtom,
   activeRepoCacheAtom,
   editorCacheSizeAtom,
   // Action atoms


### PR DESCRIPTION
## Problem

The workstation API still exposes an unused navigation wrapper, `openCodeEditorTabOrToggleChatPanelMaximized`, and an unused editor-cache selector, `getRepoCacheAtom`. Neither has a production or test caller; the selector survives only through its definition and barrel export.

## Solution

Remove both APIs and the selector's barrel export. Existing navigation commands, maximize behavior, repository switching, and cache persistence remain unchanged. The diff is limited to 17 deleted lines in three files.

## Potential risks

An untracked external consumer of these internal TypeScript APIs would need to use the existing navigation commands or cache state directly. Repository references were checked and typechecking passes. There are no storage, dependency, IPC, wire, or UI changes. Reverting this commit restores the APIs if necessary.

## Verification

- `pnpm test src/services/workStation/WorkStationViewService.test.ts src/store/workstation/tabs/__tests__/editorCache.test.ts` — 11 tests passed across two files.
- `pnpm run typecheck:fast` — passed.
- `pnpm exec eslint src/services/workStation/WorkStationViewService.ts src/store/workstation/tabs/editorCache.ts src/store/workstation/tabs/index.ts --max-warnings 0` — passed.
- `rg -n 'openCodeEditorTabOrToggleChatPanelMaximized|getRepoCacheAtom' src tests` — no remaining references.
- `git diff --check` — passed.
- Reviewed the complete diff for scope and accidental data, debug logs, or generated changes.
- No new tests: this only removes unreachable APIs; existing owning-boundary tests exercise live navigation and cache behavior.
- Native GUI checks and screenshots were not run because no rendered behavior changes.

## Architecture review

Covered compilation, call chains/dead exports, naming and API scope (layers 1–4, 6–7). Defaults, serialization, initialization parity and resolver symmetry (5, 8–10) are unaffected: their live implementations remain intact. No timer, subscription, cache ownership or lifecycle behavior changes.
