### PR TITLE
style(settings): increase sidebar section spacing

### DIFF
--- a/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
@@ -424,7 +424,7 @@ export const SettingsRootBody: React.FC<SettingsRootBodyProps> = ({
           onMenuItemClick={handleItemClick}
         />
         {namedSections.map((section) => (
-          <div key={section.id} className="mt-1">
+          <div key={section.id} className="mt-4">
             <div className="mb-1 px-2 text-[11px] font-medium tracking-wider text-text-1 uppercase">
               {section.label}
             </div>


### PR DESCRIPTION
## Problem

Settings sidebar groups are visually crowded because named sections have only a small top margin.

## Solution

Increase each named section's top margin from `mt-1` to `mt-4`, adding 12px between groups while preserving item spacing.

## Potential risks

The taller sidebar may require more scrolling in short windows. Visual checks across themes and viewport sizes were not run. This styling-only change has no persistence, API, or dependency impact.

## Verification

- Commit hooks: `oxlint -c .oxlintrc.json --max-warnings 0`, `eslint --fix`, `prettier --write`, and `npx tsgo --noEmit --pretty false` passed.
- After rebasing onto the fetched `origin/develop`, `pnpm exec eslint src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx` and `git diff --check origin/develop...HEAD` passed.
- Reviewed the final diff: one spacing class change, with no unrelated files or sensitive content.
- No new automated tests for this CSS-only adjustment. No new screenshots or desktop visual verification; computer control was not authorized.
