### PR TITLE
fix(continuation): settle failures before native prompt persistence

### DIFF
--- a/docs/org2-performance-guard-2026-09-09/NativePrepromptFailure.md
+++ b/docs/org2-performance-guard-2026-09-09/NativePrepromptFailure.md
@@ -1,0 +1,25 @@
+# Native failure before prompt persistence
+
+## Authoritative failure boundary
+
+A real secondary Claude continuation materialized six previous native messages, then the CLI exited with a rejected resume ID before writing the new prompt. The exact durable turn intent was failed. Canonical continuation nevertheless threw a recovery-pending error for the absent native anchor, leaving the shared Chat working and repeatedly revisiting the same terminal execution.
+
+The authoritative terminal is the exact backend turn intent; provider history owns portable output. The fix passes terminal status into reconciliation. Only a failed turn enters existing bounded mismatch recovery before accepting an unchanged portable pre-turn history as an empty failed tail. The existing cloud failure publisher emits an ordinary error and releases the queue owner. Late output is retained; divergent history and cancelled missing anchors remain pending. No historical source or queue row is manually rewritten.
+
+## Verification
+
+- `pnpm test src/engines/SessionCore/conversations/localConversationContinuation.test.ts src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts`: 72 passed. Coverage includes unchanged failed history, divergent history, late partial output, cancellation, native context-recovery ownership and canonical failure publication.
+- `pnpm typecheck:fast`, changed-file ESLint, normal pre-commit hooks and `git diff --check`: passed.
+- An earlier test expected a terminal native context failure with permanently unchanged history to remain pending. Its expectation now requires failed settlement while preserving its assertions that frontend code neither reruns the provider nor creates another execution.
+- Actual preserved-request recovery passed in the new secondary package: the same durable failed intent was read once, its unchanged history was reconciled, and one canonical failure event was published. Chat displayed the error and returned to idle. The old recovery attempts did not recur during the following two minutes or the next successful send. Provider/account setup remains separate; no credentials or queue rows were edited.
+
+| Area               | Verdict | Evidence                                                 | Change or reason kept                                                                | Verification                                                                         |
+| ------------------ | ------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| Background work    | fix     | Failed execution repeatedly retried an impossible anchor | Reuse bounded 250/750 ms recovery only on missing-anchor failure, then release owner | Failure and cancellation tests; same persisted request recovered and retries stopped |
+| Memory             | keep    | Existing canonical before/after arrays                   | No persistent cache or retained job; comparison temporaries end with reconciliation  | Scope inspection and tests                                                           |
+| Scope/isolation    | keep    | Exact session/turn durable terminal                      | No UI timeout or cross-account state drives finality                                 | Failure, divergence and late-output tests                                            |
+| Rendering/hot path | fix     | Root stayed working after child was terminal             | Existing canonical error publisher and adopted-lifecycle settlement own completion   | Publication tests; real root error/idle and next successful request                  |
+
+Architecture review covered terminal ownership, source authority, recovery control flow, queue finality and compatibility; no UI layout or schema changed. Rollback is a bundle revert. Performance verdict: pass for this bounded failure-finalization change. The preserved request settled once without rerunning the provider, the root became idle, and a later real send completed. No whole-app CPU improvement is claimed from unit tests.
+
+After explicitly choosing the local Claude account's Fable 5.1 model, the same shared conversation created a new native UUID under the correct source checkout. The native JSONL contained ten user/assistant records including the previous context, preserved failed request/error and the new successful answer `20`. Chat displayed `20` and returned to idle. This validates recovery followed by real cross-instance continuation with a different account-bound execution, rather than deleting the failed test and starting over. The acceptance bundle combined #1465, #1485, #1486 and this change.

--- a/src/engines/SessionCore/conversations/localConversationContinuation.test.ts
+++ b/src/engines/SessionCore/conversations/localConversationContinuation.test.ts
@@ -1036,7 +1036,7 @@ describe("local native conversation continuation", () => {
     ]);
   });
 
-  it("leaves context recovery to the native runtime and waits for its accepted anchor", async () => {
+  it("leaves context recovery to the native runtime and settles its terminal failure", async () => {
     const timeline = [
       event("u1", "user", "canonical question"),
       event("a1", "assistant", "canonical answer"),
@@ -1096,7 +1096,7 @@ describe("local native conversation continuation", () => {
         },
         turnIntentId: "turn-context-rollover",
       })
-    ).rejects.toBeInstanceOf(QueuedConversationRecoveryPendingError);
+    ).resolves.toMatchObject({ terminalStatus: "failed", agentTail: [] });
 
     expect(mocks.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1723,6 +1723,80 @@ describe("local native conversation continuation", () => {
     ).rejects.toBeInstanceOf(QueuedConversationRecoveryPendingError);
 
     expect(mocks.markTerminal).not.toHaveBeenCalled();
+  });
+
+  it("settles a failed process with unchanged history after bounded native recovery", async () => {
+    mocks.cliWaitForTurnTerminal.mockResolvedValueOnce({
+      sessionId: "agentsession-child",
+      turnIntentId: "failed-before-prompt",
+      status: "failed",
+      updatedAt: "2026-08-29T00:01:00.000Z",
+    });
+    mocks.sendMessage.mockResolvedValueOnce(undefined);
+
+    const result = await continueLocalConversation({
+      root,
+      title: "Rejected native resume ID",
+      timeline: [event("u1", "user", "original question")],
+      displayText: "continue",
+      target,
+      turnIntentId: "failed-before-prompt",
+    });
+
+    expect(result).toMatchObject({ terminalStatus: "failed", agentTail: [] });
+    expect(mocks.recoverNativeAfterMismatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not settle a failed process whose native history no longer matches", async () => {
+    mocks.cliWaitForTurnTerminal.mockResolvedValueOnce({
+      sessionId: "agentsession-child",
+      turnIntentId: "failed-rewritten-history",
+      status: "failed",
+      updatedAt: "2026-08-29T00:01:00.000Z",
+    });
+    mocks.sendMessage.mockResolvedValueOnce(undefined);
+    mocks.recoverNativeAfterMismatch.mockResolvedValueOnce([
+      event("other-user", "user", "different history"),
+    ]);
+
+    await expect(
+      continueLocalConversation({
+        root,
+        title: "Unresolved source mismatch",
+        timeline: [event("u1", "user", "original question")],
+        displayText: "continue",
+        target,
+        turnIntentId: "failed-rewritten-history",
+      })
+    ).rejects.toBeInstanceOf(QueuedConversationRecoveryPendingError);
+  });
+
+  it("retains a failed turn's partial output exposed by native recovery", async () => {
+    mocks.cliWaitForTurnTerminal.mockResolvedValueOnce({
+      sessionId: "agentsession-child",
+      turnIntentId: "failed-partial-flush",
+      status: "failed",
+      updatedAt: "2026-08-29T00:01:00.000Z",
+    });
+    mocks.sendMessage.mockResolvedValueOnce(undefined);
+    mocks.recoverNativeAfterMismatch.mockResolvedValueOnce([
+      event("u1", "user", "original question"),
+      event("u2", "user", "continue"),
+      event("a2", "assistant", "partial answer"),
+    ]);
+
+    const result = await continueLocalConversation({
+      root,
+      title: "Late native output",
+      timeline: [event("u1", "user", "original question")],
+      displayText: "continue",
+      target,
+      turnIntentId: "failed-partial-flush",
+    });
+    expect(result.terminalStatus).toBe("failed");
+    expect(
+      result.agentTail.some((item) => item.displayText === "partial answer")
+    ).toBe(true);
   });
 
   it("settles an interrupted turn the provider closed before recording its prompt", async () => {

--- a/src/engines/SessionCore/conversations/localConversationContinuation.ts
+++ b/src/engines/SessionCore/conversations/localConversationContinuation.ts
@@ -815,8 +815,10 @@ async function loadSettledTail(
   before: readonly SessionEvent[],
   turnIntentId: string,
   expectedRequest: ProviderRequestIdentity,
-  preserveInterruptedSuffix: boolean
+  terminalStatus: TurnTerminalStatus
 ): Promise<{ agentTail: SessionEvent[]; events: SessionEvent[] }> {
+  const preserveInterruptedSuffix =
+    terminalStatus === "cancelled" || terminalStatus === "failed";
   const reconcileOptions = {
     preserveInterruptedSuffix,
   };
@@ -829,6 +831,44 @@ async function loadSettledTail(
     false
   );
   if (agentTail) return { agentTail, events };
+  if (terminalStatus === "failed") {
+    // A CLI can exit before recording the prompt (for example, a rejected
+    // resume ID). Its durable terminal is authoritative, but a cached replay
+    // alone is not proof that it wrote nothing. Force the existing mismatch
+    // recovery once before accepting an unchanged portable history.
+    events = await recoverNativeTranscriptAfterMismatch(
+      sessionId,
+      events,
+      (candidate) =>
+        resolveSettledTail(
+          before,
+          candidate,
+          turnIntentId,
+          expectedRequest,
+          false
+        ) !== null,
+      reconcileOptions
+    );
+    agentTail = resolveSettledTail(
+      before,
+      events,
+      turnIntentId,
+      expectedRequest,
+      true
+    );
+    if (agentTail) return { agentTail, events };
+    const beforeItems = projectNativeConversationItems(before);
+    const afterItems = projectNativeConversationItems(events);
+    if (
+      beforeItems.length === afterItems.length &&
+      nativeConversationItemsArePrefix(beforeItems, afterItems)
+    ) {
+      // The canonical user row already exists. An empty FAILED tail goes
+      // through the ordinary failure publisher; it is never a success and
+      // must not leave an execution retrying an impossible native anchor.
+      return { agentTail: [], events };
+    }
+  }
   if (preserveInterruptedSuffix) {
     if (providerClosedTurnWithoutRecordingPrompt(before, events)) {
       // Stop reached the provider before it persisted the prompt: the native
@@ -971,7 +1011,7 @@ async function finishConversationTurn(params: {
     params.before,
     params.turnIntentId,
     params.providerRequest,
-    terminalStatus === "cancelled" || terminalStatus === "failed"
+    terminalStatus
   );
   // Fresh sends are closed only by the CLI/Agent lifecycle coordinator.
   // Crash recovery created a synthetic frontend lifecycle after the original


### PR DESCRIPTION
## Problem

A native CLI can fail before persisting its new prompt, for example when a resume ID is rejected. Its durable turn is already failed, but canonical continuation keeps waiting for a native user anchor that will never arrive. The shared Chat stays working and queue recovery repeatedly revisits the failed execution.

## Solution

Carry the authoritative terminal status into tail reconciliation. For a failed turn with no matching anchor, use the existing bounded native mismatch recovery, retain any late partial output, and accept an empty failed tail only when the portable history still exactly matches the pre-turn history. The existing failure publisher then records the failure and releases the durable queue owner. Cancellation and mismatching history remain recovery-pending under their existing rules.

## Potential risks

An anchorless failure now performs the existing bounded re-read sequence (250 ms and 750 ms delays) before settling. Successful turns incur no extra work. This relies on the exact durable turn terminal, not a UI status or timeout; read errors and divergent history still fail closed. No new persistent cache, continuous polling, schema, wire or credential change. Rollback is a bundle revert.

This fixes failure finalization, not the original provider/account configuration error. In the reproduced isolated secondary case, an ambient Claude selection searched a different native home; an explicit local account selection is needed for a successful retry.

## Verification

- `pnpm test src/engines/SessionCore/conversations/localConversationContinuation.test.ts src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts`: 72 passed. Cases cover failed unchanged history, divergent history, late partial output, cancelled missing anchors, and existing canonical failure publication.
- `pnpm typecheck:fast`, changed-file ESLint, normal pre-commit checks and `git diff --check`: passed.
- Actual secondary failure reproduced: durable turn failed, native file retained only the six old messages, and repeated queue recovery reported a missing interrupted anchor. The new package recovered that same preserved request, published one canonical failure event and returned Chat to idle without rerunning the provider. No recovery attempts recurred during the following two minutes or next send.

- After explicit selection of the local Claude account's Fable 5.1, the same shared conversation created a fresh native UUID under the source checkout and returned `20`. Native JSONL retained ten user/assistant records, including preceding history and the failed request/error. Chat displayed the successful reply and idle state.
- `pnpm run build` and the isolated secondary `pnpm exec tauri build --bundles app --config <acceptance config> -- --profile dev-build` passed; signature verification passed. The runtime bundle combined #1465, #1485, #1486 and this change.
- Lifecycle/resource evidence: `docs/org2-performance-guard-2026-09-09/NativePrepromptFailure.md`. No layout change; rendered error/idle/retry checks exercise the relevant UI state directly.

- Main reopened the original conversation and rendered both the preserved failure and the secondary Fable answer `20`, confirming the terminal publication reached the other instance.
