### PR TITLE
fix(spotlight): match list bottom spacing to side inset

### DIFF
--- a/src/scaffold/GlobalSpotlight/components/SpotlightItemList.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightItemList.tsx
@@ -219,6 +219,7 @@ export const SpotlightItemList: React.FC<SpotlightItemListProps> = ({
         className="spotlight-scrollable overflow-y-auto"
         style={{
           maxHeight: containerHeight,
+          paddingBottom: SPOTLIGHT_TOKENS.listInset - SPOTLIGHT_TOKENS.itemGap,
           scrollPaddingTop: stickyIndices.length
             ? SPOTLIGHT_TOKENS.itemHeight
             : 0,
@@ -279,7 +280,10 @@ export const SpotlightItemList: React.FC<SpotlightItemListProps> = ({
     <div
       ref={containerRef}
       className="spotlight-scrollable overflow-y-auto"
-      style={{ height: containerHeight }}
+      style={{
+        height: containerHeight,
+        paddingBottom: SPOTLIGHT_TOKENS.listInset - SPOTLIGHT_TOKENS.itemGap,
+      }}
       onScroll={handleScroll}
       onMouseMove={handleMouseMove}
       data-keyboard-mode={dataKeyboardMode}

--- a/src/scaffold/GlobalSpotlight/constants.ts
+++ b/src/scaffold/GlobalSpotlight/constants.ts
@@ -32,6 +32,8 @@ export const SPOTLIGHT_TOKENS = {
   itemHeight: 34,
   /** Item row height (with desc line) */
   itemHeightWithDesc: 48,
+  /** List edge inset, matching the row horizontal margin (mx-2). */
+  listInset: 8,
   /** Space after an option row (headers have no trailing gap). */
   itemGap: 3,
   /** Icon size inside item rows */


### PR DESCRIPTION
## Problem

The final Spotlight list row sits only 3px above the bottom edge, while rows have an 8px horizontal inset.

## Solution

Add the remaining 5px of bottom padding to both regular and virtualized lists. A list-inset token records the existing 8px horizontal margin, and the calculation accounts for the existing 3px row gap.

## Potential risks

The scrollable content gains 5px of space at its end. Virtualized lists and loading-more footers share the new padding; their desktop appearance remains unverified. There are no dependency, persistence, or API changes. Revert the two-file change to restore the previous spacing.

## Verification

- `pnpm exec eslint src/scaffold/GlobalSpotlight/constants.ts src/scaffold/GlobalSpotlight/components/SpotlightItemList.tsx --max-warnings 0` — passed in the isolated worktree.
- `pnpm exec prettier --check src/scaffold/GlobalSpotlight/constants.ts src/scaffold/GlobalSpotlight/components/SpotlightItemList.tsx` — passed.
- `git diff --check` — passed.
- Commit hooks passed lint-staged and TypeScript checks.
- No new tests for this spacing-only change. Desktop screenshots, themes, viewport constraints, and loading/empty/error states were not visually verified because computer control was not authorized.
