### PR TITLE
fix(modals): block header dismissal during pending operations

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ModalAudit-dismiss.md
+++ b/docs/frontend-ui-audit-2026-09-10/ModalAudit-dismiss.md
@@ -1,0 +1,14 @@
+# Modal dismiss UI audit
+
+Implementation follow-up to the modal audit. Scope is this PR only.
+
+| Line                                                                                                                                                                                                                               | Element                | Verdict          | Reason                                                              | Suggested change                    |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ---------------- | ------------------------------------------------------------------- | ----------------------------------- |
+| `src/modules/MainApp/TeamInbox/components/SessionHandoffComposer.tsx:99`; `src/scaffold/NavigationSidebar/connectors/SessionImportExportModal.tsx:204`; `src/modules/WorkStation/Browser/ImportCookies/ImportCookiesModal.tsx:463` | Busy dismissal sweep   | fix              | Header X bypassed the existing busy dismissal policy at three sites | Use closable={!busy}                |
+| `src/scaffold/ModalSystem/index.tsx:64`                                                                                                                                                                                            | Existing closure props | keep with reason | The shared primitive already exposes the necessary controls         | Retain its independent close routes |
+
+Verdict totals: **1 fix**, **1 keep with reason**, **0 abstract**. The fix is implemented; multi-site patterns count once.
+
+Bind header closability to the same busy state already used by the other dismissal controls in all three callers. Add rendered tests for blocked close controls and closure returning after the operation settles.
+
+Users must wait for an in-flight operation to settle before closing through the header, consistent with each existing Cancel/Escape policy. This does not add cancellation or timeouts to the underlying requests. Native Tauri operations and visual checks were not run because computer control was not authorized.

--- a/docs/org2-performance-guard-2026-09-10/ModalAudit-dismiss.md
+++ b/docs/org2-performance-guard-2026-09-10/ModalAudit-dismiss.md
@@ -1,0 +1,12 @@
+# Modal lifecycle review
+
+| Area               | Verdict | Evidence                                                       | Change or reason kept                                                        | Verification                 |
+| ------------------ | ------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------- |
+| Background work    | keep    | Existing handoff/export/import operations own their requests   | No new requests/timers/listeners                                             | Rendered busy-state tests    |
+| Memory             | keep    | Modal remains visible while existing work is pending           | No new retained structures                                                   | Pending export write test    |
+| Scope/isolation    | keep    | Existing request identity and cancellation ownership unchanged | Align only header dismissibility with existing cancel/Escape/backdrop policy | Three owning component tests |
+| Rendering/hot path | keep    | Existing busy state controls a primitive prop                  | No additional subscription or polling                                        | Typecheck and rendered tests |
+
+Lifecycle: idle closure remains available; active request blocks all modal dismissal controls; settled success/error restores existing closure behavior. App/identity/scope teardown remains owned by existing parents. Hidden state adds no work. No backend cancellation semantics are changed.
+
+Performance verdict: pass for the scoped prop-only change, supported by source inspection and rendered busy/settled-state tests. No runtime CPU/RSS improvement or native-operation verification is claimed.

--- a/src/modules/MainApp/TeamInbox/__tests__/SessionHandoffComposer.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/SessionHandoffComposer.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import React, { act, createElement } from "react";
+import { act, createElement } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import {
   afterAll,
@@ -23,11 +23,6 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
   }),
-}));
-
-vi.mock("@src/scaffold/ModalSystem", () => ({
-  default: ({ children }: { children?: React.ReactNode }) =>
-    createElement("div", { "data-testid": "modal" }, children),
 }));
 
 vi.mock("@src/components/Input", () => ({
@@ -177,7 +172,7 @@ describe("SessionHandoffComposer", () => {
       targetDate: "2026-07-30T00:00:00.000Z",
     });
 
-    const properties = container.querySelector(
+    const properties = document.body.querySelector(
       "[data-testid='shared-work-item-properties']"
     );
     expect(properties?.getAttribute("data-visible-fields")).toBe(
@@ -202,7 +197,7 @@ describe("SessionHandoffComposer", () => {
     const onChange = renderComposer(form);
 
     act(() => {
-      container
+      document.body
         .querySelector<HTMLButtonElement>(
           "[data-testid='update-shared-properties']"
         )
@@ -221,13 +216,13 @@ describe("SessionHandoffComposer", () => {
     const form = createSessionHandoffForm(DRAFT);
     const onChange = renderComposer(form, undefined, true);
 
-    const fieldset = container.querySelector(
+    const fieldset = document.body.querySelector(
       "[data-testid='team-inbox-handoff-properties']"
     );
     expect(fieldset?.hasAttribute("disabled")).toBe(true);
 
     act(() => {
-      container
+      document.body
         .querySelector<HTMLButtonElement>(
           "[data-testid='update-shared-properties']"
         )
@@ -242,8 +237,45 @@ describe("SessionHandoffComposer", () => {
       assigneeMemberId: "removed-member",
     });
 
-    expect(container.querySelector("[role='alert']")?.textContent).toBe(
+    expect(document.body.querySelector("[role='alert']")?.textContent).toBe(
       "teamInbox.handoff.validation.recipient_unavailable"
     );
+  });
+  it("blocks every close control while submitting and restores the header after failure", () => {
+    const onCancel = vi.fn();
+    const render = (submitting: boolean) =>
+      act(() =>
+        root.render(
+          createElement(SessionHandoffComposer, {
+            draft: DRAFT,
+            form: createSessionHandoffForm(DRAFT),
+            submitting,
+            onCancel,
+            onChange: vi.fn(),
+            onSubmit: vi.fn(),
+          })
+        )
+      );
+    render(true);
+    expect(document.querySelector('button[title="Close"]')).toBeNull();
+    const cancel = [
+      ...document.querySelectorAll<HTMLButtonElement>("button"),
+    ].find((b) => b.textContent === "common:actions.cancel")!;
+    expect(cancel.disabled).toBe(true);
+    act(() => {
+      cancel.click();
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      );
+      document.querySelector<HTMLElement>(".liquid-modal-mask")!.click();
+    });
+    expect(onCancel).not.toHaveBeenCalled();
+    render(false);
+    act(() =>
+      document
+        .querySelector<HTMLButtonElement>('button[title="Close"]')!
+        .click()
+    );
+    expect(onCancel).toHaveBeenCalledOnce();
   });
 });

--- a/src/modules/MainApp/TeamInbox/components/SessionHandoffComposer.tsx
+++ b/src/modules/MainApp/TeamInbox/components/SessionHandoffComposer.tsx
@@ -113,6 +113,7 @@ const SessionHandoffComposer: React.FC<SessionHandoffComposerProps> = ({
         loading: submitting,
         disabled: Boolean(validationError),
       }}
+      closable={!submitting}
       cancelButtonProps={{ disabled: submitting }}
       maskClosable={!submitting}
       escToExit={!submitting}

--- a/src/modules/WorkStation/Browser/ImportCookies/ImportCookiesModal.test.ts
+++ b/src/modules/WorkStation/Browser/ImportCookies/ImportCookiesModal.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+
+import ImportCookiesModal from "./ImportCookiesModal";
+import type { ImportCookiesController } from "./useImportCookiesController";
+
+const state = vi.hoisted(() => ({ importing: true }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("./useImportCookiesController", () => ({
+  useImportCookiesController: () =>
+    ({
+      stage: "preview",
+      sourcesLoading: false,
+      sources: [],
+      unavailableSource: null,
+      activeSource: null,
+      previewLoading: false,
+      preview: null,
+      selectedDomains: new Set<string>(),
+      importing: state.importing,
+      result: null,
+      selectSource: vi.fn(),
+      refreshSources: vi.fn(),
+      openFullDiskAccessSettings: vi.fn(),
+      toggleDomain: vi.fn(),
+      setAllDomains: vi.fn(),
+      runImport: vi.fn(),
+      backToSources: vi.fn(),
+    }) satisfies ImportCookiesController,
+}));
+afterEach(() => vi.unstubAllGlobals());
+it("prevents dismissal during import and restores closure after the request settles", () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const onClose = vi.fn();
+  const render = () =>
+    act(() => root.render(createElement(ImportCookiesModal, { onClose })));
+  try {
+    render();
+    expect(document.querySelector('button[title="Close"]')).toBeNull();
+    const cancel = [
+      ...document.querySelectorAll<HTMLButtonElement>("button"),
+    ].find((b) => b.textContent === "actions.cancel")!;
+    expect(cancel.disabled).toBe(true);
+    act(() => {
+      cancel.click();
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      );
+      document.querySelector<HTMLElement>(".liquid-modal-mask")!.click();
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    state.importing = false;
+    render();
+    act(() =>
+      document
+        .querySelector<HTMLButtonElement>('button[title="Close"]')!
+        .click()
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+  }
+});

--- a/src/modules/WorkStation/Browser/ImportCookies/ImportCookiesModal.tsx
+++ b/src/modules/WorkStation/Browser/ImportCookies/ImportCookiesModal.tsx
@@ -467,6 +467,7 @@ export const ImportCookiesModal: React.FC<ImportCookiesModalProps> = ({
       backLabel={t("actions.back")}
       title={t("browserCookieImport.title")}
       width={520}
+      closable={!importing}
       maskClosable={!importing}
       escToExit={!importing}
       footer={

--- a/src/scaffold/NavigationSidebar/connectors/SessionImportExportModal.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionImportExportModal.tsx
@@ -209,6 +209,7 @@ export function SessionImportExportModal({
       okText={okText}
       cancelText={t("common:actions.cancel")}
       okButtonProps={{ loading, disabled: okDisabled }}
+      closable={!loading}
       cancelButtonProps={{ disabled: loading }}
       width={mode === "export" ? 640 : 440}
       maskClosable={!loading}

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SessionImportExportModal.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SessionImportExportModal.test.ts
@@ -222,4 +222,27 @@ describe("SessionImportExportModal", () => {
     });
     expect(props.onClose).not.toHaveBeenCalled();
   });
+  it("keeps the export dialog open during a pending file write", async () => {
+    let resolveWrite!: () => void;
+    mocks.writeTextFile.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveWrite = resolve;
+      })
+    );
+    await render();
+    await act(async () => button("chat.importExport.exportAction").click());
+    expect(document.querySelector('button[title="Close"]')).toBeNull();
+    expect(button("common:actions.cancel").disabled).toBe(true);
+    act(() => {
+      button("common:actions.cancel").click();
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      );
+      document.querySelector<HTMLElement>(".liquid-modal-mask")!.click();
+    });
+    expect(props.onClose).not.toHaveBeenCalled();
+    await act(async () => resolveWrite());
+    expect(props.onClose).toHaveBeenCalledOnce();
+    expect(document.querySelector('button[title="Close"]')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Problem

Session handoff, session export and cookie import disabled cancel/backdrop/Escape during pending work but left the header close button active. That button could abort or hide the flow while the operation was unresolved.

## Solution

Bind header closability to the same busy state already used by the other dismissal controls in all three callers. Add rendered tests for blocked close controls and closure returning after the operation settles.

## Potential risks

Users must wait for an in-flight operation to settle before closing through the header, consistent with each existing Cancel/Escape policy. This does not add cancellation or timeouts to the underlying requests. Native Tauri operations and visual checks were not run because computer control was not authorized.

## Verification

- `pnpm typecheck:fast` — passed.
- `pnpm test -- src/modules/MainApp/TeamInbox/__tests__/SessionHandoffComposer.test.ts src/scaffold/NavigationSidebar/connectors/__tests__/SessionImportExportModal.test.ts src/modules/WorkStation/Browser/ImportCookies/ImportCookiesModal.test.ts` — 13 tests passed.
- `pnpm exec eslint src/modules/MainApp/TeamInbox/__tests__/SessionHandoffComposer.test.ts src/modules/MainApp/TeamInbox/components/SessionHandoffComposer.tsx src/modules/WorkStation/Browser/ImportCookies/ImportCookiesModal.test.ts src/modules/WorkStation/Browser/ImportCookies/ImportCookiesModal.tsx src/scaffold/NavigationSidebar/connectors/SessionImportExportModal.tsx src/scaffold/NavigationSidebar/connectors/__tests__/SessionImportExportModal.test.ts --max-warnings 0` — passed.
- `git diff --check` — passed.
- Source/prop/caller review and scoped diff inspection completed. Existing Vite CJS and Sass legacy API deprecation notices remain.
- Full application E2E, native visual checks and Rust checks were not run; this change is frontend-only.

## Audit

Scoped UI audit: `docs/frontend-ui-audit-2026-09-10/ModalAudit-dismiss.md` (1 fix, 1 keep with reason, 0 abstract).

Lifecycle review: `docs/org2-performance-guard-2026-09-10/ModalAudit-dismiss.md`.
