### PR TITLE
fix(sidebar): reveal session preview on toggle hover

### DIFF
--- a/src/scaffold/NavigationSidebar/PinnedSidebarChrome.test.ts
+++ b/src/scaffold/NavigationSidebar/PinnedSidebarChrome.test.ts
@@ -141,7 +141,39 @@ describe("PinnedSidebarChrome", () => {
     expect(group?.style.left).toBe("88px");
   });
 
-  it("offers expand and close while the hover sidebar is open", () => {
+  it("previews the collapsed sidebar on hover and expands it on click", () => {
+    act(() => store.set(sidebarCollapsedAtom, true));
+    render();
+
+    act(() => {
+      query("sidebar-chrome-show")?.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true })
+      );
+    });
+
+    expect(store.get(hoverSidebarOpenAtom)).toBe(true);
+    expect(store.get(sidebarCollapsedAtom)).toBe(true);
+    expect(query("sidebar-chrome-expand")).not.toBeNull();
+    click("sidebar-chrome-expand");
+    expect(store.get(hoverSidebarOpenAtom)).toBe(false);
+    expect(store.get(sidebarCollapsedAtom)).toBe(false);
+  });
+
+  it("does not preview the sidebar when hovering its hide button", () => {
+    act(() => store.set(sidebarCollapsedAtom, false));
+    render();
+
+    act(() => {
+      query("sidebar-chrome-hide")?.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true })
+      );
+    });
+
+    expect(store.get(hoverSidebarOpenAtom)).toBe(false);
+    expect(store.get(sidebarCollapsedAtom)).toBe(false);
+  });
+
+  it("offers expand without a close button while the hover sidebar is open", () => {
     act(() => {
       store.set(sidebarCollapsedAtom, true);
       store.set(hoverSidebarOpenAtom, true);
@@ -152,11 +184,7 @@ describe("PinnedSidebarChrome", () => {
     expect(query("pinned-sidebar-chrome")?.getAttribute("data-variant")).toBe(
       "sidebar"
     );
-    click("sidebar-chrome-close-hover");
-    expect(store.get(hoverSidebarOpenAtom)).toBe(false);
-    expect(store.get(sidebarCollapsedAtom)).toBe(true);
-
-    act(() => store.set(hoverSidebarOpenAtom, true));
+    expect(query("sidebar-chrome-close-hover")).toBeNull();
     click("sidebar-chrome-expand");
     expect(store.get(hoverSidebarOpenAtom)).toBe(false);
     expect(store.get(sidebarCollapsedAtom)).toBe(false);

--- a/src/scaffold/NavigationSidebar/SidebarChromeToggle.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarChromeToggle.tsx
@@ -2,7 +2,7 @@
  * SidebarChromeToggle
  *
  * The sidebar show / hide control, in whichever state the sidebar is in:
- * hide while it is open, show while it is collapsed, and expand + close while
+ * hide while it is open, show while it is collapsed, and expand while
  * the hover sidebar is peeking in over a collapsed one.
  *
  * macOS draws it inside `PinnedSidebarChrome`, pinned in window space after
@@ -18,7 +18,6 @@ import type { SessionHistoryNavVariant } from "@src/components/SessionHistoryNav
 import SidebarChromeIconButton from "@src/components/SidebarChromeIconButton";
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
 import {
-  Cancel01Icon,
   HugeiconsIcon,
   type IconSvgElement,
   LayoutAlignLeftIcon,
@@ -33,6 +32,7 @@ interface ChromeButtonProps {
   label: string;
   shortcutId?: string;
   onClick: () => void;
+  onMouseEnter?: React.MouseEventHandler<HTMLButtonElement>;
   testId: string;
   icon: IconSvgElement;
   dataIcon: string;
@@ -46,6 +46,7 @@ const ChromeButton: React.FC<ChromeButtonProps> = ({
   label,
   shortcutId,
   onClick,
+  onMouseEnter,
   testId,
   icon,
   dataIcon,
@@ -79,6 +80,7 @@ const ChromeButton: React.FC<ChromeButtonProps> = ({
         shortcutId={shortcutId}
         tooltipMouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}
         onClick={onClick}
+        onMouseEnter={onMouseEnter}
         className="group/toggle"
         data-testid={testId}
       >
@@ -94,6 +96,7 @@ const ChromeButton: React.FC<ChromeButtonProps> = ({
       tooltipMouseEnterDelay={SIDEBAR_TOOLTIP_HOVER_DELAY}
       nativeTitle={false}
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
       className="group/toggle"
       data-testid={testId}
     >
@@ -126,33 +129,23 @@ const SidebarChromeToggleComponent: React.FC<SidebarChromeToggleProps> = ({
 
   const hide = useCallback(() => setCollapsed(true), [setCollapsed]);
   const show = useCallback(() => setCollapsed(false), [setCollapsed]);
+  const peek = useCallback(() => setHoverOpen(true), [setHoverOpen]);
   const expandFromHover = useCallback(() => {
     setHoverOpen(false);
     setCollapsed(false);
   }, [setCollapsed, setHoverOpen]);
-  const closeHover = useCallback(() => setHoverOpen(false), [setHoverOpen]);
 
   if (collapsed && hoverOpen) {
     return (
-      <>
-        <ChromeButton
-          variant={variant}
-          label={t("common:tooltips.showSidebar")}
-          shortcutId="toggle_sidebar"
-          onClick={expandFromHover}
-          testId="sidebar-chrome-expand"
-          icon={PanelLeftIcon}
-          dataIcon="panel-left"
-        />
-        <ChromeButton
-          variant={variant}
-          label={t("common:actions.close")}
-          onClick={closeHover}
-          testId="sidebar-chrome-close-hover"
-          icon={Cancel01Icon}
-          dataIcon="x"
-        />
-      </>
+      <ChromeButton
+        variant={variant}
+        label={t("common:tooltips.showSidebar")}
+        shortcutId="toggle_sidebar"
+        onClick={expandFromHover}
+        testId="sidebar-chrome-expand"
+        icon={PanelLeftIcon}
+        dataIcon="panel-left"
+      />
     );
   }
   if (collapsed) {
@@ -162,6 +155,7 @@ const SidebarChromeToggleComponent: React.FC<SidebarChromeToggleProps> = ({
         label={t("common:tooltips.showSidebar")}
         shortcutId="toggle_sidebar"
         onClick={show}
+        onMouseEnter={peek}
         testId="sidebar-chrome-show"
         icon={LayoutAlignLeftIcon}
         dataIcon="layout-align-left"


### PR DESCRIPTION
## Problem

When the session sidebar is collapsed, hovering its toolbar button does not reveal the sidebar preview. The preview also adds a separate X beside the expand control, cluttering the header.

## Solution

Reveal the existing hover sidebar on mouse entry into the collapsed sidebar button, keeping the sidebar collapsed until the user clicks to expand it. Remove the preview's X button and its unused handler/icon. Update the existing rendered component tests to cover hover preview, click expansion, absence of the X, and hovering the expanded sidebar's hide control.

## Potential risks

The shared toggle renders in both sidebar and chat chrome. Tests exercise the macOS pinned header in jsdom; native pointer transitions, other host layouts, themes, and constrained viewports have not been visually verified. Existing mouse-leave and Escape dismissal paths are unchanged. No new timers, subscriptions, persistence formats, dependencies, or public interfaces are introduced.

## Verification

Run from an isolated worktree based on the latest origin/develop:

- `pnpm test src/scaffold/NavigationSidebar/PinnedSidebarChrome.test.ts` — passed, 6 tests.
- `pnpm exec eslint src/scaffold/NavigationSidebar/SidebarChromeToggle.tsx src/scaffold/NavigationSidebar/PinnedSidebarChrome.test.ts --max-warnings 0` — passed.
- `pnpm typecheck:fast` — passed.
- `git diff --check` — passed.
- Reviewed the two-file diff for scope, secrets, debug output, and generated artifacts.

Native desktop interaction and screenshots were not captured because desktop computer control was not authorized. The full test suite was not run for this localized control change.
