### PR TITLE
test(agent-org): align persistence failure assertion

### DIFF
--- a/src-tauri/crates/agent-core/src/core/session/turn/event_handler/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/event_handler/mod.rs
@@ -1654,7 +1654,9 @@ mod tests {
         let error = handler
             .take_assistant_persistence_error()
             .expect("unregistered durable EventStore bridge must fail closed");
-        assert!(error.contains("event pipeline persistence is not registered"));
+        assert!(error.contains(
+            "persist_events (agent-org-assistant-final) called before register for agent-org-session"
+        ));
         assert!(handler.take_assistant_persistence_error().is_none());
     }
 


### PR DESCRIPTION
## Problem

Eight pull requests in the merged 20-PR Agent Org stack (#834, #835, #841, #869, #881, #888, #1153, and #1440) failed the Rust CI job on the same regression test. The test still expected the pre-#1458 persistence-bridge error text after `develop` changed that diagnostic to include the operation label and session context.

## Solution

Update the existing Agent Org durable-assistant regression assertion to match the current bridge error contract, including `persist_events`, the `agent-org-assistant-final` label, and the exact test session. Production behavior is unchanged: an unregistered durability bridge still fails closed, the error remains observable by the turn owner, and the error can only be taken once.

## Potential risks

The change only updates one Rust unit-test assertion and does not modify production code, persistence, concurrency, lifecycle, public APIs, IPC, or wire formats. The remaining risk is future intentional rewording of this diagnostic; the assertion deliberately checks the operation label and session context because those identify the owning failure path. Rollback is the single commit.

## Verification

- `cargo test -p agent_core --lib core::session::turn::event_handler::tests::agent_org_assistant_persistence_failure_is_retained_for_turn_owner -- --exact` — passed on the final rebased commit after reproducing the old assertion failure.
- `cargo test -p agent_core --lib --no-fail-fast` — 3,545 passed, 0 failed, 3 ignored on the final rebased commit.
- `cargo clippy -p agent_core --all-targets -- -D warnings` — passed on the final rebased commit.
- `git diff --check upstream/develop...HEAD` — passed.
- `cargo fmt --check --all` — not green because current `develop` contains unrelated pre-existing rustfmt drift across files outside this PR; this PR does not touch or reformat those files.
- Full workspace CI was not run locally; GitHub CI will run it on this PR.
- UI screenshots are not applicable because this is a test-only assertion update with no user-visible behavior.
