### PR TITLE
fix(modals): name dialogs with rich titles

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ModalAudit-names.md
+++ b/docs/frontend-ui-audit-2026-09-10/ModalAudit-names.md
@@ -1,0 +1,14 @@
+# Modal names UI audit
+
+Implementation follow-up to the modal audit. Scope is this PR only.
+
+| Line                                    | Element                          | Verdict          | Reason                                                           | Suggested change                        |
+| --------------------------------------- | -------------------------------- | ---------------- | ---------------------------------------------------------------- | --------------------------------------- |
+| `src/scaffold/ModalSystem/index.tsx:64` | Rich-title accessible name       | fix              | ReactNode titles previously had no name relationship             | Associate only title content with useId |
+| `src/scaffold/ModalSystem/index.tsx:64` | String title and header controls | keep with reason | Preserve existing string names and exclude actions from the name | Retain                                  |
+
+Verdict totals: **1 fix**, **1 keep with reason**, **0 abstract**. The fix is implemented; multi-site patterns count once.
+
+Associate rich title content with a unique aria-labelledby target and accept an explicit aria-label for dialogs without a visible title. Preserve the existing string-title behavior and keep header actions outside the label.
+
+Rich titles gain a wrapper around their label content. Automated DOM coverage checks names and unique IDs; native screen-reader and visual checks were not run because computer control was not authorized. No persistence, network or dependency changes.

--- a/src/scaffold/ModalSystem/ModalSystem.test.ts
+++ b/src/scaffold/ModalSystem/ModalSystem.test.ts
@@ -214,4 +214,62 @@ describe("Modal opening focus", () => {
     const icon = back.querySelector('[data-icon="arrow-left"]');
     expect(icon).not.toBeNull();
   });
+  it("names JSX-title dialogs without including header actions", () => {
+    act(() =>
+      root.render(
+        createElement(Modal, {
+          visible: true,
+          title: createElement("span", null, "Move session to organization"),
+          headerActions: createElement("button", null, "Help"),
+        })
+      )
+    );
+    const dialog = document.querySelector('[role="dialog"]')!;
+    const labelId = dialog.getAttribute("aria-labelledby");
+    expect(labelId).toBeTruthy();
+    expect(document.getElementById(labelId!)?.textContent).toBe(
+      "Move session to organization"
+    );
+  });
+
+  it("supports an explicit name without a header", () => {
+    act(() =>
+      root.render(
+        createElement(Modal, { visible: true, "aria-label": "Sign in" })
+      )
+    );
+    const dialog = document.querySelector('[role="dialog"]')!;
+    expect(dialog.getAttribute("aria-label")).toBe("Sign in");
+    expect(dialog.hasAttribute("aria-labelledby")).toBe(false);
+  });
+
+  it("keeps string names and gives simultaneous JSX titles unique ids", () => {
+    act(() =>
+      root.render(
+        createElement(
+          "div",
+          null,
+          createElement(Modal, { visible: true, title: "Plain title" }),
+          createElement(Modal, {
+            visible: true,
+            title: createElement("span", null, "First"),
+          }),
+          createElement(Modal, {
+            visible: true,
+            title: createElement("span", null, "Second"),
+          })
+        )
+      )
+    );
+    const dialogs = [...document.querySelectorAll('[role="dialog"]')];
+    expect(dialogs[0].getAttribute("aria-label")).toBe("Plain title");
+    const ids = dialogs
+      .slice(1)
+      .map((dialog) => dialog.getAttribute("aria-labelledby"));
+    expect(new Set(ids).size).toBe(2);
+    expect(ids.map((id) => document.getElementById(id!)?.textContent)).toEqual([
+      "First",
+      "Second",
+    ]);
+  });
 });

--- a/src/scaffold/ModalSystem/index.tsx
+++ b/src/scaffold/ModalSystem/index.tsx
@@ -14,7 +14,7 @@
  * - Keyboard navigation support
  * - Support for okButtonProps and cancelButtonProps for button styling
  */
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import Button from "@src/components/Button";
@@ -72,6 +72,8 @@ interface ModalProps {
   onOk?: () => void | Promise<void>;
   /** Modal title */
   title?: React.ReactNode;
+  /** Accessible name for dialogs without a visible title; overrides title. */
+  "aria-label"?: string;
   /** Modal content */
   children?: React.ReactNode;
   /** Footer content (buttons, etc) */
@@ -136,6 +138,7 @@ const Modal: React.FC<ModalProps> = ({
   onCancel,
   onOk,
   title,
+  "aria-label": ariaLabel,
   children,
   footer,
   footerTopBorder = true,
@@ -162,6 +165,7 @@ const Modal: React.FC<ModalProps> = ({
   topDragZoneHeight = 0,
   style,
 }) => {
+  const titleId = useId();
   const handleClose = onClose || onCancel;
   const modalRef = useRef<HTMLDivElement>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
@@ -384,7 +388,10 @@ const Modal: React.FC<ModalProps> = ({
       onClick={handleMaskClick}
       role="dialog"
       aria-modal="true"
-      aria-label={typeof title === "string" ? title : undefined}
+      aria-label={ariaLabel ?? (typeof title === "string" ? title : undefined)}
+      aria-labelledby={
+        !ariaLabel && title && typeof title !== "string" ? titleId : undefined
+      }
     >
       {/* Backdrop/Mask */}
       <div
@@ -442,7 +449,9 @@ const Modal: React.FC<ModalProps> = ({
                 ) : undefined
               }
             >
-              {typeof title === "string" ? undefined : title}
+              {typeof title === "string" ? undefined : (
+                <div id={titleId}>{title}</div>
+              )}
             </PanelHeader>
           )}
 


### PR DESCRIPTION
## Problem

Modal accepts ReactNode titles but only string titles supplied an accessible dialog name. Move-to-organization and secret-capture dialogs therefore rendered visible titles without exposing their names to assistive technology.

## Solution

Associate rich title content with a unique aria-labelledby target and accept an explicit aria-label for dialogs without a visible title. Preserve the existing string-title behavior and keep header actions outside the label.

## Potential risks

Rich titles gain a wrapper around their label content. Automated DOM coverage checks names and unique IDs; native screen-reader and visual checks were not run because computer control was not authorized. No persistence, network or dependency changes.

## Verification

- `pnpm typecheck:fast` — passed.
- `pnpm test -- src/scaffold/ModalSystem/ModalSystem.test.ts` — 11 tests passed.
- `pnpm exec eslint src/scaffold/ModalSystem/ModalSystem.test.ts src/scaffold/ModalSystem/index.tsx --max-warnings 0` — passed.
- `git diff --check` — passed.
- Source/prop/caller review and scoped diff inspection completed. Existing Vite CJS and Sass legacy API deprecation notices remain.
- Full application E2E, native visual checks and Rust checks were not run; this change is frontend-only.

## Audit

Scoped UI audit: `docs/frontend-ui-audit-2026-09-10/ModalAudit-names.md` (1 fix, 1 keep with reason, 0 abstract).
