### PR TITLE
feat(spotlight): target branch commands to each repository

### DIFF
--- a/docs/architecture-audit-2026-09-10/SpotlightRepoBranchCommands.md
+++ b/docs/architecture-audit-2026-09-10/SpotlightRepoBranchCommands.md
@@ -1,0 +1,43 @@
+# Spotlight repository-specific branch commands
+
+## Behavior and scope
+
+The Working Directories group, global search, and recent commands share one derived command list. Single-repo mode produces one named branch command. Active workspace mode resolves Git repos in folder order, using repo ID then the existing path matcher, and deduplicates repeated references. Plain folders and unresolved repos produce no branch command.
+
+The action payload and transient branch route carry an optional `repoId`. Both registered actions and the fallback reach the same UI opener. It validates the repo, selects it through the existing repo selection hook, then opens the existing guarded branch picker. Selecting a command changes the active repository; it does not activate or deactivate a saved workspace. The picker uses a linked worktree path only when its repo identity matches.
+
+## Architecture review
+
+| Layer                        | Result                                                                                                                           |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Compilation               | `pnpm typecheck:fast` passes                                                                                                     |
+| 2. Ownership and duplication | One command resolver serves default, search, and recent views; checkout stays in the existing guarded flow                       |
+| 3. Naming                    | Labels name repositories; action identity includes repo ID                                                                       |
+| 4. Semantic distinctions     | Workspace folders define membership; Git repositories define branch targets                                                      |
+| 5. Defaults                  | Omitted repo ID retains existing picker behavior; unknown or plain-folder explicit targets do not open a picker for another repo |
+| 6. Boundaries                | No Git mutation logic added to item builders                                                                                     |
+| 7. Readability               | Repo resolution and command expansion isolated in `spotlightWorkingDirectoryActions.ts`                                          |
+| 8. Payload                   | Additive optional string in GUI action and transient route; no backend wire or persistent format migration                       |
+| 9. Entry parity              | Registered action and fallback carry the target to the same opener; generic entry remains supported                              |
+| 10. Resolution               | Repo name and ID come from the same resolved Repo, with ID-then-path folder resolution                                           |
+
+All ten layers reviewed for the changed frontend path. Rust, remote transport, database migration, and provider ingestion checks are inapplicable.
+
+## Lifecycle review
+
+| Area               | Verdict | Evidence                                                                                   | Change or reason kept                                        | Verification                                       |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------ | -------------------------------------------------- |
+| Background work    | keep    | No new timers, listeners, fetches, or scans                                                | Existing picker loads on selection                           | Source inspection; route lifecycle test            |
+| Memory             | keep    | Derived list bounded by current workspace repos; recent list retains existing cap of six   | No new retained cache                                        | Command dedupe and existing recent-list tests      |
+| Scope/isolation    | fix     | Payload preserves repo identity; worktree path requires matching repo                      | Invalid explicit targets cannot fall through to current repo | Command and request tests; UI opener source review |
+| Rendering/hot path | keep    | Memoized derivation depends on repo list, folder list, selected repo, workspace activation | No Git calls from rendering                                  | Typecheck, lint, command tests                     |
+
+Closed Spotlight does not consume a pending request. Opening consumes it once; reopening cannot replay it. Subsequent repo-specific and generic requests resolve independently, verified with the actual effect hook and Jotai store in jsdom.
+
+Performance verdict: blocked for desktop runtime measurement. Source and automated lifecycle checks pass; visible/hidden CPU/RSS and real Tauri close/reopen behavior were not measured because computer control was not authorized. No runtime performance improvement is claimed.
+
+## Verification scope
+
+Automated tests cover single-repo and multi-repo command generation, ID/path resolution, deduplication, plain folders, search, recent-command scope, route requests, and request consumption across close/reopen cycles. Main-hook rendering verifies selected-repo forwarding and explicit overrides. A React click on the registered status-bar callback verifies that the click event is not passed as a repository ID.
+
+The item-hook contract requires its repo-context field. The status-bar adapter invokes the parameterized opener with no arguments; other call sites already invoke it explicitly. No stored data requires remediation. See the pull request Verification section for the exact commands run on the isolated branch.

--- a/src/ActionSystem/actions/spotlightActions.zod.ts
+++ b/src/ActionSystem/actions/spotlightActions.zod.ts
@@ -139,12 +139,12 @@ const spotlightOpenBranchPicker = defineZodAction(
     id: ACTION_ID.SPOTLIGHT_OPEN_BRANCH_PICKER,
     category: "spotlight",
     description: "Open Spotlight's branch picker flow",
-    params: z.object({}),
+    params: z.object({ repoId: z.string().optional() }),
     layer: "gui",
     examples: ["switch branch", "open branch picker", "checkout branch"],
   },
-  async () => {
-    openBranchSpotlight();
+  async ({ repoId }) => {
+    openBranchSpotlight(repoId);
     return { success: true, message: "Opened branch picker" };
   }
 );

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1802,6 +1802,7 @@
           "label": "Arbeitsverzeichnis wechseln"
         },
         "switchBranch": {
+          "repoLabel": "Branch von {{repoName}} wechseln",
           "label": "Zweig wechseln"
         },
         "addWorkspace": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1633,6 +1633,7 @@
           "label": "Switch working directory"
         },
         "switchBranch": {
+          "repoLabel": "Switch the branch of {{repoName}}",
           "label": "Switch branch"
         },
         "addWorkspace": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1802,6 +1802,7 @@
           "label": "Cambiar directorio de trabajo"
         },
         "switchBranch": {
+          "repoLabel": "Cambiar la rama de {{repoName}}",
           "label": "Cambiar rama"
         },
         "addWorkspace": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1802,6 +1802,7 @@
           "label": "Changer de répertoire de travail"
         },
         "switchBranch": {
+          "repoLabel": "Changer la branche de {{repoName}}",
           "label": "Changer de branche"
         },
         "addWorkspace": {

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1802,6 +1802,7 @@
           "label": "作業ディレクトリを切り替え"
         },
         "switchBranch": {
+          "repoLabel": "{{repoName}} のブランチを切り替え",
           "label": "ブランチを切り替え"
         },
         "addWorkspace": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1802,6 +1802,7 @@
           "label": "작업 디렉터리 전환"
         },
         "switchBranch": {
+          "repoLabel": "{{repoName}}의 브랜치 전환",
           "label": "브랜치 전환"
         },
         "addWorkspace": {

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1802,6 +1802,7 @@
           "label": "Zmień katalog roboczy"
         },
         "switchBranch": {
+          "repoLabel": "Przełącz gałąź {{repoName}}",
           "label": "Przełącz gałąź"
         },
         "addWorkspace": {

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1802,6 +1802,7 @@
           "label": "Mudar diretório de trabalho"
         },
         "switchBranch": {
+          "repoLabel": "Alternar a branch de {{repoName}}",
           "label": "Alternar ramificação"
         },
         "addWorkspace": {

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1802,6 +1802,7 @@
           "label": "Сменить рабочий каталог"
         },
         "switchBranch": {
+          "repoLabel": "Переключить ветку {{repoName}}",
           "label": "Переключить ветку"
         },
         "addWorkspace": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1802,6 +1802,7 @@
           "label": "Çalışma dizinini değiştir"
         },
         "switchBranch": {
+          "repoLabel": "{{repoName}} dalını değiştir",
           "label": "Dal değiştir"
         },
         "addWorkspace": {

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1802,6 +1802,7 @@
           "label": "Chuyển thư mục làm việc"
         },
         "switchBranch": {
+          "repoLabel": "Chuyển nhánh của {{repoName}}",
           "label": "Chuyển nhánh"
         },
         "addWorkspace": {

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1802,6 +1802,7 @@
           "label": "切換工作目錄"
         },
         "switchBranch": {
+          "repoLabel": "切換 {{repoName}} 的分支",
           "label": "切換分支"
         },
         "addWorkspace": {

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1633,6 +1633,7 @@
           "label": "切换工作目录"
         },
         "switchBranch": {
+          "repoLabel": "切换 {{repoName}} 的分支",
           "label": "切换分支"
         },
         "addWorkspace": {

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellStatusBar.test.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellStatusBar.test.ts
@@ -6,7 +6,7 @@
  * Launchpad (`hostMountPolicy.ts`). These pin the affordances to the shell so
  * the workspace button keeps opening GlobalSpotlight with no host mounted.
  */
-import { Provider } from "jotai";
+import { Provider, useAtomValue } from "jotai";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -30,14 +30,21 @@ const panels = {
   bottomPanelCollapsed: false,
 } as unknown as ReturnType<typeof useWorkStationPanels>;
 
+const handleOpenSettings = () => {};
+
 function Harness() {
   useAppShellStatusBar({
     primaryPanelCollapsed: false,
     showSettingsButton: false,
-    handleOpenSettings: () => {},
+    handleOpenSettings,
     workStationPanels: panels,
   });
-  return null;
+  const callbacks = useAtomValue(perAppStatusBarCallbacksAtom).code;
+  return React.createElement(
+    "button",
+    { onClick: callbacks.onBranchClick },
+    "Switch branch"
+  );
 }
 
 async function mountShell() {
@@ -70,6 +77,21 @@ describe("useAppShellStatusBar", () => {
     });
 
     await root.unmount();
+  });
+
+  it("opens the branch route from a React click without treating the event as a repo ID", async () => {
+    const root = await mountShell();
+    try {
+      await dispatch(() => root.container.querySelector("button")!.click());
+      expect(store.get(spotlightOpenAtom)).toBe(true);
+      const request = store.get(spotlightInitialQueryAtom);
+      expect(request?.layer?.kind).toBe("branch");
+      expect(typeof (request?.layer as { repoId?: unknown }).repoId).toBe(
+        "undefined"
+      );
+    } finally {
+      await root.unmount();
+    }
   });
 
   it("registers the branch and worktree openers alongside it", async () => {

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellStatusBar.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellStatusBar.ts
@@ -20,7 +20,7 @@ import { perAppStatusBarCallbacksAtom } from "@src/store/ui/workStationLayout/st
  */
 const SPOTLIGHT_CALLBACKS = {
   onRepoClick: () => openWorkingDirectorySpotlight("switch"),
-  onBranchClick: openBranchSpotlight,
+  onBranchClick: () => openBranchSpotlight(),
   onWorktreeClick: openWorktreeSpotlight,
 } as const;
 

--- a/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightWorkingDirectoryActions.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightWorkingDirectoryActions.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Repo } from "@src/store/repo";
+import type { WorkspaceFolder } from "@src/types/workspace";
+
+import { resolveRecentDefinitions } from "../recentSpotlightActions";
+import { buildStaticActionItems } from "../spotlightItemBuilders";
+import { buildSearchModeItems } from "../spotlightSearchBuilder";
+import { buildWorkingDirectoryActions } from "../spotlightWorkingDirectoryActions";
+
+const repos: Repo[] = [
+  { id: "a", name: "Frontend", path: "/repos/front", kind: "git" },
+  { id: "b", name: "Backend", path: "/repos/back", kind: "git" },
+  { id: "c", name: "Notes", path: "/repos/notes", kind: "folder" },
+];
+const folders: WorkspaceFolder[] = repos.map((repo) => ({
+  id: `folder-${repo.id}`,
+  name: repo.name,
+  path: repo.path!,
+  uri: `file://${repo.path}`,
+  repoId: repo.id,
+  kind: repo.kind,
+  isPrimary: repo.id === "a",
+}));
+const translate = (key: string, values?: Record<string, string>) =>
+  values?.repoName ? `Switch the branch of ${values.repoName}` : key;
+const branchActions = (workspaceActive: boolean, selectedRepoId = "a") =>
+  buildWorkingDirectoryActions(
+    repos,
+    selectedRepoId,
+    folders,
+    workspaceActive
+  ).filter((action) => action.id.startsWith("switch-branch:"));
+
+describe("working-directory branch commands", () => {
+  it("names and targets the selected repo in single-repo mode", () => {
+    const actions = branchActions(false, "b");
+    const select = vi.fn();
+    const items = buildStaticActionItems(actions, select, translate);
+    expect(items.map((item) => item.label)).toEqual([
+      "Switch the branch of Backend",
+    ]);
+    items[0].action?.();
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { repoId: "b" } })
+    );
+  });
+
+  it("expands all workspace Git repos in folder order with unique identities", () => {
+    expect(
+      branchActions(true).map((action) => [action.id, action.payload])
+    ).toEqual([
+      ["switch-branch:a", { repoId: "a" }],
+      ["switch-branch:b", { repoId: "b" }],
+    ]);
+  });
+
+  it("resolves path-only roots and deduplicates repeated repo references", () => {
+    const actions = buildWorkingDirectoryActions(
+      repos,
+      "a",
+      [{ ...folders[1], repoId: undefined }, folders[1], folders[0]],
+      true
+    );
+    expect(
+      actions.filter((a) => a.id.startsWith("switch-branch:")).map((a) => a.id)
+    ).toEqual(["switch-branch:b", "switch-branch:a"]);
+  });
+
+  it("does not invent a branch target for plain folders or missing repositories", () => {
+    expect(branchActions(false, "c")).toEqual([]);
+    expect(branchActions(false, "missing")).toEqual([]);
+    expect(
+      buildWorkingDirectoryActions(repos, "a", [], true).some((a) =>
+        a.id.startsWith("switch-branch")
+      )
+    ).toBe(false);
+  });
+
+  it("searches repo names and preserves repo identity in recent commands", () => {
+    const actions = buildWorkingDirectoryActions(repos, "a", folders, true);
+    const select = vi.fn();
+    const items = buildSearchModeItems({
+      searchQuery: "Backend",
+      isEditorRoute: false,
+      staticCommandActions: actions,
+      onSelectAction: vi.fn(),
+      onSelectStaticAction: select,
+      onSelectEditorAction: vi.fn(),
+      onSelectPath: vi.fn(),
+      translate,
+    });
+    const branch = items.find((item) => item.id === "switch-branch:b");
+    expect(branch?.label).toBe("Switch the branch of Backend");
+    branch?.action?.();
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { repoId: "b" } })
+    );
+    expect(resolveRecentDefinitions(["switch-branch:b"], actions)).toHaveLength(
+      1
+    );
+    expect(
+      resolveRecentDefinitions(
+        ["switch-branch:b"],
+        buildWorkingDirectoryActions(repos, "a", [], false)
+      )
+    ).toEqual([]);
+  });
+});

--- a/src/scaffold/GlobalSpotlight/hooks/features/__tests__/useSpotlightEffects.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/__tests__/useSpotlightEffects.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { spotlightInitialQueryAtom } from "@src/store/ui/uiAtom";
+
+import { createBranchSpotlightRequest } from "../../../openSpotlight";
+import { useSpotlightEffects } from "../useSpotlightEffects";
+
+it("consumes each repo-scoped branch request once and does not replay it on reopen", () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const store = createStore();
+  const onOpenBranchLayer = vi.fn();
+  const dispatch = vi.fn();
+  const closeModal = vi.fn();
+  function Harness({ isOpen }: { isOpen: boolean }) {
+    useSpotlightEffects({ isOpen, dispatch, closeModal, onOpenBranchLayer });
+    return null;
+  }
+  const root = createRoot(document.createElement("div"));
+  const render = (isOpen: boolean) =>
+    act(() =>
+      root.render(
+        createElement(Provider, { store }, createElement(Harness, { isOpen }))
+      )
+    );
+  try {
+    store.set(
+      spotlightInitialQueryAtom,
+      createBranchSpotlightRequest("repo-b")
+    );
+    render(false);
+    expect(onOpenBranchLayer).not.toHaveBeenCalled();
+    render(true);
+    expect(onOpenBranchLayer).toHaveBeenCalledTimes(1);
+    expect(onOpenBranchLayer).toHaveBeenLastCalledWith("repo-b");
+    expect(store.get(spotlightInitialQueryAtom)).toBeNull();
+    render(false);
+    render(true);
+    expect(onOpenBranchLayer).toHaveBeenCalledTimes(1);
+    act(() =>
+      store.set(
+        spotlightInitialQueryAtom,
+        createBranchSpotlightRequest("repo-a")
+      )
+    );
+    expect(onOpenBranchLayer).toHaveBeenLastCalledWith("repo-a");
+    expect(onOpenBranchLayer).toHaveBeenCalledTimes(2);
+    act(() =>
+      store.set(spotlightInitialQueryAtom, createBranchSpotlightRequest())
+    );
+    expect(onOpenBranchLayer).toHaveBeenLastCalledWith(undefined);
+    expect(store.get(spotlightInitialQueryAtom)).toBeNull();
+  } finally {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.types.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.types.ts
@@ -23,6 +23,7 @@ export type SpotlightStaticActionId =
   | "open-agent-control"
   | "switch-workspace"
   | "switch-branch"
+  | `switch-branch:${string}`
   | "add-workspace"
   | "create-multi-repo-workspace"
   | "create-organization"
@@ -90,6 +91,7 @@ export type SpotlightEditorActionId =
 export interface SpotlightStaticActionDefinition {
   id: SpotlightStaticActionId;
   labelKey: string;
+  labelValues?: Record<string, string>;
   icon: SpotlightItem["icon"];
   keywords: string[];
   shortcut?: string;

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts
@@ -40,7 +40,10 @@ import type {
 } from "./spotlightActionDefinitions";
 import { EDITOR_ACTIONS } from "./spotlightActionDefinitions";
 
-export type Translator = (key: string) => string;
+export type Translator = (
+  key: string,
+  values?: Record<string, string>
+) => string;
 
 // ============================================
 // Header & label helpers
@@ -126,7 +129,7 @@ export function buildStaticActionItems(
 ): SpotlightItem[] {
   return actions.map((action) => ({
     id: action.id,
-    label: translate(action.labelKey),
+    label: translate(action.labelKey, action.labelValues),
     icon: action.icon,
     type: "action" as const,
     shortcut: action.shortcut,

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightSearchBuilder.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightSearchBuilder.ts
@@ -172,7 +172,7 @@ function buildStaticMatches(
 ): SpotlightItem[] {
   const results: SpotlightItem[] = [];
   staticCommandActions.forEach((action) => {
-    const label = translate(action.labelKey);
+    const label = translate(action.labelKey, action.labelValues);
     const labelMatch = !queryLower || label.toLowerCase().includes(queryLower);
     const keywordMatch = action.keywords.some((keyword) =>
       keyword.toLowerCase().includes(queryLower)

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightWorkingDirectoryActions.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightWorkingDirectoryActions.ts
@@ -1,0 +1,45 @@
+import { REPO_KIND, type Repo } from "@src/store/repo";
+import { matchRepoByPath } from "@src/store/repo/matchRepoByPath";
+import type { WorkspaceFolder } from "@src/types/workspace";
+
+import { WORKING_DIRECTORY_ACTIONS } from "./spotlightActionDefinitions.navigation";
+import type { SpotlightStaticActionDefinition } from "./spotlightActionDefinitions.types";
+
+/** Expand branch commands from the active working directory's Git repositories. */
+export function buildWorkingDirectoryActions(
+  repos: readonly Repo[],
+  selectedRepoId: string | undefined,
+  workspaceFolders: readonly WorkspaceFolder[],
+  workspaceActive: boolean
+): SpotlightStaticActionDefinition[] {
+  const candidates = workspaceActive
+    ? workspaceFolders
+        .filter((folder) => folder.kind !== "folder")
+        .map(
+          (folder) =>
+            repos.find((repo) => repo.id === folder.repoId) ??
+            matchRepoByPath(repos, folder.path)
+        )
+    : [repos.find((repo) => repo.id === selectedRepoId)];
+  const gitRepos = [
+    ...new Map(
+      candidates
+        .filter((repo): repo is Repo => repo?.kind === REPO_KIND.GIT)
+        .map((repo) => [repo.id, repo] as const)
+    ).values(),
+  ];
+
+  return WORKING_DIRECTORY_ACTIONS.flatMap((action) => {
+    if (action.id !== "switch-branch") return [action];
+    return gitRepos.map(
+      (repo): SpotlightStaticActionDefinition => ({
+        ...action,
+        id: `switch-branch:${repo.id}`,
+        labelKey: "selectors.spotlight.actions.switchBranch.repoLabel",
+        labelValues: { repoName: repo.name },
+        keywords: [...action.keywords, repo.name],
+        payload: { repoId: repo.id },
+      })
+    );
+  });
+}

--- a/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightEffects.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightEffects.ts
@@ -37,7 +37,7 @@ export interface UseSpotlightEffectsOptions {
   onOpenGitHubIssuesImportLayer?: (
     context?: SpotlightGitHubIssuesImportContext
   ) => void;
-  onOpenBranchLayer?: () => void;
+  onOpenBranchLayer?: (repoId?: string) => void;
   onOpenWorktreeLayer?: () => void;
   onOpenEditorLayer?: (
     query: string,
@@ -118,7 +118,7 @@ export function useSpotlightEffects(options: UseSpotlightEffectsOptions): void {
     } else if (initialQuery.layer?.kind === "githubIssuesImport") {
       onOpenGitHubIssuesImportLayer?.(initialQuery.layer.context);
     } else if (initialQuery.layer?.kind === "branch") {
-      onOpenBranchLayer?.();
+      onOpenBranchLayer?.(initialQuery.layer.repoId);
     } else if (initialQuery.layer?.kind === "worktree") {
       onOpenWorktreeLayer?.();
     } else if (initialQuery.layer?.kind === "editor") {

--- a/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts
@@ -24,6 +24,7 @@ import { org2CloudRemoteSessionsAtom } from "@src/features/Org2Cloud/org2CloudRe
 import { useFilteredItems } from "@src/hooks/search";
 import type { LanguagePreference } from "@src/i18n";
 import { devModeEnabledAtom } from "@src/store/platform/devModeAtom";
+import { reposAtom } from "@src/store/repo";
 import {
   type Session,
   sessionsAtom,
@@ -49,6 +50,10 @@ import { chatPanelPositionAtom } from "@src/store/ui/workStationLayout/chatPosit
 import { workStationPrimarySidebarCollapsedAtom } from "@src/store/ui/workStationLayout/primarySidebarAtoms";
 import { workStationLayoutModeAtom } from "@src/store/ui/workStationLayout/splitLayoutAtoms";
 import { activeStatusBarCallbacksAtom } from "@src/store/ui/workStationLayout/statusBarAtoms";
+import {
+  workspaceActiveAtom,
+  workspaceFoldersAtom,
+} from "@src/store/workspace";
 import { getSessionSearchText } from "@src/util/session/sessionSearch";
 
 import { NAV_DESTINATIONS } from "../../config";
@@ -74,7 +79,6 @@ import {
   STATION_MODE_ACTIONS,
   type SpotlightEditorActionId,
   type SpotlightStaticActionDefinition,
-  WORKING_DIRECTORY_ACTIONS,
   buildChatPanelSettingsActions,
   buildViewActions,
 } from "./spotlightActionDefinitions";
@@ -97,6 +101,7 @@ import {
   resolveAgentSessionSearchInput,
   resolveSpotlightCloudSessionPresentation,
 } from "./spotlightSessionSearch";
+import { buildWorkingDirectoryActions } from "./spotlightWorkingDirectoryActions";
 
 const GENERAL_SPOTLIGHT_SESSION_RESULT_LIMIT = 8;
 
@@ -135,7 +140,7 @@ interface SpotlightItemsHandlers {
     label: string,
     icon: SpotlightItem["icon"]
   ) => void;
-  currentRepoId?: string;
+  currentRepoId: string | undefined;
   isEditorRoute: boolean;
   isWorkStationRoute: boolean;
 }
@@ -146,6 +151,9 @@ export function useSpotlightItems(
   handlers: SpotlightItemsHandlers
 ): UseSpotlightItemsReturn {
   const state = useSpotlightState();
+  const repos = useAtomValue(reposAtom);
+  const workspaceFolders = useAtomValue(workspaceFoldersAtom);
+  const workspaceActive = useAtomValue(workspaceActiveAtom);
   const isSidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
   const fallbackWorkstationSidebarCollapsed = useAtomValue(
     workStationPrimarySidebarCollapsedAtom
@@ -234,6 +242,17 @@ export function useSpotlightItems(
     getSearchText: getSessionText,
   });
 
+  const workingDirectoryActions = useMemo(
+    () =>
+      buildWorkingDirectoryActions(
+        repos,
+        currentRepoId,
+        workspaceFolders,
+        workspaceActive
+      ),
+    [repos, currentRepoId, workspaceFolders, workspaceActive]
+  );
+
   const items = useMemo((): SpotlightItem[] => {
     const viewActions = buildViewActions(
       isSidebarCollapsed,
@@ -291,7 +310,7 @@ export function useSpotlightItems(
         isEditorRoute,
         staticCommandActions: [
           ...AGENT_SESSION_ACTIONS,
-          ...WORKING_DIRECTORY_ACTIONS,
+          ...workingDirectoryActions,
           ...ORGANIZATION_ACTIONS,
           ...chatPanelSettingsActions,
           ...quickNavigationActions,
@@ -372,7 +391,7 @@ export function useSpotlightItems(
     );
     const workspaceItems = [
       ...buildStaticActionItems(
-        WORKING_DIRECTORY_ACTIONS,
+        workingDirectoryActions,
         onSelectStaticAction,
         translate
       ),
@@ -414,7 +433,7 @@ export function useSpotlightItems(
     const recentItems = buildStaticActionItems(
       resolveRecentDefinitions(recentActionIds, [
         ...AGENT_SESSION_ACTIONS,
-        ...WORKING_DIRECTORY_ACTIONS,
+        ...workingDirectoryActions,
         ...ORGANIZATION_ACTIONS,
         ...chatPanelSettingsActions,
         ...quickNavigationActions,
@@ -473,6 +492,7 @@ export function useSpotlightItems(
     filteredRepos,
     filteredBranches,
     currentRepoId,
+    workingDirectoryActions,
     onSelectAction,
     onSelectStaticAction,
     onSelectEditorAction,

--- a/src/scaffold/GlobalSpotlight/hooks/useSpotlight.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/useSpotlight.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React from "react";
+import { expect, it, vi } from "vitest";
+
+import { reposAtom, selectedRepoIdAtom } from "@src/store/repo";
+import {
+  activeWorkspaceIdAtom,
+  workspaceFoldersAtom,
+} from "@src/store/workspace";
+import { createSmokeRoot, dispatch } from "@src/test/reactSmokeHarness";
+
+import { SpotlightProvider } from "./core";
+import { useSpotlight } from "./useSpotlight";
+
+vi.mock("@src/hooks/navigation/useAppNavigation", () => ({
+  useAppNavigation: () => ({ navigateTo: vi.fn() }),
+}));
+vi.mock("@src/hooks/ui/tabs/useSessionView", () => ({
+  useSessionView: () => ({ openSession: vi.fn() }),
+}));
+vi.mock("@src/features/Org2Cloud/useOpenCloudSessionReference", () => ({
+  useOpenCloudSessionReference: () => vi.fn(),
+}));
+vi.mock("./data", () => ({
+  useSharedRepoList: () => ({
+    repos: [],
+    filteredRepos: [],
+    loadRepos: vi.fn(),
+    refreshReposForce: vi.fn(),
+  }),
+  useBranches: () => ({ branches: [], fetchBranches: vi.fn() }),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, string>) =>
+      values?.repoName ? `Switch the branch of ${values.repoName}` : key,
+  }),
+}));
+
+it("keeps repo-named branch commands wired through the main hook across repo changes", async () => {
+  const store = createStore();
+  store.set(reposAtom, [
+    { id: "a", name: "Frontend", kind: "git", path: "/repos/front" },
+    { id: "b", name: "Backend", kind: "git", path: "/repos/back" },
+  ]);
+  store.set(selectedRepoIdAtom, "a");
+  store.set(activeWorkspaceIdAtom, null);
+  store.set(workspaceFoldersAtom, []);
+  const openBranch = vi.fn();
+  function Harness({ currentRepoId }: { currentRepoId?: string }) {
+    const { items } = useSpotlight({
+      isOpen: true,
+      currentRepoId,
+      onOpenBranchPicker: openBranch,
+    });
+    return React.createElement(
+      React.Fragment,
+      null,
+      ...items
+        .filter((item) => item.id.startsWith("workspace-switch-branch:"))
+        .map((item) =>
+          React.createElement(
+            "button",
+            { key: item.id, onClick: () => item.action?.() },
+            item.label
+          )
+        )
+    );
+  }
+  const root = createSmokeRoot();
+  const render = (currentRepoId?: string) =>
+    root.render(
+      React.createElement(
+        Provider,
+        { store },
+        React.createElement(
+          SpotlightProvider,
+          null,
+          React.createElement(Harness, { currentRepoId })
+        )
+      )
+    );
+  try {
+    await render();
+    expect(root.container.textContent).toBe("Switch the branch of Frontend");
+    await dispatch(() => root.container.querySelector("button")!.click());
+    expect(openBranch).toHaveBeenLastCalledWith("a");
+    await render("b");
+    expect(root.container.textContent).toBe("Switch the branch of Backend");
+    await dispatch(() => root.container.querySelector("button")!.click());
+    expect(openBranch).toHaveBeenLastCalledWith("b");
+  } finally {
+    await root.unmount();
+  }
+});

--- a/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
@@ -90,7 +90,7 @@ export function useSpotlight(
     onOpenWorkingDirectoryPicker?: (
       mode: "switch" | "open" | "add" | "create"
     ) => void;
-    onOpenBranchPicker?: () => void;
+    onOpenBranchPicker?: (repoId?: string) => void;
     onOpenEditorPalette?: (prefix: string, mode?: EditorPaletteMode) => void;
     onOpenAgentSessionSearch?: () => void;
     onOpenAllSessionsSearch?: () => void;
@@ -177,7 +177,10 @@ export function useSpotlight(
   );
 
   const runStaticActionFallback = useCallback(
-    (fallback: SpotlightStaticActionFallback) => {
+    (
+      fallback: SpotlightStaticActionFallback,
+      payload: Record<string, unknown>
+    ) => {
       const fallbackHandlers: Record<
         SpotlightStaticActionFallback,
         () => void
@@ -227,7 +230,10 @@ export function useSpotlight(
         "organization-join": () => {
           openCollabOrgSpotlight({ source: "cloud", mode: "join" });
         },
-        "branch-picker": () => onOpenBranchPicker?.(),
+        "branch-picker": () =>
+          onOpenBranchPicker?.(
+            typeof payload.repoId === "string" ? payload.repoId : undefined
+          ),
         "toggle-sidebar": () => {
           void AppViewService.toggleSidebar();
         },
@@ -305,7 +311,7 @@ export function useSpotlight(
         action.payload,
         fallback
           ? () => {
-              runStaticActionFallback(fallback);
+              runStaticActionFallback(fallback, action.payload);
             }
           : undefined
       );
@@ -485,6 +491,7 @@ export function useSpotlight(
     onSelectSession: handleSelectSession,
     onSelectCloudSessionReference: handleSelectCloudSessionReference,
     onSelectPath: handleSelectPath,
+    currentRepoId: activeRepoId,
     isEditorRoute,
     isWorkStationRoute,
   });

--- a/src/scaffold/GlobalSpotlight/index.tsx
+++ b/src/scaffold/GlobalSpotlight/index.tsx
@@ -58,6 +58,7 @@ const GlobalSpotlightInner: React.FC<
   const {
     selectedRepoId,
     currentRepo,
+    repos,
     currentBranch: selectedBranchName,
     selectRepo,
     selectBranch,
@@ -143,6 +144,18 @@ const GlobalSpotlightInner: React.FC<
     setWorktreePickerOpen,
   });
 
+  const handleOpenRepoBranchPicker = useCallback(
+    (repoId?: string) => {
+      if (repoId) {
+        if (!repos.some((repo) => repo.id === repoId && repo.kind === "git"))
+          return;
+        if (repoId !== selectedRepoId) selectRepo(repoId);
+      }
+      handleOpenBranchPicker();
+    },
+    [handleOpenBranchPicker, repos, selectRepo, selectedRepoId]
+  );
+
   // ============ ALL HOOKS MUST BE CALLED UNCONDITIONALLY ============
   // These hooks are needed for normal mode, but must always be called
   // to satisfy React's rules of hooks (same order every render)
@@ -150,7 +163,7 @@ const GlobalSpotlightInner: React.FC<
     ...props,
     closeModal,
     onOpenWorkingDirectoryPicker: handleOpenWorkingDirectoryPicker,
-    onOpenBranchPicker: handleOpenBranchPicker,
+    onOpenBranchPicker: handleOpenRepoBranchPicker,
     onOpenEditorPalette: handleOpenEditorPalette,
     onOpenAgentSessionSearch: handleOpenAgentSessionSearch,
     onOpenAllSessionsSearch: handleOpenAllSessionsSearch,
@@ -178,7 +191,7 @@ const GlobalSpotlightInner: React.FC<
     onOpenWorkingDirectoryLayer: handleOpenWorkingDirectoryPicker,
     onOpenCollabOrgLayer: handleOpenCollabOrg,
     onOpenGitHubIssuesImportLayer: handleOpenGitHubIssuesImport,
-    onOpenBranchLayer: handleOpenBranchPicker,
+    onOpenBranchLayer: handleOpenRepoBranchPicker,
     onOpenWorktreeLayer: handleOpenWorktreePicker,
     onOpenEditorLayer: handleOpenEditorPalette,
     onOpenAgentSessionSearchLayer: handleOpenAgentSessionSearch,
@@ -408,7 +421,12 @@ const GlobalSpotlightInner: React.FC<
       onDeleteBranch={handleDeleteBranch}
       onCheckoutDetached={handleCheckoutDetached}
       repoId={effectiveCurrentRepoId ?? ""}
-      repoPath={activeWorktree?.path ?? currentRepoPath}
+      repoPath={
+        activeWorktree && activeWorktree.repoId === effectiveCurrentRepoId
+          ? activeWorktree.path
+          : currentRepoPath
+      }
+      repoName={currentRepo?.name}
       currentBranchName={selectedBranchName}
       asBody
       onModeChange={setEmbeddedBranchMode}

--- a/src/scaffold/GlobalSpotlight/openSpotlight.test.ts
+++ b/src/scaffold/GlobalSpotlight/openSpotlight.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createBranchSpotlightRequest,
   createCollabOrgSpotlightRequest,
   createGitHubIssuesImportSpotlightRequest,
 } from "./openSpotlight";
@@ -39,6 +40,19 @@ describe("createGitHubIssuesImportSpotlightRequest", () => {
           repoUrl: "https://github.com/ORGII/ORGII.git",
         },
       },
+    });
+  });
+});
+
+describe("createBranchSpotlightRequest", () => {
+  it("carries an explicit repo through the branch route", () => {
+    expect(createBranchSpotlightRequest("repo-b")).toEqual({
+      query: "",
+      layer: { kind: "branch", repoId: "repo-b" },
+    });
+    expect(createBranchSpotlightRequest()).toEqual({
+      query: "",
+      layer: { kind: "branch" },
     });
   });
 });

--- a/src/scaffold/GlobalSpotlight/openSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/openSpotlight.ts
@@ -57,8 +57,13 @@ export function createGitHubIssuesImportSpotlightRequest(
   };
 }
 
-function createBranchSpotlightRequest(): SpotlightInitialQuery {
-  return { query: "", layer: { kind: "branch" } };
+export function createBranchSpotlightRequest(
+  repoId?: string
+): SpotlightInitialQuery {
+  return {
+    query: "",
+    layer: { kind: "branch", ...(repoId ? { repoId } : {}) },
+  };
 }
 
 function createWorktreeSpotlightRequest(): SpotlightInitialQuery {
@@ -140,10 +145,10 @@ export function openGitHubIssuesImportSpotlight(
   store.set(spotlightOpenAtom, true);
 }
 
-export function openBranchSpotlight(): void {
+export function openBranchSpotlight(repoId?: string): void {
   if (!isStoreInitialized()) return;
   const store = getInstrumentedStore();
-  store.set(spotlightInitialQueryAtom, createBranchSpotlightRequest());
+  store.set(spotlightInitialQueryAtom, createBranchSpotlightRequest(repoId));
   store.set(spotlightOpenAtom, true);
 }
 

--- a/src/store/ui/uiAtom.ts
+++ b/src/store/ui/uiAtom.ts
@@ -419,7 +419,7 @@ export type SpotlightInitialLayer =
       kind: "githubIssuesImport";
       context?: SpotlightGitHubIssuesImportContext;
     }
-  | { kind: "branch" }
+  | { kind: "branch"; repoId?: string }
   | { kind: "worktree" }
   | { kind: "editor"; mode?: SpotlightInitialEditorMode }
   | { kind: "agentSessionSearch" }


### PR DESCRIPTION
## Problem

Spotlight's generic Switch branch command does not identify the repository or offer separate targets in multi-repo directories. Repo-specific routing also needs to preserve context through the main hook and avoid interpreting a status-bar React click event as a repository ID.

## Solution

Show “Switch the branch of <repo name>” for each Git repository in the active working directory, with labels translated in all 13 locales. Use the same scoped definitions for default commands, search, and recent actions. Deduplicate repository references and exclude plain folders.

Carry the target repo ID through the GUI action and transient Spotlight route. The common opener validates and selects that repo before opening the existing guarded branch picker, and only uses a worktree path belonging to that repo. Require the main item hook's repo-context field and adapt the status-bar callback to invoke the opener without the React event. Add production-hook and click-event regression tests alongside command and route tests.

The menu-section dependency #1500 is merged into develop; this PR now targets develop.

## Potential risks

Choosing a named command changes the active repository before the picker opens; cancelling the picker does not restore the prior repo. The saved workspace remains active. Real Git checkout, dirty-tree conflict dialogs, desktop themes, and narrow viewports have not been manually verified.

The GUI action and transient route gain an optional `repoId` string; existing callers without it retain the current-repo behavior. No database migration, backend wire change, dependency, or persistence-format change is needed. Reverting this commit restores generic branch routing; obsolete repo-specific recent IDs are ignored by the existing resolver.

No new polling or Git reads are added to command rendering. Automated lifecycle tests verify request consumption and reopening, but desktop CPU/RSS measurements were not run.

## Verification

- `pnpm test src/scaffold/GlobalSpotlight/hooks/useSpotlight.test.ts src/modules/WorkStation/AppShell/hooks/useAppShellStatusBar.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightWorkingDirectoryActions.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/useSpotlightEffects.test.ts src/scaffold/GlobalSpotlight/openSpotlight.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightSearchBuilder.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/recentSpotlightActions.test.ts` — 38 tests passed in the isolated worktree.
- `pnpm typecheck:fast` — passed.
- `git diff --cached --check` — passed; staged content inspected for personal paths, secrets, and debug logs.
- Commit hooks passed oxlint, ESLint, Prettier, and TypeScript checks.
- Main-hook and actual React-click tests reproduced the missing-context and event-payload failures before their fixes, then passed.
- Desktop screenshots, live Git mutation/conflict checks, and runtime performance measurements were not run because computer control was not authorized. The checked-in audit states those limits.
