### PR TITLE
refactor(modals): remove ignored default footer props

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ModalAudit-footer.md
+++ b/docs/frontend-ui-audit-2026-09-10/ModalAudit-footer.md
@@ -1,0 +1,14 @@
+# Modal footer UI audit
+
+Implementation follow-up to the modal audit. Scope is this PR only.
+
+| Line                                                                                                                                                                                                                                                                                         | Element                  | Verdict          | Reason                                                         | Suggested change        |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ---------------- | -------------------------------------------------------------- | ----------------------- |
+| `src/util/dialogs/gitAuthenticationDialog.tsx:47`; `src/modules/MainApp/WorkManagement/CreateIssueModal.tsx:104`; `src/scaffold/AppUpdater/index.tsx:57`; `src/scaffold/ModalSystem/variants/Quit/index.tsx:59`; `src/engines/ChatPanel/InputArea/components/AgentOrgOverviewPanel.tsx:1552` | Custom-footer prop sweep | fix              | Seven live sites supplied ignored default-footer configuration | Remove only inert props |
+| `src/scaffold/ModalSystem/index.tsx:64`                                                                                                                                                                                                                                                      | Custom footer override   | keep with reason | Explicit footer content intentionally owns its actions         | Retain                  |
+
+Verdict totals: **1 fix**, **1 keep with reason**, **0 abstract**. The fix is implemented; multi-site patterns count once.
+
+Remove inert onOk/label/button props from git authentication and issue creation, and inert footerTopBorder props from updater, quit and three team-overview modals. Retain the explicit custom-footer handlers and styling. The eighth audited site is the dead Login modal, removed in the separate cleanup PR.
+
+No user-visible behavior change is intended: removed props were bypassed by custom footers. Future default-footer migrations must supply their own configuration. Screenshots add no evidence for removal of ignored props; no native interactions were performed.

--- a/src/engines/ChatPanel/InputArea/components/AgentOrgOverviewPanel.tsx
+++ b/src/engines/ChatPanel/InputArea/components/AgentOrgOverviewPanel.tsx
@@ -1566,7 +1566,6 @@ const AgentOrgOverviewPanel: React.FC<AgentOrgOverviewPanelProps> = memo(
           closable={!isMutatingTask}
           onCancel={() => !isMutatingTask && setTaskActionDialog(null)}
           bodyClassName="space-y-3 px-5 py-4"
-          footerTopBorder={false}
           footer={
             <div className="flex h-12 items-center justify-end gap-2 px-3">
               <Button
@@ -1651,7 +1650,6 @@ const AgentOrgOverviewPanel: React.FC<AgentOrgOverviewPanelProps> = memo(
           closable={!isMutatingTask}
           onCancel={() => !isMutatingTask && setHandoffResolutionDialog(null)}
           bodyClassName="space-y-3 px-5 py-4"
-          footerTopBorder={false}
           footer={
             <div className="flex h-12 items-center justify-end gap-2 px-3">
               <Button
@@ -1726,7 +1724,6 @@ const AgentOrgOverviewPanel: React.FC<AgentOrgOverviewPanelProps> = memo(
           closable={!isDeleting}
           onCancel={closeDeleteModal}
           bodyClassName="space-y-3 px-5 py-4"
-          footerTopBorder={false}
           footer={
             <div className="flex h-12 items-center justify-end gap-2 px-3">
               <Button

--- a/src/modules/MainApp/WorkManagement/CreateIssueModal.tsx
+++ b/src/modules/MainApp/WorkManagement/CreateIssueModal.tsx
@@ -105,10 +105,6 @@ export function CreateIssueModal({
       visible={open}
       title={labels.title}
       onCancel={handleCancel}
-      onOk={handleCreate}
-      okText={creating ? labels.creating : labels.create}
-      cancelText={labels.cancel}
-      okButtonProps={{ loading: creating, disabled: !source || !title.trim() }}
       footer={
         <PanelFooter
           left={

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -68,7 +68,6 @@ export const AppUpdater: React.FC = () => {
         onCancel={handleInstallLater}
         onClose={handleInstallLater}
         bodyClassName="px-6 py-5"
-        footerTopBorder={false}
         footer={
           <div className="flex items-center justify-between gap-3 px-5 py-4">
             <Button

--- a/src/scaffold/ModalSystem/variants/Quit/index.tsx
+++ b/src/scaffold/ModalSystem/variants/Quit/index.tsx
@@ -64,7 +64,6 @@ const QuitConfirmationModal = () => {
       maskClosable={false}
       onCancel={handleCancel}
       bodyClassName="px-5 py-3"
-      footerTopBorder={false}
       footer={
         <div className="flex h-12 items-center justify-end gap-2 px-3">
           <Button variant="tertiary" onClick={handleCancel}>

--- a/src/util/dialogs/gitAuthenticationDialog.tsx
+++ b/src/util/dialogs/gitAuthenticationDialog.tsx
@@ -49,9 +49,6 @@ function GitAuthenticationDialog({ onResolve }: GitAuthenticationDialogProps) {
       title={t("git.authDialog.title")}
       width={460}
       topDragZoneHeight={APP_TOP_DRAG_ZONE_HEIGHT}
-      okText={t("git.authDialog.openGitSettingsButton")}
-      cancelText={t("actions.cancel")}
-      onOk={handleOpenConnections}
       onCancel={handleCancel}
       onClose={handleCancel}
       maskClosable={false}


### PR DESCRIPTION
## Problem

Seven live custom-footer modal call sites also passed default-footer props. Modal returns custom footer content before consuming those props, so the duplicate configuration has no effect and misrepresents action ownership.

## Solution

Remove inert onOk/label/button props from git authentication and issue creation, and inert footerTopBorder props from updater, quit and three team-overview modals. Retain the explicit custom-footer handlers and styling. The eighth audited site is the dead Login modal, removed in the separate cleanup PR.

## Potential risks

No user-visible behavior change is intended: removed props were bypassed by custom footers. Future default-footer migrations must supply their own configuration. Screenshots add no evidence for removal of ignored props; no native interactions were performed.

## Verification

- `pnpm typecheck:fast` — passed.
- `pnpm test -- src/scaffold/ModalSystem/ModalSystem.test.ts` — 8 tests passed.
- `pnpm exec eslint src/engines/ChatPanel/InputArea/components/AgentOrgOverviewPanel.tsx src/modules/MainApp/WorkManagement/CreateIssueModal.tsx src/scaffold/AppUpdater/index.tsx src/scaffold/ModalSystem/variants/Quit/index.tsx src/util/dialogs/gitAuthenticationDialog.tsx --max-warnings 0` — passed.
- `git diff --check` — passed.
- Source/prop/caller review and scoped diff inspection completed. Existing Vite CJS and Sass legacy API deprecation notices remain.
- Full application E2E, native visual checks and Rust checks were not run; this change is frontend-only.

## Audit

Scoped UI audit: `docs/frontend-ui-audit-2026-09-10/ModalAudit-footer.md` (1 fix, 1 keep with reason, 0 abstract).
