### PR TITLE
fix(auth): route sidebar login back to the initiating app

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.test.ts
@@ -1,0 +1,64 @@
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { completePendingOrg2CloudAuthLoopback } from "@src/features/Org2Cloud/org2CloudAuthLoopback";
+
+import { useWorkstationSidebarScopeAndPagination } from "./sidebarConnector.scopeAndPagination";
+
+const mocks = vi.hoisted(() => ({
+  start: vi.fn().mockResolvedValue(49152),
+  cancel: vi.fn().mockResolvedValue(undefined),
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@fabianlars/tauri-plugin-oauth", () => mocks);
+vi.mock("@tauri-apps/plugin-opener", () => mocks);
+vi.mock("./sidebarSessionRefresh", () => ({
+  useSidebarSessionRefreshEffects: vi.fn(),
+}));
+vi.mock("./sidebarMenuCollections", () => ({
+  useChatPanelTuiSidebarSessions: () => [],
+}));
+vi.mock("./useSidebarOrgScope", () => ({
+  useSidebarOrgScope: () => ({}),
+}));
+vi.mock("@src/store/repo", async () => {
+  const { atom } = await import("jotai");
+  return { repoMapAtom: atom({}) };
+});
+vi.mock("../workstationSidebarData", () => ({
+  buildRepoPathToName: () => new Map(),
+  sortSessionsByActivity: (sessions: unknown[]) => sessions,
+}));
+
+afterEach(() => {
+  completePendingOrg2CloudAuthLoopback(sessionStorage);
+  vi.clearAllMocks();
+});
+
+describe("sidebar cloud sign-in", () => {
+  it("starts a receiver only on click and returns login to this app instance", async () => {
+    let signIn: (() => void) | undefined;
+    function Harness() {
+      // Expose the real handler from this one-shot server-render test harness.
+      // eslint-disable-next-line react-hooks/globals
+      signIn = useWorkstationSidebarScopeAndPagination({
+        sessions: [],
+      }).handleCloudSignIn;
+      return null;
+    }
+    renderToString(createElement(Harness));
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+
+    signIn!();
+
+    await vi.waitFor(() => expect(mocks.openUrl).toHaveBeenCalledTimes(1));
+    expect(mocks.start).toHaveBeenCalledTimes(1);
+    const login = new URL(mocks.openUrl.mock.calls[0][0]);
+    const callback = new URL(login.searchParams.get("return_to")!);
+    expect(callback.origin).toBe("http://localhost:49152");
+    expect(callback.pathname).toBe("/org2-cloud/auth/callback");
+    expect(callback.searchParams.get("state")).toBeTruthy();
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.ts
@@ -7,13 +7,11 @@
  * Conversations" cloud pagination window, and the cloud sign-in identity
  * used by the org selector.
  */
-import { openUrl } from "@tauri-apps/plugin-opener";
 import { useAtom, useAtomValue } from "jotai";
 import { useCallback, useMemo, useState } from "react";
 
-import { buildOrg2CloudLoginUrl } from "@src/features/Org2Cloud/config";
 import { org2CloudAuthAtom } from "@src/features/Org2Cloud/org2CloudAuthAtom";
-import { createLogger } from "@src/hooks/logger";
+import { useOrg2CloudSignIn } from "@src/features/Org2Cloud/useOrg2CloudSignIn";
 import { repoMapAtom } from "@src/store/repo";
 import type { Session } from "@src/store/session";
 
@@ -32,8 +30,6 @@ import { resetScopedSectionPagination } from "./sectionPagination";
 import { useChatPanelTuiSidebarSessions } from "./sidebarMenuCollections";
 import { useSidebarSessionRefreshEffects } from "./sidebarSessionRefresh";
 import { useSidebarOrgScope } from "./useSidebarOrgScope";
-
-const logger = createLogger("WorkstationSidebar");
 
 interface UseWorkstationSidebarScopeAndPaginationParams {
   sessions: Session[];
@@ -111,11 +107,7 @@ export function useWorkstationSidebarScopeAndPagination({
       cloudAuth.userId)
     : null;
   const cloudSignedInAvatarUrl = cloudAuth?.profile?.avatarUrl;
-  const handleCloudSignIn = useCallback(() => {
-    openUrl(buildOrg2CloudLoginUrl()).catch((error: unknown) => {
-      logger.error("failed to open ORG2 Cloud login in system browser", error);
-    });
-  }, []);
+  const handleCloudSignIn = useOrg2CloudSignIn();
 
   return {
     sortedSessions,


### PR DESCRIPTION
## Problem

Clicking the workstation sidebar's sign-in action in a development build used the legacy `orgii://auth/callback` redirect. With the production app installed, macOS could deliver the browser's login result to production, leaving development signed out. This sidebar entry point bypassed the shared app-owned loopback sign-in flow.

## Solution

Route the sidebar action through `useOrg2CloudSignIn`, matching the other cloud sign-in surfaces. The initiating app starts its temporary local callback receiver before opening the browser. Add a regression test that invokes the actual sidebar handler, verifies no receiver starts during render, and checks that login targets the receiver's localhost port with a per-login state value.

## Potential risks

This entry point now shares the existing loopback flow's requirements: the browser must reach localhost and the app must be able to start the receiver. Existing browser-open failure cleanup, replacement, expiry, and callback validation are unchanged and covered by targeted tests. Rapid concurrent clicks and Windows/Linux browser round trips were not manually exercised. No dependencies, schema, persistence formats, or public interfaces change. Reverting this commit restores the previous sidebar behavior.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.test.ts src/features/Org2Cloud/useOrg2CloudSignIn.test.ts src/features/Org2Cloud/org2CloudAuthLoopback.test.ts src/features/Org2Cloud/authCallback.test.ts` — 25 tests passed across 4 files on the isolated branch based on latest `develop`.
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.test.ts --max-warnings 0` — passed.
- `pnpm typecheck:fast` — passed on the isolated branch.
- `git diff --check` — passed.
- The reporting user retried development sign-in after the fix and confirmed it works. The agent did not independently complete the browser authentication round trip.
- Full test suite and cross-platform rendered E2E were not run for this focused entry-point change. Screenshots are not useful evidence here because appearance is unchanged; the regression concerns the browser callback destination.
