### PR TITLE
fix(permission): retain prompts until authoritative resolution

### DIFF
--- a/src-tauri/src/agent_sessions/cli/hook_approvals.rs
+++ b/src-tauri/src/agent_sessions/cli/hook_approvals.rs
@@ -173,6 +173,11 @@ pub async fn park_hook_approval(
         Err(_) => return HookApprovalDecision::Passthrough,
     }
 
+    let _lifetime = super::permission_lifecycle::PermissionLifetime::new(
+        session_id,
+        &request_id,
+        remove_pending_hook_approval,
+    );
     broadcast_permission_request(session_id, &request_id, tool_name, &tool_args);
     tracing::info!(
         session_id = %session_id,
@@ -187,9 +192,6 @@ pub async fn park_hook_approval(
         // Claude's own permission behavior instead of hanging the hook.
         _ => HookApprovalDecision::Passthrough,
     };
-    if let Ok(mut pending) = PENDING_HOOK_APPROVALS.lock() {
-        pending.remove(&request_id);
-    }
     tracing::info!(
         session_id = %session_id,
         request_id = %request_id,
@@ -197,6 +199,12 @@ pub async fn park_hook_approval(
         "[HookApproval] Resolved"
     );
     decision
+}
+
+fn remove_pending_hook_approval(request_id: &str) {
+    if let Ok(mut pending) = PENDING_HOOK_APPROVALS.lock() {
+        pending.remove(request_id);
+    }
 }
 
 /// Resolve a parked hook approval from the Tauri approval-response command.
@@ -214,10 +222,13 @@ pub fn resolve_hook_approval(
             .lock()
             .map_err(|_| "Hook approval registry lock is poisoned".to_string())?;
         let key = match request_id {
-            Some(request_id) if pending.contains_key(request_id) => Some(request_id.to_string()),
-            // No (or unknown) request id: fall back to the session's only
+            Some(request_id) => pending
+                .get(request_id)
+                .filter(|entry| entry.session_id == session_id)
+                .map(|_| request_id.to_string()),
+            // No request id: fall back to the session's only
             // pending entry — Claude blocks on one permission at a time.
-            _ => pending
+            None => pending
                 .iter()
                 .find(|(_, entry)| entry.session_id == session_id)
                 .map(|(key, _)| key.clone()),
@@ -244,8 +255,10 @@ pub fn has_pending_hook_approval(session_id: &str, request_id: Option<&str>) -> 
     PENDING_HOOK_APPROVALS
         .lock()
         .map(|pending| match request_id {
-            Some(request_id) if pending.contains_key(request_id) => true,
-            _ => pending.values().any(|entry| entry.session_id == session_id),
+            Some(request_id) => pending
+                .get(request_id)
+                .is_some_and(|entry| entry.session_id == session_id),
+            None => pending.values().any(|entry| entry.session_id == session_id),
         })
         .unwrap_or(false)
 }
@@ -317,6 +330,7 @@ mod tests {
 
         let decision = park.await.expect("join");
         assert_eq!(decision, HookApprovalDecision::Allow);
+        assert_resolved(&session);
         assert!(!has_pending_hook_approval(&session, None));
         unregister_session(&session);
     }
@@ -357,6 +371,7 @@ mod tests {
 
         let decision = park.await.expect("join");
         assert_eq!(decision, HookApprovalDecision::Deny);
+        assert_resolved(&session);
         unregister_session(&session);
     }
 
@@ -373,6 +388,7 @@ mod tests {
         .await;
         assert_eq!(decision, HookApprovalDecision::Passthrough);
         assert!(!has_pending_hook_approval(&session, None));
+        assert_resolved(&session);
         unregister_session(&session);
     }
 
@@ -410,5 +426,38 @@ mod tests {
     async fn resolve_without_pending_errors() {
         let session = unique_session("nopending");
         assert!(resolve_hook_approval(&session, None, true).is_err());
+    }
+    fn assert_resolved(session: &str) {
+        #[cfg(not(debug_assertions))]
+        let _ = session;
+        #[cfg(debug_assertions)]
+        assert!(websocket_handler::recent_events::snapshot()
+            .iter()
+            .any(|raw| {
+                let event: serde_json::Value = serde_json::from_str(raw).unwrap();
+                event["type"] == "permission:resolved" && event["sessionId"] == session
+            }));
+    }
+
+    #[tokio::test]
+    async fn cancelling_park_emits_resolution_and_removes_registry_entry() {
+        let session = unique_session("abort");
+        register_session_permission_mode(&session, CliPermissionMode::Manual);
+        let mut future = Box::pin(park_hook_approval(
+            &session,
+            "Bash",
+            serde_json::json!({}),
+            Duration::from_secs(10),
+        ));
+        assert!(tokio::time::timeout(Duration::from_millis(10), &mut future)
+            .await
+            .is_err());
+        assert!(has_pending_hook_approval(&session, None));
+        assert!(resolve_hook_approval(&session, Some("stale-id"), true).is_err());
+        assert!(has_pending_hook_approval(&session, None));
+        drop(future);
+        assert!(!has_pending_hook_approval(&session, None));
+        assert_resolved(&session);
+        unregister_session(&session);
     }
 }

--- a/src-tauri/src/agent_sessions/cli/mod.rs
+++ b/src-tauri/src/agent_sessions/cli/mod.rs
@@ -21,6 +21,7 @@ mod native_store;
 pub mod native_transcript;
 pub mod parsers;
 pub mod persistence;
+mod permission_lifecycle;
 pub mod platform_adapters;
 pub mod session_runner;
 pub mod skill_sync;

--- a/src-tauri/src/agent_sessions/cli/parsers/acp_common/approval.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/acp_common/approval.rs
@@ -5,10 +5,10 @@
 //! resolves the option id the agent expects back.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use serde_json::Value;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::oneshot;
 
 use super::AcpAgentAdapter;
 
@@ -53,10 +53,15 @@ pub async fn resolve_approval(
     always_allow: bool,
 ) -> Result<(), String> {
     let entry = {
-        let mut pending = PENDING_APPROVALS.lock().await;
+        let mut pending = PENDING_APPROVALS
+            .lock()
+            .expect("ACP approval registry poisoned");
         let key = match request_id {
-            Some(request_id) if pending.contains_key(request_id) => Some(request_id.to_string()),
-            _ => pending
+            Some(request_id) => pending
+                .get(request_id)
+                .filter(|entry| entry.session_id == session_id)
+                .map(|_| request_id.to_string()),
+            None => pending
                 .iter()
                 .find(|(_, entry)| entry.session_id == session_id)
                 .map(|(key, _)| key.clone()),
@@ -78,17 +83,36 @@ pub async fn resolve_approval(
 /// the protocol loop awaits on.
 pub(super) async fn register_acp_approval(
     session_id: &str,
-) -> (String, oneshot::Receiver<ApprovalResponse>) {
+) -> (
+    String,
+    oneshot::Receiver<ApprovalResponse>,
+    crate::agent_sessions::cli::permission_lifecycle::PermissionLifetime,
+) {
     let request_id = format!("acpperm-{}", uuid::Uuid::new_v4());
     let (tx, rx) = oneshot::channel::<ApprovalResponse>();
-    PENDING_APPROVALS.lock().await.insert(
-        request_id.clone(),
-        PendingAcpApproval {
-            session_id: session_id.to_string(),
-            sender: tx,
-        },
+    PENDING_APPROVALS
+        .lock()
+        .expect("ACP approval registry poisoned")
+        .insert(
+            request_id.clone(),
+            PendingAcpApproval {
+                session_id: session_id.to_string(),
+                sender: tx,
+            },
+        );
+    let lifetime = crate::agent_sessions::cli::permission_lifecycle::PermissionLifetime::new(
+        session_id,
+        &request_id,
+        remove_pending_acp_approval,
     );
-    (request_id, rx)
+    (request_id, rx, lifetime)
+}
+
+fn remove_pending_acp_approval(request_id: &str) {
+    PENDING_APPROVALS
+        .lock()
+        .expect("ACP approval registry poisoned")
+        .remove(request_id);
 }
 
 /// Await a parked approval. On timeout or a dropped sender the legacy
@@ -102,7 +126,10 @@ pub(super) async fn await_acp_approval(
         Ok(Ok(resp)) => resp,
         _ => {
             tracing::info!("[ACP] Approval timed out or channel closed — auto-approving");
-            PENDING_APPROVALS.lock().await.remove(request_id);
+            PENDING_APPROVALS
+                .lock()
+                .expect("ACP approval registry poisoned")
+                .remove(request_id);
             ApprovalResponse {
                 approved: true,
                 always_allow: false,
@@ -259,4 +286,52 @@ pub(super) fn broadcast_acp_permission_request(
         "origin": "acp",
     });
     crate::api::websocket_handler::broadcast(msg.to_string());
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn permission_lifetime_cleans_timeout_response_and_cancel() {
+        for mode in ["timeout", "response", "cancel"] {
+            let session = format!("acp-lifetime-{}", uuid::Uuid::new_v4());
+            let (id, rx, lifetime) = register_acp_approval(&session).await;
+            assert!(resolve_approval(&session, Some("stale-id"), true, false)
+                .await
+                .is_err());
+            assert!(resolve_approval("wrong-session", Some(&id), true, false)
+                .await
+                .is_err());
+            assert!(PENDING_APPROVALS.lock().unwrap().contains_key(&id));
+            if mode == "response" {
+                resolve_approval(&session, Some(&id), false, false)
+                    .await
+                    .unwrap();
+                assert!(
+                    !await_acp_approval(&id, rx, Duration::from_millis(1))
+                        .await
+                        .approved
+                );
+            } else if mode == "timeout" {
+                assert!(
+                    await_acp_approval(&id, rx, Duration::from_millis(1))
+                        .await
+                        .approved
+                );
+            }
+            drop(lifetime);
+            assert!(!PENDING_APPROVALS.lock().unwrap().contains_key(&id));
+            #[cfg(debug_assertions)]
+            assert!(crate::api::websocket_handler::recent_events::snapshot()
+                .iter()
+                .any(|raw| {
+                    let event: Value = serde_json::from_str(raw).unwrap();
+                    event["type"] == "permission:resolved"
+                        && event["requestId"] == id
+                        && event["sessionId"] == session
+                }));
+        }
+    }
 }

--- a/src-tauri/src/agent_sessions/cli/parsers/acp_common/protocol.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/acp_common/protocol.rs
@@ -431,7 +431,7 @@ async fn process_notification<A: AcpAgentAdapter>(
 
                 // Register the oneshot BEFORE broadcasting so a fast
                 // frontend response always finds the entry.
-                let (request_id, rx) = register_acp_approval(session_id).await;
+                let (request_id, rx, permission_lifetime) = register_acp_approval(session_id).await;
 
                 // Emit an ask_user_permissions chunk (transcript record)
                 let mut chunk =
@@ -465,6 +465,7 @@ async fn process_notification<A: AcpAgentAdapter>(
 
                 // 5-minute timeout for user response; auto-approve on timeout
                 let response = await_acp_approval(&request_id, rx, ACP_APPROVAL_TIMEOUT).await;
+                drop(permission_lifetime);
 
                 let option_id =
                     select_acp_option_id(&params, response.approved, response.always_allow);

--- a/src-tauri/src/agent_sessions/cli/permission_lifecycle.rs
+++ b/src-tauri/src/agent_sessions/cli/permission_lifecycle.rs
@@ -1,0 +1,32 @@
+//! Own the lifetime of a frontend CLI permission prompt, including cancelled futures.
+
+pub(super) struct PermissionLifetime {
+    session_id: String,
+    request_id: String,
+    cleanup: fn(&str),
+}
+
+impl PermissionLifetime {
+    pub(super) fn new(session_id: &str, request_id: &str, cleanup: fn(&str)) -> Self {
+        Self {
+            session_id: session_id.into(),
+            request_id: request_id.into(),
+            cleanup,
+        }
+    }
+}
+
+impl Drop for PermissionLifetime {
+    fn drop(&mut self) {
+        (self.cleanup)(&self.request_id);
+        crate::api::websocket_handler::broadcast(
+            serde_json::json!({
+                "type": "permission:resolved",
+                "session_id": self.session_id,
+                "sessionId": self.session_id,
+                "requestId": self.request_id,
+            })
+            .to_string(),
+        );
+    }
+}

--- a/src/api/tauri/agent/session.ts
+++ b/src/api/tauri/agent/session.ts
@@ -238,8 +238,8 @@ export async function respondPermission(
 /**
  * Resolve a permission request parked on the CLI side: a managed
  * session's PermissionRequest hook (`origin: "cli_hook"`) or an ACP
- * agent's `session/request_permission` (`origin: "acp"`) on the
- * `agent-permission-request` event. Routes to
+ * agent's `session/request_permission` (`origin: "acp"`) from the
+ * session-scoped permission request store. Routes to
  * `cli_agent_approval_response`, which checks the hook registry first
  * and falls back to the ACP registry by `requestId`. For hooks,
  * `always_allow` is treated as a plain allow — persistent rules stay

--- a/src/engines/ChatPanel/InputArea/PermissionCard/index.tsx
+++ b/src/engines/ChatPanel/InputArea/PermissionCard/index.tsx
@@ -3,10 +3,12 @@
  *
  * Displays pending permission requests from OS Agent, SDE Agent, and Custom Agents.
  * Allows the user to Approve, Deny, or Always Allow tool executions.
- * Listens for "agent-permission-request" CustomEvents from the WebSocket handler.
+ * Renders the session-scoped pending permission store populated by the agent
+ * event handler, so requests survive component remounts and session switches.
  *
  * Delegates all rendering to PermissionCardBody (shared with ApprovalPreview).
  */
+import { useAtomValue, useSetAtom } from "jotai";
 import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -15,8 +17,12 @@ import {
   respondPermission,
 } from "@src/api/tauri/agent";
 import Message from "@src/components/Message";
-import type { PermissionRequestEvent } from "@src/engines/SessionCore/sync/adapters/shared";
 import { createLogger } from "@src/hooks/logger";
+import {
+  clearPendingPermissionRequest,
+  pendingPermissionRequestsAtom,
+  permissionRequestsForSessionAtomFamily,
+} from "@src/store/session/permissionRequestAtom";
 
 import { PermissionCardBody } from "./PermissionCardBody";
 
@@ -48,32 +54,13 @@ const PermissionCard: React.FC<PermissionCardProps> = ({
   onHasDataChange,
 }) => {
   const { t } = useTranslation("sessions");
-  const [queue, setQueue] = useState<PermissionRequestEvent[]>([]);
+  const queue = useAtomValue(
+    permissionRequestsForSessionAtomFamily(sessionId ?? "")
+  );
+  const setPermissionMap = useSetAtom(pendingPermissionRequestsAtom);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const pending = queue.length > 0 ? queue[0] : null;
-
-  useEffect(() => {
-    const handler = (evt: Event) => {
-      const detail = (evt as CustomEvent<PermissionRequestEvent>).detail;
-      // Only accept events for the session this card belongs to.
-      // Without this filter, a permission request from session B would
-      // appear in the card rendered for session A.
-      if (sessionId && detail?.sessionId && detail.sessionId !== sessionId)
-        return;
-      if (detail?.requestId) {
-        setQueue((prev) => {
-          if (prev.some((req) => req.requestId === detail.requestId))
-            return prev;
-          return [...prev, detail];
-        });
-      }
-    };
-    window.addEventListener("agent-permission-request", handler);
-    return () => {
-      window.removeEventListener("agent-permission-request", handler);
-    };
-  }, [sessionId]);
 
   const respond = useCallback(
     async (response: "allow" | "deny" | "always_allow") => {
@@ -100,8 +87,8 @@ const PermissionCard: React.FC<PermissionCardProps> = ({
             pending.args
           );
         }
-        setQueue((prev) =>
-          prev.filter((req) => req.requestId !== respondingId)
+        setPermissionMap((prev) =>
+          clearPendingPermissionRequest(prev, pending.sessionId, respondingId)
         );
       } catch (err) {
         log.error("[PermissionCard] Failed to respond:", err);
@@ -110,7 +97,7 @@ const PermissionCard: React.FC<PermissionCardProps> = ({
         setIsSubmitting(false);
       }
     },
-    [pending, t]
+    [pending, setPermissionMap, t]
   );
 
   useEffect(() => {

--- a/src/engines/SessionCore/sync/adapters/cli/__tests__/createCliEventHandler.test.ts
+++ b/src/engines/SessionCore/sync/adapters/cli/__tests__/createCliEventHandler.test.ts
@@ -4,17 +4,21 @@
  * `createCliEventHandler` is where raw CLI/ACP wire frames first become ORGII
  * domain state. Everything below asserts on the state that survives the
  * boundary — the event-store contents, the plan-approval atom, the runtime
- * status atom, the dispatched permission CustomEvent — not on whether a
+ * status atom, the pending permission queue — not on whether a
  * collaborator happened to be called.
  *
  * Only true I/O edges are mocked: the Rust event store (Tauri RPC + `es:changed`
  * listener) and the Rust normalization RPC. `cliLifecycle`, the Jotai atoms,
  * the streaming accumulator and the tool-arg parsers all run for real.
  */
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { sessionRuntimeStatusAtom } from "@src/store/session/cliSessionStatusAtom";
+import {
+  getPendingPermissionRequests,
+  pendingPermissionRequestsAtom,
+} from "@src/store/session/permissionRequestAtom";
 import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
 import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import type { ActivityChunk } from "@src/types/session/session";
@@ -2236,23 +2240,16 @@ describe("createCliEventHandler ingestion boundary", () => {
   // -------------------------------------------------------------------------
 
   describe("permission requests", () => {
-    let dispatched: CustomEvent[];
-    let originalDispatch: typeof window.dispatchEvent;
+    beforeEach(() =>
+      getInstrumentedStore().set(pendingPermissionRequestsAtom, new Map())
+    );
+    const requests = () =>
+      getPendingPermissionRequests(
+        getInstrumentedStore().get(pendingPermissionRequestsAtom),
+        SESSION_ID
+      );
 
-    beforeEach(() => {
-      dispatched = [];
-      originalDispatch = window.dispatchEvent;
-      window.dispatchEvent = ((event: Event) => {
-        dispatched.push(event as CustomEvent);
-        return true;
-      }) as typeof window.dispatchEvent;
-    });
-
-    afterEach(() => {
-      window.dispatchEvent = originalDispatch;
-    });
-
-    it("dispatches a fully formed permission request for cli_hook origin", () => {
+    it("stores a fully formed permission request for cli_hook origin", () => {
       handler.handleEvent({
         type: "permission:request",
         session_id: SESSION_ID,
@@ -2263,9 +2260,8 @@ describe("createCliEventHandler ingestion boundary", () => {
         toolArgs: { command: "ls" },
       });
 
-      expect(dispatched).toHaveLength(1);
-      expect(dispatched[0].type).toBe("agent-permission-request");
-      expect(dispatched[0].detail).toEqual({
+      expect(requests()).toHaveLength(1);
+      expect(requests()[0]).toEqual({
         requestId: "req-1",
         sessionId: SESSION_ID,
         tool: "bash",
@@ -2284,11 +2280,38 @@ describe("createCliEventHandler ingestion boundary", () => {
         toolArgs: "not-an-object",
       });
 
-      expect(dispatched[0].detail).toMatchObject({
+      expect(requests()[0]).toMatchObject({
         tool: "unknown",
         args: {},
         origin: "acp",
       });
+    });
+
+    it("clears resolved requests without removing the next prompt", () => {
+      for (const requestId of ["expired", "next"])
+        handler.handleEvent({
+          type: "permission:request",
+          session_id: SESSION_ID,
+          origin: "cli_hook",
+          requestId,
+        });
+      handler.handleEvent({
+        type: "permission:resolved",
+        session_id: "other",
+        requestId: "expired",
+      });
+      expect(requests()).toHaveLength(2);
+      handler.handleEvent({
+        type: "permission:resolved",
+        session_id: SESSION_ID,
+        requestId: "expired",
+      });
+      handler.handleEvent({
+        type: "permission:resolved",
+        session_id: SESSION_ID,
+        requestId: "expired",
+      });
+      expect(requests().map((request) => request.requestId)).toEqual(["next"]);
     });
 
     it("rejects permission frames from an unknown origin or without a requestId", () => {
@@ -2310,7 +2333,7 @@ describe("createCliEventHandler ingestion boundary", () => {
         requestId: "",
       });
 
-      expect(dispatched).toEqual([]);
+      expect(requests()).toEqual([]);
     });
   });
 

--- a/src/engines/SessionCore/sync/adapters/cli/createCliEventHandler.ts
+++ b/src/engines/SessionCore/sync/adapters/cli/createCliEventHandler.ts
@@ -10,6 +10,11 @@ import {
 } from "@src/engines/SessionCore/sync/utils/activityIds";
 import { createLogger } from "@src/hooks/logger";
 import {
+  clearPendingPermissionRequest,
+  pendingPermissionRequestsAtom,
+  upsertPendingPermissionRequest,
+} from "@src/store/session/permissionRequestAtom";
+import {
   clearPendingPlanApproval,
   pendingPlanApprovalsAtom,
   upsertPendingPlanApproval,
@@ -592,8 +597,8 @@ export function createCliEventHandler(
           : {},
       origin,
     };
-    window.dispatchEvent(
-      new CustomEvent("agent-permission-request", { detail: permissionEvent })
+    getStore()?.set(pendingPermissionRequestsAtom, (prev) =>
+      upsertPendingPermissionRequest(prev, permissionEvent)
     );
   }
 
@@ -606,6 +611,16 @@ export function createCliEventHandler(
 
       if (raw.type === "agent:interaction_finalized") {
         handleInteractionFinalized(raw as unknown as AgentWSEvent, sessionId);
+      } else if (raw.type === "permission:resolved") {
+        if (typeof raw.requestId === "string" && raw.requestId) {
+          getStore()?.set(pendingPermissionRequestsAtom, (prev) =>
+            clearPendingPermissionRequest(
+              prev,
+              sessionId,
+              raw.requestId as string
+            )
+          );
+        }
       } else if (raw.type === "permission:request") {
         handleCliPermissionRequest(raw);
       } else if (raw.type === "agent:plan_ready_for_approval") {

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/__tests__/permissionLifecycle.test.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/__tests__/permissionLifecycle.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
+import {
+  getPendingPermissionRequests,
+  pendingPermissionRequestsAtom,
+} from "@src/store/session/permissionRequestAtom";
+import {
+  createInstrumentedStore,
+  getInstrumentedStore,
+  resetInstrumentedStore,
+} from "@src/util/core/state/instrumentedStore";
+
+import type { AgentWSEvent } from "../../../shared/types";
+import { handlePermissionRequest } from "../agentSpecific";
+import { handleInteractionFinalized } from "../toolHandlers";
+import type { EventHandlerContext } from "../types";
+
+vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
+  eventStoreProxy: { mergeEvents: vi.fn().mockResolvedValue(undefined) },
+}));
+
+beforeEach(() => {
+  resetInstrumentedStore();
+  createInstrumentedStore();
+  vi.clearAllMocks();
+});
+describe("permission lifecycle at the Rust event boundary", () => {
+  it.each([false, true])(
+    "finalizes an unmounted card even when transcript persistence fails (%s)",
+    async (fails) => {
+      const store = getInstrumentedStore();
+      const ctx = { getDefaultStore: () => store } as EventHandlerContext;
+      handlePermissionRequest(
+        {
+          type: "permission:request",
+          sessionId: "s1",
+          requestId: "request-1",
+          toolCallId: "call-1",
+          tool: "bash",
+        } as AgentWSEvent,
+        "s1",
+        ctx
+      );
+      expect(
+        getPendingPermissionRequests(
+          store.get(pendingPermissionRequestsAtom),
+          "s1"
+        )
+      ).toHaveLength(1);
+      if (fails)
+        vi.mocked(eventStoreProxy.mergeEvents).mockRejectedValueOnce(
+          new Error("offline")
+        );
+      const result = handleInteractionFinalized(
+        {
+          type: "agent:interaction_finalized",
+          sessionId: "s1",
+          tool: "permission",
+          toolCallId: "call-1",
+          resultObject: { status: "approved" },
+        } as AgentWSEvent,
+        "s1"
+      );
+      if (fails) await expect(result).rejects.toThrow("offline");
+      else await result;
+      expect(store.get(pendingPermissionRequestsAtom).size).toBe(0);
+    }
+  );
+});

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/agentSpecific.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/agentSpecific.ts
@@ -15,6 +15,10 @@ import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { sanitizeTodoDisplayText } from "@src/engines/SessionCore/hooks/session/todoNormalization";
 import { createLogger } from "@src/hooks/logger";
 import {
+  pendingPermissionRequestsAtom,
+  upsertPendingPermissionRequest,
+} from "@src/store/session/permissionRequestAtom";
+import {
   clearPendingPlanApproval,
   pendingPlanApprovalsAtom,
   upsertPendingPlanApproval,
@@ -121,24 +125,23 @@ export function handlePermissionRequest(
   ctx: EventHandlerContext
 ): void {
   const reqId = event.requestId;
-  if (reqId && eventSessionId && ctx.onPermissionRequestRef) {
-    const agentType = getRustAgentType(eventSessionId);
+  if (!reqId || !eventSessionId) return;
 
-    const permEvent: PermissionRequestEvent = {
-      requestId: reqId,
-      sessionId: eventSessionId,
-      tool: event.toolName || event.tool || "unknown",
-      toolCallId: getToolCallId(event),
-      args: event.toolArgs ?? event.args ?? {},
-      agentType,
-    };
-    ctx.onPermissionRequestRef.current?.(permEvent);
+  const agentType = getRustAgentType(eventSessionId);
+  const permEvent: PermissionRequestEvent = {
+    requestId: reqId,
+    sessionId: eventSessionId,
+    tool: event.toolName || event.tool || "unknown",
+    toolCallId: getToolCallId(event),
+    args: event.toolArgs ?? event.args ?? {},
+    agentType,
+  };
 
-    // Dispatch unified event for PermissionCard
-    window.dispatchEvent(
-      new CustomEvent("agent-permission-request", { detail: permEvent })
-    );
-  }
+  const store = ctx.getDefaultStore();
+  store?.set(pendingPermissionRequestsAtom, (prev) =>
+    upsertPendingPermissionRequest(prev, permEvent)
+  );
+  ctx.onPermissionRequestRef?.current?.(permEvent);
 }
 
 // ============================================================================

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/toolHandlers.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/toolHandlers.ts
@@ -29,6 +29,14 @@ import {
   markCanvasRevisionDraftApplying,
 } from "@src/store/session/canvasRevisionDraftAtom";
 import { clearMcpProgressForCallAtom } from "@src/store/session/mcpProgressAtom";
+import {
+  clearFinalizedPermissionRequest,
+  pendingPermissionRequestsAtom,
+} from "@src/store/session/permissionRequestAtom";
+import {
+  getInstrumentedStore,
+  isStoreInitialized,
+} from "@src/util/core/state/instrumentedStore";
 
 import {
   SPAWNED_SESSION_RE,
@@ -375,6 +383,17 @@ export async function handleInteractionFinalized(
     ...(resultEvent.result as Record<string, unknown>),
     ...resultObject,
   };
+  if (event.tool === "permission" && isStoreInitialized()) {
+    const requestId =
+      typeof event.requestId === "string" ? event.requestId : undefined;
+    getInstrumentedStore().set(pendingPermissionRequestsAtom, (prev) =>
+      clearFinalizedPermissionRequest(prev, sessionId, {
+        requestId,
+        toolCallId,
+      })
+    );
+  }
+
   await eventStoreProxy.mergeEvents([resultEvent], sessionId);
 
   if (isAutoModeSwitchAccept(event.tool, resultObject)) {

--- a/src/store/session/__tests__/permissionRequestAtom.test.ts
+++ b/src/store/session/__tests__/permissionRequestAtom.test.ts
@@ -1,0 +1,97 @@
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import type { PermissionRequestEvent } from "@src/engines/SessionCore/sync/adapters/shared";
+
+import {
+  pendingPermissionRequestsAtom,
+  permissionRequestsForSessionAtomFamily,
+} from "../permissionRequestAtom";
+import {
+  type PendingPermissionRequestMap,
+  clearFinalizedPermissionRequest,
+  clearPendingPermissionRequest,
+  getPendingPermissionRequests,
+  upsertPendingPermissionRequest,
+} from "../permissionRequestAtom";
+
+function request(
+  requestId: string,
+  sessionId = "session-1"
+): PermissionRequestEvent {
+  return {
+    requestId,
+    sessionId,
+    tool: "edit_file",
+    args: { path: "src/app.ts" },
+  };
+}
+
+describe("permissionRequestAtom helpers", () => {
+  it("keeps independent ordered queues per session", () => {
+    let state: PendingPermissionRequestMap = new Map();
+    state = upsertPendingPermissionRequest(state, request("r1"));
+    state = upsertPendingPermissionRequest(state, request("r2"));
+    state = upsertPendingPermissionRequest(
+      state,
+      request("other", "session-2")
+    );
+
+    expect(
+      getPendingPermissionRequests(state, "session-1").map(
+        (item) => item.requestId
+      )
+    ).toEqual(["r1", "r2"]);
+    expect(getPendingPermissionRequests(state, "session-2")[0]?.requestId).toBe(
+      "other"
+    );
+  });
+
+  it("clears only the matching session and request", () => {
+    let state: PendingPermissionRequestMap = new Map();
+    state = upsertPendingPermissionRequest(state, request("r1"));
+    state = upsertPendingPermissionRequest(state, request("r2"));
+    state = clearPendingPermissionRequest(state, "session-1", "r1");
+
+    expect(getPendingPermissionRequests(state, "session-1")[0]?.requestId).toBe(
+      "r2"
+    );
+  });
+
+  it("clears a finalized request by tool-call identity", () => {
+    let state: PendingPermissionRequestMap = new Map();
+    state = upsertPendingPermissionRequest(state, {
+      ...request("r1"),
+      toolCallId: "call-1",
+    });
+    state = clearFinalizedPermissionRequest(state, "session-1", {
+      toolCallId: "call-1",
+    });
+
+    expect(getPendingPermissionRequests(state, "session-1")).toEqual([]);
+  });
+  it("does not notify a session view about another session's requests", () => {
+    const store = createStore();
+    const scoped = permissionRequestsForSessionAtomFamily("session-1");
+    let notifications = 0;
+    const stop = store.sub(scoped, () => {
+      notifications++;
+    });
+    store.set(pendingPermissionRequestsAtom, (prev) =>
+      upsertPendingPermissionRequest(prev, request("r2", "session-2"))
+    );
+    expect(notifications).toBe(0);
+    stop();
+  });
+
+  it("does not use the tool call fallback when an explicit request ID differs", () => {
+    const pending = { ...request("new"), toolCallId: "same-tool" };
+    const state = upsertPendingPermissionRequest(new Map(), pending);
+    expect(
+      clearFinalizedPermissionRequest(state, "session-1", {
+        requestId: "old",
+        toolCallId: "same-tool",
+      })
+    ).toBe(state);
+  });
+});

--- a/src/store/session/permissionRequestAtom.ts
+++ b/src/store/session/permissionRequestAtom.ts
@@ -1,0 +1,92 @@
+import { atom } from "jotai";
+import { atomFamily } from "jotai-family";
+
+import type { PermissionRequestEvent } from "@src/engines/SessionCore/sync/adapters/shared";
+
+export type PendingPermissionRequestMap = Map<
+  string,
+  Map<string, PermissionRequestEvent>
+>;
+
+export const pendingPermissionRequestsAtom = atom<PendingPermissionRequestMap>(
+  new Map()
+);
+pendingPermissionRequestsAtom.debugLabel = "pendingPermissionRequestsAtom";
+
+export function getPendingPermissionRequests(
+  state: PendingPermissionRequestMap,
+  sessionId: string | null | undefined
+): PermissionRequestEvent[] {
+  if (!sessionId) return [];
+  return Array.from(state.get(sessionId)?.values() ?? []);
+}
+
+export function upsertPendingPermissionRequest(
+  state: PendingPermissionRequestMap,
+  request: PermissionRequestEvent
+): PendingPermissionRequestMap {
+  const currentSession = state.get(request.sessionId);
+  if (currentSession?.get(request.requestId) === request) return state;
+
+  const nextSession = new Map(currentSession);
+  nextSession.set(request.requestId, request);
+  const next = new Map(state);
+  next.set(request.sessionId, nextSession);
+  return next;
+}
+
+export function clearFinalizedPermissionRequest(
+  state: PendingPermissionRequestMap,
+  sessionId: string,
+  identity: { requestId?: string; toolCallId?: string }
+): PendingPermissionRequestMap {
+  const currentSession = state.get(sessionId);
+  if (!currentSession) return state;
+  const matchingRequest = Array.from(currentSession.values()).find((request) =>
+    identity.requestId
+      ? request.requestId === identity.requestId
+      : !!identity.toolCallId && request.toolCallId === identity.toolCallId
+  );
+  return matchingRequest
+    ? clearPendingPermissionRequest(state, sessionId, matchingRequest.requestId)
+    : state;
+}
+
+export function clearPendingPermissionRequest(
+  state: PendingPermissionRequestMap,
+  sessionId: string,
+  requestId: string
+): PendingPermissionRequestMap {
+  const currentSession = state.get(sessionId);
+  if (!currentSession?.has(requestId)) return state;
+
+  const next = new Map(state);
+  const nextSession = new Map(currentSession);
+  nextSession.delete(requestId);
+  if (nextSession.size === 0) next.delete(sessionId);
+  else next.set(sessionId, nextSession);
+  return next;
+}
+
+const EMPTY_REQUESTS: PermissionRequestEvent[] = [];
+export const permissionRequestsForSessionAtomFamily = atomFamily(
+  (sessionId: string) => {
+    const sessionMapAtom = atom((get) =>
+      get(pendingPermissionRequestsAtom).get(sessionId)
+    );
+    return atom((get) => {
+      const requests = get(sessionMapAtom);
+      return requests ? Array.from(requests.values()) : EMPTY_REQUESTS;
+    });
+  }
+);
+
+export function clearSessionPermissionRequests(
+  state: PendingPermissionRequestMap,
+  sessionId: string
+): PendingPermissionRequestMap {
+  if (!state.has(sessionId)) return state;
+  const next = new Map(state);
+  next.delete(sessionId);
+  return next;
+}

--- a/src/store/session/sessionAtom/__tests__/mutations.test.ts
+++ b/src/store/session/sessionAtom/__tests__/mutations.test.ts
@@ -18,6 +18,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import * as streamHelpers from "@src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/streamHelpers";
 import { conversationComposerModeAtomFamily } from "@src/features/Org2Cloud/SessionConversation/conversationComposerMode";
+import {
+  pendingPermissionRequestsAtom,
+  upsertPendingPermissionRequest,
+} from "@src/store/session/permissionRequestAtom";
 import { pendingPlanApprovalForSessionAtomFamily } from "@src/store/session/planApprovalAtom";
 import {
   chatFindInChatOpenAtomFamily,
@@ -304,6 +308,23 @@ describe("updateSessionStatus", () => {
 });
 
 describe("removeSession", () => {
+  it("evicts only the removed session's permission prompts", () => {
+    const store = getInstrumentedStore();
+    for (const sessionId of ["gone", "keep"])
+      store.set(pendingPermissionRequestsAtom, (prev) =>
+        upsertPendingPermissionRequest(prev, {
+          sessionId,
+          requestId: sessionId,
+          tool: "bash",
+          args: {},
+        })
+      );
+    mutations.removeSession("gone");
+    expect([...store.get(pendingPermissionRequestsAtom).keys()]).toEqual([
+      "keep",
+    ]);
+  });
+
   it("drops the session and disposes its rust-agent streaming state", async () => {
     const { upsertSession, sessionsAtom, store } = await loadModule();
 

--- a/src/store/session/sessionAtom/mutations.ts
+++ b/src/store/session/sessionAtom/mutations.ts
@@ -37,6 +37,11 @@ import { disposeSessionStreamingState } from "@src/engines/SessionCore/sync/adap
 import { conversationComposerModeAtomFamily } from "@src/features/Org2Cloud/SessionConversation/conversationComposerMode";
 import { disposeCanvasRevisionDraftState } from "@src/store/session/canvasRevisionDraftAtom";
 import { cursorIdeTurnSummariesAtomFamily } from "@src/store/session/cursorIdeTurnSummariesAtom";
+import {
+  clearSessionPermissionRequests,
+  pendingPermissionRequestsAtom,
+  permissionRequestsForSessionAtomFamily,
+} from "@src/store/session/permissionRequestAtom";
 import { pendingPlanApprovalForSessionAtomFamily } from "@src/store/session/planApprovalAtom";
 import { tuiModeAtom } from "@src/store/session/tuiModeAtom";
 import {
@@ -197,6 +202,10 @@ export const removeSession = (sessionId: string) => {
   // A removed session has no live viewers, so free its per-session caches.
   // Without this they accumulate one entry per session for the app lifetime —
   // and tuiMode additionally leaves a `orgii:tuiMode:<id>` localStorage key.
+  store.set(pendingPermissionRequestsAtom, (prev) =>
+    clearSessionPermissionRequests(prev, sessionId)
+  );
+  permissionRequestsForSessionAtomFamily.remove(sessionId);
   cursorIdeTurnSummariesAtomFamily.remove(sessionId);
   tuiModeAtom.remove(sessionId);
   // jotai-family pins every key it has ever been called with, so a family that


### PR DESCRIPTION
## Problem

Permission prompts are lost when their card is unmounted. Keeping them in an app-lifetime queue alone leaves expired CLI/ACP prompts stale, and a response carrying an unknown request ID can otherwise resolve a different pending request.

## Solution

Keep requests in session-scoped state. Emit an additive `permission:resolved` event when CLI/ACP waits finish or are cancelled, and clear exactly that request at the frontend event boundary. Reject explicit unknown or cross-session response IDs instead of falling back to another request. Evict deleted sessions and scope subscriptions so unrelated sessions do not notify the card. Rust-agent finalization clears the prompt even if transcript persistence fails. This is the permission-only follow-up to #456.

## Potential risks

The new resolution event requires matched frontend/backend versions for CLI/ACP cleanup. Existing timeout decisions are preserved. Queues are in memory; this does not add durable recovery across app restarts or recovery of events dropped by the transport. ACP registry locking is synchronous for short map operations so cancellation can remove entries synchronously; no I/O or await occurs under that lock. No schema or dependency changes. Revert the commit as one unit to restore the previous event/card path.

## Verification

- `pnpm test src/store/session/__tests__/permissionRequestAtom.test.ts src/store/session/sessionAtom/__tests__/mutations.test.ts src/engines/SessionCore/sync/adapters/cli/__tests__/createCliEventHandler.test.ts src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/__tests__/permissionLifecycle.test.ts` — 109 tests passed independently after splitting.
- `node scripts/tauri/prepare-sidecars.cjs --profile debug` — built the required local sidecar after the first app-test build reported it missing.
- `cargo test --lib agent_sessions::cli::hook_approvals` — 8 tests passed.
- Ran the resulting `app_lib` test binary with filter `agent_sessions::cli::parsers::acp_common::approval::lifecycle_tests --nocapture` — 1 test passed (timeout, response, cancellation, stale-ID and cross-session rejection).
- The combined implementation passed `pnpm typecheck` before splitting.

No GUI automation or CPU/RSS profiling was run, consistent with the workspace's explicit computer-control opt-in. No historical data is deleted.

## Architecture and lifecycle review

Covered CLI/ACP registration, cancellation and timeout ownership, exact request/session matching, frontend event ingestion, Rust-agent finalization, and deletion cleanup. The standard hook and ACP timeout decisions are unchanged. No live account-switch, disconnected-transport, or multi-instance recovery claim is made.

| Area | Verdict | Evidence | Decision | Verification |
| --- | --- | --- | --- | --- |
| Background work | fix | Existing approval waits own prompt lifetime | Drop finalizes on response, timeout, cancellation | Backend lifecycle tests |
| Memory | fix | Pending registries and session queue | Remove on completion and session deletion | Registry and deletion tests |
| Scope/isolation | fix | Session plus exact request ID | No stale-ID fallback to another request | Boundary tests |
| Rendering | fix | Per-session derived atom | Other sessions do not notify the card | Subscription test |

Performance verdict: blocked for live CPU/RSS and GUI profiling; correctness coverage is listed above.

- Normal commit hooks passed after correcting the test event envelope: staged Oxlint/ESLint/Prettier, `tsgo --noEmit --pretty false`, and scoped `cargo clippy` for `org2`.
- The corrected permission event-boundary fixture was rerun: 2 tests passed.
- `git diff origin/develop --check` — passed; final scope and artifact/secret inspection completed.
