### PR TITLE
fix(session-replay): prefer authoritative shell and delete data

### DIFF
--- a/src/modules/WorkStation/CodeEditor/SessionReplay/converters/__tests__/fileConverter.test.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/converters/__tests__/fileConverter.test.ts
@@ -46,6 +46,46 @@ describe("parseFilePath", () => {
 });
 
 describe("convertToFileOperation", () => {
+  it("prefers the authoritative deleted path over stale args", () => {
+    const event = minimalSessionEvent({
+      id: "delete-1",
+      functionName: "delete_file",
+      uiCanonical: "edit_file",
+      args: { path: "src/old.ts" },
+      extracted: {
+        kind: "deleteFile",
+        filePath: "packages/app/src/old.ts",
+        fileName: "old.ts",
+      },
+    });
+
+    const op = convertToFileOperation(event, true);
+
+    expect(op).toMatchObject({
+      type: "delete",
+      filePath: "packages/app/src/old.ts",
+      fileName: "old.ts",
+      directory: "packages/app/src",
+    });
+  });
+
+  it("keeps an extracted delete operation when legacy args omit the path", () => {
+    const event = minimalSessionEvent({
+      id: "delete-extracted-only",
+      functionName: "delete_file",
+      uiCanonical: "edit_file",
+      extracted: {
+        kind: "deleteFile",
+        filePath: "src/removed.ts",
+        fileName: "removed.ts",
+      },
+    });
+
+    expect(convertToFileOperation(event, false)?.filePath).toBe(
+      "src/removed.ts"
+    );
+  });
+
   it("builds a read operation when extractFileData finds a path", () => {
     const event = minimalSessionEvent({
       id: "read-1",

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/converters/__tests__/shellConverter.test.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/converters/__tests__/shellConverter.test.ts
@@ -62,6 +62,35 @@ describe("shell command display", () => {
 });
 
 describe("convertToShellOperation", () => {
+  it("prefers authoritative Rust shell extraction over stale payload fields", () => {
+    const event = minimalSessionEvent({
+      functionName: "run_shell",
+      uiCanonical: "run_shell",
+      args: { command: "pnpm test --old-filter" },
+      result: { output: "stale partial output" },
+      extracted: {
+        kind: "shell",
+        command: "pnpm test",
+        output: "all tests passed",
+        exitCode: 0,
+        cwd: "/repo",
+        executionTime: 1250,
+        isFailure: false,
+        gitArtifacts: [],
+      },
+    });
+
+    const operation = convertToShellOperation(event, true);
+
+    expect(operation).toMatchObject({
+      command: "pnpm test",
+      output: "all tests passed",
+      exitCode: 0,
+      cwd: "/repo",
+      executionTime: 1250,
+    });
+  });
+
   it("keeps completed inspect_terminals result output visible", () => {
     const event = minimalSessionEvent({
       args: { action: "list" },

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/converters/fileConverter.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/converters/fileConverter.ts
@@ -157,7 +157,12 @@ export function convertToFileOperation(
 
   if (type === FILE_OPERATION_TYPE.DELETE) {
     const args = event.args || {};
+    const extractedPath =
+      event.extracted?.kind === "deleteFile"
+        ? event.extracted.filePath
+        : undefined;
     const filePath =
+      extractedPath ||
       (typeof args.path === "string" && args.path) ||
       (typeof args.file_path === "string" && args.file_path) ||
       (typeof args.target_file === "string" && args.target_file) ||

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/converters/shellConverter.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/converters/shellConverter.ts
@@ -53,6 +53,10 @@ export function convertToShellOperation(
       status: statusString,
       variant: "simulator" as const,
       context: "simulator" as const,
+      rustExtracted: event.extracted,
+      shellPid: event.shellPid,
+      shellProcessStatus: event.shellProcessStatus,
+      shellLogPath: event.shellLogPath,
     };
 
     const data = extractShellData(propsForExtraction);


### PR DESCRIPTION
## Problem

Session Replay reconstructs shell and file-delete operations from legacy payload fields even when authoritative normalized data is present, so displayed output, status, or deleted paths can be stale.

## Solution

Pass Rust extraction and reconciled shell process fields to the shared shell extractor. Prefer the extracted delete path while retaining legacy fallbacks. This is the replay-only follow-up to #456.

## Potential risks

Changes are limited to replay conversion. Existing fallback behavior remains for events without extraction. No writes, wire changes, schema changes, or dependencies are introduced; reverting restores the previous display conversion.

## Verification

- `pnpm test src/modules/WorkStation/CodeEditor/SessionReplay/converters/__tests__` — 45 tests passed independently after splitting.
- The combined implementation passed `pnpm typecheck` before splitting.

No GUI automation or CPU/RSS profiling was run, consistent with the workspace's explicit computer-control opt-in. No historical data is deleted.

- Normal commit hooks passed: staged Oxlint/ESLint/Prettier and `tsgo --noEmit --pretty false`.
- `git diff origin/develop --check` — passed; final scope and artifact/secret inspection completed.
