### PR TITLE
feat(spotlight): add floating project and work item creators

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ManualSpotlightCreator.md
+++ b/docs/frontend-ui-audit-2026-09-10/ManualSpotlightCreator.md
@@ -1,0 +1,13 @@
+# ManualSpotlightCreator UI audit
+
+| Line                               | Element            | Verdict          | Reason                                                                           | Suggested change |
+| ---------------------------------- | ------------------ | ---------------- | -------------------------------------------------------------------------------- | ---------------- |
+| `ManualSpotlightCreator.tsx:47`    | Overlay            | keep with reason | Uses the existing SpotlightShell for portal, backdrop and dismissal              | None             |
+| `ManualSpotlightCreator.tsx:57`    | Title and spacing  | keep with reason | Uses theme text and standard spacing utilities; no new arbitrary colors or sizes | None             |
+| `CreateProjectView/index.tsx:523`  | Project composer   | keep with reason | Reuses ManualCreateComposer and design-system Button/LaunchButton                | None             |
+| `CreateWorkItemView/index.tsx:303` | Work item composer | keep with reason | Reuses the same manual composer and Cancel button in the Spotlight variant       | None             |
+| `CreateComposerScaffold.tsx:123`   | Composer variation | keep with reason | Only omits page-specific glow; shared composer chrome remains authoritative      | None             |
+
+Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.
+
+Reviewed only this feature diff. Automated component tests passed; native screenshots, theme/viewport inspection and keyboard interaction in Tauri were not run because computer control is not authorized.

--- a/docs/org2-performance-guard-2026-09-10/ManualSpotlightCreator.md
+++ b/docs/org2-performance-guard-2026-09-10/ManualSpotlightCreator.md
@@ -1,0 +1,12 @@
+# ManualSpotlightCreator lifecycle review
+
+| Area               | Verdict | Evidence                                           | Change or reason kept                                             | Verification                                   |
+| ------------------ | ------- | -------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------- |
+| Background work    | keep    | Host lazy-loads on a non-null request              | Child forms unmount on dismissal; existing overlay owns listeners | Three open/close cycles in host test           |
+| Memory             | keep    | Two fixed manual draft IDs in existing capped maps | Drafts survive dismissal without sharing Agent keys               | Draft isolation test and map source inspection |
+| Scope/isolation    | keep    | Organization context travels in request            | Late completion cannot navigate after unmount                     | Completion and routing tests                   |
+| Rendering/hot path | keep    | Host observes request and Spotlight visibility     | No new polling or streaming loops                                 | Source review and host test                    |
+
+Lifecycle matrix: closed/start/idle has no manual form; open mounts one form; dismiss and reopening regular Spotlight remove it; repeated cycles remain bounded; late completion does not navigate. Visible/hidden documents use existing form resources with no new recurring task. Network and identity behavior of existing create APIs is unchanged; account/endpoint switching while a form is open was not exercised. Draft payload shape is unchanged, with two additional fixed keys.
+
+Performance verdict: blocked for native visible/hidden idle CPU/RSS and account-switch measurements because computer control is not authorized. Automated lifecycle tests and full frontend typecheck passed. No measured performance improvement is claimed.

--- a/src/engines/ChatPanel/hooks/useChatPanelNavigationActions.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelNavigationActions.ts
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 
 import { clearSessionAtom } from "@src/engines/SessionCore/core/atoms";
 import {
-  openCreateTargetInChatPanelStartPageAtom,
+  openChatPanelCreateTargetAtom,
   openExploreInChatPanelTabAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
 import {
@@ -21,9 +21,7 @@ export function useChatPanelNavigationActions() {
   const setStartPageOpen = useSetAtom(chatPanelStartPageOpenAtom);
   const navigateChatPanel = useSetAtom(chatPanelNavigateAtom);
   const openExploreTab = useSetAtom(openExploreInChatPanelTabAtom);
-  const openCreateTargetInStartPage = useSetAtom(
-    openCreateTargetInChatPanelStartPageAtom
-  );
+  const openCreateTarget = useSetAtom(openChatPanelCreateTargetAtom);
   const dispatchClearSession = useSetAtom(clearSessionAtom);
   const setWorkstationActiveSessionId = useSetAtom(
     workstationActiveSessionIdAtom
@@ -47,18 +45,16 @@ export function useChatPanelNavigationActions() {
   }, [resetActiveSession, showSessionSurface]);
 
   const openWorkItemCreate = useCallback(() => {
-    openCreateTargetInStartPage({
+    openCreateTarget({
       target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
     });
-    resetActiveSession();
-  }, [openCreateTargetInStartPage, resetActiveSession]);
+  }, [openCreateTarget]);
 
   const openProjectCreate = useCallback(() => {
-    openCreateTargetInStartPage({
+    openCreateTarget({
       target: CHAT_PANEL_CREATE_TARGET.PROJECT,
     });
-    resetActiveSession();
-  }, [openCreateTargetInStartPage, resetActiveSession]);
+  }, [openCreateTarget]);
 
   const openWorkspaceExplore = useCallback(() => {
     openExploreTab();

--- a/src/engines/ChatPanel/panels/ProjectOrgPanelView.tsx
+++ b/src/engines/ChatPanel/panels/ProjectOrgPanelView.tsx
@@ -14,7 +14,7 @@ import { ProjectOrgHubContent } from "@src/modules/ProjectManager/ProjectManager
 import { ProjectOrgSurfacePillSwitch } from "@src/modules/ProjectManager/ProjectManagerLayout/components/ProjectOrgSurfacePillSwitch";
 import {
   closeProjectOrgChatPanelTabsAtom,
-  openCreateTargetInChatPanelStartPageAtom,
+  openChatPanelCreateTargetAtom,
   openOrganizationInChatPanelTabAtom,
   openProjectInChatPanelTabAtom,
   openWorkItemInChatPanelTabAtom,
@@ -42,9 +42,7 @@ export const ProjectOrgPanelView: React.FC<ProjectOrgPanelViewProps> = ({
   selectedProjectOrg,
 }) => {
   const { t } = useTranslation("projects");
-  const openCreateTargetInStartPage = useSetAtom(
-    openCreateTargetInChatPanelStartPageAtom
-  );
+  const openCreateTarget = useSetAtom(openChatPanelCreateTargetAtom);
   const openProjectTab = useSetAtom(openProjectInChatPanelTabAtom);
   const openWorkItemTab = useSetAtom(openWorkItemInChatPanelTabAtom);
   const closeProjectOrgTabs = useSetAtom(closeProjectOrgChatPanelTabsAtom);
@@ -84,32 +82,24 @@ export const ProjectOrgPanelView: React.FC<ProjectOrgPanelViewProps> = ({
   );
 
   const handleCreateProject = useCallback(() => {
-    openCreateTargetInStartPage({
+    openCreateTarget({
       target: CHAT_PANEL_CREATE_TARGET.PROJECT,
       createProjectContext: {
         orgId: selectedProjectOrg.orgId,
         scopeBreadcrumbLabel: selectedProjectOrg.orgName,
       },
     });
-  }, [
-    openCreateTargetInStartPage,
-    selectedProjectOrg.orgId,
-    selectedProjectOrg.orgName,
-  ]);
+  }, [openCreateTarget, selectedProjectOrg.orgId, selectedProjectOrg.orgName]);
 
   const handleCreateWorkItem = useCallback(() => {
-    openCreateTargetInStartPage({
+    openCreateTarget({
       target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
       createProjectContext: {
         orgId: selectedProjectOrg.orgId,
         scopeBreadcrumbLabel: selectedProjectOrg.orgName,
       },
     });
-  }, [
-    openCreateTargetInStartPage,
-    selectedProjectOrg.orgId,
-    selectedProjectOrg.orgName,
-  ]);
+  }, [openCreateTarget, selectedProjectOrg.orgId, selectedProjectOrg.orgName]);
 
   const handleExpandWorkItemToTab = useCallback(
     async (

--- a/src/hooks/project/useWorkItemCreatorDraft.test.ts
+++ b/src/hooks/project/useWorkItemCreatorDraft.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React, { act, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { MANUAL_WORK_ITEM_CREATOR_DRAFT_ID } from "@src/store/workstation/projectManager";
+
+import { useWorkItemCreatorDraft } from "./useWorkItemCreatorDraft";
+
+it("editing or clearing the floating draft preserves the mounted Agent draft", () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const drafts: Record<string, ReturnType<typeof useWorkItemCreatorDraft>> = {};
+  function Harness({ kind }: { kind: "agent" | "manual" }) {
+    const draft = useWorkItemCreatorDraft({
+      draftId:
+        kind === "manual" ? MANUAL_WORK_ITEM_CREATOR_DRAFT_ID : undefined,
+    });
+    useEffect(() => {
+      drafts[kind] = draft;
+    }, [draft, kind]);
+    return null;
+  }
+  const root = createRoot(document.createElement("div"));
+  try {
+    act(() =>
+      root.render(
+        React.createElement(
+          Provider,
+          { store: createStore() },
+          React.createElement(Harness, { kind: "agent" }),
+          React.createElement(Harness, { kind: "manual" })
+        )
+      )
+    );
+    act(() => drafts.agent.updateDraft({ name: "Agent draft" }));
+    act(() => drafts.manual.updateDraft({ name: "Manual draft" }));
+    expect(drafts.agent.draft.name).toBe("Agent draft");
+    expect(drafts.manual.draft.name).toBe("Manual draft");
+    act(() => drafts.manual.clearDraft());
+    expect(drafts.agent.draft.name).toBe("Agent draft");
+  } finally {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/hooks/project/useWorkItemCreatorDraft.ts
+++ b/src/hooks/project/useWorkItemCreatorDraft.ts
@@ -1,8 +1,6 @@
 /**
- * Shared draft state for the work item creator (chat panel + create modal).
- *
- * Both surfaces read/write the same jotai entry so in-progress form data
- * survives switching between the chat-panel creator and the modal.
+ * Keyed creator drafts. Agent and floating manual creators keep independent
+ * entries so both surfaces can remain mounted without overwriting each other.
  */
 import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
@@ -21,6 +19,7 @@ import type { WorkItem as WorkItemExtended } from "@src/types/core/workItem";
 export { WORK_ITEM_CREATOR_DRAFT_ID };
 
 export interface UseWorkItemCreatorDraftOptions {
+  draftId?: string;
   /** Seed project once when the draft has no project (modal launch context). */
   seedProjectId?: string;
   /** Seed project once when the draft has no project (e.g. first loaded project). */
@@ -95,7 +94,12 @@ export function mapWorkItemUpdatesToDraftPatch(
 export function useWorkItemCreatorDraft(
   options: UseWorkItemCreatorDraftOptions = {}
 ): UseWorkItemCreatorDraftReturn {
-  const { seedProjectId, defaultProjectId, onSetUnsaved } = options;
+  const {
+    draftId = WORK_ITEM_CREATOR_DRAFT_ID,
+    seedProjectId,
+    defaultProjectId,
+    onSetUnsaved,
+  } = options;
   const draftsMap = useAtomValue(workItemDraftsAtom);
   const setDraftAtom = useSetAtom(setWorkItemDraftAtom);
   const patchDraftAtom = useSetAtom(patchWorkItemDraftAtom);
@@ -105,80 +109,79 @@ export function useWorkItemCreatorDraft(
   const seedProjectAppliedRef = useRef(false);
   const defaultProjectAppliedRef = useRef(false);
 
-  const draft =
-    draftsMap.get(WORK_ITEM_CREATOR_DRAFT_ID) ?? createDefaultWorkItemDraft();
+  const draft = draftsMap.get(draftId) ?? createDefaultWorkItemDraft();
 
   useEffect(() => {
     if (initializedRef.current) return;
     initializedRef.current = true;
-    if (!draftsMap.has(WORK_ITEM_CREATOR_DRAFT_ID)) {
+    if (!draftsMap.has(draftId)) {
       setDraftAtom({
-        tabId: WORK_ITEM_CREATOR_DRAFT_ID,
+        tabId: draftId,
         draft: createDefaultWorkItemDraft(),
       });
     }
-  }, [draftsMap, setDraftAtom]);
+  }, [draftId, draftsMap, setDraftAtom]);
 
   useEffect(() => {
     if (seedProjectAppliedRef.current || !seedProjectId) return;
-    const existing = draftsMap.get(WORK_ITEM_CREATOR_DRAFT_ID);
+    const existing = draftsMap.get(draftId);
     if (existing?.projectId) {
       seedProjectAppliedRef.current = true;
       return;
     }
     patchDraftAtom({
-      tabId: WORK_ITEM_CREATOR_DRAFT_ID,
+      tabId: draftId,
       patch: { projectId: seedProjectId },
     });
     seedProjectAppliedRef.current = true;
-  }, [draftsMap, patchDraftAtom, seedProjectId]);
+  }, [draftId, draftsMap, patchDraftAtom, seedProjectId]);
 
   useEffect(() => {
     if (defaultProjectAppliedRef.current || !defaultProjectId) return;
-    const existing = draftsMap.get(WORK_ITEM_CREATOR_DRAFT_ID);
+    const existing = draftsMap.get(draftId);
     if (existing?.projectId) {
       defaultProjectAppliedRef.current = true;
       return;
     }
     patchDraftAtom({
-      tabId: WORK_ITEM_CREATOR_DRAFT_ID,
+      tabId: draftId,
       patch: { projectId: defaultProjectId },
     });
     defaultProjectAppliedRef.current = true;
-  }, [defaultProjectId, draftsMap, patchDraftAtom]);
+  }, [draftId, defaultProjectId, draftsMap, patchDraftAtom]);
 
   const updateDraft = useCallback(
     (patch: Partial<WorkItemDraft>) => {
-      patchDraftAtom({ tabId: WORK_ITEM_CREATOR_DRAFT_ID, patch });
+      patchDraftAtom({ tabId: draftId, patch });
       onSetUnsaved?.(true);
     },
-    [onSetUnsaved, patchDraftAtom]
+    [draftId, onSetUnsaved, patchDraftAtom]
   );
 
   const setDraft = useCallback(
     (nextDraft: WorkItemDraft) => {
-      setDraftAtom({ tabId: WORK_ITEM_CREATOR_DRAFT_ID, draft: nextDraft });
+      setDraftAtom({ tabId: draftId, draft: nextDraft });
     },
-    [setDraftAtom]
+    [draftId, setDraftAtom]
   );
 
   const resetDraft = useCallback(
     (projectId?: string) => {
       setDraftAtom({
-        tabId: WORK_ITEM_CREATOR_DRAFT_ID,
+        tabId: draftId,
         draft: createDefaultWorkItemDraft(projectId),
       });
       onSetUnsaved?.(false);
     },
-    [onSetUnsaved, setDraftAtom]
+    [draftId, onSetUnsaved, setDraftAtom]
   );
 
   const clearDraft = useCallback(() => {
-    removeDraftAtom(WORK_ITEM_CREATOR_DRAFT_ID);
+    removeDraftAtom(draftId);
     initializedRef.current = false;
     seedProjectAppliedRef.current = false;
     defaultProjectAppliedRef.current = false;
-  }, [removeDraftAtom]);
+  }, [draftId, removeDraftAtom]);
 
   return {
     draft,

--- a/src/modules/MainApp/WorkManagement/WorkManagementProjectsSurface.tsx
+++ b/src/modules/MainApp/WorkManagement/WorkManagementProjectsSurface.tsx
@@ -15,13 +15,11 @@ import type { LinearProjectSelection } from "@src/modules/ProjectManager/Panels/
 import type { ProjectWorkItemSelection } from "@src/modules/ProjectManager/ProjectManagerLayout/components/ProjectWorkItemsTabContent";
 import type { ActiveRepoView } from "@src/modules/ProjectManager/ProjectManagerLayout/types";
 import {
-  openCreateTargetInChatPanelStartPageAtom,
+  openChatPanelCreateTargetAtom,
   openWorkItemInChatPanelTabAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { projectListRefreshAtom } from "@src/store/project/projectAtom";
 import { CHAT_PANEL_CREATE_TARGET } from "@src/store/ui/chatPanel/selectionAtoms";
-import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
-import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import {
   STORY_ORG_SCOPE,
   WORK_MANAGEMENT_PROJECTS_VIEW,
@@ -100,11 +98,7 @@ const WorkManagementProjectsSurface: React.FC<{
   const { openTab } = useWorkStationTabs();
   const openWorkItemInChatPanel = useSetAtom(openWorkItemInChatPanelTabAtom);
 
-  const setStationMode = useSetAtom(stationModeAtom);
-  const setStationChatVisible = useSetAtom(activeStationChatVisibleAtom);
-  const openCreateTargetInStartPage = useSetAtom(
-    openCreateTargetInChatPanelStartPageAtom
-  );
+  const openCreateTarget = useSetAtom(openChatPanelCreateTargetAtom);
 
   const activeOrgScope =
     view.kind === "repo" ? (view.orgScope ?? STORY_ORG_SCOPE.ALL) : null;
@@ -182,20 +176,16 @@ const WorkManagementProjectsSurface: React.FC<{
   }, [bumpProjectListRefresh, handleOpenProjects]);
 
   const handleCreateProject = useCallback(() => {
-    openCreateTargetInStartPage({
+    openCreateTarget({
       target: CHAT_PANEL_CREATE_TARGET.PROJECT,
     });
-    setStationMode("my-station");
-    setStationChatVisible("my-station", true);
-  }, [openCreateTargetInStartPage, setStationChatVisible, setStationMode]);
+  }, [openCreateTarget]);
 
   const handleCreateWorkItem = useCallback(() => {
-    openCreateTargetInStartPage({
+    openCreateTarget({
       target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
     });
-    setStationMode("my-station");
-    setStationChatVisible("my-station", true);
-  }, [openCreateTargetInStartPage, setStationChatVisible, setStationMode]);
+  }, [openCreateTarget]);
 
   const handleOpenProjectWorkItem = useCallback(
     (

--- a/src/modules/ProjectManager/ProjectManagerLayout/hooks/useProjectTabActions.ts
+++ b/src/modules/ProjectManager/ProjectManagerLayout/hooks/useProjectTabActions.ts
@@ -14,13 +14,13 @@ import { useTranslation } from "react-i18next";
 
 import type { ProjectOrg } from "@src/api/http/project";
 import type { QuickAction } from "@src/modules/WorkStation/shared";
-import { openCreateTargetInChatPanelStartPageAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
+import { openChatPanelCreateTargetAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { openOrFocusSessionInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { CHAT_PANEL_CREATE_TARGET } from "@src/store/ui/chatPanel/selectionAtoms";
-import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
-import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import { workStationPrimarySidebarCollapsedPersistAtom } from "@src/store/ui/workStationLayout/primarySidebarAtoms";
 import {
+  MANUAL_PROJECT_CREATOR_DRAFT_ID,
+  MANUAL_WORK_ITEM_CREATOR_DRAFT_ID,
   PROJECT_CREATOR_DRAFT_ID,
   WORK_ITEM_CREATOR_DRAFT_ID,
   projectDraftsAtom,
@@ -75,9 +75,11 @@ export function useProjectTabActions({
   useEffect(() => {
     const liveProjectDraftIds = new Set(tabs.map((tab) => tab.id));
     liveProjectDraftIds.add(PROJECT_CREATOR_DRAFT_ID);
+    liveProjectDraftIds.add(MANUAL_PROJECT_CREATOR_DRAFT_ID);
 
     const liveWorkItemDraftIds = new Set(tabs.map((tab) => tab.id));
     liveWorkItemDraftIds.add(WORK_ITEM_CREATOR_DRAFT_ID);
+    liveWorkItemDraftIds.add(MANUAL_WORK_ITEM_CREATOR_DRAFT_ID);
 
     for (const draftTabId of projectDrafts.keys()) {
       if (!liveProjectDraftIds.has(draftTabId)) {
@@ -98,11 +100,7 @@ export function useProjectTabActions({
     removeWorkItemDraft,
   ]);
 
-  const stationMode = useAtomValue(stationModeAtom);
-  const setStationChatVisible = useSetAtom(activeStationChatVisibleAtom);
-  const openCreateTargetInStartPage = useSetAtom(
-    openCreateTargetInChatPanelStartPageAtom
-  );
+  const openCreateTarget = useSetAtom(openChatPanelCreateTargetAtom);
   const setLayout = useSetAtom(workstationLayoutAtom);
 
   /**
@@ -206,7 +204,7 @@ export function useProjectTabActions({
   );
 
   const handleCreateProject = useCallback(() => {
-    openCreateTargetInStartPage({
+    openCreateTarget({
       target: CHAT_PANEL_CREATE_TARGET.PROJECT,
       createProjectContext: {
         orgId: activeProjectOrg?.orgId ?? STORY_PERSONAL_ORG_FILTER_ID,
@@ -214,27 +212,15 @@ export function useProjectTabActions({
           activeProjectOrg?.orgName ?? t("projects:orgs.personalOrg"),
       },
     });
-    if (stationMode === "my-station" || stationMode === "agent-station") {
-      setStationChatVisible(stationMode, true);
-    }
-  }, [
-    activeProjectOrg,
-    openCreateTargetInStartPage,
-    setStationChatVisible,
-    stationMode,
-    t,
-  ]);
+  }, [activeProjectOrg, openCreateTarget, t]);
 
   const handleCreateWorkItem = useCallback(
     (_projectId?: string, _projectName?: string, _projectSlug?: string) => {
-      openCreateTargetInStartPage({
+      openCreateTarget({
         target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
       });
-      if (stationMode === "my-station" || stationMode === "agent-station") {
-        setStationChatVisible(stationMode, true);
-      }
     },
-    [openCreateTargetInStartPage, setStationChatVisible, stationMode]
+    [openCreateTarget]
   );
 
   const handleOpenProjects = useCallback(() => {

--- a/src/modules/ProjectManager/Projects/components/CreateProjectView/index.tsx
+++ b/src/modules/ProjectManager/Projects/components/CreateProjectView/index.tsx
@@ -27,6 +27,7 @@ import {
   projectApi,
   projectDataToUI,
 } from "@src/api/http/project";
+import Button from "@src/components/Button";
 import Message from "@src/components/Message";
 import type { SelectOption } from "@src/components/Select";
 import { INPUT_AREA_EDITOR_HEIGHT } from "@src/config/inputAreaTokens";
@@ -56,6 +57,7 @@ import MarkdownEditorModeSwitch from "@src/modules/shared/components/MarkdownTex
 import { CreatorContentLayout } from "@src/modules/shared/layouts/blocks";
 import { reposAtom } from "@src/store/repo";
 import { DEFAULT_SESSION_ORG_ID } from "@src/store/session";
+import { manualCreatorAtom } from "@src/store/ui/manualCreatorAtom";
 import {
   type ProjectDraft,
   createDefaultProjectDraft,
@@ -83,6 +85,8 @@ export interface CreatedProjectResult {
 }
 
 interface CreateProjectViewProps {
+  layout?: "page" | "spotlight";
+  onCancel?: () => void;
   /** Tab ID used to key the draft cache */
   tabId: string;
   /**
@@ -101,7 +105,7 @@ interface CreateProjectViewProps {
   /** Mark this tab as having unsaved changes */
   onSetUnsaved: (hasUnsaved: boolean) => void;
   /** Called after project is successfully created */
-  onProjectCreated: (result: CreatedProjectResult) => void;
+  onProjectCreated?: (result: CreatedProjectResult) => void;
   /** Show the Agent composer instead of the manual Project composer. */
   aiGenerateMode?: boolean;
   /** Optional content centered in the page above the bottom-docked manual composer. */
@@ -138,12 +142,15 @@ const CreateProjectView: React.FC<CreateProjectViewProps> = ({
   onSetUnsaved,
   onProjectCreated,
   aiGenerateMode = false,
+  layout = "page",
+  onCancel,
   middleContent,
   creatorModeControl,
   renderAgentComposer,
   publishHeaderToWorkstation = false,
 }) => {
   const { t } = useTranslation("projects");
+  const manualCreator = useAtomValue(manualCreatorAtom);
   const [saving, setSaving] = useState(false);
   const [editorMode, setEditorMode] = useState<MarkdownEditorMode>("write");
   const [availableOrgs, setAvailableOrgs] = useState<ProjectOrg[]>([]);
@@ -201,7 +208,7 @@ const CreateProjectView: React.FC<CreateProjectViewProps> = ({
   const propertiesRef = useRef<HTMLDivElement>(null);
 
   const undoStack = useUndoStackWithRestore<ProjectDraft>({
-    keyboardShortcut: true,
+    keyboardShortcut: layout === "spotlight" || !manualCreator,
     currentValue: draft,
     onRestore: (prev) => setDraft({ tabId, draft: prev }),
   });
@@ -322,7 +329,7 @@ const CreateProjectView: React.FC<CreateProjectViewProps> = ({
 
       await emit("orgii-data-changed");
       removeDraft(tabId);
-      onProjectCreated({
+      onProjectCreated?.({
         project: projectDataToUI(
           { meta, description, slug },
           { labelMap: new Map(), memberMap: new Map() }
@@ -353,7 +360,10 @@ const CreateProjectView: React.FC<CreateProjectViewProps> = ({
 
   useKeyboardSave(
     handleCreate,
-    !aiGenerateMode && !saving && !!draft.name.trim()
+    (layout === "spotlight" || !manualCreator) &&
+      !aiGenerateMode &&
+      !saving &&
+      !!draft.name.trim()
   );
 
   const selectableOrgs = useMemo(
@@ -510,6 +520,44 @@ const CreateProjectView: React.FC<CreateProjectViewProps> = ({
     />
   );
 
+  const manualComposer = (
+    <ManualCreateComposer
+      spotlight={layout === "spotlight"}
+      dataTestId="create-project-manual-composer"
+      editorRef={editorRef}
+      headerContent={composerHeaderContent}
+      editorContent={projectEditor}
+      pinnedActionsContent={projectPinnedActions}
+      pills={
+        <MarkdownEditorModeSwitch
+          mode={editorMode}
+          onModeChange={setEditorMode}
+          disabled={saving}
+          dataTestId="create-project-description-mode-switch"
+        />
+      }
+      submitButton={
+        <>
+          {layout === "spotlight" && onCancel && (
+            <Button variant="secondary" size="small" onClick={onCancel}>
+              {t("common:actions.cancel")}
+            </Button>
+          )}
+          <LaunchButton
+            ariaLabel={t("projects.createProject")}
+            dataTestId="create-project-submit"
+            disabled={!draft.name.trim() || saving}
+            loading={saving}
+            onClick={() => {
+              void handleCreate();
+            }}
+          />
+        </>
+      }
+    />
+  );
+  if (layout === "spotlight") return manualComposer;
+
   return (
     <DetailSplitLayout
       title={t("projects.newProject")}
@@ -522,36 +570,9 @@ const CreateProjectView: React.FC<CreateProjectViewProps> = ({
           contentDataTestId="create-project-creator-content"
           middleContent={middleContent}
         >
-          {aiGenerateMode && renderAgentComposer ? (
-            renderAgentComposer(composerHeaderContent, projectPinnedActions)
-          ) : (
-            <ManualCreateComposer
-              dataTestId="create-project-manual-composer"
-              editorRef={editorRef}
-              headerContent={composerHeaderContent}
-              editorContent={projectEditor}
-              pinnedActionsContent={projectPinnedActions}
-              pills={
-                <MarkdownEditorModeSwitch
-                  mode={editorMode}
-                  onModeChange={setEditorMode}
-                  disabled={saving}
-                  dataTestId="create-project-description-mode-switch"
-                />
-              }
-              submitButton={
-                <LaunchButton
-                  ariaLabel={t("projects.createProject")}
-                  dataTestId="create-project-submit"
-                  disabled={!draft.name.trim() || saving}
-                  loading={saving}
-                  onClick={() => {
-                    void handleCreate();
-                  }}
-                />
-              }
-            />
-          )}
+          {aiGenerateMode && renderAgentComposer
+            ? renderAgentComposer(composerHeaderContent, projectPinnedActions)
+            : manualComposer}
         </CreatorContentLayout>
       }
     />

--- a/src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/InlineCreateWorkItemFields.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/InlineCreateWorkItemFields.tsx
@@ -98,6 +98,7 @@ export interface InlineCreateWorkItemFieldsState {
 }
 
 export interface UseInlineCreateWorkItemFieldsOptions {
+  draftId?: string;
   aiGenerateMode?: boolean;
   availableLabels?: WorkItemLabel[];
   availableMembers?: Person[];
@@ -123,6 +124,7 @@ export interface UseInlineCreateWorkItemFieldsOptions {
 }
 
 export function useInlineCreateWorkItemFields({
+  draftId,
   aiGenerateMode = false,
   availableLabels = [],
   availableMembers = [],
@@ -156,6 +158,7 @@ export function useInlineCreateWorkItemFields({
 
   const { draft, updateDraft, setDraft, resetDraft, clearDraft } =
     useWorkItemCreatorDraft({
+      draftId,
       seedProjectId: projectId,
       defaultProjectId,
       onSetUnsaved,

--- a/src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/index.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/index.tsx
@@ -1,4 +1,5 @@
 import { emit } from "@tauri-apps/api/event";
+import { useAtomValue } from "jotai";
 import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -22,7 +23,11 @@ import {
   CreatorContentLayout,
   PANEL_HEADER_TOKENS,
 } from "@src/modules/shared/layouts/blocks";
-import type { WorkItemDraft } from "@src/store/workstation/projectManager";
+import { manualCreatorAtom } from "@src/store/ui/manualCreatorAtom";
+import {
+  MANUAL_WORK_ITEM_CREATOR_DRAFT_ID,
+  type WorkItemDraft,
+} from "@src/store/workstation/projectManager";
 import type { Person } from "@src/types/core/shared";
 import type {
   WorkItemLabel,
@@ -50,6 +55,7 @@ const CREATE_WORK_ITEM_HEADER_ACTION_ACTIVE_CLASS =
 export type { CreatedWorkItemResult };
 
 interface CreateWorkItemViewProps {
+  layout?: "page" | "spotlight";
   projectId?: string;
   projectSlug?: string;
   projectName?: string;
@@ -99,6 +105,7 @@ interface CreateWorkItemViewProps {
 const logger = createLogger("CreateWorkItemView");
 
 const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
+  layout = "page",
   projectId,
   projectSlug,
   projectName,
@@ -129,6 +136,7 @@ const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
   defaultAiExecutionTarget = null,
 }) => {
   const { t } = useTranslation("projects");
+  const manualCreator = useAtomValue(manualCreatorAtom);
   const [saving, setSaving] = useState(false);
   const [createMore, setCreateMore] = useState(false);
   const [localAiGenerateMode, setLocalAiGenerateMode] = useState(true);
@@ -139,6 +147,8 @@ const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
     controlledAiGenerateMode ?? localAiGenerateMode;
 
   const inlineFields = useInlineCreateWorkItemFields({
+    draftId:
+      layout === "spotlight" ? MANUAL_WORK_ITEM_CREATOR_DRAFT_ID : undefined,
     aiGenerateMode: resolvedAiGenerateMode,
     availableLabels,
     availableMembers,
@@ -146,7 +156,7 @@ const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
     availableProjects,
     chatPanelFooter,
     defaultProjectId: projectId,
-    dockedComposer: Boolean(renderAgentComposer),
+    dockedComposer: layout === "spotlight" || Boolean(renderAgentComposer),
     onDraftChange,
     onSetUnsaved,
     orgId,
@@ -271,7 +281,10 @@ const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
 
   useKeyboardSave(
     handleCreate,
-    !resolvedAiGenerateMode && !saving && !!draft.name.trim()
+    (layout === "spotlight" || !manualCreator) &&
+      !resolvedAiGenerateMode &&
+      !saving &&
+      !!draft.name.trim()
   );
 
   const composerHeaderContent = (
@@ -286,6 +299,43 @@ const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
       {inlineFields.inlinePropertyPills}
     </CreateComposerPinnedActions>
   );
+
+  const manualComposer = (
+    <ManualCreateComposer
+      spotlight={layout === "spotlight"}
+      dataTestId="create-work-item-manual-composer"
+      editorRef={editorRef}
+      headerContent={composerHeaderContent}
+      editorContent={inlineFields.descriptionSection}
+      pinnedActionsContent={workItemPropertyPills}
+      pills={
+        <MarkdownEditorModeSwitch
+          mode={inlineFields.editorMode}
+          onModeChange={inlineFields.setEditorMode}
+          disabled={saving}
+          dataTestId="create-work-item-description-mode-switch"
+        />
+      }
+      submitButton={
+        <>
+          {layout === "spotlight" && (
+            <Button variant="secondary" size="small" onClick={onCancel}>
+              {t("common:actions.cancel")}
+            </Button>
+          )}
+          <LaunchButton
+            ariaLabel={t("common:actions.save")}
+            disabled={!draft.name.trim() || saving}
+            loading={saving}
+            onClick={() => {
+              void handleCreate();
+            }}
+          />
+        </>
+      }
+    />
+  );
+  if (layout === "spotlight") return manualComposer;
 
   return (
     <DetailSplitLayout
@@ -380,31 +430,7 @@ const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
           {resolvedAiGenerateMode && renderAgentComposer ? (
             renderAgentComposer(composerHeaderContent, workItemPropertyPills)
           ) : renderAgentComposer ? (
-            <ManualCreateComposer
-              dataTestId="create-work-item-manual-composer"
-              editorRef={editorRef}
-              headerContent={composerHeaderContent}
-              editorContent={inlineFields.descriptionSection}
-              pinnedActionsContent={workItemPropertyPills}
-              pills={
-                <MarkdownEditorModeSwitch
-                  mode={inlineFields.editorMode}
-                  onModeChange={inlineFields.setEditorMode}
-                  disabled={saving}
-                  dataTestId="create-work-item-description-mode-switch"
-                />
-              }
-              submitButton={
-                <LaunchButton
-                  ariaLabel={t("common:actions.save")}
-                  disabled={!draft.name.trim() || saving}
-                  loading={saving}
-                  onClick={() => {
-                    void handleCreate();
-                  }}
-                />
-              }
-            />
+            manualComposer
           ) : (
             <div className={`${DETAIL_PANEL_TOKENS.headerWidth} h-full px-4`}>
               <InlineCreateWorkItemFields state={inlineFields} />

--- a/src/modules/ProjectManager/shared/components/CreateComposerScaffold.test.ts
+++ b/src/modules/ProjectManager/shared/components/CreateComposerScaffold.test.ts
@@ -61,6 +61,19 @@ describe("CreateComposerScaffold", () => {
     );
   });
 
+  it("omits the bottom glow only for Spotlight", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ManualCreateComposer, {
+        spotlight: true,
+        editorRef,
+        headerContent: null,
+        editorContent: null,
+        pinnedActionsContent: null,
+      })
+    );
+    expect(markup).not.toContain("composer-bottom-glow");
+  });
+
   it("uses body typography for the shared Project and Work Item title", () => {
     const markup = renderToStaticMarkup(
       createElement(CreateComposerTitleInput, {

--- a/src/modules/ProjectManager/shared/components/CreateComposerScaffold.tsx
+++ b/src/modules/ProjectManager/shared/components/CreateComposerScaffold.tsx
@@ -85,6 +85,7 @@ export interface ManualCreateEditorRef {
 }
 
 export interface ManualCreateComposerProps {
+  spotlight?: boolean;
   dataTestId?: string;
   editorContent: ReactNode;
   editorRef: RefObject<ManualCreateEditorRef | null>;
@@ -97,6 +98,7 @@ export interface ManualCreateComposerProps {
 
 /** Shared manual-create shell for Project and Work Item composers. */
 export function ManualCreateComposer({
+  spotlight = false,
   dataTestId,
   editorContent,
   editorRef,
@@ -117,7 +119,9 @@ export function ManualCreateComposer({
         <div className="scrollbar-hide flex w-full min-w-0 items-center overflow-x-auto px-1 py-0.5">
           {pinnedActionsContent}
         </div>
-        <div className="session-creator-chat-panel-fullscreen-composer-group session-creator-chat-panel-fullscreen-composer composer-bottom-glow relative w-full">
+        <div
+          className={`session-creator-chat-panel-fullscreen-composer-group session-creator-chat-panel-fullscreen-composer ${spotlight ? "" : "composer-bottom-glow"} relative w-full`}
+        >
           <ComposerSurface
             className="session-creator-chat-panel-fullscreen-input-shell relative z-2 pt-1.5!"
             onAddContent={() => editorRef.current?.triggerAtMention()}

--- a/src/modules/ProjectManager/shared/components/ManualSpotlightCreator.test.ts
+++ b/src/modules/ProjectManager/shared/components/ManualSpotlightCreator.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { Provider, atom, createStore } from "jotai";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type CreateProjectView from "@src/modules/ProjectManager/Projects/components/CreateProjectView";
+import type CreateWorkItemView from "@src/modules/ProjectManager/WorkItems/components/CreateWorkItemView";
+import type { ManualCreatorRequest } from "@src/store/ui/manualCreatorAtom";
+import type { Project } from "@src/types/core/project";
+import type { WorkItem } from "@src/types/core/workItem";
+
+import ManualSpotlightCreator from "./ManualSpotlightCreator";
+
+const mocks = vi.hoisted(() => ({
+  projectProps: null as React.ComponentProps<typeof CreateProjectView> | null,
+  workItemProps: null as React.ComponentProps<typeof CreateWorkItemView> | null,
+  openProject: vi.fn(),
+  openWorkItem: vi.fn(),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock(
+  "@src/modules/ProjectManager/Projects/components/CreateProjectView",
+  () => ({
+    default: (props: React.ComponentProps<typeof CreateProjectView>) => {
+      mocks.projectProps = props;
+      return null;
+    },
+  })
+);
+vi.mock(
+  "@src/modules/ProjectManager/WorkItems/components/CreateWorkItemView",
+  () => ({
+    default: (props: React.ComponentProps<typeof CreateWorkItemView>) => {
+      mocks.workItemProps = props;
+      return null;
+    },
+  })
+);
+vi.mock("@src/store/chatPanel/chatPanelTabsAtom", () => ({
+  openProjectInChatPanelTabAtom: atom(null, (_get, _set, value) =>
+    mocks.openProject(value)
+  ),
+  openWorkItemInChatPanelTabAtom: atom(null, (_get, _set, value) =>
+    mocks.openWorkItem(value)
+  ),
+}));
+vi.mock("@src/store/workspace", () => ({
+  primaryWorkspaceRootAtom: atom({ path: "/repo", name: "Repo" }),
+}));
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+});
+
+const cleanups: (() => void)[] = [];
+afterEach(() => {
+  cleanups
+    .splice(0)
+    .reverse()
+    .forEach((cleanup) => cleanup());
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+function render(target: ManualCreatorRequest["target"]) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  const close = vi.fn();
+  act(() =>
+    root.render(
+      React.createElement(
+        Provider,
+        { store: createStore() },
+        React.createElement(
+          MemoryRouter,
+          null,
+          React.createElement(ManualSpotlightCreator, {
+            request: {
+              target,
+              createProjectContext: {
+                orgId: "org-a",
+                scopeBreadcrumbLabel: "Team A",
+              },
+            },
+            onClose: close,
+          })
+        )
+      )
+    )
+  );
+  let unmounted = false;
+  const unmount = () => {
+    if (!unmounted) {
+      act(() => root.unmount());
+      unmounted = true;
+    }
+  };
+  cleanups.push(() => {
+    unmount();
+    host.remove();
+  });
+  return { close, host, unmount };
+}
+
+describe("ManualSpotlightCreator", () => {
+  it("renders a manual scoped work item and supports cancel and create another", () => {
+    const { close } = render("workItem");
+    expect(
+      document.querySelector('[data-testid="manual-spotlight-creator"]')
+    ).not.toBeNull();
+    expect(mocks.workItemProps).toMatchObject({
+      layout: "spotlight",
+      orgId: "org-a",
+      repoPath: "/repo",
+    });
+    mocks.workItemProps!.onWorkItemCreated({
+      shortId: "WI-1",
+      orgId: "org-a",
+      keepOpen: true,
+    });
+    expect(close).not.toHaveBeenCalled();
+    expect(mocks.openWorkItem).not.toHaveBeenCalled();
+    act(() => mocks.workItemProps!.onCancel());
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("opens the created work item with its organization", () => {
+    const { close } = render("workItem");
+    mocks.workItemProps!.onWorkItemCreated({
+      shortId: "WI-1",
+      orgId: "org-a",
+      workItem: { session_id: "wi-1" } as WorkItem,
+    });
+    expect(close).toHaveBeenCalledOnce();
+    expect(mocks.openWorkItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shortId: "WI-1",
+        orgId: "org-a",
+        orgName: "Team A",
+      })
+    );
+  });
+
+  it("opens the successfully created project", () => {
+    const { close } = render("project");
+    const result = {
+      project: { id: "p-1" } as Project,
+      projectSlug: "p-1",
+      orgId: "org-a",
+    };
+    mocks.projectProps!.onProjectCreated!(result);
+    expect(close).toHaveBeenCalledOnce();
+    expect(mocks.openProject).toHaveBeenCalledWith(result);
+  });
+
+  it("carries project scope and ignores a completion after the modal unmounts", () => {
+    const { close, unmount } = render("project");
+    expect(mocks.projectProps!.onCancel).toBe(close);
+    expect(mocks.projectProps).toMatchObject({
+      layout: "spotlight",
+      orgId: "org-a",
+      repoPath: "/repo",
+    });
+    const completed = mocks.projectProps!.onProjectCreated!;
+    unmount();
+    completed({
+      project: { id: "p-1" } as Project,
+      projectSlug: "p-1",
+      orgId: "org-a",
+    });
+    expect(close).not.toHaveBeenCalled();
+    expect(mocks.openProject).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/ProjectManager/shared/components/ManualSpotlightCreator.tsx
+++ b/src/modules/ProjectManager/shared/components/ManualSpotlightCreator.tsx
@@ -1,0 +1,120 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import React, { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+
+import { workItemDataToUI } from "@src/api/http/project";
+import CreateProjectView from "@src/modules/ProjectManager/Projects/components/CreateProjectView";
+import CreateWorkItemView from "@src/modules/ProjectManager/WorkItems/components/CreateWorkItemView";
+import { SpotlightShell } from "@src/scaffold/GlobalSpotlight/shell/SpotlightShell";
+import {
+  openProjectInChatPanelTabAtom,
+  openWorkItemInChatPanelTabAtom,
+} from "@src/store/chatPanel/chatPanelTabsAtom";
+import { projectListRefreshAtom } from "@src/store/project/projectAtom";
+import type { ManualCreatorRequest } from "@src/store/ui/manualCreatorAtom";
+import { primaryWorkspaceRootAtom } from "@src/store/workspace";
+import { MANUAL_PROJECT_CREATOR_DRAFT_ID } from "@src/store/workstation/projectManager";
+
+const ignoreUnsaved = () => undefined;
+
+export default function ManualSpotlightCreator({
+  request,
+  onClose,
+}: {
+  request: ManualCreatorRequest;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation("projects");
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  const workspace = useAtomValue(primaryWorkspaceRootAtom);
+  const openProject = useSetAtom(openProjectInChatPanelTabAtom);
+  const openWorkItem = useSetAtom(openWorkItemInChatPanelTabAtom);
+  const refreshProjects = useSetAtom(projectListRefreshAtom);
+  const context = request.createProjectContext;
+  const title = t(
+    request.target === "project"
+      ? "projects.newProject"
+      : "workItems.newWorkItem"
+  );
+
+  return (
+    <SpotlightShell isOpen onClose={onClose} hideFooter>
+      <section
+        aria-label={title}
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && !event.defaultPrevented) {
+            event.stopPropagation();
+            onClose();
+          }
+        }}
+      >
+        <div className="px-4 pt-4 pb-2 text-sm font-medium text-text-1">
+          {title}
+        </div>
+        <div className="pb-4" data-testid="manual-spotlight-creator">
+          {request.target === "project" ? (
+            <CreateProjectView
+              tabId={MANUAL_PROJECT_CREATOR_DRAFT_ID}
+              layout="spotlight"
+              orgId={context?.orgId}
+              scopeBreadcrumbLabel={context?.scopeBreadcrumbLabel}
+              repoPath={workspace?.path}
+              repoName={workspace?.name}
+              onSetUnsaved={ignoreUnsaved}
+              onCancel={onClose}
+              onProjectCreated={(result) => {
+                refreshProjects((value) => value + 1);
+                if (!mounted.current) return;
+                onClose();
+                openProject(result);
+              }}
+            />
+          ) : (
+            <CreateWorkItemView
+              layout="spotlight"
+              aiGenerateMode={false}
+              orgId={context?.orgId}
+              repoPath={workspace?.path}
+              onSetUnsaved={ignoreUnsaved}
+              onCancel={onClose}
+              onWorkItemCreated={(result) => {
+                if (!mounted.current || !result || result.keepOpen) return;
+                const workItem =
+                  result.workItem ??
+                  (result.item
+                    ? workItemDataToUI(result.item, {
+                        labelMap: new Map(),
+                        memberMap: new Map(),
+                      })
+                    : null);
+                if (!workItem) return;
+                onClose();
+                openWorkItem({
+                  workItem,
+                  shortId: result.shortId,
+                  projectSlug: result.projectSlug ?? "",
+                  projectId:
+                    result.item?.frontmatter.project ??
+                    workItem.project?.id ??
+                    "",
+                  projectName: workItem.project?.name ?? "",
+                  orgId: result.orgId,
+                  orgName:
+                    result.orgId === context?.orgId
+                      ? context?.scopeBreadcrumbLabel
+                      : undefined,
+                });
+              }}
+            />
+          )}
+        </div>
+      </section>
+    </SpotlightShell>
+  );
+}

--- a/src/modules/ProjectManager/shared/components/ManualSpotlightCreatorHost.test.ts
+++ b/src/modules/ProjectManager/shared/components/ManualSpotlightCreatorHost.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React, { act, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { manualCreatorAtom } from "@src/store/ui/manualCreatorAtom";
+
+import { ManualSpotlightCreatorHost } from "./ManualSpotlightCreatorHost";
+
+const lifecycle = vi.hoisted(() => ({ mount: vi.fn(), unmount: vi.fn() }));
+vi.mock("./ManualSpotlightCreator", () => ({
+  default: function MockCreator() {
+    useEffect(() => {
+      lifecycle.mount();
+      return () => lifecycle.unmount();
+    }, []);
+    return React.createElement("div", { "data-testid": "spotlight" });
+  },
+}));
+
+it("mounts only on demand and disposes every closed spotlight creator", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const store = createStore();
+  const host = document.createElement("div");
+  const root = createRoot(host);
+  try {
+    await act(async () =>
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(ManualSpotlightCreatorHost)
+        )
+      )
+    );
+    expect(lifecycle.mount).not.toHaveBeenCalled();
+    for (let cycle = 1; cycle <= 3; cycle++) {
+      await act(async () =>
+        store.set(manualCreatorAtom, { target: "workItem" })
+      );
+      expect(host.children).toHaveLength(1);
+      expect(lifecycle.mount).toHaveBeenCalledTimes(cycle);
+      await act(async () => store.set(manualCreatorAtom, null));
+      expect(host.children).toHaveLength(0);
+      expect(lifecycle.unmount).toHaveBeenCalledTimes(cycle);
+    }
+  } finally {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/modules/ProjectManager/shared/components/ManualSpotlightCreatorHost.tsx
+++ b/src/modules/ProjectManager/shared/components/ManualSpotlightCreatorHost.tsx
@@ -1,0 +1,27 @@
+import { useAtom, useAtomValue } from "jotai";
+import React, { Suspense, useEffect } from "react";
+
+import { manualCreatorAtom } from "@src/store/ui/manualCreatorAtom";
+import { spotlightOpenAtom } from "@src/store/ui/uiAtom";
+
+const ManualSpotlightCreator = React.lazy(
+  () => import("./ManualSpotlightCreator")
+);
+
+export function ManualSpotlightCreatorHost() {
+  const [request, setRequest] = useAtom(manualCreatorAtom);
+  const spotlightOpen = useAtomValue(spotlightOpenAtom);
+  useEffect(() => {
+    if (spotlightOpen) setRequest(null);
+  }, [spotlightOpen, setRequest]);
+  if (!request || spotlightOpen) return null;
+  return (
+    <Suspense fallback={null}>
+      <ManualSpotlightCreator
+        key={`${request.target}:${request.createProjectContext?.orgId ?? ""}`}
+        request={request}
+        onClose={() => setRequest(null)}
+      />
+    </Suspense>
+  );
+}

--- a/src/modules/WorkStation/ActionSystem/registration/actions/workStationViewActions.zod.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/workStationViewActions.zod.ts
@@ -263,21 +263,19 @@ export const workstationCreateProject = defineZodAction(
   {
     id: ACTION_ID.WORKSTATION_CREATE_PROJECT,
     category: "navigation",
-    description: "Navigate to My Station and open the Create Project form",
+    description: "Open the Create Project form",
     params: z.object({}),
     tags: ["workstation", "project", "create", "navigation"],
     examples: ["create project", "new project", "add project"],
   },
   async () => {
-    const workStationViewService = await getWorkStationViewService();
-    await workStationViewService.openStationMode("my-station");
-    const { openCreateTargetInChatPanelStartPageAtom } =
+    const { openChatPanelCreateTargetAtom } =
       await import("@src/store/chatPanel/chatPanelTabsAtom");
     const { CHAT_PANEL_CREATE_TARGET } =
       await import("@src/store/ui/chatPanel/selectionAtoms");
     const { getInstrumentedStore } =
       await import("@src/util/core/state/instrumentedStore");
-    getInstrumentedStore().set(openCreateTargetInChatPanelStartPageAtom, {
+    getInstrumentedStore().set(openChatPanelCreateTargetAtom, {
       target: CHAT_PANEL_CREATE_TARGET.PROJECT,
     });
     return { success: true, message: "Opened Create Project" };
@@ -288,7 +286,7 @@ export const workstationCreateWorkItem = defineZodAction(
   {
     id: ACTION_ID.WORKSTATION_CREATE_WORK_ITEM,
     category: "navigation",
-    description: "Navigate to My Station and open the Create Work Item form",
+    description: "Open the Create Work Item form",
     params: z.object({}),
     tags: ["workstation", "work-item", "create", "navigation"],
     examples: [
@@ -299,15 +297,13 @@ export const workstationCreateWorkItem = defineZodAction(
     ],
   },
   async () => {
-    const workStationViewService = await getWorkStationViewService();
-    await workStationViewService.openStationMode("my-station");
-    const { openCreateTargetInChatPanelStartPageAtom } =
+    const { openChatPanelCreateTargetAtom } =
       await import("@src/store/chatPanel/chatPanelTabsAtom");
     const { CHAT_PANEL_CREATE_TARGET } =
       await import("@src/store/ui/chatPanel/selectionAtoms");
     const { getInstrumentedStore } =
       await import("@src/util/core/state/instrumentedStore");
-    getInstrumentedStore().set(openCreateTargetInChatPanelStartPageAtom, {
+    getInstrumentedStore().set(openChatPanelCreateTargetAtom, {
       target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
     });
     return { success: true, message: "Opened Create Work Item" };

--- a/src/scaffold/GlobalSpotlight/GlobalSpotlightPortal.tsx
+++ b/src/scaffold/GlobalSpotlight/GlobalSpotlightPortal.tsx
@@ -8,6 +8,7 @@
 import { useAtom } from "jotai";
 import React, { Suspense } from "react";
 
+import { ManualSpotlightCreatorHost } from "@src/modules/ProjectManager/shared/components/ManualSpotlightCreatorHost";
 import { spotlightOpenAtom } from "@src/store/ui/uiAtom";
 
 const GlobalSpotlight = React.lazy(() =>
@@ -19,11 +20,17 @@ const GlobalSpotlight = React.lazy(() =>
 export const GlobalSpotlightPortal: React.FC = () => {
   const [spotlightOpen, setSpotlightOpen] = useAtom(spotlightOpenAtom);
 
-  if (!spotlightOpen) return null;
-
   return (
-    <Suspense fallback={null}>
-      <GlobalSpotlight isOpen={true} onClose={() => setSpotlightOpen(false)} />
-    </Suspense>
+    <>
+      <ManualSpotlightCreatorHost />
+      {spotlightOpen && (
+        <Suspense fallback={null}>
+          <GlobalSpotlight
+            isOpen={true}
+            onClose={() => setSpotlightOpen(false)}
+          />
+        </Suspense>
+      )}
+    </>
   );
 };

--- a/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
@@ -187,34 +187,20 @@ export function useSpotlight(
       > = {
         "open-session-creator": openSessionCreatorSpotlight,
         "create-project": () => {
-          void WorkStationViewService.openStationMode("my-station").then(
-            async () => {
-              const { openCreateTargetInChatPanelStartPageAtom } =
-                await import("@src/store/chatPanel/chatPanelTabsAtom");
-              const { CHAT_PANEL_CREATE_TARGET } =
-                await import("@src/store/ui/chatPanel/selectionAtoms");
-              getInstrumentedStore().set(
-                openCreateTargetInChatPanelStartPageAtom,
-                {
-                  target: CHAT_PANEL_CREATE_TARGET.PROJECT,
-                }
-              );
+          void import("@src/store/chatPanel/chatPanelTabsAtom").then(
+            ({ openChatPanelCreateTargetAtom }) => {
+              getInstrumentedStore().set(openChatPanelCreateTargetAtom, {
+                target: "project",
+              });
             }
           );
         },
         "create-work-item": () => {
-          void WorkStationViewService.openStationMode("my-station").then(
-            async () => {
-              const { openCreateTargetInChatPanelStartPageAtom } =
-                await import("@src/store/chatPanel/chatPanelTabsAtom");
-              const { CHAT_PANEL_CREATE_TARGET } =
-                await import("@src/store/ui/chatPanel/selectionAtoms");
-              getInstrumentedStore().set(
-                openCreateTargetInChatPanelStartPageAtom,
-                {
-                  target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
-                }
-              );
+          void import("@src/store/chatPanel/chatPanelTabsAtom").then(
+            ({ openChatPanelCreateTargetAtom }) => {
+              getInstrumentedStore().set(openChatPanelCreateTargetAtom, {
+                target: "workItem",
+              });
             }
           );
         },

--- a/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
@@ -37,6 +37,7 @@ import {
 import { AppViewService } from "@src/services/app";
 import { PanelService } from "@src/services/panel";
 import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
+import { openChatPanelCreateTargetAtom } from "@src/store/chatPanel/openChatPanelCreateTargetAtom";
 import { selectedRepoAtom } from "@src/store/repo";
 import { REPO_KIND } from "@src/store/repo/types";
 import type { Session } from "@src/store/session";
@@ -187,22 +188,14 @@ export function useSpotlight(
       > = {
         "open-session-creator": openSessionCreatorSpotlight,
         "create-project": () => {
-          void import("@src/store/chatPanel/chatPanelTabsAtom").then(
-            ({ openChatPanelCreateTargetAtom }) => {
-              getInstrumentedStore().set(openChatPanelCreateTargetAtom, {
-                target: "project",
-              });
-            }
-          );
+          getInstrumentedStore().set(openChatPanelCreateTargetAtom, {
+            target: "project",
+          });
         },
         "create-work-item": () => {
-          void import("@src/store/chatPanel/chatPanelTabsAtom").then(
-            ({ openChatPanelCreateTargetAtom }) => {
-              getInstrumentedStore().set(openChatPanelCreateTargetAtom, {
-                target: "workItem",
-              });
-            }
-          );
+          getInstrumentedStore().set(openChatPanelCreateTargetAtom, {
+            target: "workItem",
+          });
         },
         "search-agent-sessions": () => onOpenAgentSessionSearch?.(),
         "search-all-sessions": () => onOpenAllSessionsSearch?.(),

--- a/src/store/chatPanel/__tests__/openChatPanelCreateTargetAtom.test.ts
+++ b/src/store/chatPanel/__tests__/openChatPanelCreateTargetAtom.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ROUTES } from "@src/config/routes";
+import { activeSessionIdAtom } from "@src/store/session/viewAtom";
+import { chatPanelCreateTargetAtom } from "@src/store/ui/chatPanel/selectionAtoms";
+import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
+import { stationChatVisibilityAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
+import { chatWidthAtom } from "@src/store/ui/chatPanel/widthAtoms";
+import { manualCreatorAtom } from "@src/store/ui/manualCreatorAtom";
+import { stationModeAtom } from "@src/store/ui/simulatorAtom";
+import { spotlightOpenAtom } from "@src/store/ui/uiAtom";
+
+import { chatPanelTabsAtom } from "../chatPanelTabsState";
+import { openChatPanelCreateTargetAtom } from "../openChatPanelCreateTargetAtom";
+
+describe("openChatPanelCreateTargetAtom", () => {
+  const originalPath = window.location.pathname;
+  beforeEach(() =>
+    window.history.replaceState(null, "", ROUTES.workStation.code.path)
+  );
+  afterEach(() => window.history.replaceState(null, "", originalPath));
+  function setup(launchpad: boolean) {
+    const store = createStore();
+    store.set(stationModeAtom, "my-station");
+    store.set(chatPanelMaximizedAtom, false);
+    store.set(chatWidthAtom, 400);
+    store.set(stationChatVisibilityAtom, {
+      "my-station": true,
+      "agent-station": true,
+    });
+    store.set(chatPanelTabsAtom, {
+      tabs: launchpad
+        ? [{ id: "launchpad", type: "start-page", title: "Launchpad" }]
+        : [
+            {
+              id: "session",
+              type: "session",
+              title: "Session",
+              sessionId: "session-a",
+            },
+          ],
+      activeTabId: launchpad ? "launchpad" : "session",
+    });
+    return store;
+  }
+
+  it.each(["project", "workItem"] as const)(
+    "opens %s over the active session with its organization",
+    (target) => {
+      const store = setup(false);
+      const tabs = store.get(chatPanelTabsAtom);
+      store.set(activeSessionIdAtom, "session-a");
+      store.set(spotlightOpenAtom, true);
+      const request = {
+        target,
+        createProjectContext: {
+          orgId: "org-a",
+          scopeBreadcrumbLabel: "Team A",
+        },
+      };
+      store.set(openChatPanelCreateTargetAtom, request);
+      expect(store.get(manualCreatorAtom)).toEqual(request);
+      expect(store.get(spotlightOpenAtom)).toBe(false);
+      expect(store.get(chatPanelTabsAtom)).toBe(tabs);
+      expect(store.get(activeSessionIdAtom)).toBe("session-a");
+      store.set(spotlightOpenAtom, false);
+      expect(store.get(chatPanelTabsAtom)).toBe(tabs);
+    }
+  );
+
+  it.each(["project", "workItem"] as const)(
+    "keeps %s in the visible Launchpad",
+    (target) => {
+      const store = setup(true);
+      store.set(openChatPanelCreateTargetAtom, { target });
+      expect(store.get(manualCreatorAtom)).toBeNull();
+      expect(store.get(chatPanelCreateTargetAtom)).toBe(target);
+      expect(store.get(chatPanelTabsAtom).activeTabId).toBe("launchpad");
+    }
+  );
+
+  it("opens over Settings even when the remembered tab is Launchpad", () => {
+    const store = setup(true);
+    window.history.replaceState(null, "", ROUTES.app.settings.path);
+    store.set(openChatPanelCreateTargetAtom, { target: "project" });
+    expect(store.get(manualCreatorAtom)?.target).toBe("project");
+    expect(window.location.pathname).toBe(ROUTES.app.settings.path);
+  });
+
+  it("does not navigate to a hidden Launchpad", () => {
+    const store = setup(true);
+    store.set(stationChatVisibilityAtom, {
+      "my-station": false,
+      "agent-station": true,
+    });
+    store.set(openChatPanelCreateTargetAtom, { target: "project" });
+    expect(store.get(manualCreatorAtom)?.target).toBe("project");
+    expect(store.get(stationChatVisibilityAtom)["my-station"]).toBe(false);
+  });
+  it("preserves in-page creation on a maximized Launchpad even if station chat is hidden", () => {
+    const store = setup(true);
+    store.set(chatPanelMaximizedAtom, true);
+    store.set(stationChatVisibilityAtom, {
+      "my-station": false,
+      "agent-station": false,
+    });
+    store.set(openChatPanelCreateTargetAtom, { target: "workItem" });
+    expect(store.get(manualCreatorAtom)).toBeNull();
+    expect(store.get(chatPanelCreateTargetAtom)).toBe("workItem");
+  });
+
+  it("uses Spotlight when the Launchpad slot has zero width", () => {
+    const store = setup(true);
+    store.set(chatWidthAtom, 0);
+    store.set(openChatPanelCreateTargetAtom, { target: "workItem" });
+    expect(store.get(manualCreatorAtom)?.target).toBe("workItem");
+  });
+});

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -116,3 +116,5 @@ export {
   openRecentChatPanelTabAtom,
   recentChatPanelTabsAtom,
 } from "./chatPanelRecentTabs";
+
+export { openChatPanelCreateTargetAtom } from "./openChatPanelCreateTargetAtom";

--- a/src/store/chatPanel/openChatPanelCreateTargetAtom.ts
+++ b/src/store/chatPanel/openChatPanelCreateTargetAtom.ts
@@ -1,0 +1,56 @@
+import { atom } from "jotai";
+
+import { ROUTES } from "@src/config/routes";
+import type {
+  ChatPanelCreateProjectContext,
+  ChatPanelCreateTarget,
+} from "@src/store/ui/chatPanel/selectionAtoms";
+import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
+import { stationChatVisibilityAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
+import { chatWidthAtom } from "@src/store/ui/chatPanel/widthAtoms";
+import { manualCreatorAtom } from "@src/store/ui/manualCreatorAtom";
+import { stationModeAtom } from "@src/store/ui/simulatorAtom";
+import { spotlightOpenAtom } from "@src/store/ui/uiAtom";
+
+import { openCreateTargetInChatPanelStartPageAtom } from "./chatPanelTabOpen/startPage";
+import { activeChatPanelTabAtom } from "./chatPanelTabsState";
+
+/** Preserve visible Launchpad creation; use Spotlight from other pages. */
+export const openChatPanelCreateTargetAtom = atom(
+  null,
+  (
+    get,
+    set,
+    options: {
+      target: ChatPanelCreateTarget;
+      title?: string;
+      createProjectContext?: ChatPanelCreateProjectContext | null;
+    }
+  ) => {
+    const pathname =
+      typeof window === "undefined" ? "" : window.location.pathname;
+    const workstationPath = ROUTES.workStation.base.path;
+    const inWorkstation =
+      pathname === workstationPath ||
+      pathname.startsWith(workstationPath + "/");
+    const launchpadVisible =
+      inWorkstation &&
+      get(activeChatPanelTabAtom)?.type === "start-page" &&
+      (get(chatPanelMaximizedAtom) ||
+        (get(stationChatVisibilityAtom)[get(stationModeAtom)] &&
+          get(chatWidthAtom) > 0));
+    if (
+      !launchpadVisible &&
+      (options.target === "project" || options.target === "workItem")
+    ) {
+      set(spotlightOpenAtom, false);
+      set(manualCreatorAtom, {
+        target: options.target,
+        createProjectContext: options.createProjectContext,
+      });
+      return;
+    }
+    set(manualCreatorAtom, null);
+    set(openCreateTargetInChatPanelStartPageAtom, options);
+  }
+);

--- a/src/store/ui/manualCreatorAtom.ts
+++ b/src/store/ui/manualCreatorAtom.ts
@@ -1,0 +1,11 @@
+import { atom } from "jotai";
+
+import type { ChatPanelCreateProjectContext } from "./chatPanel/selectionAtoms";
+
+export interface ManualCreatorRequest {
+  target: "project" | "workItem";
+  createProjectContext?: ChatPanelCreateProjectContext | null;
+}
+
+/** A single Spotlight manual creator, disposed when dismissed. */
+export const manualCreatorAtom = atom<ManualCreatorRequest | null>(null);

--- a/src/store/workstation/projectManager/drafts.ts
+++ b/src/store/workstation/projectManager/drafts.ts
@@ -22,10 +22,17 @@ export const PROJECT_CREATOR_DRAFT_ID = "project-creator";
 /** Shared draft key for chat-panel and modal work item creators. */
 export const WORK_ITEM_CREATOR_DRAFT_ID = "work-item-creator";
 
-const PINNED_PROJECT_DRAFT_IDS = new Set<string>([PROJECT_CREATOR_DRAFT_ID]);
+export const MANUAL_PROJECT_CREATOR_DRAFT_ID = "manual-project-creator";
+export const MANUAL_WORK_ITEM_CREATOR_DRAFT_ID = "manual-work-item-creator";
+
+const PINNED_PROJECT_DRAFT_IDS = new Set<string>([
+  PROJECT_CREATOR_DRAFT_ID,
+  MANUAL_PROJECT_CREATOR_DRAFT_ID,
+]);
 
 const PINNED_WORK_ITEM_DRAFT_IDS = new Set<string>([
   WORK_ITEM_CREATOR_DRAFT_ID,
+  MANUAL_WORK_ITEM_CREATOR_DRAFT_ID,
 ]);
 
 function writeDraftMapEntry<K, V>(

--- a/src/store/workstation/projectManager/index.ts
+++ b/src/store/workstation/projectManager/index.ts
@@ -19,6 +19,8 @@ export {
   patchProjectDraftAtom,
   removeProjectDraftAtom,
   PROJECT_CREATOR_DRAFT_ID,
+  MANUAL_PROJECT_CREATOR_DRAFT_ID,
+  MANUAL_WORK_ITEM_CREATOR_DRAFT_ID,
   setWorkItemDraftAtom,
   patchWorkItemDraftAtom,
   removeWorkItemDraftAtom,


### PR DESCRIPTION
## Problem

Creating a project or work item outside a visible Launchpad redirects the user into the chat panel instead of preserving their current page. Reusing the same draft keys for an overlay would also let simultaneously mounted forms overwrite one another.

## Solution

Route creation through one atom that preserves in-page creation on a visible Launchpad and otherwise opens an on-demand Spotlight manual creator. Reuse the existing project/work-item composers with Cancel controls, two fixed independent draft keys and existing organization/workspace context. Pause underlying save/undo shortcuts where applicable and prevent late completion from navigating after dismissal.

Includes only creator routing, forms, draft ownership, supporting tests and focused audit reports. Session import is a separate PR. Creator fallbacks synchronously write the routing atom; the discarded dynamic-import promises reported by typed lint have been removed.

## Potential risks

Routing depends on route, selected tab, chat visibility and width; focused tests cover Settings, hidden Launchpad, maximized Launchpad and zero-width cases. Native focus/keyboard behavior and account or endpoint switches while forms are open remain unverified. Existing drafts retain their format; two additional fixed keys use the existing bounded draft maps. Reverting this commit restores prior routing; no database, dependency or wire-format migration is needed. Native visible/hidden CPU/RSS verification remains blocked, so no runtime performance improvement is claimed.

## Verification

- `pnpm check:typed-lint` — passed with zero new or increased findings after removing discarded dynamic-import promises.

- `pnpm test src/scaffold/GlobalSpotlight/hooks/useSpotlight.test.ts src/store/chatPanel/__tests__/openChatPanelCreateTargetAtom.test.ts` — 9 tests passed after the synchronous fallback fix.

- `pnpm test src/modules/ProjectManager/shared/components src/hooks/project/useWorkItemCreatorDraft.test.ts src/store/chatPanel/__tests__/openChatPanelCreateTargetAtom.test.ts src/store/workstation/projectManager src/engines/ChatPanel/ChatPanelStartPage.test.ts` — 54 tests passed in 15 files, including draft isolation, scoped completion, three mount/unmount cycles and Launchpad layout.
- `pnpm test src/scaffold/GlobalSpotlight/hooks/useSpotlight.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/useSpotlightEffects.test.ts src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/createWorkItemFromDraft.test.ts` — 11 tests passed in 3 files.
- `pnpm typecheck:fast` — passed across the full frontend.
- Commit hook `npx lint-staged` — passed (Oxlint, ESLint and Prettier); hook TypeScript check also passed.
- `pnpm check:test-placement` — passed, 540 directories.
- `pnpm check:circular` — fails on three existing cycles, reproduced identically on clean `origin/develop` at `cefceac8419a94f14b71f50eeffe33118409c049`: two SessionCore/composer/slash-command cycles and one SessionHoverCard cycle. No added cycle.
- `git diff --check` — passed. Final diff inspected for unrelated edits, secrets, personal paths and generated files.
- Native Tauri interaction, screenshots across themes/viewports, CPU/RSS measurements and full E2E were not run: computer control is not authorized. Full repository tests were not run; focused suites cover the affected boundaries.

## Audit

UI review: 0 fix, 5 keep with reason, 0 abstract. Lifecycle evidence and native measurement gaps are recorded in `docs/org2-performance-guard-2026-09-10/ManualSpotlightCreator.md`.

