### PR TITLE
fix(updater): persist Later reminder cooldown

### DIFF
--- a/src/scaffold/AppUpdater/component-app-updater-1226.md
+++ b/src/scaffold/AppUpdater/component-app-updater-1226.md
@@ -34,8 +34,8 @@ relaunch remain explicit user actions.
   without showing progress toasts or forcing a restart, then show one
   confirmation dialog. Installation only starts after the user confirms.
 - **Dialog actions:** users can skip the detected version, postpone the
-  decision while keeping the package ready, or install and restart. Skipped
-  versions remain suppressed across app launches.
+  decision for 24 hours while keeping the package ready, or install and restart.
+  Skipped versions remain suppressed across app launches.
 
 Installing is never automatic because the Tauri updater installer can
 terminate the running process on Windows. Users can postpone installation and
@@ -87,3 +87,15 @@ read-only UI projections and are not independent sources of truth.
 - `@tauri-apps/plugin-updater` for check/download/install
 - `@tauri-apps/plugin-process` for relaunch
 - central settings registry for update-channel selection
+
+## Later reminder policy
+
+`service.tsx` owns the durable reminder decision. Choosing Later stores one
+version and an absolute 24-hour deadline in localStorage, then hides the prompt.
+Startup, interval, foreground, online recovery, and retry preparation all respect
+that deadline for both in-place and separate-application installation. Explicit
+install actions may reopen the prompt during the cooldown. A different release
+is never suppressed by an older reminder. Expired or malformed records are
+removed when read; skipping or confirming installation clears the current
+version's reminder. No reminder timer or subscription is added: the next eligible
+automatic check after expiry can show the prompt again.

--- a/src/scaffold/AppUpdater/index.test.ts
+++ b/src/scaffold/AppUpdater/index.test.ts
@@ -382,7 +382,7 @@ describe("AppUpdater", () => {
 
     capturedButton("Later").onClick?.();
 
-    expect(mocks.setInstallPromptVisible).toHaveBeenCalledWith(false);
+    expect(mocks.storeSet).toHaveBeenCalledWith(expect.anything(), false);
     expect(update.install).not.toHaveBeenCalled();
     expect(mocks.relaunch).not.toHaveBeenCalled();
   });

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -11,6 +11,7 @@ import { DownloadProgressOrb } from "./DownloadProgress";
 import {
   expandDownloadProgressNotice,
   installAvailableAppUpdate,
+  postponeAppUpdate,
   skipAppUpdateVersion,
   startAutomaticAppUpdates,
   usesSeparateApplicationInstall,
@@ -33,8 +34,8 @@ export const AppUpdater: React.FC = () => {
   const settingsLoaded = useAtomValue(settingsLoadedAtom);
 
   const handleInstallLater = useCallback(() => {
-    setInstallPromptVisible(false);
-  }, [setInstallPromptVisible]);
+    postponeAppUpdate(availableUpdate?.version);
+  }, [availableUpdate]);
 
   const handleSkipVersion = useCallback(() => {
     skipAppUpdateVersion(availableUpdate?.version);

--- a/src/scaffold/AppUpdater/service.test.ts
+++ b/src/scaffold/AppUpdater/service.test.ts
@@ -5,14 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as actions from "./actions";
 import {
   checkForUpdatesManually,
+  installAvailableAppUpdate,
+  postponeAppUpdate,
   resetAppUpdaterForTests,
+  skipAppUpdateVersion,
   startAutomaticAppUpdates,
 } from "./service";
-import { availableAppUpdateAtom } from "./state";
+import { appUpdateInstallPromptAtom, availableAppUpdateAtom } from "./state";
 
 const mocks = vi.hoisted(() => ({
   check: vi.fn(),
   provenance: vi.fn(),
+  separateInstall: vi.fn(),
+  relaunch: vi.fn(),
   store: null as ReturnType<typeof createStore> | null,
 }));
 vi.mock("@tauri-apps/api/app", () => ({ getVersion: async () => "1.0.0" }));
@@ -35,21 +40,37 @@ vi.mock("@src/hooks/logger", () => ({
   createLogger: () => ({ warn: vi.fn(), error: vi.fn() }),
 }));
 
+vi.mock("./separateInstall", () => ({
+  installAppUpdateSeparately: mocks.separateInstall,
+}));
+vi.mock("@tauri-apps/plugin-process", () => ({ relaunch: mocks.relaunch }));
+
 const provenance = { kind: "release", installStrategy: "inPlace" };
 
 describe("AppUpdater service boundary", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-10T00:00:00Z"));
+    const values = new Map<string, string>();
     mocks.store = createStore();
     vi.clearAllMocks();
     mocks.provenance.mockResolvedValue(provenance);
     mocks.check.mockResolvedValue(null);
+    mocks.separateInstall.mockResolvedValue({
+      version: "1.0.1",
+      targetPath: "/Applications/ORG2.app",
+    });
+    mocks.relaunch.mockResolvedValue(undefined);
     vi.stubGlobal(
       "window",
       Object.assign(new EventTarget(), {
         setTimeout: globalThis.setTimeout,
         clearTimeout: globalThis.clearTimeout,
-        localStorage: { getItem: () => null },
+        localStorage: {
+          getItem: (key: string) => values.get(key) ?? null,
+          setItem: (key: string, value: string) => values.set(key, value),
+          removeItem: (key: string) => values.delete(key),
+        },
       })
     );
     vi.stubGlobal(
@@ -65,6 +86,116 @@ describe("AppUpdater service boundary", () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });
+
+  describe.each(["inPlace", "separateMacosApplication"])(
+    "%s reminder",
+    (installStrategy) => {
+      beforeEach(() =>
+        mocks.provenance.mockResolvedValue({ kind: "release", installStrategy })
+      );
+
+      it.each(["startup", "interval", "foreground", "online", "retry"])(
+        "respects Later through the real %s scheduler trigger",
+        async (reason) => {
+          const update = updateFixture();
+          mocks.check.mockResolvedValue(update);
+          await installAvailableAppUpdate();
+          postponeAppUpdate(update.version);
+          expect(JSON.parse(window.localStorage.getItem(reminderKey)!)).toEqual(
+            {
+              version: update.version,
+              remindAfter: Date.now() + day,
+            }
+          );
+          // Simulate restart: only durable storage survives.
+          resetAppUpdaterForTests();
+          mocks.check.mockClear();
+          if (reason === "retry")
+            mocks.check.mockRejectedValueOnce(new Error("offline"));
+          const stop = startAutomaticAppUpdates();
+          await vi.advanceTimersByTimeAsync(10_000);
+          if (reason === "interval")
+            await vi.advanceTimersByTimeAsync(2 * 60 * 60_000);
+          if (reason === "foreground" || reason === "online") {
+            await vi.advanceTimersByTimeAsync(5 * 60_000);
+            window.dispatchEvent(
+              new Event(reason === "foreground" ? "focus" : "online")
+            );
+            await vi.advanceTimersByTimeAsync(750);
+          }
+          if (reason === "retry") await vi.advanceTimersByTimeAsync(72_000);
+          expect(mocks.check).toHaveBeenCalledTimes(
+            reason === "startup" ? 1 : 2
+          );
+          expect(mocks.store!.get(appUpdateInstallPromptAtom)).toBe(false);
+          stop();
+          expect(vi.getTimerCount()).toBe(0);
+        }
+      );
+
+      it("expires after 24 hours and permits explicit prompts during cooldown", async () => {
+        const update = updateFixture();
+        mocks.check.mockResolvedValue(update);
+        await installAvailableAppUpdate();
+        postponeAppUpdate(update.version);
+        await installAvailableAppUpdate();
+        expect(mocks.store!.get(appUpdateInstallPromptAtom)).toBe(true);
+        postponeAppUpdate(update.version);
+        vi.setSystemTime(Date.now() + day);
+        const stop = startAutomaticAppUpdates();
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(mocks.store!.get(appUpdateInstallPromptAtom)).toBe(true);
+        expect(window.localStorage.getItem(reminderKey)).toBeNull();
+        stop();
+      });
+
+      it("does not suppress a newer version", async () => {
+        postponeAppUpdate("1.0.1");
+        mocks.check.mockResolvedValue(updateFixture("1.0.2"));
+        const stop = startAutomaticAppUpdates();
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(mocks.store!.get(appUpdateInstallPromptAtom)).toBe(true);
+        stop();
+      });
+
+      it.each([
+        "{bad",
+        "null",
+        "{}",
+        '{"version":"1.0.1","remindAfter":"tomorrow"}',
+      ])("discards invalid persisted state %s", async (stored) => {
+        window.localStorage.setItem(reminderKey, stored);
+        mocks.check.mockResolvedValue(updateFixture());
+        const stop = startAutomaticAppUpdates();
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(mocks.store!.get(appUpdateInstallPromptAtom)).toBe(true);
+        expect(window.localStorage.getItem(reminderKey)).toBeNull();
+        stop();
+      });
+
+      it("clears the reminder on explicit confirmed installation", async () => {
+        const update = updateFixture();
+        mocks.check.mockResolvedValue(update);
+        await installAvailableAppUpdate();
+        postponeAppUpdate(update.version);
+        await installAvailableAppUpdate({ confirmed: true });
+        expect(window.localStorage.getItem(reminderKey)).toBeNull();
+        if (installStrategy === "inPlace") {
+          expect(update.install).toHaveBeenCalledOnce();
+          expect(mocks.relaunch).toHaveBeenCalledOnce();
+        } else {
+          expect(mocks.separateInstall).toHaveBeenCalledOnce();
+          expect(update.install).not.toHaveBeenCalled();
+        }
+      });
+
+      it("clears the reminder when skipping the version", () => {
+        postponeAppUpdate("1.0.1");
+        skipAppUpdateVersion("1.0.1");
+        expect(window.localStorage.getItem(reminderKey)).toBeNull();
+      });
+    }
+  );
 
   it("shares one in-flight coordinator and state between lazy actions and the mounted service", async () => {
     let resolveCheck!: (update: Update) => void;
@@ -130,3 +261,15 @@ describe("AppUpdater service boundary", () => {
     }
   });
 });
+
+const reminderKey = "orgii:updater:deferred-update-reminder";
+const day = 24 * 60 * 60_000;
+function updateFixture(version = "1.0.1"): Update {
+  return {
+    version,
+    available: true,
+    download: vi.fn().mockResolvedValue(undefined),
+    install: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Update;
+}

--- a/src/scaffold/AppUpdater/service.tsx
+++ b/src/scaffold/AppUpdater/service.tsx
@@ -52,6 +52,15 @@ const SKIPPED_UPDATE_VERSION_STORAGE_KEY =
 const SEPARATELY_INSTALLED_RELEASE_VERSION_STORAGE_KEY =
   "orgii:updater:separately-installed-release-version";
 
+const DEFERRED_UPDATE_REMINDER_STORAGE_KEY =
+  "orgii:updater:deferred-update-reminder";
+const UPDATE_REMINDER_DEFER_DURATION_MS = 24 * 60 * 60_000;
+
+interface DeferredUpdateReminder {
+  version: string;
+  remindAfter: number;
+}
+
 export interface CheckForAppUpdatesOptions {
   notify?: boolean;
   force?: boolean;
@@ -119,6 +128,57 @@ function clearSkippedUpdateVersion(version: string): void {
   if (typeof window !== "undefined" && getSkippedUpdateVersion() === version) {
     window.localStorage.removeItem(SKIPPED_UPDATE_VERSION_STORAGE_KEY);
   }
+}
+
+function getDeferredUpdateReminder(): DeferredUpdateReminder | null {
+  if (typeof window === "undefined") return null;
+
+  const stored = window.localStorage.getItem(
+    DEFERRED_UPDATE_REMINDER_STORAGE_KEY
+  );
+  if (!stored) return null;
+
+  try {
+    const parsed = JSON.parse(stored) as Partial<DeferredUpdateReminder>;
+    if (
+      typeof parsed.version === "string" &&
+      typeof parsed.remindAfter === "number" &&
+      Number.isFinite(parsed.remindAfter) &&
+      parsed.remindAfter > Date.now()
+    ) {
+      return { version: parsed.version, remindAfter: parsed.remindAfter };
+    }
+  } catch {
+    // Invalid persisted state should never suppress an update reminder.
+  }
+
+  window.localStorage.removeItem(DEFERRED_UPDATE_REMINDER_STORAGE_KEY);
+  return null;
+}
+
+function deferUpdateReminder(version: string): void {
+  if (typeof window === "undefined") return;
+  const reminder: DeferredUpdateReminder = {
+    version,
+    remindAfter: Date.now() + UPDATE_REMINDER_DEFER_DURATION_MS,
+  };
+  window.localStorage.setItem(
+    DEFERRED_UPDATE_REMINDER_STORAGE_KEY,
+    JSON.stringify(reminder)
+  );
+}
+
+function clearDeferredUpdateReminder(version: string): void {
+  if (typeof window === "undefined") return;
+  const reminder = getDeferredUpdateReminder();
+  if (reminder?.version === version) {
+    window.localStorage.removeItem(DEFERRED_UPDATE_REMINDER_STORAGE_KEY);
+  }
+}
+
+function isUpdateReminderDeferred(version: string): boolean {
+  const reminder = getDeferredUpdateReminder();
+  return reminder?.version === version;
 }
 
 function getSeparatelyInstalledReleaseVersion(): string | null {
@@ -325,16 +385,24 @@ export interface InstallAvailableAppUpdateOptions {
 
 async function prepareAvailableAppUpdate(
   update: Update,
-  silentDownload: boolean
+  options: {
+    silentDownload: boolean;
+    promptPolicy: "always" | "respect-reminder";
+  }
 ): Promise<void> {
   const provenance = await resolveAppBuildProvenance();
-  const progressReporter = silentDownload
+  const progressReporter = options.silentDownload
     ? undefined
     : createProgressReporter();
   clearSkippedUpdateVersion(update.version);
 
   if (usesSeparateApplicationInstall(provenance)) {
-    store().set(appUpdateInstallPromptAtom, true);
+    if (
+      options.promptPolicy === "always" ||
+      !isUpdateReminderDeferred(update.version)
+    ) {
+      store().set(appUpdateInstallPromptAtom, true);
+    }
     return;
   }
 
@@ -343,7 +411,12 @@ async function prepareAvailableAppUpdate(
   try {
     await coordinator.downloadAvailableUpdate(progressReporter);
     endDownloadProgress();
-    store().set(appUpdateInstallPromptAtom, true);
+    if (
+      options.promptPolicy === "always" ||
+      !isUpdateReminderDeferred(update.version)
+    ) {
+      store().set(appUpdateInstallPromptAtom, true);
+    }
   } catch (error) {
     if (progressReporter) endDownloadProgress();
     throw error;
@@ -423,9 +496,14 @@ export async function installAvailableAppUpdate(
     coordinator.getAvailableUpdate() ?? (await checkForUpdatesManually());
   if (!update) return;
 
+  if (confirmed) clearDeferredUpdateReminder(update.version);
+
   if (!confirmed) {
     try {
-      await prepareAvailableAppUpdate(update, silentDownload);
+      await prepareAvailableAppUpdate(update, {
+        silentDownload,
+        promptPolicy: "always",
+      });
       activeAutomaticScheduler?.resetRetry();
     } catch (error) {
       showDownloadFailure(error, {
@@ -520,7 +598,10 @@ async function executeAutomaticUpdate(
   try {
     // Installing can terminate the app on Windows. Every automatic path only
     // prepares the package and asks the user before installing or relaunching.
-    await prepareAvailableAppUpdate(update, true);
+    await prepareAvailableAppUpdate(update, {
+      silentDownload: true,
+      promptPolicy: "respect-reminder",
+    });
   } catch (error) {
     showDownloadFailure(error, {
       automatic: true,
@@ -567,8 +648,16 @@ export function startAutomaticAppUpdates(): () => void {
   };
 }
 
+export function postponeAppUpdate(version: string | undefined): void {
+  if (version) deferUpdateReminder(version);
+  store().set(appUpdateInstallPromptAtom, false);
+}
+
 export function skipAppUpdateVersion(version: string | undefined): void {
-  if (version) setSkippedUpdateVersion(version);
+  if (version) {
+    setSkippedUpdateVersion(version);
+    clearDeferredUpdateReminder(version);
+  }
   coordinator.clearAvailableUpdate();
 }
 


### PR DESCRIPTION
## Problem

Choosing Later only hid the install dialog. The next automatic update trigger could reopen it because the updater service had no durable reminder decision. This replaces closed #602 on current develop, preserving the updater service/UI separation introduced since that PR.

## Solution

Persist a single version-scoped 24-hour reminder deadline in localStorage through the service's Later action. All automatic preparation paths respect it for both in-place updates and official applications installed beside local builds. Explicit install actions still reopen the prompt. Different versions bypass an older reminder; expired or malformed records are discarded on read, and skipping or confirming installation clears the current version's reminder.

The authoritative write path is the modal's Later action → postponeAppUpdate → localStorage. The service enforces the reminder when projecting automatic preparation into dialog visibility. No historical data cleanup is needed; invalid reminder records are lazily removed. No timers, listeners, dependencies, wire changes, or database migrations are added.

## Potential risks

- The deadline uses wall-clock time; clock changes can shorten or extend postponement. Clearing localStorage also clears the reminder.
- The new optional localStorage record is compatible with the format proposed in #602. Older builds ignore it; rollback is a code revert, optionally removing only `orgii:updater:deferred-update-reminder`.
- Real installation/relaunch and desktop CPU/RSS measurements were not performed. Installer calls are mocked in the tests. The existing scheduler remains unchanged.
- Repository-wide circular checking reports an existing SessionHoverCard cycle outside this diff.

## Verification

- `pnpm test src/scaffold/AppUpdater` — 64 tests passed across 7 files. The service tests exercise real startup, interval, foreground, online, and retry scheduler entry points for both installation strategies, persistence across service reset, expiry, newer versions, malformed storage, manual override, skip, and confirmed installation.
- `pnpm exec eslint src/scaffold/AppUpdater/service.tsx src/scaffold/AppUpdater/service.test.ts src/scaffold/AppUpdater/index.tsx src/scaffold/AppUpdater/index.test.ts` — passed.
- `pnpm run typecheck:fast` — passed (full-project tsgo).
- `pnpm run check:test-placement` — passed across 539 directories.
- `git diff --check` — passed.
- Pre-commit lint-staged (oxlint, ESLint, Prettier) and scoped TypeScript hook — passed.
- `pnpm run check:circular` — failed on the existing `HoverCardBase.tsx → singletonStore.ts → HoverCardBase.tsx` cycle. Both files are unchanged from develop.
- No desktop UI control or real installer/relaunch run. Markup and styling are unchanged, so screenshots would not demonstrate the time-dependent behavior; scheduler and action tests provide behavioral evidence.

## Audit

Architecture review covered compilation, production call ownership/deduplication, names and semantic scope, automatic versus explicit policy, updater-local ownership, documentation clarity, persisted record validation, startup/manual parity, and both install-strategy branches (layers 1–10). Rust initialization and network serialization are not applicable. Frontend UI audit is skipped for this focused bug fix with no markup/style changes; React performance guidance is not triggered.

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Existing scheduler exclusively owns timers and listeners | No new background resources | All five triggers, scheduler visibility tests, repeated mount/stop cleanup |
| Memory | keep | One localStorage record | Overwritten on Later; stale/invalid entries removed on read | Persistence, expiry and malformed-state tests |
| Scope/isolation | fix | Reminder scoped to update version in this app's localStorage | New version bypasses older reminder | Both installation strategies and newer-version tests |
| Rendering/hot path | keep | Existing prompt atom; storage read only at prompt decision | No new subscription or rendering loop | Service/action regression tests |

Performance verdict: blocked for real desktop measurement (not authorized); automated lifecycle and bounded-storage checks passed. No measured CPU/RSS improvement is claimed.
