### PR TITLE
style(auth): remove trailing logout description punctuation

### DIFF
--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "Anmelden",
     "signOut": "Abmelden",
     "signOutConfirmTitle": "Abmelden?",
-    "signOutConfirmBody": "Du musst dich erneut anmelden, um auf dein Konto zuzugreifen.",
+    "signOutConfirmBody": "Du musst dich erneut anmelden, um auf dein Konto zuzugreifen",
     "signedInAs": "Angemeldet als {{name}}",
     "signedInToast": "Bei ORG2 Cloud angemeldet",
     "sessionExpired": "Deine ORG2-Cloud-Sitzung ist abgelaufen. Melde dich erneut an, um fortzufahren.",

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -421,7 +421,7 @@
     "signIn": "Login",
     "signOut": "Logout",
     "signOutConfirmTitle": "Sign out?",
-    "signOutConfirmBody": "You will need to sign in again to access your account.",
+    "signOutConfirmBody": "You will need to sign in again to access your account",
     "signedInToast": "Signed in to ORG2 Cloud",
     "sessionExpired": "Your ORG2 Cloud session expired. Sign in again to continue.",
     "customEndpoint": {

--- a/src/i18n/locales/es/navigation.json
+++ b/src/i18n/locales/es/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "Iniciar sesión",
     "signOut": "Cerrar sesión",
     "signOutConfirmTitle": "¿Cerrar sesión?",
-    "signOutConfirmBody": "Tendrás que volver a iniciar sesión para acceder a tu cuenta.",
+    "signOutConfirmBody": "Tendrás que volver a iniciar sesión para acceder a tu cuenta",
     "signedInAs": "Sesión iniciada como {{name}}",
     "signedInToast": "Sesión iniciada en ORG2 Cloud",
     "sessionExpired": "Tu sesión de ORG2 Cloud ha caducado. Inicia sesión de nuevo para continuar.",

--- a/src/i18n/locales/fr/navigation.json
+++ b/src/i18n/locales/fr/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "Connexion",
     "signOut": "Déconnexion",
     "signOutConfirmTitle": "Se déconnecter ?",
-    "signOutConfirmBody": "Vous devrez vous reconnecter pour accéder à votre compte.",
+    "signOutConfirmBody": "Vous devrez vous reconnecter pour accéder à votre compte",
     "signedInAs": "Connecté en tant que {{name}}",
     "signedInToast": "Connecté à ORG2 Cloud",
     "sessionExpired": "Votre session ORG2 Cloud a expiré. Reconnectez-vous pour continuer.",

--- a/src/i18n/locales/ja/navigation.json
+++ b/src/i18n/locales/ja/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "ログイン",
     "signOut": "ログアウト",
     "signOutConfirmTitle": "ログアウトしますか？",
-    "signOutConfirmBody": "アカウントにアクセスするには、再度ログインする必要があります。",
+    "signOutConfirmBody": "アカウントにアクセスするには、再度ログインする必要があります",
     "signedInAs": "{{name}} としてログイン中",
     "signedInToast": "ORG2 クラウドにサインインしました",
     "sessionExpired": "ORG2 Cloud のセッションが期限切れです。続行するには再度サインインしてください。",

--- a/src/i18n/locales/ko/navigation.json
+++ b/src/i18n/locales/ko/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "로그인",
     "signOut": "로그아웃",
     "signOutConfirmTitle": "로그아웃할까요?",
-    "signOutConfirmBody": "계정에 접근하려면 다시 로그인해야 합니다.",
+    "signOutConfirmBody": "계정에 접근하려면 다시 로그인해야 합니다",
     "signedInAs": "로그인 계정: {{name}}",
     "signedInToast": "ORG2 클라우드에 로그인했습니다",
     "sessionExpired": "ORG2 Cloud 세션이 만료되었습니다. 계속하려면 다시 로그인하세요.",

--- a/src/i18n/locales/pl/navigation.json
+++ b/src/i18n/locales/pl/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "Zaloguj się",
     "signOut": "Wyloguj się",
     "signOutConfirmTitle": "Wylogować się?",
-    "signOutConfirmBody": "Aby uzyskać dostęp do konta, musisz zalogować się ponownie.",
+    "signOutConfirmBody": "Aby uzyskać dostęp do konta, musisz zalogować się ponownie",
     "signedInAs": "Zalogowano jako {{name}}",
     "signedInToast": "Signed in to ORG2 Cloud",
     "sessionExpired": "Sesja ORG2 Cloud wygasła. Zaloguj się ponownie, aby kontynuować.",

--- a/src/i18n/locales/pt/navigation.json
+++ b/src/i18n/locales/pt/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "Entrar",
     "signOut": "Sair",
     "signOutConfirmTitle": "Sair da conta?",
-    "signOutConfirmBody": "Você precisará entrar novamente para acessar sua conta.",
+    "signOutConfirmBody": "Você precisará entrar novamente para acessar sua conta",
     "signedInAs": "Sessão iniciada como {{name}}",
     "signedInToast": "Signed in to ORG2 Cloud",
     "sessionExpired": "Sua sessão do ORG2 Cloud expirou. Entre novamente para continuar.",

--- a/src/i18n/locales/ru/navigation.json
+++ b/src/i18n/locales/ru/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "Войти",
     "signOut": "Выйти",
     "signOutConfirmTitle": "Выйти из аккаунта?",
-    "signOutConfirmBody": "Для доступа к аккаунту потребуется войти снова.",
+    "signOutConfirmBody": "Для доступа к аккаунту потребуется войти снова",
     "signedInAs": "Выполнен вход как {{name}}",
     "signedInToast": "Выполнен вход в ORG2 Cloud",
     "sessionExpired": "Сеанс ORG2 Cloud истёк. Войдите снова, чтобы продолжить.",

--- a/src/i18n/locales/tr/navigation.json
+++ b/src/i18n/locales/tr/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "Giriş yap",
     "signOut": "Çıkış yap",
     "signOutConfirmTitle": "Çıkış yapılsın mı?",
-    "signOutConfirmBody": "Hesabınıza erişmek için yeniden giriş yapmanız gerekecek.",
+    "signOutConfirmBody": "Hesabınıza erişmek için yeniden giriş yapmanız gerekecek",
     "signedInAs": "{{name}} olarak giriş yapıldı",
     "signedInToast": "Signed in to ORG2 Cloud",
     "sessionExpired": "ORG2 Cloud oturumunuzun süresi doldu. Devam etmek için yeniden giriş yapın.",

--- a/src/i18n/locales/vi/navigation.json
+++ b/src/i18n/locales/vi/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "Đăng nhập",
     "signOut": "Đăng xuất",
     "signOutConfirmTitle": "Đăng xuất?",
-    "signOutConfirmBody": "Bạn sẽ cần đăng nhập lại để truy cập tài khoản của mình.",
+    "signOutConfirmBody": "Bạn sẽ cần đăng nhập lại để truy cập tài khoản của mình",
     "signedInAs": "Đã đăng nhập: {{name}}",
     "signedInToast": "Đã đăng nhập ORG2 Cloud",
     "sessionExpired": "Phiên ORG2 Cloud đã hết hạn. Hãy đăng nhập lại để tiếp tục.",

--- a/src/i18n/locales/zh-Hant/navigation.json
+++ b/src/i18n/locales/zh-Hant/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "登入",
     "signOut": "登出",
     "signOutConfirmTitle": "確認登出？",
-    "signOutConfirmBody": "登出後，你需要重新登入才能存取你的帳戶。",
+    "signOutConfirmBody": "登出後，你需要重新登入才能存取你的帳戶",
     "signedInToast": "已登入 ORG2 雲端",
     "sessionExpired": "ORG2 雲端登入已過期，請重新登入後繼續。",
     "customEndpoint": {

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -366,7 +366,7 @@
     "signIn": "登录",
     "signOut": "退出登录",
     "signOutConfirmTitle": "确认退出登录？",
-    "signOutConfirmBody": "退出后，你需要重新登录才能访问你的账户。",
+    "signOutConfirmBody": "退出后，你需要重新登录才能访问你的账户",
     "signedInToast": "已登录 ORG2 云",
     "sessionExpired": "ORG2 云登录已过期，请重新登录后继续。",
     "customEndpoint": {


### PR DESCRIPTION
## Problem

Logout confirmation descriptions end with a period or Chinese full stop, contrary to the requested authentication-dialog copy style.

## Solution

Remove only the trailing `.` or `。` from the logout description in all 13 locales. Preserve the wording and confirmation title.

## Potential risks

Copy-only change with no runtime, persistence, dependency, or API impact. No screenshot is attached because this removes a single punctuation glyph per locale without changing layout structure. Reverting the commit restores the previous punctuation.

## Verification

- `pnpm run check:i18n-keys` — passed with zero locale gaps, missing keys, locale extras, or placeholder mismatches.
- `git diff --check` — passed; reviewed all 13 one-line changes.
- Commit hooks: formatting and commitlint passed; TypeScript and Rust checks skipped because neither language changed.
- Runtime tests and visual checks were not run for this punctuation-only change.
