### PR TITLE
fix(continuation): prefer the matching source checkout

### DIFF
--- a/docs/org2-performance-guard-2026-09-09/ContinuationCheckout.md
+++ b/docs/org2-performance-guard-2026-09-09/ContinuationCheckout.md
@@ -1,0 +1,23 @@
+# Shared continuation checkout selection
+
+## Source and invariant
+
+The execution workspace comes from the shared local checkout resolver. A real secondary Claude conversation belonged to one local checkout, but main continuation chose a sibling clone with the same Git remote because repo-list order won before the exact source-path fallback. This was a persisted native execution path, not a sidebar label defect.
+
+Prefer the source path within the already known, existing local candidate list before repository-scope resolution. The same resolver still checks repository identity and can choose another matching clone; no foreign path becomes a new candidate. The existing no-scope fallback is unchanged. No user-specific path or project name is hardcoded. Existing histories are left intact; a workspace mismatch makes the continuation runner create a fresh native child rather than reuse the old execution.
+
+## Verification
+
+- `pnpm test src/features/TeamCollaboration/forkSession.test.ts`: 35 passed, including two-clone preference, identity verification, stale-path rejection and canonical-root behavior.
+- `pnpm typecheck:fast`, changed-file ESLint and normal pre-commit checks passed. The new worktree initially lacked the generated Husky bootstrap; `pnpm exec husky install` restored it and hooks then ran normally.
+- Real main package combines native replay #1465, roster loading #1485 and this change. Before the fix, main continued a secondary Opus conversation in the sibling clone. After the fix and normal app restart, logs explicitly rejected reuse of that child's mismatching workspace and created a fresh native UUID under the source checkout.
+- Raw JSONL contained all 13 user/assistant records including both instances' previous answers and the latest successful answer. Chat rendered that final answer and returned to idle. The original child/history was not moved or deleted.
+
+| Area               | Verdict | Evidence                                             | Change or reason kept                                            | Verification                                                   |
+| ------------------ | ------- | ---------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------- |
+| Background work    | keep    | Existing action-time existence/scope probes          | Reorders the same candidates, no timer, retry or additional scan | Resolver call and real execution checks                        |
+| Memory             | keep    | Request-local candidate array                        | One linear preference pass, no retained cache                    | Scope inspection and typecheck                                 |
+| Scope/isolation    | fix     | Same-remote clone order selected wrong persisted cwd | Prefer known existing source candidate, retain scope checking    | Two-clone, stale-path and identity tests; native cwd read-back |
+| Rendering/hot path | keep    | No component or subscription change                  | Resolver feeds the existing execution boundary                   | Actual Chat final response and idle state                      |
+
+Performance verdict: pass for this bounded resolver change; no whole-app CPU improvement is claimed. Passive cloud refresh is an independent issue. Rollback is a bundle revert; no migration, credential, schema or historical cleanup occurs.

--- a/src/features/TeamCollaboration/forkSession.test.ts
+++ b/src/features/TeamCollaboration/forkSession.test.ts
@@ -195,6 +195,47 @@ beforeEach(() => {
 });
 
 describe("resolveForkWorkspacePath", () => {
+  it("prefers the known source checkout over another clone of the same repo", async () => {
+    store.set(sessionsAtom, [
+      { session_id: "other", repoPath: "/repo/other-clone" } as Session,
+      { session_id: "source", repoPath: "/repo/shared" } as Session,
+    ]);
+    existsMock.mockResolvedValue(true);
+    resolveCheckoutMock.mockImplementation(
+      async (_scopeKey, candidates) => candidates[0] ?? null
+    );
+
+    await expect(
+      resolveForkWorkspacePath(
+        makeRemote({ repoScopeKey: "github.com/example/repo" })
+      )
+    ).resolves.toBe("/repo/shared");
+    expect(resolveCheckoutMock).toHaveBeenCalledWith(
+      "github.com/example/repo",
+      ["/repo/shared", "/repo/other-clone"]
+    );
+  });
+
+  it("still verifies the preferred checkout's repository identity", async () => {
+    store.set(sessionsAtom, [
+      { session_id: "other", repoPath: "/repo/other-clone" } as Session,
+      { session_id: "source", repoPath: "/repo/shared" } as Session,
+    ]);
+    existsMock.mockResolvedValue(true);
+    // The source path exists here but belongs to a different repository.
+    resolveCheckoutMock.mockImplementation(
+      async (_scopeKey, candidates) =>
+        candidates.find((candidate) => candidate === "/repo/other-clone") ??
+        null
+    );
+
+    await expect(
+      resolveForkWorkspacePath(
+        makeRemote({ repoScopeKey: "github.com/example/repo" })
+      )
+    ).resolves.toBe("/repo/other-clone");
+  });
+
   it("ignores stale imported paths and probes only checkouts that exist locally", async () => {
     store.set(sessionsAtom, [
       { session_id: "stale", repoPath: "/Users/owner/ORG2" } as Session,

--- a/src/features/TeamCollaboration/forkWorkspaceResolution.ts
+++ b/src/features/TeamCollaboration/forkWorkspaceResolution.ts
@@ -85,6 +85,20 @@ export async function resolveForkWorkspacePath(
     }
   }
 
+  // Several local clones can share the same remote. Prefer the source's
+  // checkout when it is already a known, existing local candidate, rather
+  // than letting repo-list order silently move a continuation to a sibling.
+  // It still goes through scope verification below; a foreign path is never
+  // introduced as a new candidate by this preference.
+  const sourcePath = normalizeRepoScopeKey(remoteSession.repoPath ?? "");
+  const sourceIndex = existingCandidates.findIndex(
+    (candidate) => normalizeRepoScopeKey(candidate) === sourcePath
+  );
+  if (sourceIndex > 0) {
+    const [sourceCandidate] = existingCandidates.splice(sourceIndex, 1);
+    existingCandidates.unshift(sourceCandidate);
+  }
+
   const byScopeKey = await resolveLocalCheckoutForScopeKey(
     remoteSession.repoScopeKey,
     existingCandidates


### PR DESCRIPTION
## Problem

When two local clones share the same Git remote, continuing a shared native conversation can run in the first clone in the repository list instead of the conversation's existing local checkout. The shared resolver checks repository scope before its exact-path fallback, so native history is persisted under the wrong local project directory.

## Solution

Prioritize the source path within the already known, existing local candidate list before the shared repository-scope resolver runs. The preferred candidate still undergoes the same repository identity check; a foreign path is never added merely because the remote session named it. All continuation callers share this resolver.

## Potential risks

This intentionally changes automatic selection when multiple local clones match and the source checkout exists here. A stale or unknown path does not gain priority. Existing no-scope fallback behavior is unchanged. An existing execution in a different workspace is left intact; the runner creates a new native child instead of relocating history.

No dependency, schema, wire, credential or persistence-format change. Rollback is a bundle revert. Passive cloud roster/replay refresh and execution account selection are outside this fix.

## Verification

- `pnpm test src/features/TeamCollaboration/forkSession.test.ts`: 35 passed, including same-repo clone preference, scope verification, stale paths and canonical roots.
- `pnpm test src/features/TeamCollaboration/repoScopeResolver.test.ts src/features/Org2Cloud/SessionConversation/useCloudConversationSource.test.ts`: 27 passed.
- `pnpm typecheck:fast`, changed-file ESLint, normal pre-commit hooks and `git diff --check`: passed.
- Built an actual main Tauri acceptance package combining #1465, #1485 and this change. Before the fix, main's Opus continuation selected the sibling clone. After restart with this fix, logs rejected reuse of that mismatching execution and created a new native UUID in the source checkout.
- Raw native JSONL retained all 13 user/assistant records, including both instances' preceding turns. Chat displayed the final answer and returned to idle. No old session was moved or deleted.
- Resource ownership and exact runtime scope are documented in `docs/org2-performance-guard-2026-09-09/ContinuationCheckout.md`. No UI layout changed; persisted cwd and native-file read-back verify the relevant behavior directly.
