### PR TITLE
fix(settings): keep path action buttons visible

### DIFF
--- a/src/modules/shared/layouts/SectionLayout/PathCopyOpenRow.tsx
+++ b/src/modules/shared/layouts/SectionLayout/PathCopyOpenRow.tsx
@@ -50,11 +50,10 @@ const PathCopyOpenRow: React.FC<PathCopyOpenRowProps> = memo(
   }) => {
     return (
       <SectionRow label={label} description={description}>
-        <div className={`group ${SECTION_ACTION_GAP_CLASSES}`}>
+        <div className={SECTION_ACTION_GAP_CLASSES}>
           <span className={SECTION_PATH_TEXT_CLASSES}>{path}</span>
           <Button
             onClick={onCopy}
-            className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
             icon={
               <HugeiconsIcon icon={Copy01Icon} data-icon="copy" size={14} />
             }
@@ -64,7 +63,6 @@ const PathCopyOpenRow: React.FC<PathCopyOpenRowProps> = memo(
           />
           <Button
             onClick={onOpen}
-            className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
             icon={
               <HugeiconsIcon
                 icon={FolderOpenIcon}


### PR DESCRIPTION
## Problem

Copy and open-folder buttons on settings path rows are hidden until hover or keyboard focus, making the available actions harder to discover.

## Solution

Remove hover-dependent opacity classes from the shared PathCopyOpenRow buttons and remove the unused group class. Path action buttons remain visible on General and Storage settings rows, including their existing disabled states.

## Potential risks

Path rows will show more persistent visual controls. Theme, narrow-window, and disabled-state appearance have not been visually verified. Event handlers and disabled behavior are unchanged; there are no persistence, API, or dependency changes.

## Verification

- Commit hooks: `oxlint -c .oxlintrc.json --max-warnings 0`, `eslint --fix`, `prettier --write`, and `npx tsgo --noEmit --pretty false` passed.
- After rebasing onto the fetched `origin/develop`, `pnpm exec eslint src/modules/shared/layouts/SectionLayout/PathCopyOpenRow.tsx` and `git diff --check origin/develop...HEAD` passed.
- Inspected shared-component usage in General and Storage and reviewed the final diff for scope and sensitive content.
- No new automated tests for this CSS-only adjustment. No new screenshots or desktop visual verification; computer control was not authorized.
