### PR TITLE
fix(modals): honor semantic action button statuses

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ModalAudit-status.md
+++ b/docs/frontend-ui-audit-2026-09-10/ModalAudit-status.md
@@ -1,0 +1,14 @@
+# Modal status UI audit
+
+Implementation follow-up to the modal audit. Scope is this PR only.
+
+| Line                                       | Element               | Verdict          | Reason                                                   | Suggested change                      |
+| ------------------------------------------ | --------------------- | ---------------- | -------------------------------------------------------- | ------------------------------------- |
+| `src/scaffold/ModalSystem/index.tsx:64`    | Action status mapping | fix              | Accepted warning/success statuses were silently ignored  | Use existing Button semantic variants |
+| `src/components/Button/presentation.tsx:1` | Semantic palettes     | keep with reason | The design system already supports all required statuses | Reuse existing tokens                 |
+
+Verdict totals: **1 fix**, **1 keep with reason**, **0 abstract**. The fix is implemented; multi-site patterns count once.
+
+Forward every supported semantic status to the existing Button variant API; keep default and omitted status mapped to primary. Cover danger, warning, success, default and omitted values on rendered actions.
+
+The work-item return action now uses the intended warning palette. Existing danger/default behavior is covered. Native visual checks were not run because computer control was not authorized; no dependency, persistence or wire changes.

--- a/src/scaffold/ModalSystem/ModalSystem.status.test.ts
+++ b/src/scaffold/ModalSystem/ModalSystem.status.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Modal from "./index";
+
+describe("Modal action status", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+  it.each([
+    ["danger", "bg-danger-6"],
+    ["warning", "bg-warning-6"],
+    ["success", "bg-success-6"],
+    ["default", "bg-primary-6"],
+    [undefined, "bg-primary-6"],
+  ] as const)(
+    "renders the requested %s status on the actual action",
+    (status, color) => {
+      const onOk = vi.fn();
+      act(() =>
+        root.render(
+          createElement(Modal, {
+            visible: true,
+            title: "Confirm",
+            onOk,
+            okButtonProps: { status, loading: false },
+          })
+        )
+      );
+      const primary = [
+        ...document.querySelectorAll<HTMLButtonElement>("button"),
+      ].find((button) => button.textContent === "OK")!;
+      expect(primary.classList.contains(color)).toBe(true);
+      act(() => primary.click());
+      expect(onOk).toHaveBeenCalledOnce();
+    }
+  );
+});

--- a/src/scaffold/ModalSystem/index.tsx
+++ b/src/scaffold/ModalSystem/index.tsx
@@ -229,7 +229,9 @@ const Modal: React.FC<ModalProps> = ({
       const isLoading = okButtonProps?.loading ?? okLoading;
       const isDisabled = okButtonProps?.disabled;
       const primaryVariant =
-        okButtonProps?.status === "danger" ? "danger" : "primary";
+        !okButtonProps?.status || okButtonProps.status === "default"
+          ? "primary"
+          : okButtonProps.status;
 
       return (
         <PanelFooter


### PR DESCRIPTION
## Problem

ModalProps allowed warning and success action statuses, but the implementation rendered both as primary. The work-item return dialog already requests warning.

## Solution

Forward every supported semantic status to the existing Button variant API; keep default and omitted status mapped to primary. Cover danger, warning, success, default and omitted values on rendered actions.

## Potential risks

The work-item return action now uses the intended warning palette. Existing danger/default behavior is covered. Native visual checks were not run because computer control was not authorized; no dependency, persistence or wire changes.

## Verification

- `pnpm typecheck:fast` — passed.
- `pnpm test -- src/scaffold/ModalSystem/ModalSystem.test.ts src/scaffold/ModalSystem/ModalSystem.status.test.ts` — 13 tests passed.
- `pnpm exec eslint src/scaffold/ModalSystem/ModalSystem.status.test.ts src/scaffold/ModalSystem/index.tsx --max-warnings 0` — passed.
- `git diff --check` — passed.
- Source/prop/caller review and scoped diff inspection completed. Existing Vite CJS and Sass legacy API deprecation notices remain.
- Full application E2E, native visual checks and Rust checks were not run; this change is frontend-only.

## Audit

Scoped UI audit: `docs/frontend-ui-audit-2026-09-10/ModalAudit-status.md` (1 fix, 1 keep with reason, 0 abstract).
