### PR TITLE
fix(todo): synchronize authoritative completed snapshots

### DIFF
--- a/src/engines/SessionCore/hooks/session/__tests__/syncTodosFromReplayEvents.test.ts
+++ b/src/engines/SessionCore/hooks/session/__tests__/syncTodosFromReplayEvents.test.ts
@@ -136,4 +136,64 @@ describe("syncTodosFromReplayEvents", () => {
 
     expect(result?.todos.map((todo) => todo.content)).toEqual(["Old task"]);
   });
+  it.each(["running", "pending", "failed", "completed"] as const)(
+    "only clears a completed authoritative empty result (%s)",
+    (displayStatus) => {
+      const result = syncTodosFromReplayEvents({
+        sessionId: "session-a",
+        pipelineSessionId: "session-a",
+        simulatorEvents: [],
+        currentEvent: null,
+        lastSnapshot: null,
+        liveEvents: [
+          makeManageTodoEvent(
+            {
+              id: "empty",
+              displayStatus,
+              result: {},
+              extracted: { kind: "todo", todos: [], wasMerge: false },
+            },
+            []
+          ),
+        ],
+      });
+      if (displayStatus === "completed") expect(result?.todos).toEqual([]);
+      else expect(result).toBeNull();
+    }
+  );
+
+  it("refreshes a same-ID tool result without rewinding to the replay cursor", () => {
+    const event = makeManageTodoEvent({
+      id: "same",
+      extracted: {
+        kind: "todo",
+        todos: [{ id: "1", content: "Task", status: "pending" }],
+        wasMerge: false,
+      },
+    });
+    const input = {
+      sessionId: "session-a",
+      pipelineSessionId: "session-a",
+      liveEvents: [event],
+      simulatorEvents: [],
+      currentEvent: null,
+      lastSnapshot: null,
+    };
+    const before = syncTodosFromReplayEvents(input)!;
+    const after = syncTodosFromReplayEvents({
+      ...input,
+      lastSnapshot: before.snapshot,
+      liveEvents: [
+        {
+          ...event,
+          extracted: {
+            kind: "todo",
+            todos: [{ id: "1", content: "Task", status: "completed" }],
+            wasMerge: false,
+          },
+        },
+      ],
+    });
+    expect(after?.todos[0].status).toBe("completed");
+  });
 });

--- a/src/engines/SessionCore/hooks/session/__tests__/useTodoSync.helpers.test.ts
+++ b/src/engines/SessionCore/hooks/session/__tests__/useTodoSync.helpers.test.ts
@@ -321,6 +321,79 @@ describe("extractTodosFromManageTodoSequence", () => {
     ].join("\n");
   }
 
+  it("prefers the authoritative Rust snapshot over stale tool args", () => {
+    const staleArgs = Array.from({ length: 7 }, (_, index) => ({
+      id: `todo-${index}`,
+      content: `Task ${index + 1}`,
+      status: index < 2 ? "completed" : "pending",
+    }));
+    const authoritativeTodos = staleArgs.map((todo, index) => ({
+      ...todo,
+      status: index < 6 ? "completed" : "in_progress",
+    }));
+
+    const events = [
+      makeManageTodoEvent({
+        id: "todo-update",
+        args: { action: "update", todos: staleArgs },
+        extracted: {
+          kind: "todo",
+          todos: authoritativeTodos,
+          wasMerge: false,
+        },
+      }),
+    ];
+
+    const todos = extractTodosFromManageTodoSequence(events, "sdeagent-test");
+
+    expect(todos).toHaveLength(7);
+    expect(todos.filter((todo) => todo.status === "completed")).toHaveLength(6);
+    expect(todos[6]?.status).toBe("in_progress");
+  });
+
+  it("treats a completed authoritative empty snapshot as a clear", () => {
+    const events = [
+      makeManageTodoEvent({
+        id: "todo-write",
+        extracted: {
+          kind: "todo",
+          todos: [{ id: "todo-1", content: "Task", status: "pending" }],
+          wasMerge: false,
+        },
+      }),
+      makeManageTodoEvent({
+        id: "todo-clear",
+        extracted: { kind: "todo", todos: [], wasMerge: false },
+      }),
+    ];
+
+    expect(extractTodosFromManageTodoSequence(events, "sdeagent-test")).toEqual(
+      []
+    );
+  });
+
+  it("does not clear from an incomplete pre-result event", () => {
+    const events = [
+      makeManageTodoEvent({
+        id: "todo-write",
+        extracted: {
+          kind: "todo",
+          todos: [{ id: "todo-1", content: "Task", status: "pending" }],
+          wasMerge: false,
+        },
+      }),
+      makeManageTodoEvent({
+        id: "todo-running",
+        displayStatus: "running",
+        extracted: { kind: "todo", todos: [], wasMerge: false },
+      }),
+    ];
+
+    expect(extractTodosFromManageTodoSequence(events, "sdeagent-test")).toEqual(
+      [{ id: "todo-1", content: "Task", status: "pending" }]
+    );
+  });
+
   it("backfills empty titles in later update snapshots from earlier todo events", () => {
     const events = [
       makeManageTodoEvent({

--- a/src/engines/SessionCore/hooks/session/syncTodosFromReplayEvents.ts
+++ b/src/engines/SessionCore/hooks/session/syncTodosFromReplayEvents.ts
@@ -4,6 +4,7 @@ import type { TodoItem } from "@src/store/ui/todoAtom";
 import {
   extractTodosFromManageTodoSequence,
   findLatestManageTodoEvent,
+  hasAuthoritativeEmptyTodoSnapshot,
   serializeTodoSnapshot,
 } from "./todoReplayDerivation";
 
@@ -79,7 +80,16 @@ export function syncTodosFromReplayEvents(
     sessionId,
     maxIndex
   );
-  if (todos.length === 0) {
+  if (
+    todos.length === 0 &&
+    !replayEvents
+      .slice(0, maxIndex + 1)
+      .some(
+        (event) =>
+          (!event.sessionId || event.sessionId === sessionId) &&
+          hasAuthoritativeEmptyTodoSnapshot(event)
+      )
+  ) {
     return null;
   }
 

--- a/src/engines/SessionCore/hooks/session/todoReplayDerivation.ts
+++ b/src/engines/SessionCore/hooks/session/todoReplayDerivation.ts
@@ -62,6 +62,7 @@ function extractTodosFromEvent(event: SessionEvent): TodoItem[] {
     status: "success" as const,
     variant: "chat" as const,
     context: "chat" as const,
+    rustExtracted: event.extracted,
   });
 
   return todoData.todos.map((todo, idx) => {
@@ -83,6 +84,16 @@ function extractTodosFromEvent(event: SessionEvent): TodoItem[] {
   });
 }
 
+export function hasAuthoritativeEmptyTodoSnapshot(
+  event: SessionEvent
+): boolean {
+  return (
+    event.displayStatus === "completed" &&
+    event.extracted?.kind === "todo" &&
+    event.extracted.todos.length === 0
+  );
+}
+
 export function extractTodosFromManageTodoSequence(
   events: readonly SessionEvent[],
   sessionId: string,
@@ -97,7 +108,10 @@ export function extractTodosFromManageTodoSequence(
     if (!eventMatchesSession(event, sessionId)) continue;
 
     const nextTodos = extractTodosFromEvent(event);
-    if (nextTodos.length === 0) continue;
+    if (nextTodos.length === 0) {
+      if (hasAuthoritativeEmptyTodoSnapshot(event)) todos = [];
+      continue;
+    }
     todos = preserveTodoContent(todos, nextTodos);
   }
 


### PR DESCRIPTION
## Problem

The pinned todo list can disagree with a completed Rust tool result because replay derivation reads legacy arguments/results and ignores authoritative empty snapshots.

## Solution

Prefer Rust-extracted todos and accept an empty snapshot only from a completed event. Preserve the current scoped subscription, same-ID result updates, and separation between the live list and simulator cursor. This is the todo-only replacement for #456, rebuilt on current develop.

## Potential risks

Only Rust-extracted completed empty snapshots clear the list; failed, pending, and running events do not. Legacy extraction remains available. No schema, dependency, or persistence-format change. Revert this commit to recover the previous projection behavior.

## Verification

- `pnpm test src/engines/SessionCore/hooks/session/__tests__` — 147 tests passed on the integrated implementation, whose four-file todo diff is preserved here.
- The combined implementation passed `pnpm typecheck` before splitting.

No GUI automation or CPU/RSS profiling was run, consistent with the workspace's explicit computer-control opt-in. No historical data is deleted.

- Normal commit hooks passed: staged Oxlint/ESLint/Prettier and `tsgo --noEmit --pretty false`.
- `git diff origin/develop --check` — passed; final scope and artifact/secret inspection completed.

## Lifecycle review

| Area | Verdict | Evidence | Decision | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Existing push subscription | No timer added | Source trace |
| Memory | keep | Existing derived snapshot | No new retained cache | Source trace |
| Scope/isolation | keep | Session and cursor checks | Preserve current subscription | 147 session-hook tests |
| Rendering | keep | Same-ID and completed-empty derivation | Update owning projection | Regression tests |

Performance verdict: blocked for live CPU/RSS profiling; no runtime performance improvement is claimed.
