### PR TITLE
fix(key-vault): use the shared credential selection modal

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ModalAudit-keys.md
+++ b/docs/frontend-ui-audit-2026-09-10/ModalAudit-keys.md
@@ -1,0 +1,14 @@
+# Modal keys UI audit
+
+Implementation follow-up to the modal audit. Scope is this PR only.
+
+| Line                                                                              | Element                 | Verdict          | Reason                                                                              | Suggested change                     |
+| --------------------------------------------------------------------------------- | ----------------------- | ---------------- | ----------------------------------------------------------------------------------- | ------------------------------------ |
+| `src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.tsx:52` | Custom backdrop/header  | fix              | Bypassed named dialog, keyboard and overlay behavior                                | Use Modal and the existing footer    |
+| `src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.tsx:52` | Credential option cards | keep with reason | Selectable cards have native button semantics and dynamic credential detail content | Preserve validation and presentation |
+
+Verdict totals: **1 fix**, **1 keep with reason**, **0 abstract**. The fix is implemented; multi-site patterns count once.
+
+Compose the existing Modal with a string title and the existing credential body and PanelFooter. Cover named dialog semantics, selection validation, keyboard focus, Escape, focus restoration, overlay registration and repeated mount/unmount cleanup.
+
+The shared shell changes header spacing, portal placement and overlay stacking to the app defaults. The real Tauri/webview surface, themes and viewport layouts were not visually verified because computer control was not authorized. Shared modal timer/listener cleanup is tested; no CPU/RSS improvement is claimed. No API or persistence changes.

--- a/docs/org2-performance-guard-2026-09-10/ModalAudit-keys.md
+++ b/docs/org2-performance-guard-2026-09-10/ModalAudit-keys.md
@@ -1,0 +1,12 @@
+# Modal lifecycle review
+
+| Area               | Verdict | Evidence                                                       | Change or reason kept                                                          | Verification                                                                            |
+| ------------------ | ------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| Background work    | keep    | Modal owns one opening-focus timeout plus Escape/Tab listeners | Start only while mounted; shared cleanup runs on unmount                       | Rendered test asserts Escape stops after close and quick close clears the focus timeout |
+| Memory             | keep    | Overlay contribution belongs to mounted modal                  | Unmount returns store count to baseline; no cache or retained key copies added | Repeated mount/unmount test                                                             |
+| Scope/isolation    | keep    | Overlay reference uses the active Jotai store                  | Provider-scoped store; no identity/network requests added                      | Isolated-store test                                                                     |
+| Rendering/hot path | keep    | Credential data supplied by parent                             | Existing validation and card callbacks retained                                | Selection and token-detection tests                                                     |
+
+Lifecycle: closed/start/after-close owns no modal listener or overlay reference; open/active owns one of each. Hidden documents receive no new recurring work; the existing one-shot focus timeout is not changed. Network/account/scope changes do not create a new request or cache here. App shutdown follows unmount cleanup. Native webview layering and CPU/RSS were not measured.
+
+Performance verdict: blocked for real Tauri layering/measurement verification because computer control was not authorized. Automated resource-lifecycle checks pass; no measured performance claim is made.

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.test.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { type ComponentProps, act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { activeOverlayCountAtom } from "@src/store/ui/overlayLayerAtom";
+
+import KeySelectionModal from "./KeySelectionModal";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("../config", () => ({
+  useProviderConfig: () => ({ config: undefined }),
+  findEndpointByBaseUrl: () => null,
+}));
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+it("uses a named dialog, keeps selection validation, and disposes focus/overlay ownership", () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.useFakeTimers();
+  const schedule = vi.spyOn(globalThis, "setTimeout");
+  const cancelTimer = vi.spyOn(globalThis, "clearTimeout");
+  const store = createStore();
+  const opener = document.createElement("button");
+  const container = document.createElement("div");
+  document.body.append(opener, container);
+  opener.focus();
+  const root = createRoot(container);
+  const onClose = vi.fn();
+  const onConfirm = vi.fn();
+  const onSelectIndex = vi.fn();
+  const props: ComponentProps<typeof KeySelectionModal> = {
+    keys: [
+      {
+        id: "valid",
+        name: "Validated",
+        auth_method: "api_key",
+        validated: true,
+      },
+      {
+        id: "invalid",
+        name: "Invalid",
+        auth_method: "api_key",
+        validated: false,
+      },
+    ],
+    agentType: "openai_api",
+    selectedIndex: 0,
+    onClose,
+    onConfirm,
+    onSelectIndex,
+  };
+  const render = (open: boolean) =>
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          open ? createElement(KeySelectionModal, props) : null
+        )
+      )
+    );
+  try {
+    render(true);
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]')!;
+    expect(dialog.getAttribute("aria-label")).toBe(
+      "keyVault.quickActions.multipleKeysFound"
+    );
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(store.get(activeOverlayCountAtom)).toBe(1);
+    act(() => vi.advanceTimersByTime(150));
+    expect(dialog.contains(document.activeElement)).toBe(true);
+    const buttons = [...dialog.querySelectorAll<HTMLButtonElement>("button")];
+    const invalid = buttons.find((b) =>
+      b.textContent?.includes("keyVault.quickActions.invalid")
+    )!;
+    const valid = buttons.find((b) =>
+      b.textContent?.includes("keyVault.quickActions.valid")
+    )!;
+    act(() => {
+      invalid.click();
+      valid.click();
+    });
+    expect(onSelectIndex).toHaveBeenCalledOnce();
+    expect(onSelectIndex).toHaveBeenCalledWith(0);
+    const confirm = buttons.find(
+      (b) => b.textContent === "keyVault.quickActions.useSelected"
+    )!;
+    act(() => {
+      confirm.focus();
+      confirm.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+    expect(document.activeElement).toBe(buttons[0]);
+    act(() => confirm.click());
+    expect(onConfirm).toHaveBeenCalledOnce();
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      )
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+    render(false);
+    expect(document.activeElement).toBe(opener);
+    expect(store.get(activeOverlayCountAtom)).toBe(0);
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      )
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+
+    render(true);
+    expect(store.get(activeOverlayCountAtom)).toBe(1);
+    const focusTimerIndex = schedule.mock.calls
+      .map((call) => call[1])
+      .lastIndexOf(100);
+    expect(focusTimerIndex).toBeGreaterThanOrEqual(0);
+    const focusTimer = schedule.mock.results[focusTimerIndex].value;
+    render(false);
+    expect(cancelTimer).toHaveBeenCalledWith(focusTimer);
+    expect(store.get(activeOverlayCountAtom)).toBe(0);
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+    opener.remove();
+  }
+});

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.tsx
@@ -11,7 +11,6 @@ import type { DetectedKey, ModelType } from "@src/api/types/keys";
 import PageNotice from "@src/components/PageNotice";
 import {
   AlertCircleIcon,
-  Cancel01Icon,
   CheckmarkCircle01Icon,
   HugeiconsIcon,
   Key01Icon,
@@ -19,6 +18,7 @@ import {
   Tick01Icon,
 } from "@src/icons";
 import { PanelFooter } from "@src/modules/shared/layouts/blocks";
+import Modal from "@src/scaffold/ModalSystem";
 
 import { findEndpointByBaseUrl, useProviderConfig } from "../config";
 
@@ -49,177 +49,13 @@ const KeySelectionModal: React.FC<KeySelectionModalProps> = ({
     findEndpointByBaseUrl(providerConfig?.endpoints ?? [], baseUrl)?.label ??
     null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-xl bg-bg-2 shadow-2xl">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-border-2 p-4">
-          <h3 className="text-[15px] font-semibold text-text-1">
-            {t("keyVault.quickActions.multipleKeysFound")}
-          </h3>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-1 text-text-3 hover:bg-fill-2 hover:text-text-1"
-          >
-            <HugeiconsIcon icon={Cancel01Icon} data-icon="x" size={18} />
-          </button>
-        </div>
-
-        {/* Body */}
-        <div className="p-4">
-          <p className="mb-4 text-[13px] text-text-2">
-            {t("keyVault.keysFoundForAgent", {
-              count: keys.length,
-            })}
-          </p>
-
-          <div className="space-y-3">
-            {keys.map((cred, index) => (
-              <button
-                key={cred.id}
-                onClick={() => cred.validated && onSelectIndex(index)}
-                disabled={!cred.validated}
-                className={`w-full rounded-lg border p-4 text-left transition-all ${
-                  !cred.validated
-                    ? "cursor-not-allowed border-dashed border-danger-3 bg-danger-1"
-                    : selectedIndex === index
-                      ? "border-primary-6 bg-primary-1"
-                      : "border-border-2 bg-fill-2 hover:border-border-3 hover:bg-fill-1"
-                }`}
-              >
-                <div className="flex items-start gap-3">
-                  {/* Selection indicator */}
-                  {cred.validated ? (
-                    selectedIndex === index ? (
-                      <HugeiconsIcon
-                        icon={Tick01Icon}
-                        data-icon="check"
-                        size={16}
-                        className="mt-0.5 shrink-0 text-primary-6"
-                      />
-                    ) : (
-                      <div className="mt-0.5 h-4 w-4 shrink-0" />
-                    )
-                  ) : (
-                    <HugeiconsIcon
-                      icon={AlertCircleIcon}
-                      data-icon="alert-circle"
-                      size={16}
-                      className="mt-0.5 shrink-0 text-danger-6"
-                    />
-                  )}
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2">
-                      {cred.auth_method === "oauth" ? (
-                        <HugeiconsIcon
-                          icon={Key02Icon}
-                          data-icon="key-round"
-                          size={16}
-                          className={
-                            cred.validated ? "text-primary-6" : "text-danger-6"
-                          }
-                        />
-                      ) : (
-                        <HugeiconsIcon
-                          icon={Key01Icon}
-                          data-icon="key"
-                          size={16}
-                          className={
-                            cred.validated ? "text-success-6" : "text-danger-6"
-                          }
-                        />
-                      )}
-                      <span
-                        className={`text-[14px] font-medium ${cred.validated ? "text-text-1" : "text-danger-6"}`}
-                      >
-                        {cred.auth_method === "oauth"
-                          ? "OAuth"
-                          : t("keyVault.apiKeyLabel")}
-                      </span>
-                      {/* Validation status badge */}
-                      {endpointLabel(cred.base_url) && (
-                        <span className="rounded-full bg-fill-3 px-2 py-0.5 text-[10px] text-text-2">
-                          {endpointLabel(cred.base_url)}
-                        </span>
-                      )}
-                      {cred.validated === true ? (
-                        <span className="flex items-center gap-1 rounded-full bg-success-1 px-2 py-0.5 text-[10px] text-success-6">
-                          <HugeiconsIcon
-                            icon={CheckmarkCircle01Icon}
-                            data-icon="check-circle"
-                            size={10}
-                          />
-                          {t("keyVault.quickActions.valid")}
-                        </span>
-                      ) : cred.validated === false ? (
-                        <span className="flex items-center gap-1 rounded-full bg-danger-1 px-2 py-0.5 text-[10px] font-medium text-danger-6">
-                          <HugeiconsIcon
-                            icon={AlertCircleIcon}
-                            data-icon="alert-circle"
-                            size={10}
-                          />
-                          {t("keyVault.quickActions.invalid")}
-                        </span>
-                      ) : null}
-                    </div>
-                    <div
-                      className={`mt-1 text-[12px] ${cred.validated ? "text-text-3" : "text-danger-6/70"}`}
-                    >
-                      {cred.auth_method === "oauth" ? (
-                        <>
-                          {cred.quota_info?.plan_type && (
-                            <span className="mr-2">
-                              {t("keyVault.quickActions.planType", {
-                                plan: cred.quota_info.plan_type,
-                              })}
-                            </span>
-                          )}
-                          {typeof cred.quota_info?.remaining_percentage ===
-                            "number" && (
-                            <span className="text-success-6">
-                              {t("keyVault.quickActions.percentRemaining", {
-                                percent: Math.round(
-                                  cred.quota_info.remaining_percentage
-                                ),
-                              })}
-                            </span>
-                          )}
-                          {!cred.quota_info?.plan_type &&
-                            !cred.quota_info?.remaining_percentage && (
-                              <span>{t("keyVault.fromCodexAuthLogin")}</span>
-                            )}
-                        </>
-                      ) : (
-                        <>
-                          {cred.api_key && (
-                            <span>
-                              {cred.api_key.slice(0, 8)}...
-                              {cred.api_key.slice(-4)}
-                            </span>
-                          )}
-                        </>
-                      )}
-                    </div>
-                    {cred.validated === false && cred.validation_message && (
-                      <PageNotice type="danger">
-                        {cred.validation_message}
-                      </PageNotice>
-                    )}
-                    {cred.validated &&
-                      cred.available_models &&
-                      cred.available_models.length > 0 && (
-                        <div className="mt-2 text-[11px] text-text-3">
-                          {t("keyVault.quickActions.modelsAvailable", {
-                            count: cred.available_models.length,
-                          })}
-                        </div>
-                      )}
-                  </div>
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
-
+    <Modal
+      visible
+      title={t("keyVault.quickActions.multipleKeysFound")}
+      onClose={onClose}
+      width={448}
+      bodyClassName="p-0"
+      footer={
         <PanelFooter
           secondaryActions={[
             { label: t("common:actions.cancel"), onClick: onClose },
@@ -230,8 +66,164 @@ const KeySelectionModal: React.FC<KeySelectionModalProps> = ({
             disabled: !keys[selectedIndex]?.validated,
           }}
         />
+      }
+    >
+      {/* Body */}
+      <div className="p-4">
+        <p className="mb-4 text-[13px] text-text-2">
+          {t("keyVault.keysFoundForAgent", {
+            count: keys.length,
+          })}
+        </p>
+
+        <div className="space-y-3">
+          {keys.map((cred, index) => (
+            <button
+              key={cred.id}
+              onClick={() => cred.validated && onSelectIndex(index)}
+              disabled={!cred.validated}
+              className={`w-full rounded-lg border p-4 text-left transition-all ${
+                !cred.validated
+                  ? "cursor-not-allowed border-dashed border-danger-3 bg-danger-1"
+                  : selectedIndex === index
+                    ? "border-primary-6 bg-primary-1"
+                    : "border-border-2 bg-fill-2 hover:border-border-3 hover:bg-fill-1"
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                {/* Selection indicator */}
+                {cred.validated ? (
+                  selectedIndex === index ? (
+                    <HugeiconsIcon
+                      icon={Tick01Icon}
+                      data-icon="check"
+                      size={16}
+                      className="mt-0.5 shrink-0 text-primary-6"
+                    />
+                  ) : (
+                    <div className="mt-0.5 h-4 w-4 shrink-0" />
+                  )
+                ) : (
+                  <HugeiconsIcon
+                    icon={AlertCircleIcon}
+                    data-icon="alert-circle"
+                    size={16}
+                    className="mt-0.5 shrink-0 text-danger-6"
+                  />
+                )}
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    {cred.auth_method === "oauth" ? (
+                      <HugeiconsIcon
+                        icon={Key02Icon}
+                        data-icon="key-round"
+                        size={16}
+                        className={
+                          cred.validated ? "text-primary-6" : "text-danger-6"
+                        }
+                      />
+                    ) : (
+                      <HugeiconsIcon
+                        icon={Key01Icon}
+                        data-icon="key"
+                        size={16}
+                        className={
+                          cred.validated ? "text-success-6" : "text-danger-6"
+                        }
+                      />
+                    )}
+                    <span
+                      className={`text-[14px] font-medium ${cred.validated ? "text-text-1" : "text-danger-6"}`}
+                    >
+                      {cred.auth_method === "oauth"
+                        ? "OAuth"
+                        : t("keyVault.apiKeyLabel")}
+                    </span>
+                    {/* Validation status badge */}
+                    {endpointLabel(cred.base_url) && (
+                      <span className="rounded-full bg-fill-3 px-2 py-0.5 text-[10px] text-text-2">
+                        {endpointLabel(cred.base_url)}
+                      </span>
+                    )}
+                    {cred.validated === true ? (
+                      <span className="flex items-center gap-1 rounded-full bg-success-1 px-2 py-0.5 text-[10px] text-success-6">
+                        <HugeiconsIcon
+                          icon={CheckmarkCircle01Icon}
+                          data-icon="check-circle"
+                          size={10}
+                        />
+                        {t("keyVault.quickActions.valid")}
+                      </span>
+                    ) : cred.validated === false ? (
+                      <span className="flex items-center gap-1 rounded-full bg-danger-1 px-2 py-0.5 text-[10px] font-medium text-danger-6">
+                        <HugeiconsIcon
+                          icon={AlertCircleIcon}
+                          data-icon="alert-circle"
+                          size={10}
+                        />
+                        {t("keyVault.quickActions.invalid")}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div
+                    className={`mt-1 text-[12px] ${cred.validated ? "text-text-3" : "text-danger-6/70"}`}
+                  >
+                    {cred.auth_method === "oauth" ? (
+                      <>
+                        {cred.quota_info?.plan_type && (
+                          <span className="mr-2">
+                            {t("keyVault.quickActions.planType", {
+                              plan: cred.quota_info.plan_type,
+                            })}
+                          </span>
+                        )}
+                        {typeof cred.quota_info?.remaining_percentage ===
+                          "number" && (
+                          <span className="text-success-6">
+                            {t("keyVault.quickActions.percentRemaining", {
+                              percent: Math.round(
+                                cred.quota_info.remaining_percentage
+                              ),
+                            })}
+                          </span>
+                        )}
+                        {!cred.quota_info?.plan_type &&
+                          !cred.quota_info?.remaining_percentage && (
+                            <span>{t("keyVault.fromCodexAuthLogin")}</span>
+                          )}
+                      </>
+                    ) : (
+                      <>
+                        {cred.api_key && (
+                          <span>
+                            {cred.api_key.slice(0, 8)}...
+                            {cred.api_key.slice(-4)}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
+                  {cred.validated === false && cred.validation_message && (
+                    <PageNotice type="danger">
+                      {cred.validation_message}
+                    </PageNotice>
+                  )}
+                  {cred.validated &&
+                    cred.available_models &&
+                    cred.available_models.length > 0 && (
+                      <div className="mt-2 text-[11px] text-text-3">
+                        {t("keyVault.quickActions.modelsAvailable", {
+                          count: cred.available_models.length,
+                        })}
+                      </div>
+                    )}
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
## Problem

Credential selection rebuilt modal chrome with a fixed div, an unlabeled close icon and no dialog role, focus trap or Escape handling. It also bypassed shared overlay registration used to layer React content over native webviews.

## Solution

Compose the existing Modal with a string title and the existing credential body and PanelFooter. Cover named dialog semantics, selection validation, keyboard focus, Escape, focus restoration, overlay registration and repeated mount/unmount cleanup.

## Potential risks

The shared shell changes header spacing, portal placement and overlay stacking to the app defaults. The real Tauri/webview surface, themes and viewport layouts were not visually verified because computer control was not authorized. Shared modal timer/listener cleanup is tested; no CPU/RSS improvement is claimed. No API or persistence changes.

## Verification

- `pnpm typecheck:fast` — passed.
- `pnpm test -- src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.test.ts src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.test.ts` — 4 tests passed.
- `pnpm exec eslint src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.test.ts src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.tsx --max-warnings 0` — passed.
- `git diff --check` — passed.
- Source/prop/caller review and scoped diff inspection completed. Existing Vite CJS and Sass legacy API deprecation notices remain.
- Full application E2E, native visual checks and Rust checks were not run; this change is frontend-only.

## Audit

Scoped UI audit: `docs/frontend-ui-audit-2026-09-10/ModalAudit-keys.md` (1 fix, 1 keep with reason, 0 abstract).

Lifecycle review: `docs/org2-performance-guard-2026-09-10/ModalAudit-keys.md`.
