### PR TITLE
fix(spotlight): organize commands by working directory and org

### DIFF
--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Agent Session",
-        "workspace": "Workspace",
+        "workspace": "Arbeitsverzeichnisse",
+        "organization": "ORG / Arbeitsbereich",
         "quickNavigation": "Schnellnavigation",
         "editor": "Editor",
         "view": "Ansicht",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1598,7 +1598,8 @@
       },
       "groups": {
         "agentSession": "Agent Session",
-        "workspace": "Workspace",
+        "workspace": "Working Directories",
+        "organization": "ORG / Workspace",
         "quickNavigation": "Quick Navigation",
         "editor": "Editor",
         "view": "View",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Sesión de Agent",
-        "workspace": "Espacio de trabajo",
+        "workspace": "Directorios de trabajo",
+        "organization": "ORG / Espacio de trabajo",
         "quickNavigation": "Navegación rápida",
         "editor": "Editor",
         "view": "Vista",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Session Agent",
-        "workspace": "Espace de travail",
+        "workspace": "Répertoires de travail",
+        "organization": "ORG / Espace de travail",
         "quickNavigation": "Navigation rapide",
         "editor": "Éditeur",
         "view": "Vue",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Agent セッション",
-        "workspace": "Workspace",
+        "workspace": "作業ディレクトリ",
+        "organization": "組織 / ワークスペース",
         "quickNavigation": "クイックナビゲーション",
         "editor": "エディター",
         "view": "表示",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Agent 세션",
-        "workspace": "Workspace",
+        "workspace": "작업 디렉터리",
+        "organization": "조직 / 워크스페이스",
         "quickNavigation": "빠른 탐색",
         "editor": "에디터",
         "view": "보기",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Sesja Agent",
-        "workspace": "Workspace",
+        "workspace": "Katalogi robocze",
+        "organization": "ORG / Obszar roboczy",
         "quickNavigation": "Szybka nawigacja",
         "editor": "Edytor",
         "view": "Widok",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Sessão de Agent",
-        "workspace": "Workspace",
+        "workspace": "Diretórios de trabalho",
+        "organization": "ORG / Espaço de trabalho",
         "quickNavigation": "Navegação rápida",
         "editor": "Editor",
         "view": "Visualização",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Сессия Agent",
-        "workspace": "Workspace",
+        "workspace": "Рабочие каталоги",
+        "organization": "Организация / Рабочее пространство",
         "quickNavigation": "Быстрая навигация",
         "editor": "Редактор",
         "view": "Вид",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Agent oturumu",
-        "workspace": "Workspace",
+        "workspace": "Çalışma dizinleri",
+        "organization": "ORG / Çalışma alanı",
         "quickNavigation": "Hızlı gezinme",
         "editor": "Düzenleyici",
         "view": "Görünüm",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Phiên Agent",
-        "workspace": "Workspace",
+        "workspace": "Thư mục làm việc",
+        "organization": "Tổ chức / Không gian làm việc",
         "quickNavigation": "Điều hướng nhanh",
         "editor": "Trình chỉnh sửa",
         "view": "Chế độ xem",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1767,7 +1767,8 @@
       },
       "groups": {
         "agentSession": "Agent 會話",
-        "workspace": "工作區",
+        "workspace": "工作目錄",
+        "organization": "組織 / 工作區",
         "quickNavigation": "快速導覽",
         "editor": "編輯器",
         "view": "檢視",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1598,7 +1598,8 @@
       },
       "groups": {
         "agentSession": "Agent 会话",
-        "workspace": "工作区",
+        "workspace": "工作目录",
+        "organization": "组织 / 工作区",
         "quickNavigation": "快速导航",
         "editor": "编辑器",
         "view": "视图",

--- a/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightItemBuilders.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightItemBuilders.test.ts
@@ -30,6 +30,26 @@ const translations: Record<string, string> = {
 const translate: Translator = (key) => translations[key] ?? key;
 
 describe("Spotlight settings item builders", () => {
+  it("groups repo commands under Workspace and app preferences under View", () => {
+    const onSelectAction = vi.fn();
+    const workspace = buildActionItems(onSelectAction, translate, "workspace");
+    const view = buildActionItems(onSelectAction, translate, "view");
+
+    expect(workspace.map((item) => item.id)).toEqual(["show-in-finder"]);
+    expect(view.map((item) => item.label)).toEqual([
+      "common:spotlightActions.changeLanguage",
+      "Change theme",
+      "Change skin",
+    ]);
+    expect([...workspace, ...view]).toHaveLength(ACTIONS.length);
+    for (const item of view) {
+      item.action?.();
+      expect(onSelectAction).toHaveBeenLastCalledWith(
+        ACTIONS.find((action) => action.id === item.id)
+      );
+    }
+  });
+
   it("shows Follow system with a native-language suffix", () => {
     const items = buildLanguageItems(
       LANGUAGE_PREFERENCE.SYSTEM,

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts
@@ -78,9 +78,18 @@ function namespaceSectionItems(
 
 export function buildActionItems(
   onSelectAction: (action: ActionDefinition) => void,
-  translate: Translator
+  translate: Translator,
+  group?: "workspace" | "view"
 ): SpotlightItem[] {
-  return ACTIONS.map((action) => ({
+  const actions = group
+    ? ACTIONS.filter((action) =>
+        group === "workspace"
+          ? action.requiredParams.includes("repo")
+          : !action.requiredParams.includes("repo")
+      )
+    : ACTIONS;
+
+  return actions.map((action) => ({
     id: action.id,
     label: resolveActionLabel(action, translate),
     icon: action.icon,
@@ -315,6 +324,7 @@ export function buildGroupedDefaultItems(
   recentItems: SpotlightItem[],
   agentSessionItems: SpotlightItem[],
   workspaceItems: SpotlightItem[],
+  organizationItems: SpotlightItem[],
   quickNavigationItems: SpotlightItem[],
   editorItems: SpotlightItem[],
   viewItems: SpotlightItem[],
@@ -345,7 +355,12 @@ export function buildGroupedDefaultItems(
       "workspace",
       translate("selectors.spotlight.groups.workspace")
     ),
-    ...namespaceSectionItems("workspace", workspaceItems)
+    ...namespaceSectionItems("workspace", workspaceItems),
+    buildSectionHeader(
+      "organization",
+      translate("selectors.spotlight.groups.organization")
+    ),
+    ...namespaceSectionItems("organization", organizationItems)
   );
 
   const quickNavigationGroupItems = [...quickNavigationItems, ...editorItems];

--- a/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts
@@ -376,13 +376,13 @@ export function useSpotlightItems(
         onSelectStaticAction,
         translate
       ),
-      ...buildStaticActionItems(
-        ORGANIZATION_ACTIONS,
-        onSelectStaticAction,
-        translate
-      ),
-      ...buildActionItems(onSelectAction, translate),
+      ...buildActionItems(onSelectAction, translate, "workspace"),
     ];
+    const organizationItems = buildStaticActionItems(
+      ORGANIZATION_ACTIONS,
+      onSelectStaticAction,
+      translate
+    );
     const quickNavigationItems = buildStaticActionItems(
       quickNavigationActions,
       onSelectStaticAction,
@@ -391,11 +391,14 @@ export function useSpotlightItems(
     const editorItems = isEditorRoute
       ? buildEditorActionItems(onSelectEditorAction, translate)
       : [];
-    const viewItems = buildStaticActionItems(
-      [...chatPanelSettingsActions, ...viewActions, ...APP_ACTIONS],
-      onSelectStaticAction,
-      translate
-    );
+    const viewItems = [
+      ...buildActionItems(onSelectAction, translate, "view"),
+      ...buildStaticActionItems(
+        [...chatPanelSettingsActions, ...viewActions, ...APP_ACTIONS],
+        onSelectStaticAction,
+        translate
+      ),
+    ];
     const navActionItems = NAV_DESTINATIONS.filter(
       (destination) =>
         destination.group === "actions" &&
@@ -426,6 +429,7 @@ export function useSpotlightItems(
       recentItems,
       agentSessionItems,
       workspaceItems,
+      organizationItems,
       quickNavigationItems,
       editorItems,
       viewItems,


### PR DESCRIPTION
## Problem

Spotlight mixes organization creation/join commands and app preferences into its workspace group, making working-directory actions harder to find.

## Solution

Separate Create/Join organization into an ORG / Workspace section, rename the existing section to Working Directories, and move language, theme, and skin commands into View. Update the section headings in all 13 locales and cover preference grouping and callbacks with a regression test.

## Potential risks

This changes the default menu order and headings. Search behavior and command execution are unchanged. No dependency, persistence, or API format changes are required. Reverting this commit restores the prior grouping. Desktop visual verification was not run, so theme and narrow-viewport presentation remain unverified.

## Verification

- `pnpm test src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightItemBuilders.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightSearchBuilder.test.ts` — 21 tests passed in the isolated worktree.
- `pnpm typecheck:fast` — passed.
- `pnpm exec eslint src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightItemBuilders.test.ts --max-warnings 0` — passed.
- `git diff --check` — passed; commit hooks also passed lint-staged and TypeScript checks.
- No new screenshots or desktop checks: computer control was not authorized. The supplied screenshots show the prior menu state, not verification of this change.
