### PR TITLE
fix(cloud-replay): publish authoritative native root history

### DIFF
--- a/docs/org2-performance-guard-2026-09-09/NativeCloudAuthority.md
+++ b/docs/org2-performance-guard-2026-09-09/NativeCloudAuthority.md
@@ -1,0 +1,47 @@
+# Native cloud replay authority
+
+## Failure and invariant
+
+A real new Codex session had a complete native rollout with its user prompt, assistant commentary, package.json tool call/result and final answer. The live EventStore persisted only two assistant messages. Cloud upload preferred any populated EventStore and published those two rows. Remote streaming import persisted them but produced no turn headers, then failed with `Failed to hydrate streamed replay turn window`.
+
+The native provider transcript is authoritative whenever the CLI binding says native. The cloud owner now includes the native root revision in its existing execution revision stamp, even without continuation children. That selects the existing canonical root-plus-child reader, rejects unavailable/changed reads, invalidates cold partial-cache proofs, and preserves unchanged-pass skipping. Legacy chunk-backed and non-CLI sources keep their existing reader. There is no added polling, timer, listener, cache or database format.
+
+The transient writer is `session_runner/helpers.rs::persist_and_broadcast_streaming_complete`; its partial output is legitimate. The defect was the consuming upload boundary treating it as complete. No UI filter or manually seeded history was introduced.
+
+## Verification
+
+- `pnpm test src/features/Org2Cloud/org2CloudSessionSync src/features/Org2Cloud/org2CloudSyncEngine`: 152 passed across 15 files, including native root with populated partial cache, unchanged-pass skip, root-only revision change, unstable/unavailable roots, legacy behavior and two cold owners.
+- `pnpm typecheck`, changed-file ESLint, `git diff --check`: passed. An initial direct Vitest command omitted the repository config and collected no tests; corrected to the package script above.
+- Production frontend and both signed macOS bundles built. Integration includes #1465, #1485, #1486 and #1487 plus this change.
+- Two actual ORG2 instances on the same Mac, independent homes/provider roots/accounts. No model or transport mocks, cache injection or database repair.
+- Before fix: new Astra source published 2 assistant-only events and A failed to import. Native source retained all history.
+- After fix: a fresh Astra source with a real read-only package.json tool request published 6 events at epoch 1; A's first open displayed the complete turn. B began with 31 and project marker 白桦. A Astra answered 33; B Astra received it and answered 36. A's new native UUID and B's original UUID both remain in the selected repository checkout.
+- On that same history B switched to Claude. Opus rejected an ordinary continuation with provider `reasoning_extraction`; the request settled idle. Fable 5.1 High then retained package/version/marker and answered 37. A reopened the cloud view, selected Astra, and answered 38; B displayed 38. The refusal remained in history. Earlier Opus conversion on the 青松 history succeeded (17 → 20), followed by A Astra 22 and B Astra 23.
+- Source native JSONL and receiving Chat were inspected, including original tool use/result and all prior user/assistant pairs. Switching provider generates the appropriate native session binding; returning to the original account can reuse its original UUID.
+- Fleet ledger: 2901 → 2903 rows, 2 added test roots, 0 removals, 0 deletion/access changes. Two existing native Codex roots repaired assistant-only replay (counts 2 → 13 and 1 → 12; epochs 2 → 3 and 1 → 2). No count decreases. The fixed fresh source reached 16 events at epoch 1; the earlier malformed test source recovered at epoch 2. These are legitimate authority corrections, not a claim of zero epoch changes.
+
+## Performance and lifecycle
+
+| Area               | Verdict | Evidence                                                | Change or reason kept                                   | Verification                                                                   |
+| ------------------ | ------- | ------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Background work    | keep    | Existing scoped sync-pass owner                         | Add root revision to the existing clean stamp; no timer | Unchanged second pass skips canonical read                                     |
+| Memory             | keep    | Canonical full replay already returns a complete result | No retained body cache introduced                       | Real short-session roundtrips; earlier #1465 large-reader results are separate |
+| Scope/isolation    | keep    | Existing endpoint/account/org cursor identity           | No new global cache or credentials path                 | Primary + isolated Instance 2 with distinct local accounts                     |
+| Rendering/hot path | fix     | Remote import cannot index an assistant-only replay     | Correct producer source instead of filtering UI         | Fresh cloud turn renders on first open                                         |
+
+Two minimized instances were sampled with calibrated libproc counters, four attributed processes each. A 59.3-second settled observation averaged about 4.92% CPU for A and 1.40% for B (one core = 100%); summed physical footprint was stable at approximately 819.2 / 606.8 MiB. Earlier post-interaction cooldown was noisier. This is not zero whole-app CPU, a controlled develop comparison, or proof of document visibility timing. Existing user data/background services were present, and other work was active on the machine. Root revision queries add filesystem metadata work to an already scheduled pass; changed native roots still require a complete canonical replay. A large cold catalog can do more correct initial work than the former partial-cache shortcut.
+
+| Provider                | Raw transition                  | App/UI state                               | Topology/boundary      | Expected invariant                     | Observed evidence                                                        |
+| ----------------------- | ------------------------------- | ------------------------------------------ | ---------------------- | -------------------------------------- | ------------------------------------------------------------------------ |
+| Codex Astra             | create + real tool output       | fresh B; first A open                      | B → cloud → A          | Full user/tool/answer replay           | 6 events, epoch 1, first open succeeds                                   |
+| Codex Astra             | append / new UUID               | both open; normal restart between packages | B → A → B              | Context and checkout preserved         | 31 → 33 → 36, native files inspected                                     |
+| Claude Opus / Fable 5.1 | convert from Codex              | existing conversation                      | B conversion → A Astra | Native history survives runtime switch | Opus earlier pass; later provider refusal preserved; Fable 37 → Astra 38 |
+| Both                    | compact / rotate / large export | not rerun for this upload fix              | not run                | No unsupported coverage claim          | See #1465 source-reader evidence, separate scope                         |
+
+Already-open cloud replay can require reopening (#1467). Team Chat comments are separate from native user messages. Official native App foreground continuation was not repeated by this cloud test; conversion project assignment is a separate follow-up. No account/endpoint switch, revocation, Windows/Linux or second physical computer certification is claimed.
+
+Performance verdict: blocked for a blanket whole-app idle/full-lifecycle certification; functional upload/roundtrip checks pass. The measured run does not demonstrate near-zero whole-app idle CPU, and no controlled attribution to this change was performed.
+
+## Recovery
+
+Existing malformed cloud replay is repaired by the ordinary authoritative sync pass, with its existing epoch reconciliation. No native histories or cloud rows were deleted. Revert the bundled frontend change to roll back; complete native histories remain intact, although the old incomplete-upload defect would return.

--- a/src/features/Org2Cloud/org2CloudSessionSync.continuation.test.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.continuation.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getImportedHistorySourceBySessionId } from "@src/api/tauri/externalHistory";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { loadCliTranscriptRevision } from "@src/engines/SessionCore/sync/adapters/cli/cliHistory";
 import { COLLAB_SESSION_ACCESS_MODE } from "@src/store/collaboration/types";
 import type { Session } from "@src/store/session";
 
@@ -18,6 +19,10 @@ const mocks = vi.hoisted(() => ({
   canonicalSnapshot: vi.fn(),
   persistedRevision: vi.fn(),
   persistedEvents: vi.fn(),
+}));
+
+vi.mock("@src/engines/SessionCore/sync/adapters/cli/cliHistory", () => ({
+  loadCliTranscriptRevision: vi.fn(async () => undefined),
 }));
 
 vi.mock(
@@ -99,6 +104,7 @@ describe("Org2CloudSessionSync local continuation replay", () => {
   afterEach(() => vi.restoreAllMocks());
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(loadCliTranscriptRevision).mockResolvedValue(undefined);
     mocks.childRevision.mockResolvedValue("[]");
     mocks.persistedRevision.mockResolvedValue(null);
     mocks.persistedEvents.mockResolvedValue([]);
@@ -115,6 +121,78 @@ describe("Org2CloudSessionSync local continuation replay", () => {
       sync.endPass();
     }
   }
+
+  it("publishes a native root with user/tool history despite an assistant-only cache, and skips unchanged reads", async () => {
+    const store = createStore();
+    const cloud = client();
+    const sync = new Org2CloudSessionSync(() => store, cloud);
+    const complete = [
+      event("user", "question"),
+      event("tool", "read result"),
+      event("assistant", "answer"),
+    ];
+    mocks.persistedEvents.mockResolvedValue([complete[2]]);
+    vi.mocked(loadCliTranscriptRevision).mockResolvedValue("native-1");
+    mocks.canonicalSnapshot.mockResolvedValue({
+      events: complete,
+      childRevision: "[]",
+    });
+    await pushPass(sync);
+    await pushPass(sync);
+    expect(mocks.canonicalSnapshot).toHaveBeenCalledTimes(1);
+    expect(mocks.persistedEvents).not.toHaveBeenCalled();
+    expect(
+      store.get(org2CloudPushCursorsAtom)[`org-1:${SESSION.session_id}`]
+        ?.pushedCount
+    ).toBe(3);
+
+    vi.mocked(loadCliTranscriptRevision).mockResolvedValue("native-2");
+    mocks.canonicalSnapshot.mockResolvedValue({
+      events: [...complete, event("next", "reply")],
+      childRevision: "[]",
+    });
+    await pushPass(sync);
+    expect(mocks.canonicalSnapshot).toHaveBeenCalledTimes(2);
+    expect(
+      store.get(org2CloudPushCursorsAtom)[`org-1:${SESSION.session_id}`]
+        ?.pushedCount
+    ).toBe(4);
+  });
+
+  it("refuses a native root that changes during replay materialization", async () => {
+    const sync = new Org2CloudSessionSync(() => createStore(), client());
+    vi.mocked(loadCliTranscriptRevision)
+      .mockResolvedValueOnce("before")
+      .mockResolvedValue("after");
+    mocks.canonicalSnapshot.mockResolvedValue({
+      events: [event("partial", "partial")],
+      childRevision: "[]",
+    });
+    await expect(
+      (
+        sync as unknown as {
+          loadPushEvents(id: string): Promise<SessionEvent[]>;
+        }
+      ).loadPushEvents(SESSION.session_id)
+    ).rejects.toThrow("changed while preparing cloud replay");
+    expect(mocks.persistedEvents).not.toHaveBeenCalled();
+  });
+
+  it("refuses unavailable native roots instead of certifying cached partial output", async () => {
+    const sync = new Org2CloudSessionSync(() => createStore(), client());
+    vi.mocked(loadCliTranscriptRevision).mockResolvedValue(null);
+    mocks.canonicalSnapshot.mockResolvedValue({
+      events: [event("partial", "partial")],
+      childRevision: "[]",
+    });
+    await expect(
+      (
+        sync as unknown as {
+          loadPushEvents(id: string): Promise<SessionEvent[]>;
+        }
+      ).loadPushEvents(SESSION.session_id)
+    ).rejects.toThrow("changed while preparing cloud replay");
+  });
 
   it("publishes the verified root-plus-child snapshot through the full replay owner", async () => {
     const store = createStore();
@@ -285,36 +363,49 @@ describe("Org2CloudSessionSync local continuation replay", () => {
     ).toBeGreaterThan(1);
   });
 
-  it("revalidates a persisted continuation cursor across two cold engines without rewriting", async () => {
-    const store = createStore();
-    const cloud = client();
-    const combined = [event("root", "root"), event("child", "child")];
-    mocks.childRevision.mockResolvedValue("stable-1");
-    mocks.canonicalSnapshot.mockResolvedValue({
-      events: combined,
-      childRevision: "stable-1",
-    });
-    await pushPass(new Org2CloudSessionSync(() => store, cloud));
-    const cursorBefore = store.get(org2CloudPushCursorsAtom)[
-      `org-1:${SESSION.session_id}`
-    ];
-    cloud.rewriteSessionEvents.mockClear();
-    cloud.appendSessionEvents.mockClear();
-    mocks.canonicalSnapshot.mockClear();
+  it.each([false, true])(
+    "revalidates a persisted cursor across two cold engines without rewriting (native root: %s)",
+    async (nativeRoot) => {
+      const store = createStore();
+      const cloud = client();
+      const combined = [event("root", "root"), event("child", "child")];
+      mocks.childRevision.mockResolvedValue("stable-1");
+      mocks.canonicalSnapshot.mockResolvedValue({
+        events: combined,
+        childRevision: "stable-1",
+      });
+      if (nativeRoot) {
+        vi.mocked(loadCliTranscriptRevision).mockResolvedValue(
+          "root-native-stable"
+        );
+        mocks.childRevision.mockResolvedValue("[]");
+        mocks.canonicalSnapshot.mockResolvedValue({
+          events: combined,
+          childRevision: "[]",
+        });
+      }
+      await pushPass(new Org2CloudSessionSync(() => store, cloud));
+      const cursorBefore = store.get(org2CloudPushCursorsAtom)[
+        `org-1:${SESSION.session_id}`
+      ];
+      cloud.rewriteSessionEvents.mockClear();
+      cloud.appendSessionEvents.mockClear();
+      mocks.canonicalSnapshot.mockClear();
 
-    for (let boot = 0; boot < 2; boot += 1) {
-      const sync = new Org2CloudSessionSync(() => store, cloud);
-      for (let pass = 0; pass < 3; pass += 1) await pushPass(sync);
+      for (let boot = 0; boot < 2; boot += 1) {
+        const sync = new Org2CloudSessionSync(() => store, cloud);
+        for (let pass = 0; pass < 3; pass += 1) await pushPass(sync);
+      }
+      // Each cold owner really reads the snapshot once; clean later passes are
+      // bounded. Zero mutations are paired with this positive liveness proof.
+      expect(mocks.canonicalSnapshot).toHaveBeenCalledTimes(2);
+      expect(cloud.rewriteSessionEvents).not.toHaveBeenCalled();
+      expect(cloud.appendSessionEvents).not.toHaveBeenCalled();
+      expect(
+        store.get(org2CloudPushCursorsAtom)[`org-1:${SESSION.session_id}`]
+      ).toEqual(cursorBefore);
     }
-    // Each cold owner really reads the snapshot once; clean later passes are
-    // bounded. Zero mutations are paired with this positive liveness proof.
-    expect(mocks.canonicalSnapshot).toHaveBeenCalledTimes(2);
-    expect(cloud.rewriteSessionEvents).not.toHaveBeenCalled();
-    expect(cloud.appendSessionEvents).not.toHaveBeenCalled();
-    expect(
-      store.get(org2CloudPushCursorsAtom)[`org-1:${SESSION.session_id}`]
-    ).toEqual(cursorBefore);
-  });
+  );
 
   it("refuses unstable child snapshots before any cloud mutation and recovers after stabilization", async () => {
     let now = Date.now();

--- a/src/features/Org2Cloud/org2CloudSessionSync.pushEvents.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.pushEvents.ts
@@ -18,6 +18,7 @@ import {
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { processChunksRust } from "@src/engines/SessionCore/ingestion/rustBridge";
+import { loadCliTranscriptRevision } from "@src/engines/SessionCore/sync/adapters/cli/cliHistory";
 import { createLogger } from "@src/hooks/logger";
 import type { ActivityChunk } from "@src/types/session/session";
 import {
@@ -134,7 +135,15 @@ export class Org2CloudSessionSyncPushEvents extends Org2CloudSessionSyncState {
     sessionId: string
   ): Promise<string | null | undefined> {
     const root = this.localConversationRoot(sessionId);
-    return root ? loadLocalExecutionChildrenRevision(root) : undefined;
+    if (!root) return undefined;
+    const childRevision = await loadLocalExecutionChildrenRevision(root);
+    if (!isCliSession(sessionId)) return childRevision;
+    const nativeRevision = await loadCliTranscriptRevision(sessionId);
+    if (nativeRevision === undefined) return childRevision;
+    if (nativeRevision === null || childRevision === null) return null;
+    // A native root can have no continuation children yet. Its transient
+    // EventStore rows are not a complete replay or a durable clean stamp.
+    return JSON.stringify({ childRevision, nativeRevision });
   }
 
   private async loadFullPushEvents(
@@ -151,7 +160,13 @@ export class Org2CloudSessionSyncPushEvents extends Org2CloudSessionSyncState {
       const root = this.localConversationRoot(sessionId);
       if (root) {
         const snapshot = await loadLocalCanonicalConversationSnapshot(root);
-        if (snapshot.childRevision === null) {
+        const revisionAfterRead =
+          await this.loadLocalExecutionRevision(sessionId);
+        if (
+          snapshot.childRevision === null ||
+          localExecutionRevision === null ||
+          revisionAfterRead !== localExecutionRevision
+        ) {
           // A repeated partial read is not evidence of an intentional shrink.
           // Refuse it before the planner can replace any cloud segments; the
           // sync engine's existing retry gate handles the transient failure.
@@ -161,7 +176,7 @@ export class Org2CloudSessionSyncPushEvents extends Org2CloudSessionSyncState {
         }
         return {
           events: snapshot.events,
-          localExecutionRevision: snapshot.childRevision,
+          localExecutionRevision: revisionAfterRead,
         };
       }
     }

--- a/src/features/Org2Cloud/org2CloudSyncEngine.testUtils.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.testUtils.ts
@@ -108,6 +108,10 @@ vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
   },
 }));
 
+vi.mock("@src/engines/SessionCore/sync/adapters/cli/cliHistory", () => ({
+  loadCliTranscriptRevision: vi.fn(async () => undefined),
+}));
+
 vi.mock(
   "@src/engines/SessionCore/conversations/localConversationExecutionTail",
   () => ({


### PR DESCRIPTION
## Problem

New native Codex conversations could appear in a teammate's list but fail to open: cloud upload preferred a populated transient EventStore containing only assistant output over the complete provider rollout. The resulting replay had no user turn headers (`Failed to hydrate streamed replay turn window`). A partial cache could also seed a false clean state after restart.

## Solution

Include the native root file revision in the existing cloud clean stamp, even when the root has no execution children. Use the existing authoritative canonical reader, verify the revision across the read, and refuse unstable/unavailable snapshots. Unchanged passes still skip full reads; legacy chunk-backed sessions retain their current path. Ordinary sync repairs already-incomplete cloud replay. No UI filtering, polling, new retained cache, schema change, dependency or destructive cleanup.

## Potential risks

- A cold native catalog now performs the complete read required for correctness instead of accepting a cheap partial cache. Changed native roots still materialize full canonical replay; this is not a streaming cloud-upload redesign.
- Real two-instance short-session/transfer checks pass, but minimized whole-app CPU was not zero (roughly 4.92% / 1.40% over one settled 59-second sample). Full idle/lifecycle certification and controlled develop attribution are not claimed. See the report for CPU/RAM limitations.
- Existing incomplete replay can require a legitimate epoch rewrite. Two historical native roots repaired 2→13 and 1→12 events, with one epoch increment each. Fleet ledger showed no removed rows, deletion/access changes or count decreases.
- Already-open cloud replay freshness (#1467), Team Chat native-history semantics and converted Codex App project assignment are separate. Opus rejected one benign continuation at the provider; Fable 5.1 High successfully continued the same history. Windows/Linux, revocation/account switching and large compaction/rotation were not repeated here.
- Rollback: revert the frontend bundle; native histories remain intact, though the original partial-upload behavior returns.

## Verification

- `pnpm test src/features/Org2Cloud/org2CloudSessionSync src/features/Org2Cloud/org2CloudSyncEngine`: **152 passed, 15 files**. Includes native-root partial-cache regression, root revision changes, unstable/missing source refusal, unchanged-pass skip and two cold owners.
- `pnpm typecheck`, changed-file ESLint and `git diff --check`: passed. Production frontend and both signed macOS Tauri bundles built.
- Real primary + Instance 2 on one Mac, separate homes/provider roots/accounts, integration with #1465/#1485/#1486/#1487: fresh Astra source uploaded **6 complete events at epoch 1**, first remote open succeeded; Codex B→A→B preserved package.json tool history and context (**31→33→36**).
- Codex→Claude Fable 5.1→Codex preserved package/version/project marker (**36→37→38**), both receiving Chat views verified. Earlier Opus transfer also passed (**17→20→22→23** across providers/instances). The later provider rejection remains in history and settled idle.
- Raw Codex/Claude files and repository paths checked. Fresh fixed source reached **16 events at epoch 1**. Fleet snapshot: **2901→2903 rows, two new test roots, no removals or deletion/access changes**.
- No visual layout changed; actual existing Chat/first-open/model-switch controls were exercised. Unrelated user screenshots are omitted.

Detailed source, lifecycle, resource and recovery evidence: [NativeCloudAuthority](docs/org2-performance-guard-2026-09-09/NativeCloudAuthority.md).
