### PR TITLE
fix(plan): persist pending edits and reject stale rehydration

### DIFF
--- a/src-tauri/crates/agent-core/src/core/interaction/plan_approval/manager.rs
+++ b/src-tauri/crates/agent-core/src/core/interaction/plan_approval/manager.rs
@@ -192,6 +192,69 @@ impl PlanApprovalManager {
         self.pending.lock().await.clone()
     }
 
+    /// Durably update the body of the current pending plan without resolving it.
+    ///
+    /// The pending mutex serializes Save against Build/Skip/supersede. The plan
+    /// file is written before the SQLite row, and restored to its prior bytes if
+    /// the row update fails, so the two durable representations cannot silently
+    /// diverge. `plan_revision_id` prevents a stale card from editing a newer
+    /// pending revision for the same session.
+    pub async fn update_pending_content(
+        &self,
+        session_id: &str,
+        plan_revision_id: Option<&str>,
+        content: String,
+    ) -> Result<PendingPlanApproval, String> {
+        let mut guard = self.pending.lock().await;
+        let current = guard
+            .as_ref()
+            .ok_or_else(|| format!("No pending plan approval for session {session_id}"))?;
+
+        if current.session_id != session_id {
+            return Err(format!(
+                "Pending plan belongs to session {}, not {session_id}",
+                current.session_id
+            ));
+        }
+        if let Some(expected_revision) = plan_revision_id {
+            if current.plan_revision_id != expected_revision {
+                return Err(format!(
+                    "Pending plan revision changed (expected {expected_revision}, current {})",
+                    current.plan_revision_id
+                ));
+            }
+        }
+
+        let mut updated = current.clone();
+        updated.plan_content = content;
+        let row = updated.to_row();
+        let plan_path = updated.plan_path.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let previous_bytes = std::fs::read(&plan_path).map_err(|err| {
+                format!("Failed to read pending plan before Save ({plan_path}): {err}")
+            })?;
+            std::fs::write(&plan_path, row.plan_content.as_bytes()).map_err(|err| {
+                format!("Failed to write pending plan ({plan_path}): {err}")
+            })?;
+
+            if let Err(err) = PlanApprovalStore::upsert(&row) {
+                if let Err(rollback_err) = std::fs::write(&plan_path, previous_bytes) {
+                    return Err(format!(
+                        "Failed to persist pending plan snapshot: {err}; file rollback also failed: {rollback_err}"
+                    ));
+                }
+                return Err(format!("Failed to persist pending plan snapshot: {err}"));
+            }
+            Ok::<(), String>(())
+        })
+        .await
+        .map_err(|err| format!("Pending plan Save task failed: {err}"))??;
+
+        *guard = Some(updated.clone());
+        Ok(updated)
+    }
+
     /// Synchronous best-effort pending snapshot for LLM schema rendering.
     ///
     /// Tool descriptions are built through a synchronous trait method, so they

--- a/src-tauri/crates/agent-core/src/core/interaction/plan_approval/tests.rs
+++ b/src-tauri/crates/agent-core/src/core/interaction/plan_approval/tests.rs
@@ -611,3 +611,66 @@ async fn gc_collects_orphans_and_keeps_rows_regardless_of_mode() {
     remaining_ids.sort_unstable();
     assert_eq!(remaining_ids, vec!["s_gc_left_mode", "s_gc_live"]);
 }
+
+#[tokio::test]
+async fn update_pending_content_persists_file_memory_and_rehydrate() {
+    let _lock = lock_and_prepare();
+    let plan_path = temp_home().join("saved.plan.md");
+    std::fs::write(&plan_path, "original").unwrap();
+    let session_id = "s_save";
+    let mgr = PlanApprovalManager::new();
+    mgr.mark_ready(
+        session_id,
+        plan_path.to_str().unwrap(),
+        "Title",
+        "original",
+        Some("call_save"),
+    )
+    .await;
+    wait_for_pending_row(session_id).await;
+    let revision = mgr.pending_snapshot().await.unwrap().plan_revision_id;
+
+    let updated = mgr
+        .update_pending_content(session_id, Some(&revision), "edited".into())
+        .await
+        .unwrap();
+    assert_eq!(updated.plan_content, "edited");
+    assert_eq!(std::fs::read_to_string(&plan_path).unwrap(), "edited");
+    assert_eq!(
+        PlanApprovalStore::load_by_session(session_id)
+            .unwrap()
+            .unwrap()
+            .plan_content,
+        "edited"
+    );
+
+    let fresh = PlanApprovalManager::new();
+    fresh.rehydrate_from_db(session_id).await.unwrap();
+    assert_eq!(
+        fresh.pending_snapshot().await.unwrap().plan_content,
+        "edited"
+    );
+}
+
+#[tokio::test]
+async fn update_pending_content_rejects_stale_revision() {
+    let _lock = lock_and_prepare();
+    let plan_path = temp_home().join("stale-save.plan.md");
+    std::fs::write(&plan_path, "original").unwrap();
+    let mgr = PlanApprovalManager::new();
+    mgr.mark_ready(
+        "s_stale",
+        plan_path.to_str().unwrap(),
+        "T",
+        "original",
+        None,
+    )
+    .await;
+
+    let error = mgr
+        .update_pending_content("s_stale", Some("old-revision"), "edited".into())
+        .await
+        .unwrap_err();
+    assert!(error.contains("revision changed"));
+    assert_eq!(std::fs::read_to_string(&plan_path).unwrap(), "original");
+}

--- a/src-tauri/crates/agent-core/src/state/commands/session/interaction.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/interaction.rs
@@ -268,6 +268,48 @@ pub async fn agent_get_pending_plan_approval(
     })))
 }
 
+/// Save edited content for the current pending plan without approving it.
+/// The manager owns file + SQLite snapshot consistency and rejects stale
+/// revision ids, so every frontend surface can treat the returned snapshot as
+/// a mirror of durable backend state.
+#[tauri::command]
+pub async fn agent_update_pending_plan_content(
+    state: tauri::State<'_, AgentAppState>,
+    session_id: String,
+    plan_revision_id: Option<String>,
+    content: String,
+) -> Result<serde_json::Value, String> {
+    if state.get_session(&session_id).await.is_none() {
+        crate::init::register_session_with_rehydrate(&state, &session_id).await?;
+    }
+
+    let session = state
+        .get_session(&session_id)
+        .await
+        .ok_or_else(|| format!("No session found: {session_id}"))?;
+    let manager = session
+        .plan_approval_manager
+        .as_ref()
+        .ok_or_else(|| format!("Session {session_id} has no plan-approval manager"))?;
+    let snapshot = manager
+        .update_pending_content(&session_id, plan_revision_id.as_deref(), content)
+        .await?;
+    let auto_approve_at_ms =
+        crate::interaction::plan_approval::auto_approve_deadline_for_snapshot(&snapshot);
+
+    Ok(serde_json::json!({
+        "sessionId": &snapshot.session_id,
+        "planPath": &snapshot.plan_path,
+        "planTitle": &snapshot.plan_title,
+        "planContent": &snapshot.plan_content,
+        "toolCallId": &snapshot.tool_call_id,
+        "planId": &snapshot.plan_id,
+        "planRevisionId": &snapshot.plan_revision_id,
+        "originToolCallId": &snapshot.origin_tool_call_id,
+        "autoApproveAt": auto_approve_at_ms,
+    }))
+}
+
 /// Build button response from the plan card.
 ///
 /// `choice` is `"approve"` (plain), `"approve_with_edits"` (edited plan

--- a/src-tauri/src/commands/handler_list.inc
+++ b/src-tauri/src/commands/handler_list.inc
@@ -1128,6 +1128,7 @@ agent_core::state::commands::agent_get_pending_questions,
 agent_core::state::commands::agent_mode_switch_response,
 agent_core::state::commands::agent_plan_approval_response,
 agent_core::state::commands::agent_get_pending_plan_approval,
+agent_core::state::commands::agent_update_pending_plan_content,
 agent_core::state::commands::debug_seed_pending_plan,
 // User presence — global snapshot for runtime enforcement (auto-resolve
 // deadlines, goal loop). Pushed by the FE on every mode switch.

--- a/src/api/tauri/agent/session.ts
+++ b/src/api/tauri/agent/session.ts
@@ -283,7 +283,7 @@ export async function respondModeSwitch(
  * Used on session mount/switch to rehydrate `pendingPlanApprovalsAtom`
  * after a page refresh or window re-focus.
  */
-export async function getPendingPlanApproval(sessionId: string): Promise<{
+export interface PendingPlanApprovalSnapshot {
   sessionId: string;
   planPath: string;
   planTitle: string;
@@ -293,8 +293,24 @@ export async function getPendingPlanApproval(sessionId: string): Promise<{
   planRevisionId?: string;
   originToolCallId?: string;
   autoApproveAt?: number | null;
-} | null> {
+}
+
+export async function getPendingPlanApproval(
+  sessionId: string
+): Promise<PendingPlanApprovalSnapshot | null> {
   return rpc.agentSession.getPendingPlanApproval({ sessionId });
+}
+
+export async function updatePendingPlanContent(
+  sessionId: string,
+  content: string,
+  planRevisionId?: string
+): Promise<PendingPlanApprovalSnapshot> {
+  return rpc.agentSession.updatePendingPlanContent({
+    sessionId,
+    content,
+    planRevisionId,
+  });
 }
 
 /**

--- a/src/api/tauri/rpc/procedures/agentSession.ts
+++ b/src/api/tauri/rpc/procedures/agentSession.ts
@@ -121,6 +121,10 @@ export const agentSession = {
     .input(schemas.agentSession.SessionIdInput)
     .output(schemas.agentSession.PendingPlanApprovalSchema)
     .build(),
+  updatePendingPlanContent: defineProcedure("agent_update_pending_plan_content")
+    .input(schemas.agentSession.UpdatePendingPlanContentInput)
+    .output(schemas.agentSession.PendingPlanApprovalSchema.unwrap())
+    .build(),
   respondPlanApproval: defineProcedure("agent_plan_approval_response")
     .input(schemas.agentSession.PlanApprovalResponseInput)
     .build(),

--- a/src/api/tauri/rpc/schemas/agentSession.ts
+++ b/src/api/tauri/rpc/schemas/agentSession.ts
@@ -319,6 +319,12 @@ export const PendingPlanApprovalSchema = z
   })
   .nullable();
 
+export const UpdatePendingPlanContentInput = z.object({
+  sessionId: z.string(),
+  planRevisionId: z.string().optional(),
+  content: z.string(),
+});
+
 export const PlanApprovalResponseInput = z.object({
   sessionId: z.string(),
   choice: z.enum(["approve", "approve_with_edits", "reject"]),

--- a/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
+++ b/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
@@ -11,7 +11,10 @@ import { useAtomValue, useSetAtom } from "jotai";
 import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { respondPlanApproval } from "@src/api/tauri/agent";
+import {
+  updatePendingPlanContent as persistPendingPlanContent,
+  respondPlanApproval,
+} from "@src/api/tauri/agent";
 import Button from "@src/components/Button";
 import Markdown from "@src/components/MarkDown";
 import Message from "@src/components/Message";
@@ -36,7 +39,6 @@ import {
 import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import { Cancel01Icon, HugeiconsIcon } from "@src/icons";
-import { FileService } from "@src/services/file";
 import { startVisibilityAwareInterval } from "@src/shared/scheduling/visibilityAwareInterval";
 import { sessionRuntimeStatusAtom } from "@src/store/session/cliSessionStatusAtom";
 import { creatorDefaultModelSelectionAtom } from "@src/store/session/creatorDefaultModelAtom";
@@ -340,11 +342,11 @@ const CreatePlanCard: React.FC<CreatePlanCardProps> = memo(
       try {
         await persistEditedPlanContent({
           sessionId,
-          planPath: pendingSnapshot?.planPath ?? null,
+          planRevisionId: pendingSnapshot?.planRevisionId,
           pendingAliases: getPendingPlanAliases(pendingSnapshot),
           content: editedContent,
           io: {
-            saveFile: (path, content) => FileService.save(path, content),
+            persistPendingContent: persistPendingPlanContent,
             getEvents: (id) => eventStoreProxy.getEvents(id),
             patchEvent: (id, args, sid) =>
               eventStoreProxy.updateById(id, { args }, sid),

--- a/src/engines/SessionCore/derived/__tests__/planContentPersistence.test.ts
+++ b/src/engines/SessionCore/derived/__tests__/planContentPersistence.test.ts
@@ -208,18 +208,18 @@ describe("updatePendingPlanContent", () => {
 describe("persistEditedPlanContent", () => {
   function createIO(events: SessionEvent[]) {
     return {
-      saveFile: vi.fn().mockResolvedValue(true),
+      persistPendingContent: vi.fn().mockResolvedValue(true),
       getEvents: vi.fn().mockResolvedValue(events),
       patchEvent: vi.fn().mockResolvedValue(undefined),
       saveCache: vi.fn().mockResolvedValue(0),
     };
   }
 
-  it("writes the plan file then patches every matching event, then flushes cache", async () => {
+  it("persists the backend snapshot before patching matching events and cache", async () => {
     const io = createIO([createPlanEvent()]);
     const order: string[] = [];
-    io.saveFile.mockImplementation(async () => {
-      order.push("file");
+    io.persistPendingContent.mockImplementation(async () => {
+      order.push("backend");
     });
     io.patchEvent.mockImplementation(async () => {
       order.push("patch");
@@ -230,32 +230,39 @@ describe("persistEditedPlanContent", () => {
 
     await persistEditedPlanContent({
       sessionId: "s1",
-      planPath: "/tmp/plan.md",
+      planRevisionId: "rev-1",
       pendingAliases: ["rev-1"],
       content: "edited body",
       io,
     });
 
-    expect(io.saveFile).toHaveBeenCalledWith("/tmp/plan.md", "edited body");
+    expect(io.persistPendingContent).toHaveBeenCalledWith(
+      "s1",
+      "edited body",
+      "rev-1"
+    );
     expect(io.patchEvent).toHaveBeenCalledTimes(1);
     expect(io.patchEvent).toHaveBeenCalledWith(
       "rev-1",
       expect.objectContaining({ content: "edited body" }),
       "s1"
     );
-    expect(order).toEqual(["file", "patch", "cache"]);
+    expect(order).toEqual(["backend", "patch", "cache"]);
   });
 
-  it("skips the file write when no plan path is known", async () => {
+  it("persists through the backend even when no revision id is available", async () => {
     const io = createIO([createPlanEvent()]);
     await persistEditedPlanContent({
       sessionId: "s1",
-      planPath: null,
       pendingAliases: ["rev-1"],
       content: "edited",
       io,
     });
-    expect(io.saveFile).not.toHaveBeenCalled();
+    expect(io.persistPendingContent).toHaveBeenCalledWith(
+      "s1",
+      "edited",
+      undefined
+    );
     expect(io.patchEvent).toHaveBeenCalledTimes(1);
   });
 
@@ -263,7 +270,7 @@ describe("persistEditedPlanContent", () => {
     const io = createIO([createPlanEvent()]);
     await persistEditedPlanContent({
       sessionId: "s1",
-      planPath: "/tmp/plan.md",
+      planRevisionId: "rev-1",
       pendingAliases: ["does-not-match"],
       content: "edited",
       io,
@@ -278,7 +285,7 @@ describe("persistEditedPlanContent", () => {
     await expect(
       persistEditedPlanContent({
         sessionId: "s1",
-        planPath: "/tmp/plan.md",
+        planRevisionId: "rev-1",
         pendingAliases: ["rev-1"],
         content: "edited",
         io,

--- a/src/engines/SessionCore/derived/planContentPersistence.ts
+++ b/src/engines/SessionCore/derived/planContentPersistence.ts
@@ -126,8 +126,12 @@ export function updatePendingPlanContent(
 }
 
 export interface PersistPlanEditIO {
-  /** Write the plan markdown file (no-op skipped when no path is known). */
-  saveFile: (path: string, content: string) => Promise<unknown>;
+  /** Atomically update the backend pending snapshot and its backing plan file. */
+  persistPendingContent: (
+    sessionId: string,
+    content: string,
+    planRevisionId?: string
+  ) => Promise<unknown>;
   /** Read the current events for a session from the event store. */
   getEvents: (sessionId: string) => Promise<SessionEvent[]>;
   /** Patch a single event's args in the event store. */
@@ -147,16 +151,14 @@ export interface PersistPlanEditIO {
  */
 export async function persistEditedPlanContent(params: {
   sessionId: string;
-  planPath: string | null;
+  planRevisionId?: string;
   pendingAliases: readonly string[];
   content: string;
   io: PersistPlanEditIO;
 }): Promise<void> {
-  const { sessionId, planPath, pendingAliases, content, io } = params;
+  const { sessionId, planRevisionId, pendingAliases, content, io } = params;
 
-  if (planPath) {
-    await io.saveFile(planPath, content);
-  }
+  await io.persistPendingContent(sessionId, content, planRevisionId);
 
   const events = await io.getEvents(sessionId);
   const patches = buildPlanContentPatches(events, pendingAliases, content);

--- a/src/engines/SessionCore/sync/__tests__/sessionSyncPlanApproval.test.ts
+++ b/src/engines/SessionCore/sync/__tests__/sessionSyncPlanApproval.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getPendingPlanApproval } from "@src/api/tauri/agent";
+import {
+  type PlanApprovalStateMap,
+  clearPendingPlanApproval,
+  upsertPendingPlanApproval,
+} from "@src/store/session/planApprovalAtom";
+
+import { rehydratePendingPlanApproval } from "../sessionSyncPlanApproval";
+
+vi.mock("@src/api/tauri/agent", () => ({
+  getPendingPlanApproval: vi.fn(),
+}));
+
+const mockedGetPending = vi.mocked(getPendingPlanApproval);
+
+function existingState(): PlanApprovalStateMap {
+  return new Map([
+    [
+      "session-1",
+      {
+        current: {
+          sessionId: "session-1",
+          planPath: "/plan.md",
+          planTitle: "Plan",
+          planContent: "stale",
+          planRevisionId: "rev-1",
+        },
+      },
+    ],
+  ]);
+}
+
+async function flushRehydrate(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("rehydratePendingPlanApproval", () => {
+  it("clears stale frontend state when the backend reports no pending plan", async () => {
+    mockedGetPending.mockResolvedValueOnce(null);
+    let state = existingState();
+
+    rehydratePendingPlanApproval(
+      "session-1",
+      new AbortController(),
+      (update) => {
+        state = update(state);
+      }
+    );
+    await flushRehydrate();
+
+    expect(state.get("session-1")?.current).toBeNull();
+  });
+
+  it("refreshes content for the same authoritative backend revision", async () => {
+    mockedGetPending.mockResolvedValueOnce({
+      sessionId: "session-1",
+      planPath: "/plan.md",
+      planTitle: "Plan",
+      planContent: "fresh",
+      planRevisionId: "rev-1",
+    });
+    let state = existingState();
+
+    rehydratePendingPlanApproval(
+      "session-1",
+      new AbortController(),
+      (update) => {
+        state = update(state);
+      }
+    );
+    await flushRehydrate();
+
+    expect(state.get("session-1")?.current?.planContent).toBe("fresh");
+  });
+
+  it("replaces a stale local revision when no live mutation raced the fetch", async () => {
+    mockedGetPending.mockResolvedValueOnce({
+      sessionId: "session-1",
+      planPath: "/plan.md",
+      planTitle: "Plan",
+      planContent: "current backend content",
+      planRevisionId: "rev-2",
+    });
+    let state = existingState();
+
+    rehydratePendingPlanApproval(
+      "session-1",
+      new AbortController(),
+      (update) => {
+        state = update(state);
+      }
+    );
+    await flushRehydrate();
+
+    expect(state.get("session-1")?.current?.planContent).toBe(
+      "current backend content"
+    );
+  });
+  it.each(["new plan", "save", "finalize"])(
+    "ignores a late snapshot after %s",
+    async (mutation) => {
+      let resolve!: (
+        value: Awaited<ReturnType<typeof getPendingPlanApproval>>
+      ) => void;
+      mockedGetPending.mockReturnValueOnce(
+        new Promise((done) => {
+          resolve = done;
+        })
+      );
+      let state = existingState();
+      const original = state.get("session-1")!.current!;
+      rehydratePendingPlanApproval(
+        "session-1",
+        new AbortController(),
+        (update) => {
+          state = update(state);
+        }
+      );
+      state =
+        mutation === "finalize"
+          ? clearPendingPlanApproval(state, "session-1")
+          : upsertPendingPlanApproval(state, {
+              ...original,
+              planContent: "live edit",
+              planRevisionId:
+                mutation === "save" ? original.planRevisionId : "new-revision",
+            });
+      const live = state;
+      resolve(mutation === "new plan" ? null : original);
+      await flushRehydrate();
+      expect(state).toBe(live);
+    }
+  );
+
+  it("does not discard a snapshot for an unrelated session update", async () => {
+    mockedGetPending.mockResolvedValueOnce(null);
+    let state = existingState();
+    rehydratePendingPlanApproval(
+      "session-1",
+      new AbortController(),
+      (update) => {
+        state = update(state);
+      }
+    );
+    state = upsertPendingPlanApproval(state, {
+      ...state.get("session-1")!.current!,
+      sessionId: "other",
+    });
+    await flushRehydrate();
+    expect(state.get("session-1")?.current).toBeNull();
+    expect(state.get("other")?.current).toBeTruthy();
+  });
+});

--- a/src/engines/SessionCore/sync/sessionSyncPlanApproval.ts
+++ b/src/engines/SessionCore/sync/sessionSyncPlanApproval.ts
@@ -1,7 +1,9 @@
 import { getPendingPlanApproval } from "@src/api/tauri/agent";
 import {
   type PlanApprovalStateMap,
-  rehydratePendingPlanApprovalIfNewer,
+  type SessionPlanApprovalState,
+  clearPendingPlanApproval,
+  upsertPendingPlanApproval,
 } from "@src/store/session/planApprovalAtom";
 
 export function rehydratePendingPlanApproval(
@@ -11,16 +13,26 @@ export function rehydratePendingPlanApproval(
     update: (prev: PlanApprovalStateMap) => PlanApprovalStateMap
   ) => void
 ): void {
+  // Jotai functional setters run synchronously. Capture the session slot, not
+  // the whole map: another session's update must not invalidate this fetch.
+  let initialState: SessionPlanApprovalState | undefined;
+  setPendingPlanApprovals((prev) => {
+    initialState = prev.get(sessionId);
+    return prev;
+  });
   const rehydrate = async () => {
     try {
       const snapshot = await getPendingPlanApproval(sessionId);
       // Guard: abort signal may have fired while the RPC was in flight.
-      if (abortController.signal.aborted || !snapshot) return;
-      // Use the revision-aware merge to avoid clobbering a live
-      // plan_ready_for_approval push that arrived before this RPC resolved.
-      setPendingPlanApprovals((prev) =>
-        rehydratePendingPlanApprovalIfNewer(prev, snapshot)
-      );
+      if (abortController.signal.aborted) return;
+      setPendingPlanApprovals((prev) => {
+        // A live push, save, finalization, or another completed fetch wins
+        // over any snapshot sampled before that mutation, including null.
+        if (prev.get(sessionId) !== initialState) return prev;
+        return snapshot
+          ? upsertPendingPlanApproval(prev, snapshot)
+          : clearPendingPlanApproval(prev, sessionId);
+      });
     } catch {
       // Non-critical: the Build button stays disabled until Rust broadcasts
       // agent:plan_ready_for_approval again.

--- a/src/modules/WorkStation/Chat/Communication/usePlanApproval.ts
+++ b/src/modules/WorkStation/Chat/Communication/usePlanApproval.ts
@@ -2,7 +2,10 @@ import { useAtomValue, useSetAtom } from "jotai";
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { respondPlanApproval } from "@src/api/tauri/agent";
+import {
+  updatePendingPlanContent as persistPendingPlanContent,
+  respondPlanApproval,
+} from "@src/api/tauri/agent";
 import Message from "@src/components/Message";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import {
@@ -18,7 +21,6 @@ import {
   planAliasesContain,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
-import { FileService } from "@src/services/file";
 import { sessionRuntimeStatusAtom } from "@src/store/session/cliSessionStatusAtom";
 import { creatorDefaultModelSelectionAtom } from "@src/store/session/creatorDefaultModelAtom";
 import {
@@ -253,11 +255,11 @@ export function usePlanApproval({
     try {
       await persistEditedPlanContent({
         sessionId: planSessionId,
-        planPath,
+        planRevisionId: currentPendingPlan?.planRevisionId,
         pendingAliases: planApprovalAliases,
         content: editedContent,
         io: {
-          saveFile: (path, content) => FileService.save(path, content),
+          persistPendingContent: persistPendingPlanContent,
           getEvents: (sessionId) => eventStoreProxy.getEvents(sessionId),
           patchEvent: (id, args, sessionId) =>
             eventStoreProxy.updateById(id, { args }, sessionId),
@@ -279,7 +281,7 @@ export function usePlanApproval({
   }, [
     planSessionId,
     buildDisabled,
-    planPath,
+    currentPendingPlan,
     planApprovalAliases,
     editedContent,
     setPendingPlanApprovals,


### PR DESCRIPTION
## Problem

Saving a pending plan only writes the markdown file and frontend mirrors, leaving the persisted approval snapshot stale after rehydration. A late null snapshot could also remove a newer live plan.

## Solution

Save through the Rust approval manager, serializing against resolution and checking revision identity. Update the plan file and SQLite snapshot before updating frontend mirrors, restoring the previous file bytes if the SQLite write fails. Capture the session state before rehydration and reject the result if that session changed during the request. This is the plan-only follow-up to #456.

## Potential risks

The new IPC command is additive and ships with its caller; old backends do not support it. No database migration or persistence-format change. File and SQLite writes are serialized with error rollback, but are not a crash-atomic transaction across both storage systems: process termination between writes remains a limitation. Reverting restores the previous save path; previously saved plan content remains compatible. Durable save, rehydration, and stale-revision rejection were tested at the module boundary. SQLite failure/rollback and process-crash paths were not fault-injected; no running-app verification was performed.

## Verification

- `pnpm test src/engines/SessionCore/derived/__tests__/planContentPersistence.test.ts src/engines/SessionCore/sync/__tests__/sessionSyncPlanApproval.test.ts` — 22 tests passed independently after splitting.
- `cargo test -p agent_core interaction::plan_approval --lib` — 22 Rust tests passed on the integrated implementation, including durable save, rehydration, and stale revision rejection.
- The combined implementation passed `pnpm typecheck` before splitting.

No GUI automation or CPU/RSS profiling was run, consistent with the workspace's explicit computer-control opt-in. No historical data is deleted.

- Normal commit hooks passed: staged Oxlint/ESLint/Prettier, `tsgo --noEmit --pretty false`, and scoped `cargo clippy` for `agent_core`.
- `git diff origin/develop --check` — passed; final scope and artifact/secret inspection completed.

## Architecture and lifecycle review

Covered command registration, Rust/TypeScript schema alignment, both plan-save callers, durable ownership, session initialization, null/non-null snapshot races, and error rollback. Broad naming/dead-code sweeps and live wire/UI profiling are outside this focused fix.

| Area | Verdict | Evidence | Decision | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Existing one-shot rehydrate | No polling added | Source trace |
| Memory | keep | Per-fetch captured slot | Released after completion | Source trace |
| Scope/isolation | fix | Capture session slot before RPC | Reject late writes after live changes | New plan/save/finalize race tests |
| Rendering | keep | Existing cards | No visual structure changes | Frontend tests; GUI not run |

Performance verdict: blocked for real-app profiling; stale-write regression tests pass.
