### PR TITLE
fix(codex-project): assign converted threads to repository projects

### DIFF
--- a/docs/org2-performance-guard-2026-09-09/ConvertedCodexProject.md
+++ b/docs/org2-performance-guard-2026-09-09/ConvertedCodexProject.md
@@ -1,0 +1,35 @@
+# Converted Codex project membership
+
+## Producing boundary
+
+A real Claude→Codex conversion resumed correctly under the selected repository but its new native Codex thread had `project_id = NULL`. Ordinary fresh launches resolve `projectId`; conversion registers a thread in `native_materializer::materialize_cli` / `catalog::register_thread`, injects history, then resumes it. Registration omitted project membership and resume correctly preserved that omission.
+
+Registration now calls the existing bounded native `ensure_project` helper with the session repository root, and sends its ID in the creating `thread/start`. The execution cwd remains independent, including worktrees. No repository name/path is hardcoded, no private App UI tables are written, and existing assigned threads are not reassigned during resume. Old unassigned conversions are not bulk migrated.
+
+## Verification
+
+- `CARGO_TARGET_DIR=<shared-target> cargo test --manifest-path src-tauri/Cargo.toml --lib converted_thread_preserves_repository_project_across_resume -- --ignored --nocapture`: passed with a real installed app-server, isolated storage, distinct repository/worktree paths, and two resumes/reopens. No model or network request. An initial sidebar-list assertion was corrected: before a real model turn app-server leaves `has_user_event=0`; the isolated fixture checks authoritative project membership instead.
+- `CARGO_TARGET_DIR=<shared-target> cargo test --manifest-path src-tauri/Cargo.toml --lib agent_sessions::cli::`: 457 passed, 5 ignored.
+- `CARGO_TARGET_DIR=<shared-target> cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`: passed. Diff check passed; matching signed macOS bundle built.
+- Real ORG2 Fable 5.1 source answered 紫杉，41; switch to Astra created a new native UUID and answered 紫杉，42. The native DB row contains the resolved repository project ID; cwd remains the repository.
+- Codex App's first-class task APIs opened/read this exact thread. `list_projects` and `list_threads` agree that it belongs to the existing ORGII project, unlike earlier failing conversions listed with null project. Sending a continuation through Codex App returned 紫杉，43 with no tools and no error. The raw thread remains the same UUID. Native CUA refuses automation of Codex itself; these are App task-interface checks, not a claimed visual screenshot/search-latency measurement.
+- This acceptance exposed a separate ORG2 refresh issue: converted child writes were absent from the root-only revision probe. That belongs to #1465 and is fixed/tested there, not folded into this project-assignment change. Cloud upload authority is #1488.
+
+## Lifecycle and resource assessment
+
+| Area               | Verdict | Evidence                                             | Change or reason kept                                            | Verification                                     |
+| ------------------ | ------- | ---------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------ |
+| Background work    | keep    | Existing native registration only                    | No new timer/listener/idle work                                  | Real registration and two resumes                |
+| Memory             | keep    | Existing project list limits and RPC client lifetime | No retained project/history cache                                | Isolated app-server lifecycle completes          |
+| Scope/isolation    | fix     | Repository root differs from execution worktree      | Resolve inside the target native home; preserve assigned resumes | Distinct roots fixture plus real App project IDs |
+| Rendering/hot path | keep    | No React or streaming changes                        | Single creation-time project registration                        | Actual provider continuation                     |
+
+Performance verdict: pass for this bounded creation-time change; no whole-app CPU/RAM or large-catalog latency claim. Existing project discovery is capped at 100 pages and a deadline, and uses its existing idempotent creation key. Registration failure stops conversion rather than creating a knowingly unassigned thread.
+
+| Provider                       | Raw transition                              | App/UI state                        | Topology/boundary            | Expected invariant                                    | Observed evidence                    |
+| ------------------------------ | ------------------------------------------- | ----------------------------------- | ---------------------------- | ----------------------------------------------------- | ------------------------------------ |
+| Claude Fable 5.1 → Codex Astra | new native UUID with injected prior history | ORG2 model switch                   | local conversion → Codex App | Repository project set at creation; context preserved | 41 → 42, App project list membership |
+| Codex Astra                    | resume existing converted UUID              | Codex App task interface            | native App continuation      | Membership and prior context preserved                | 43, same UUID                        |
+| Codex app-server               | registration + two resumes                  | isolated native home, no model turn | native catalog               | Worktree cwd does not become project root             | Native DB assertion passes twice     |
+
+Existing null-project histories are preserved; this is prevention at the creating boundary, not a bulk migration. Other native Apps, physical-machine topology, compaction/rotation and UI list refresh delay are not re-certified by this PR. Rollback is reverting the app bundle; no schema/dependency/credential change or destructive cleanup.

--- a/src-tauri/src/agent_sessions/cli/native_materializer.rs
+++ b/src-tauri/src/agent_sessions/cli/native_materializer.rs
@@ -2148,6 +2148,12 @@ fn materialize_cli(
                 &cwd,
                 &title,
                 &codex_response_items(items),
+                session
+                    .repo_path
+                    .as_deref()
+                    .filter(|path| !path.trim().is_empty())
+                    .map(Path::new)
+                    .unwrap_or(&cwd),
             )?;
             let staged = persistence::stage_cli_session_id_for_account(
                 session_id,

--- a/src-tauri/src/agent_sessions/cli/parsers/codex_app_server/catalog.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/codex_app_server/catalog.rs
@@ -410,7 +410,11 @@ pub(crate) fn register_thread(
     cwd: &Path,
     title: &str,
     items: &[Value],
+    project_root: &Path,
 ) -> Result<CodexCatalogEntry, String> {
+    // Converted histories start a new provider thread here, then resume it in
+    // the runner. Assign membership at creation, exactly like fresh runs.
+    let project_id = ensure_project(codex_home, project_root)?;
     with_rpc(codex_home, cwd, |runtime, client| {
         let model_provider = effective_model_provider(runtime, client, cwd)?;
         let result = request(
@@ -420,6 +424,7 @@ pub(crate) fn register_thread(
             json!({
                 "cwd": cwd,
                 "modelProvider": model_provider,
+                "projectId": project_id,
                 "ephemeral": false,
                 "historyMode": "legacy",
                 "experimentalRawEvents": false
@@ -538,6 +543,50 @@ pub(crate) fn archive_thread(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[ignore = "requires installed Codex app-server; isolated storage, no model requests"]
+    fn converted_thread_preserves_repository_project_across_resume() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        let home = root.join("codex-home");
+        let project = root.join("repository");
+        let worktree = root.join("execution-worktree");
+        for path in [&home, &project, &worktree] {
+            std::fs::create_dir(path).unwrap();
+        }
+        let project_id = ensure_project(&home, &project).unwrap();
+        let items = vec![
+            json!({"type":"message", "role":"user", "content":[{"type":"input_text","text":"conversion project fixture"}]}),
+        ];
+        let entry =
+            register_thread(&home, &worktree, "Converted fixture", &items, &project).unwrap();
+        for _ in 0..2 {
+            synchronize_thread(
+                &home,
+                &entry.path,
+                &entry.id,
+                &worktree,
+                "Converted fixture",
+                &[],
+            )
+            .unwrap();
+            // No model turn is sent by this isolated test. The app-server has
+            // not set has_user_event yet, so its default sidebar query hides
+            // the pending thread. Check the authoritative membership instead.
+            let db = rusqlite::Connection::open(home.join("state_5.sqlite")).unwrap();
+            let (saved_project, saved_cwd): (Option<String>, String) = db
+                .query_row(
+                    "SELECT project_id, cwd FROM threads WHERE id=?1",
+                    [&entry.id],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .unwrap();
+            assert_eq!(saved_project.as_deref(), Some(project_id.as_str()));
+            assert_eq!(Path::new(&saved_cwd), worktree);
+            assert_eq!(ensure_project(&home, &project).unwrap(), project_id);
+        }
+    }
 
     #[test]
     fn parses_supported_thread_catalog_shape() {


### PR DESCRIPTION
## Problem

Claude→Codex and imported/continued histories create a native Codex UUID through `catalog::register_thread`, then resume it. Unlike the ordinary fresh-launch path, registration omitted `projectId`. The conversation could retain the correct repository cwd and resume successfully while Codex App placed it outside the repository project.

## Solution

Resolve the target native App project with the existing `ensure_project` helper at conversion registration, using the session repository root independently of its execution worktree. Pass the resolved ID in the creating `thread/start`. Existing assigned resumes remain unchanged. No hardcoded project/path, private App projection-table writes, polling, schema or credential changes.

## Potential risks

- A conversion now depends on the same native project APIs used by ordinary fresh launches. Project discovery/creation failure stops registration; the existing helper has bounded pagination/deadline and an idempotency key.
- Existing unassigned histories are preserved, not bulk migrated. This prevents new orphaned conversions without overriding a user's existing project assignment.
- Actual Codex App verification used its first-class task APIs because native CUA disallows controlling Codex itself. Project membership and a successful App continuation were checked; visual sidebar/search latency is not claimed. Claude App UI, other platforms and unrelated lifecycle/rotation behavior were not re-certified here.
- ORG2's converted-child native refresh is a separate #1465 follow-up; cloud replay authority is #1488. No whole-app CPU/RAM ceiling is asserted for this creation-time fix.
- Roll back by reverting the bundle. Existing native history and project data remain intact; there is no destructive cleanup or migration.

## Verification

- `CARGO_TARGET_DIR=<shared-target> cargo test --manifest-path src-tauri/Cargo.toml --lib converted_thread_preserves_repository_project_across_resume -- --ignored --nocapture`: **passed**, real installed app-server, isolated home, repository/worktree distinction, two resumes/reopens, no model request. A pending injected thread has `has_user_event=0` before its first model turn, so this test asserts durable project membership rather than claiming sidebar visibility before a turn exists.
- `CARGO_TARGET_DIR=<shared-target> cargo test --manifest-path src-tauri/Cargo.toml --lib agent_sessions::cli::`: **457 passed, 5 ignored**.
- Scoped `cargo clippy --lib -- -D warnings`, diff check and signed production macOS bundle build: passed.
- Real ORG2 Fable 5.1 conversation → Astra conversion: **紫杉，41 → 紫杉，42**, new native UUID, correct repository cwd and native project field.
- Codex App `list_projects`/`list_threads` place this exact converted thread in its existing **ORGII** project. App open/read and continuation succeeded, returning **紫杉，43** on the same native UUID with no tools or error.
- No visual layout change. [Source/lifecycle evidence](docs/org2-performance-guard-2026-09-09/ConvertedCodexProject.md).
