### PR TITLE
fix(rspack): inline browser startup environment gates

### DIFF
--- a/config/rspack.config.js
+++ b/config/rspack.config.js
@@ -24,6 +24,7 @@ const {
 const repoRoot = path.resolve(__dirname, "..");
 
 module.exports = () => {
+  const isE2E = process.env.ORGII_E2E === "1" || process.env.WEBDRIVER === "1";
   const devServerPort = Number.parseInt(
     process.env.WEBPACK_DEV_SERVER_PORT ?? process.env.PORT ?? "1998",
     10
@@ -363,6 +364,11 @@ module.exports = () => {
       new rspack.DefinePlugin({
         "process.env.NODE_ENV": JSON.stringify("development"),
         "process.env.ORGII_DEV_EAGER_APP": JSON.stringify(String(eagerDevApp)),
+        // Match webpack: browser startup must never read a runtime process global.
+        "process.env.ORGII_E2E": JSON.stringify(isE2E ? "1" : "0"),
+        "process.env.ORGII_AGENT_ORG_REDESIGN": JSON.stringify(
+          isE2E ? "1" : (process.env.ORGII_AGENT_ORG_REDESIGN ?? "1")
+        ),
         "process.env.ORGII_IDE_SERVER_PORT": JSON.stringify(
           process.env.ORGII_IDE_SERVER_PORT ?? "13847"
         ),

--- a/scripts/dev/rspack-config-e2e.test.cjs
+++ b/scripts/dev/rspack-config-e2e.test.cjs
@@ -1,0 +1,163 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+const rspack = require("@rspack/core");
+const ts = require("typescript");
+
+const createRspackConfig = require("../../config/rspack.config.js");
+
+// Discover actual expressions (excluding comments and test-only Node code).
+// Compiling them catches new env reads that lack a browser build definition.
+async function frontendEnvExpressions(root) {
+  const expressions = new Set();
+  async function walk(directory) {
+    for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+      const filename = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== "__tests__") await walk(filename);
+      } else if (
+        /\.[jt]sx?$/.test(entry.name) &&
+        !/\.(test|spec|d)\.[jt]sx?$/.test(entry.name)
+      ) {
+        const source = ts.createSourceFile(
+          filename,
+          await fs.readFile(filename, "utf8"),
+          ts.ScriptTarget.Latest,
+          true
+        );
+        function visit(node) {
+          if (
+            ts.isPropertyAccessExpression(node) &&
+            ts.isPropertyAccessExpression(node.expression) &&
+            node.expression.expression.getText(source) === "process" &&
+            node.expression.name.text === "env"
+          ) {
+            expressions.add(`process.env.${node.name.text}`);
+          }
+          ts.forEachChild(node, visit);
+        }
+        visit(source);
+      }
+    }
+  }
+  await walk(root);
+  return [...expressions].sort();
+}
+
+const envExpressions = frontendEnvExpressions(
+  path.resolve(__dirname, "../../src")
+);
+
+for (const [name, e2e, webdriver, exposed, rollout, enabled] of [
+  ["ordinary dev", undefined, undefined, false, undefined, true],
+  ["explicit E2E", "1", undefined, true, "0", true],
+  ["WebDriver", "0", "1", true, "0", true],
+  ["rollout opt-out", undefined, undefined, false, "0", false],
+]) {
+  test(`${name} startup configs run without a browser process global`, async () => {
+    const keys = [
+      "ORGII_E2E",
+      "WEBDRIVER",
+      "ORGII_IDE_SERVER_PORT",
+      "ORGII_AGENT_ORG_REDESIGN",
+    ];
+    const previous = keys.map((key) => process.env[key]);
+    let config;
+    try {
+      for (const [index, value] of [
+        e2e,
+        webdriver,
+        "13847",
+        rollout,
+      ].entries()) {
+        if (value === undefined) delete process.env[keys[index]];
+        else process.env[keys[index]] = value;
+      }
+      config = createRspackConfig();
+    } finally {
+      keys.forEach((key, index) => {
+        if (previous[index] === undefined) delete process.env[key];
+        else process.env[key] = previous[index];
+      });
+    }
+
+    const outputPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "orgii-ide-env-")
+    );
+    const compiler = rspack.rspack({
+      mode: config.mode,
+      context: config.context,
+      target: "web",
+      entry: {
+        ide: "./src/config/ideServer.ts",
+        rollout: "./src/config/agentOrgRedesign.ts",
+        env: `data:text/javascript,${encodeURIComponent(`export default [${(await envExpressions).join(",")}];`)}`,
+      },
+      module: config.module,
+      resolve: config.resolve,
+      plugins: config.plugins.filter(
+        (plugin) => plugin.constructor.name === "DefinePlugin"
+      ),
+      devtool: false,
+      output: {
+        path: outputPath,
+        filename: "[name].js",
+        library: { name: "ideConfig", type: "var" },
+      },
+    });
+    try {
+      await new Promise((resolve, reject) => {
+        compiler.run((error, stats) => {
+          if (error) return reject(error);
+          if (stats.hasErrors()) return reject(new Error(stats.toString()));
+          resolve();
+        });
+      });
+      const context = vm.createContext({ window: {} });
+      vm.runInNewContext(
+        await fs.readFile(path.join(outputPath, "env.js"), "utf8"),
+        {}
+      );
+      vm.runInContext(
+        await fs.readFile(path.join(outputPath, "ide.js"), "utf8"),
+        context
+      );
+      const rolloutContext = vm.createContext({});
+      vm.runInContext(
+        await fs.readFile(path.join(outputPath, "rollout.js"), "utf8"),
+        rolloutContext
+      );
+      assert.equal(
+        rolloutContext.ideConfig.AGENT_ORG_REDESIGN_ENABLED,
+        enabled
+      );
+      const key = "__ORGII_E2E_IDE_SERVER_WS_URL__";
+      assert.equal(
+        context.window[key],
+        exposed ? "ws://localhost:13847/ws" : undefined
+      );
+      assert.equal(
+        context.ideConfig.configureIdeServerForIdentifier(
+          "org2ai.org2.instance2"
+        ),
+        13848
+      );
+      assert.equal(
+        context.ideConfig.IDE_SERVER_WS_URL,
+        "ws://localhost:13848/ws"
+      );
+      assert.equal(
+        context.window[key],
+        exposed ? "ws://localhost:13848/ws" : undefined
+      );
+    } finally {
+      await new Promise((resolve, reject) => {
+        compiler.close((error) => (error ? reject(error) : resolve()));
+      });
+      await fs.rm(outputPath, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
## Problem

Rspack development bundles left `process.env.ORGII_E2E` and `process.env.ORGII_AGENT_ORG_REDESIGN` unresolved. Browser module evaluation consequently threw `ReferenceError: Can't find variable: process`, first in `ideServer.ts` and then in `agentOrgRedesign.ts` while loading App. Webpack already defined both constants.

## Solution

Define both constants in Rspack with the same semantics as Webpack: ordinary development disables E2E helpers and enables the Agent Org rollout by default, an explicit rollout opt-out is preserved, and E2E/WebDriver builds force-enable the rollout.

Add compilation regression tests using the real Rspack configuration and startup modules, evaluated in VM contexts without a `process` global. Cover ordinary development, explicit E2E, WebDriver, and rollout opt-out, including isolated-instance IDE URL updates. Discover frontend property-access environment expressions through the TypeScript AST and compile/evaluate them to catch missing definitions beyond these two modules.

## Potential risks

This changes development build constants only; production Webpack behavior, dependencies, stored data, and IPC formats are unchanged. Running dev servers must be restarted because the configuration is read at startup. Roll back by reverting this commit and restarting the server, although that restores the original startup failures. The AST coverage targets property-access environment reads and does not claim coverage of computed or aliased environment access. Full desktop UI behavior and cross-platform launches were not exercised.

## Verification

- `node --test scripts/dev/rspack-config-e2e.test.cjs scripts/dev/rspack-config-mobile.test.cjs scripts/dev/webpack-config-light.test.cjs` — 13 tests passed in an isolated worktree based on the latest `origin/develop`.
- Regression tests reproduced `process is not defined` before the respective missing definitions were added.
- `git diff --check origin/develop...HEAD` — passed.
- Repository commit hooks — lint-staged and commitlint passed; TypeScript and Rust checks were skipped by the hooks because no TypeScript or Rust files changed.
- Local runtime check: restarted the Rspack/Tauri development session, fetched `src_App_tsx.js` over HTTP, and verified the rollout value was inlined with no runtime `process` reference in that module. The Tauri binary relaunched. This check used the original working tree; the isolated PR worktree received the automated checks above.
- Full production build, rendered E2E suite, and desktop GUI inspection were not run. Screenshots are not useful for this build-configuration fix; there are no visual layout changes.
