### PR TITLE
style(quota): simplify balance cards and weekly history

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/StartPageQuotaGrid.md
+++ b/docs/frontend-ui-audit-2026-09-10/StartPageQuotaGrid.md
@@ -1,0 +1,11 @@
+# StartPageQuotaGrid UI audit
+
+| Line                         | Element                     | Verdict          | Reason                                                                                                | Suggested change |
+| ---------------------------- | --------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------- | ---------------- |
+| `StartPageQuotaGrid.tsx:50`  | Card spacing and typography | keep with reason | Uses existing spacing, typography and theme tokens                                                    | None             |
+| `StartPageQuotaGrid.tsx:74`  | Stacked balance             | keep with reason | A plain label and larger currency amount meet the requested hierarchy without interactive scaffolding | None             |
+| `StartPageQuotaGrid.tsx:103` | Percentage and meter        | keep with reason | Bare percentages retain shared quota colors and existing provider values                              | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+Reviewed D1–D5 for the changed card styling. Refresh lifecycle is unchanged. No cross-file sweep identified.

--- a/docs/frontend-ui-audit-2026-09-10/WeeklyQuotaHistoryPanel.md
+++ b/docs/frontend-ui-audit-2026-09-10/WeeklyQuotaHistoryPanel.md
@@ -1,0 +1,13 @@
+# WeeklyQuotaHistoryPanel UI audit
+
+| Line                              | Element             | Verdict          | Reason                                                                                                                                                                     | Suggested change |
+| --------------------------------- | ------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `WeeklyQuotaHistoryPanel.tsx:58`  | Error notice        | keep with reason | Fetch failures reuse compact PageNotice with status semantics                                                                                                              | None             |
+| `WeeklyQuotaHistoryPanel.tsx:145` | Account heading     | keep with reason | Preserves account names and removes the Codex provider suffix as requested; selector follows the same rule                                                                 | None             |
+| `WeeklyQuotaHistoryPanel.tsx:261` | Week controls       | keep with reason | Week picker sits below the chart; shared Button provides keyboard behavior, labels and disabled states                                                                     | None             |
+| `WeeklyQuotaHistoryPanel.tsx:194` | Chart styling       | keep with reason | Uses shared chart tokens and existing responsive dimensions; no new color or size values                                                                                   | None             |
+| `WeeklyQuotaHistoryPanel.tsx:154` | Account status line | keep with reason | One prioritized status left of the timestamp with a decorative separator; paused uses danger-6 and stale uses warning-6; paused sampling supersedes stale age as requested | None             |
+
+Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.
+
+Reviewed D1–D5 for this panel. No cross-file sweep identified. Sampling and refresh lifecycle are unchanged. Verified through rendered component tests and lint; no desktop UI control used.

--- a/docs/org2-performance-guard-2026-09-10/QuotaDisplay.md
+++ b/docs/org2-performance-guard-2026-09-10/QuotaDisplay.md
@@ -1,0 +1,12 @@
+# Quota display performance review
+
+| Area               | Verdict | Evidence                                                                                                   | Change or reason kept                                     | Verification                                     |
+| ------------------ | ------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------ |
+| Background work    | keep    | Sampling and refresh hooks are unchanged; week buttons update component state only                         | No added timers, requests, subscriptions or workers       | Source inspection and quota grid lifecycle tests |
+| Memory             | keep    | Backend history reads are capped at 672 samples per account; weeklyQuotaRange filters one selected account | Derived array is render-local, and week offset is clamped | Five range tests                                 |
+| Scope/isolation    | keep    | Account selection resets week state, with keyId guarding the applied offset                                | No added shared cache or persistence                      | Source inspection                                |
+| Rendering/hot path | keep    | One selected chart; bar animations disabled; one pass over bounded samples                                 | Navigation is on demand                                   | Rendered sparse-bar and paused/stale tests       |
+
+Lifecycle matrix: active navigation performs a bounded local projection; idle/hidden views add no recurring work; unmount releases component state. Network, sign-out, endpoint changes, sampling, and multi-instance resources remain owned by unchanged hooks. There are no provider ingestion or transport changes.
+
+Performance verdict: blocked for real desktop CPU/RSS measurements, which were not run because desktop control is not authorized. Static resource review, frontend typecheck, and focused tests passed; no runtime performance improvement is claimed.

--- a/src/components/QuotaBar/index.tsx
+++ b/src/components/QuotaBar/index.tsx
@@ -10,9 +10,12 @@ import React from "react";
 
 import { HugeiconsIcon, Tick01Icon } from "@src/icons";
 
-export function getQuotaTextColorClass(percentage: number): string {
+export function getQuotaTextColorClass(
+  percentage: number,
+  healthyThreshold = 30
+): string {
   if (percentage < 10) return "text-danger-6";
-  if (percentage < 30) return "text-warning-6";
+  if (percentage < healthyThreshold) return "text-warning-6";
   return "text-success-6";
 }
 

--- a/src/engines/ChatPanel/StartPageQuotaGrid.test.ts
+++ b/src/engines/ChatPanel/StartPageQuotaGrid.test.ts
@@ -119,21 +119,27 @@ describe("StartPageQuotaGrid", () => {
     expect(markup).toContain("flex min-h-9 items-center justify-between gap-3");
     expect(markup).toContain("border-0 bg-transparent text-text-2");
     expect(markup).toContain(
-      "truncate text-xs leading-4 font-semibold text-text-1"
+      "truncate text-sm leading-5 font-semibold text-text-1"
     );
-    expect(markup).toContain("truncate text-[11px] leading-4 text-text-3");
-    expect(markup).toContain("min-w-0 p-3 rounded-lg");
-    expect(markup).toContain("mb-2 flex min-w-0 items-center gap-2");
-    expect(markup).toContain("space-y-2.5");
+    expect(markup).toContain("truncate text-xs leading-5 text-text-3");
+    expect(markup).toContain("min-w-0 p-4 rounded-lg");
+    expect(markup).toContain("mb-3 flex min-w-0 items-center gap-2");
+    expect(markup).toContain("space-y-3");
     expect(markup).toContain("Balance");
     expect(markup).toContain("$12.34");
+    expect(markup).toContain('class="flex min-w-0 flex-col gap-1"');
+    expect(markup).toContain(
+      "text-2xl leading-8 font-semibold break-words text-text-1 tabular-nums"
+    );
+    expect(markup).toContain(">75%</span>");
+    expect(markup).not.toContain("keyVault.quota.percentLeft");
     expect(markup).toContain('class="space-y-1"');
     expect(markup).toContain(
       "grid grid-cols-1 gap-3 @[640px]/quota:grid-cols-2"
     );
     expect(markup).not.toContain("grid gap-2");
     expect(markup).toContain(
-      "flex items-center justify-between gap-2 text-[11px] leading-4"
+      "flex items-center justify-between gap-2 text-xs leading-4"
     );
   });
 

--- a/src/engines/ChatPanel/StartPageQuotaGrid.tsx
+++ b/src/engines/ChatPanel/StartPageQuotaGrid.tsx
@@ -47,8 +47,8 @@ function StartPageQuotaCard({
   const { t: tIntegrations } = useTranslation("integrations");
 
   return (
-    <div className={`min-w-0 p-3 ${START_PAGE_QUOTA_SURFACE_CLASS}`}>
-      <div className="mb-2 flex min-w-0 items-center gap-2">
+    <div className={`min-w-0 p-4 ${START_PAGE_QUOTA_SURFACE_CLASS}`}>
+      <div className="mb-3 flex min-w-0 items-center gap-2">
         <ModelIcon agentType={entry.modelType} size="small" />
         <div
           className="min-w-0 flex-1"
@@ -58,27 +58,24 @@ function StartPageQuotaCard({
               : entry.accountName
           }
         >
-          <div className="truncate text-xs leading-4 font-semibold text-text-1">
+          <div className="truncate text-sm leading-5 font-semibold text-text-1">
             {entry.accountName}
           </div>
-          <div className="truncate text-[11px] leading-4 text-text-3">
+          <div className="truncate text-xs leading-5 text-text-3">
             {entry.accountPlan ?? "-"}
             {entry.quotaMessage ? ` · ${entry.quotaMessage}` : ""}
           </div>
         </div>
       </div>
-      <div className="space-y-2.5">
+      <div className="space-y-3">
         {entry.metrics.map((metric) => {
           if (metric.kind === "value") {
             return (
-              <div
-                key={metric.key}
-                className="flex items-center justify-between gap-2 text-[11px] leading-4"
-              >
-                <span className="min-w-0 truncate text-text-3">
+              <div key={metric.key} className="flex min-w-0 flex-col gap-1">
+                <span className="truncate text-xs leading-4 text-text-3">
                   {metric.label}
                 </span>
-                <span className="shrink-0 font-semibold text-text-1 tabular-nums">
+                <span className="text-2xl leading-8 font-semibold break-words text-text-1 tabular-nums">
                   {metric.value}
                 </span>
               </div>
@@ -96,7 +93,7 @@ function StartPageQuotaCard({
           );
           return (
             <div key={metric.key} className="space-y-1">
-              <div className="flex items-center justify-between gap-2 text-[11px] leading-4">
+              <div className="flex items-center justify-between gap-2 text-xs leading-4">
                 <span className="min-w-0 truncate text-text-3">
                   {metric.label}
                   {resetHint ? (
@@ -106,9 +103,7 @@ function StartPageQuotaCard({
                 <span
                   className={`shrink-0 font-semibold tabular-nums ${textColorClass}`}
                 >
-                  {tIntegrations("keyVault.quota.percentLeft", {
-                    percent: Math.round(metric.remainingPercent),
-                  })}
+                  {Math.round(metric.remainingPercent)}%
                 </span>
               </div>
               <div className="h-1 w-full overflow-hidden rounded-full bg-fill-3">

--- a/src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.rendering.test.ts
+++ b/src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.rendering.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { type ReactElement, act, cloneElement, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+
+import WeeklyQuotaHistoryPanel from "./WeeklyQuotaHistoryPanel";
+
+const fixture = vi.hoisted(() => ({ samplingEnabled: false }));
+
+const now = 1_788_970_200;
+vi.mock("@src/hooks/keyVault/useWeeklyQuotaHistory", () => ({
+  useWeeklyQuotaHistory: () => ({
+    accounts: [
+      {
+        keyId: "codex",
+        name: "OpenAI",
+        provider: "codex",
+        status: "ok",
+        samplingEnabled: fixture.samplingEnabled,
+        points: [100, 95, 87].map((remainingPercent, index) => ({
+          capturedAt: now - [10, 7, 1][index] * 3600,
+          remainingPercent,
+          resetAt: null,
+        })),
+      },
+    ],
+    observedAt: now + 3 * 3600,
+    loading: false,
+    error: false,
+    refresh: vi.fn(),
+  }),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, options: { defaultValue: string }) =>
+      options.defaultValue,
+    i18n: { language: "zh" },
+  }),
+}));
+vi.mock("./RuntimeSectionHeader", () => ({
+  RuntimeSectionHeader: () => null,
+  RuntimeRefreshButton: () => null,
+}));
+vi.mock("@src/components/Select", () => ({ default: () => null }));
+// Give the real chart a measurable viewport without mocking its SVG renderer.
+vi.mock("recharts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("recharts")>()),
+  ResponsiveContainer: ({ children }: { children: ReactElement }) =>
+    cloneElement(children, { width: 900, height: 160 } as object),
+}));
+let root: ReturnType<typeof createRoot>;
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  vi.unstubAllGlobals();
+});
+it.each([false, true])(
+  "renders quota history with sampling enabled: %s",
+  async (samplingEnabled) => {
+    fixture.samplingEnabled = samplingEnabled;
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    root = createRoot(container);
+    await act(async () => root.render(createElement(WeeklyQuotaHistoryPanel)));
+    expect(
+      container.querySelector('[aria-live="polite"]')?.textContent
+    ).toMatch(/^Sep \d+ – Sep \d+$/);
+    expect(container.textContent).not.toMatch(/[月日]/);
+    expect(container.textContent).toMatch(/87% · Sep \d+, \d{2}:\d{2}/);
+    expect(container.textContent).not.toContain("OpenAI · codex");
+    const notices = Array.from(container.querySelectorAll('[role="status"]'));
+    expect(
+      notices.some((notice) =>
+        notice.textContent?.includes("over two hours old")
+      )
+    ).toBe(samplingEnabled);
+    expect(
+      notices.some((notice) => notice.textContent?.includes("Sampling paused"))
+    ).toBe(!samplingEnabled);
+    expect(notices.every((notice) => notice.tagName !== "P")).toBe(true);
+    const status = notices[0];
+    expect(
+      status.classList.contains(
+        samplingEnabled ? "text-warning-6" : "text-danger-6"
+      )
+    ).toBe(true);
+    expect(status.nextElementSibling?.classList.contains("border-fill-3")).toBe(
+      true
+    );
+    expect(
+      status.nextElementSibling?.nextElementSibling?.textContent
+    ).toContain("87%");
+    expect(status.parentElement?.querySelector("button")).toBeNull();
+    const chart = container.querySelector('[role="group"]')!;
+    const picker = container.querySelector('[aria-live="polite"]')!;
+    expect(
+      chart.compareDocumentPosition(picker) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    const bars = container.querySelectorAll(".recharts-bar-rectangle path");
+    expect(bars).toHaveLength(3);
+    for (const bar of bars) {
+      expect(Number(bar.getAttribute("width"))).toBeGreaterThanOrEqual(1);
+      expect(Number(bar.getAttribute("height"))).toBeGreaterThan(0);
+      expect(Number(bar.getAttribute("x"))).toBeGreaterThanOrEqual(40);
+      expect(Number(bar.getAttribute("x"))).toBeLessThan(900);
+    }
+  }
+);

--- a/src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.test.ts
+++ b/src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.test.ts
@@ -36,6 +36,8 @@ vi.mock("./RuntimeSectionHeader", () => ({
 }));
 vi.mock("@src/components/Chart", () => ({
   CHART_AXIS_TICK: {},
+  CHART_GRID_STROKE: "currentColor",
+  CHART_MARGIN: {},
   CHART_TOOLTIP: {},
 }));
 vi.mock("@src/components/Select", () => ({
@@ -59,9 +61,11 @@ vi.mock("@src/components/Select", () => ({
 }));
 vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: unknown }) => children,
-  LineChart: ({ children }: { children: unknown }) =>
+  BarChart: ({ children }: { children: unknown }) =>
     createElement("div", { "data-testid": "quota-chart" }, children as never),
-  Line: () => null,
+  Bar: () => null,
+  CartesianGrid: () => null,
+  Cell: () => null,
   XAxis: () => null,
   YAxis: () => null,
   Tooltip: () => null,

--- a/src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.tsx
+++ b/src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.tsx
@@ -1,26 +1,37 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  Line,
-  LineChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
 
-import { CHART_AXIS_TICK, CHART_TOOLTIP } from "@src/components/Chart";
+import Button from "@src/components/Button";
+import {
+  CHART_AXIS_TICK,
+  CHART_GRID_STROKE,
+  CHART_MARGIN,
+  CHART_TOOLTIP,
+} from "@src/components/Chart";
+import PageNotice from "@src/components/PageNotice";
+import { getQuotaTextColorClass } from "@src/components/QuotaBar";
 import Select from "@src/components/Select";
 import { useWeeklyQuotaHistory } from "@src/hooks/keyVault/useWeeklyQuotaHistory";
+import { ArrowLeft01Icon, ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
 
 import {
   RuntimeRefreshButton,
   RuntimeSectionHeader,
 } from "./RuntimeSectionHeader";
-import { weeklyQuotaChartPoints } from "./weeklyQuotaChartPoints";
+import { weeklyQuotaRange } from "./weeklyQuotaRange";
 
 export default function WeeklyQuotaHistoryPanel() {
-  const { t, i18n } = useTranslation("sessions");
+  const { t } = useTranslation("sessions");
   const {
     accounts,
     loading,
@@ -29,6 +40,7 @@ export default function WeeklyQuotaHistoryPanel() {
     observedAt: now,
   } = useWeeklyQuotaHistory();
   const [selectedId, setSelectedId] = useState<string>();
+  const [week, setWeek] = useState({ keyId: "", offset: 0 });
   const selected =
     accounts.find((account) => account.keyId === selectedId) ?? accounts[0];
   const text = (key: string, fallback: string) =>
@@ -42,29 +54,23 @@ export default function WeeklyQuotaHistoryPanel() {
           refreshing={loading}
         />
       </RuntimeSectionHeader>
-      <p className="text-xs text-text-3">
-        {text(
-          "description",
-          "Quota remaining · Last 28 days · Sampled hourly while the app is visible and online · Missing readings are gaps"
-        )}
-      </p>
       {error ? (
-        <p role="status" className="text-xs text-text-3">
+        <PageNotice compact type="warning" role="status">
           {text(
             "error",
             "Quota history is unavailable. It will retry when you return to this window"
           )}
-        </p>
+        </PageNotice>
       ) : null}
       {!accounts.length && !error ? (
-        <p role="status" className="text-xs text-text-3">
+        <PageNotice compact role="status">
           {loading
             ? text("loading", "Loading quota history…")
             : text(
                 "empty",
                 "Connect a Claude Code, Codex, or OpenCode Go account in Key Vault to start tracking"
               )}
-        </p>
+        </PageNotice>
       ) : null}
       {accounts.length > 1 ? (
         <Select
@@ -72,26 +78,63 @@ export default function WeeklyQuotaHistoryPanel() {
           ariaLabel={text("account", "Account")}
           options={accounts.map((account) => ({
             value: account.keyId,
-            label: `${account.name} · ${account.provider}`,
+            label:
+              account.provider === "codex"
+                ? account.name
+                : `${account.name} · ${account.provider}`,
           }))}
-          onChange={(value) => setSelectedId(String(value))}
+          onChange={(value) => {
+            setSelectedId(String(value));
+            setWeek({ keyId: String(value), offset: 0 });
+          }}
           showSearch
         />
       ) : null}
       {accounts.length === 128 ? (
-        <p className="text-xs text-text-3">
+        <PageNotice compact role="status">
           {text("limit", "Showing up to 128 accounts")}
-        </p>
+        </PageNotice>
       ) : null}
       <div className="grid grid-cols-1 gap-3">
         {(selected ? [selected] : []).map((account) => {
           const latest = account.points.at(-1);
+          const range = weeklyQuotaRange(
+            account.points,
+            now,
+            week.keyId === account.keyId ? week.offset : 0
+          );
+          const chartPoints = range.points;
+          const visibleLatest = chartPoints.at(-1);
+          const accountStatus =
+            account.samplingEnabled === false
+              ? text("disabled", "Sampling paused for this disabled account")
+              : account.status === "unsupported"
+                ? text(
+                    "unsupported",
+                    "This account does not report a weekly quota"
+                  )
+                : account.status === "unavailable"
+                  ? text(
+                      "unavailable",
+                      "Latest reading unavailable; check the account connection in Key Vault"
+                    )
+                  : account.status !== "ok" || !latest
+                    ? text("pending", "Waiting for the next hourly sample")
+                    : now - latest.capturedAt > 2 * 3600
+                      ? text("stale", "Last observation is over two hours old")
+                      : null;
+          const formatDay = (value: number) =>
+            new Date(value * 1000).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+            });
           const formatDate = (value: number) =>
-            new Date(value * 1000).toLocaleString(i18n.language, {
+            new Date(value * 1000).toLocaleString("en-US", {
               month: "short",
               day: "numeric",
               hour: "numeric",
               minute: "2-digit",
+              hourCycle: "h23",
             });
           return (
             <div
@@ -100,60 +143,74 @@ export default function WeeklyQuotaHistoryPanel() {
             >
               <div className="flex flex-wrap justify-between gap-2 text-xs text-text-1">
                 <span className="font-semibold">
-                  {account.name} · {account.provider}
+                  {account.name}
+                  {account.provider !== "codex"
+                    ? ` · ${account.provider}`
+                    : null}
                 </span>
-                {latest ? (
-                  <span>
-                    {latest.remainingPercent.toFixed(0)}% ·{" "}
-                    {formatDate(latest.capturedAt)}
-                  </span>
-                ) : null}
+                <div className="flex min-w-0 items-center gap-2">
+                  {accountStatus ? (
+                    <span
+                      role="status"
+                      className={
+                        account.samplingEnabled === false
+                          ? "min-w-0 text-danger-6"
+                          : account.status === "ok" &&
+                              latest &&
+                              now - latest.capturedAt > 2 * 3600
+                            ? "min-w-0 text-warning-6"
+                            : "min-w-0 text-text-3"
+                      }
+                    >
+                      {accountStatus}
+                    </span>
+                  ) : null}
+                  {accountStatus && visibleLatest ? (
+                    <span
+                      aria-hidden="true"
+                      className="h-4 shrink-0 border-l border-fill-3"
+                    />
+                  ) : null}
+                  {visibleLatest ? (
+                    <span className="shrink-0">
+                      {visibleLatest.remainingPercent.toFixed(0)}% ·{" "}
+                      {formatDate(visibleLatest.capturedAt)}
+                    </span>
+                  ) : null}
+                </div>
               </div>
-              {latest && now - latest.capturedAt > 2 * 3600 ? (
-                <p className="text-xs text-text-3">
-                  {text("stale", "Last observation is over two hours old")}
-                </p>
-              ) : null}
-              {account.samplingEnabled === false ? (
-                <p className="text-xs text-text-3">
-                  {text(
-                    "disabled",
-                    "Sampling paused for this disabled account"
-                  )}
-                </p>
-              ) : account.status !== "ok" || !latest ? (
-                <p className="text-xs text-text-3">
-                  {account.status === "unsupported"
-                    ? text(
-                        "unsupported",
-                        "This account does not report a weekly quota"
-                      )
-                    : account.status === "unavailable"
-                      ? text(
-                          "unavailable",
-                          "Latest reading unavailable; check the account connection in Key Vault"
-                        )
-                      : text("pending", "Waiting for the next hourly sample")}
-                </p>
+              {latest && !chartPoints.length ? (
+                <PageNotice compact role="status">
+                  {text("emptyWeek", "No readings for this week")}
+                </PageNotice>
               ) : null}
               {latest ? (
                 <div
                   className="h-40 w-full"
                   role="group"
-                  aria-label={`${account.name}: ${latest.remainingPercent.toFixed(0)}%`}
+                  aria-label={`${account.name}: ${formatDay(range.start)} – ${formatDay(range.end)}`}
                 >
                   <ResponsiveContainer width="100%" height="100%">
-                    <LineChart
-                      data={weeklyQuotaChartPoints(account.points)}
+                    <BarChart
+                      data={chartPoints}
+                      margin={CHART_MARGIN}
                       accessibilityLayer
                     >
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        vertical={false}
+                        stroke={CHART_GRID_STROKE}
+                      />
                       <XAxis
                         dataKey="capturedAt"
                         type="number"
-                        domain={[now - 28 * 24 * 3600, now]}
+                        domain={[range.start, range.end]}
+                        allowDataOverflow
                         tickFormatter={formatDate}
                         tick={CHART_AXIS_TICK}
                         minTickGap={50}
+                        axisLine={false}
+                        tickLine={false}
                       />
                       <YAxis
                         domain={[0, 100]}
@@ -161,24 +218,74 @@ export default function WeeklyQuotaHistoryPanel() {
                         tickFormatter={(value) => `${value}%`}
                         tick={CHART_AXIS_TICK}
                         width={40}
+                        axisLine={false}
+                        tickLine={false}
                       />
                       <Tooltip
                         contentStyle={CHART_TOOLTIP.content}
                         labelStyle={CHART_TOOLTIP.label}
                         itemStyle={CHART_TOOLTIP.item}
                         labelFormatter={(value) => formatDate(Number(value))}
+                        formatter={(value) => `${Number(value).toFixed(0)}%`}
                       />
-                      <Line
+                      <Bar
                         name={text("remaining", "Remaining %")}
                         dataKey="remainingPercent"
-                        type="stepAfter"
-                        stroke="var(--color-primary-6)"
-                        dot={{ r: 2 }}
-                        connectNulls={false}
+                        barSize={3}
+                        minPointSize={(value) => (value === 0 ? 2 : 0)}
+                        radius={[2, 2, 0, 0]}
                         isAnimationActive={false}
-                      />
-                    </LineChart>
+                      >
+                        {chartPoints.map((point) => (
+                          <Cell
+                            key={point.capturedAt}
+                            fill="currentColor"
+                            className={getQuotaTextColorClass(
+                              point.remainingPercent ?? 0,
+                              50
+                            )}
+                          />
+                        ))}
+                      </Bar>
+                    </BarChart>
                   </ResponsiveContainer>
+                </div>
+              ) : null}
+              {latest ? (
+                <div className="flex items-center justify-center gap-2 text-xs text-text-2">
+                  <Button
+                    htmlType="button"
+                    variant="tertiary"
+                    size="small"
+                    iconOnly
+                    aria-label={text("previousWeek", "Previous week")}
+                    disabled={range.offset >= range.maxOffset}
+                    onClick={() =>
+                      setWeek({
+                        keyId: account.keyId,
+                        offset: range.offset + 1,
+                      })
+                    }
+                    icon={<HugeiconsIcon icon={ArrowLeft01Icon} size={16} />}
+                  />
+                  <span aria-live="polite">
+                    {formatDay(range.start)} – {formatDay(range.end)}
+                  </span>
+                  <Button
+                    htmlType="button"
+                    variant="tertiary"
+                    size="small"
+                    iconOnly
+                    aria-label={text("nextWeek", "Next week")}
+                    disabled={range.offset === 0}
+                    onClick={() =>
+                      setWeek({
+                        keyId: account.keyId,
+                        offset: range.offset - 1,
+                      })
+                    }
+                    icon={<HugeiconsIcon icon={ArrowRight01Icon} size={16} />}
+                  />
                 </div>
               ) : null}
             </div>

--- a/src/modules/shared/dataSource/weeklyQuotaRange.test.ts
+++ b/src/modules/shared/dataSource/weeklyQuotaRange.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { weeklyQuotaRange } from "./weeklyQuotaRange";
+
+const day = 86400;
+const end = Date.parse("2026-09-12T12:00:00Z") / 1000;
+const point = (
+  capturedAt: number,
+  remainingPercent = 87,
+  resetAt: string | null = new Date(end * 1000).toISOString()
+) => ({ capturedAt, remainingPercent, resetAt });
+
+describe("weeklyQuotaRange", () => {
+  it("defaults to the provider's current seven-day cycle without inventing 100%", () => {
+    const points = [
+      point(end - 8 * day),
+      point(end - 7 * day),
+      point(end - day),
+    ];
+    const range = weeklyQuotaRange(points, end - day, 0);
+    expect([range.start, range.end]).toEqual([end - 7 * day, end]);
+    expect(range.points).toEqual(points.slice(1));
+  });
+  it("pages backward and clamps both navigation limits", () => {
+    const points = [
+      point(end - 20 * day),
+      point(end - 10 * day),
+      point(end - day),
+    ];
+    expect(weeklyQuotaRange(points, end - day, 1).points).toEqual([points[1]]);
+    const oldest = weeklyQuotaRange(points, end - day, 99);
+    expect(oldest.offset).toBe(2);
+    expect(oldest.points).toEqual([points[0]]);
+    expect(weeklyQuotaRange(points, end - day, -1).offset).toBe(0);
+  });
+  it("uses a rolling week for absent or invalid reset metadata", () => {
+    for (const reset of [
+      null,
+      "invalid",
+      new Date((end + 20 * day) * 1000).toISOString(),
+    ]) {
+      const points = [point(end - 8 * day, 90, reset), point(end, 0, reset)];
+      const range = weeklyQuotaRange(points, end, 0);
+      expect(range.end - range.start).toBe(7 * day);
+      expect(range.points).toEqual([points[1]]);
+    }
+  });
+  it("advances an expired cycle and leaves the new cycle empty", () => {
+    const points = [point(end - day)];
+    const range = weeklyQuotaRange(points, end, 0);
+    expect([range.start, range.end]).toEqual([end, end + 7 * day]);
+    expect(range.points).toEqual([]);
+    expect(weeklyQuotaRange(points, end, 1).points).toEqual(points);
+  });
+  it("does not offer history navigation for an empty account", () => {
+    expect(weeklyQuotaRange([], end, 10).maxOffset).toBe(0);
+  });
+});

--- a/src/modules/shared/dataSource/weeklyQuotaRange.ts
+++ b/src/modules/shared/dataSource/weeklyQuotaRange.ts
@@ -1,0 +1,42 @@
+import type { WeeklyQuotaHistory } from "@src/api/tauri/rpc/schemas/weeklyQuotaHistory";
+
+const WEEK = 7 * 24 * 3600;
+
+/** Use the provider's reset boundary; never manufacture a 100% observation. */
+export function weeklyQuotaRange(
+  points: WeeklyQuotaHistory[number]["points"],
+  now: number,
+  requestedOffset: number
+) {
+  const latest = points.at(-1);
+  const reset = latest?.resetAt ? Date.parse(latest.resetAt) / 1000 : NaN;
+  const validReset =
+    latest &&
+    Number.isFinite(reset) &&
+    reset > latest.capturedAt &&
+    reset - latest.capturedAt <= WEEK;
+  // Without reset metadata, use a rolling seven-day window including `now`.
+  const currentEnd = validReset
+    ? reset + Math.max(0, Math.floor((now - reset) / WEEK) + 1) * WEEK
+    : now + 1;
+  const earliest = Math.max(points[0]?.capturedAt ?? now, now - 4 * WEEK);
+  const maxOffset = Math.max(
+    0,
+    Math.ceil((currentEnd - WEEK - earliest) / WEEK)
+  );
+  const offset = Math.min(maxOffset, Math.max(0, requestedOffset));
+  const end = currentEnd - offset * WEEK;
+  const start = end - WEEK;
+  return {
+    start,
+    end,
+    offset,
+    maxOffset,
+    points: points.filter(
+      (point) =>
+        point.capturedAt >= start &&
+        point.capturedAt < end &&
+        point.capturedAt <= now
+    ),
+  };
+}


### PR DESCRIPTION
## Problem

Quota cards use small, wordy percentages and inline currency balances. Weekly history repeats paused/stale messages, exposes the Codex provider suffix, and uses locale-dependent dates. The week controls and sparse sample display need to match the reviewed quota view.

## Solution

- Increase card spacing, show bare percentages, and stack balance labels over larger amounts while preserving currency.
- Display weekly history as sparse bars with bounded seven-day navigation below the chart, using provider reset boundaries when available and a rolling-week fallback. Do not manufacture readings at reset boundaries.
- Use English abbreviated dates with local 24-hour time. Remove the Codex suffix from account labels.
- Put one status left of the percentage/timestamp with a fill-3 separator. Paused sampling uses danger-6 and suppresses the stale warning; stale active sampling uses warning-6. Keep fetch/empty states in PageNotice and retain only the section-level Refresh action.
- Allow the chart to select its healthy-color threshold while retaining the existing default for other quota consumers.

## Potential risks

English month names intentionally override the app language in this panel. Week boundaries depend on provider reset metadata; absent or invalid metadata falls back to a rolling week. Long translated statuses and narrow layouts need desktop visual review. The sparse bar chart and week-range helper are included to make the reviewed layout self-contained against develop.

No API integration, credentials, persistence, backend sampling, IPC, or dependency changes are included. Existing quota consumers retain their default color thresholds. Rollback is a revert of this UI commit.

Desktop screenshots, theme/viewport checks, and real CPU/RSS measurements were not captured because desktop control was not authorized. The performance guard records this measurement gap; no runtime performance improvement is claimed.

## Verification

- CI follow-up: updated the pre-existing 128-account test's Recharts and chart-token mocks for the bar chart. This preserves its single-selected-chart assertion; no application behavior changed.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.test.ts src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.rendering.test.ts src/modules/shared/dataSource/weeklyQuotaRange.test.ts src/engines/ChatPanel/StartPageQuotaGrid.test.ts src/engines/ChatPanel/StartPageQuotaModal.test.ts src/hooks/keyVault/accountQuotaDisplay.test.ts` — all 47 tests passed after the CI fix.

- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/StartPageQuotaGrid.test.ts src/engines/ChatPanel/StartPageQuotaModal.test.ts src/hooks/keyVault/accountQuotaDisplay.test.ts src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.rendering.test.ts src/modules/shared/dataSource/weeklyQuotaRange.test.ts` — 44 tests passed before extending the status regression.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.rendering.test.ts` — both final paused/stale cases passed, including separator, status color, date format, and picker placement assertions.
- `pnpm typecheck:fast` — passed against the isolated develop-based branch.
- `pnpm exec eslint src/engines/ChatPanel/StartPageQuotaGrid.tsx src/engines/ChatPanel/StartPageQuotaGrid.test.ts src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.tsx src/modules/shared/dataSource/WeeklyQuotaHistoryPanel.rendering.test.ts src/modules/shared/dataSource/weeklyQuotaRange.ts src/modules/shared/dataSource/weeklyQuotaRange.test.ts src/components/QuotaBar/index.tsx --max-warnings 0` — passed; the amended rendering test was linted again.
- `git diff --cached --check` — passed. Scoped diff inspected for credentials, personal paths, generated artifacts, and unrelated changes.
- Desktop visual and runtime performance verification: not run, as noted above. Backend checks are not applicable to this frontend-only change.

## Audit

UI audit: 0 fix candidates, 8 kept with reasons, 0 abstractions across the two panels. Performance review: bounded local pagination with no added background resources; desktop measurement remains unverified.

