### PR TITLE
feat(spotlight): add shared session import

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/ImportSharedSessionDialog.md
+++ b/docs/frontend-ui-audit-2026-09-10/ImportSharedSessionDialog.md
@@ -1,0 +1,12 @@
+# ImportSharedSessionDialog UI audit
+
+| Line                                | Element              | Verdict          | Reason                                                                                   | Suggested change |
+| ----------------------------------- | -------------------- | ---------------- | ---------------------------------------------------------------------------------------- | ---------------- |
+| `ImportSharedSessionDialog.tsx:59`  | Navigation pill      | keep with reason | Reuses SpotlightPillBar for the back action                                              | None             |
+| `ImportSharedSessionDialog.tsx:81`  | Input and validation | keep with reason | Uses Textarea, an accessible name, initial focus, aria-invalid and linked error feedback | None             |
+| `ImportSharedSessionDialog.tsx:119` | Actions              | keep with reason | Reuses PanelFooter with disabled empty submission                                        | None             |
+| `ImportSharedSessionDialog.tsx:135` | Overlay ownership    | keep with reason | Standalone use owns SpotlightShell; embedded use returns only the body                   | None             |
+
+Verdict totals: **0 fix**, **4 keep with reason**, **0 abstract**.
+
+Reviewed only this feature diff. Automated component tests passed; native screenshots, theme/viewport inspection and keyboard interaction in Tauri were not run because computer control is not authorized.

--- a/docs/org2-performance-guard-2026-09-10/ImportSharedSessionDialog.md
+++ b/docs/org2-performance-guard-2026-09-10/ImportSharedSessionDialog.md
@@ -1,0 +1,12 @@
+# ImportSharedSessionDialog lifecycle review
+
+| Area               | Verdict | Evidence                                     | Change or reason kept                              | Verification                           |
+| ------------------ | ------- | -------------------------------------------- | -------------------------------------------------- | -------------------------------------- |
+| Background work    | keep    | Submission uses existing pending-share queue | No new network, timers or subscriptions            | Queue tests and source trace           |
+| Memory             | keep    | One overlay flag and form input state        | Close resets state; embedded form unmounts on back | Dialog tests and overlay source review |
+| Scope/isolation    | keep    | Existing queue remains authoritative         | No identity/cache or transport changes             | Pending-share tests                    |
+| Rendering/hot path | keep    | Form exists only for active import layer     | Embedded form avoids a second shell                | Embedded component test                |
+
+Lifecycle matrix: closed has no embedded form; open enables the selected layer; back restores parent selection; close clears overlay state; submit parses and queues via the existing import boundary. No new work depends on visibility, offline/reconnect, provider or instance topology. Existing cloud resolve/import network behavior is unchanged and was not exercised against a live account.
+
+Performance verdict: blocked for native overlay/listener and visible/hidden CPU/RSS measurement because computer control is not authorized. Twelve focused tests and full frontend typecheck passed. No measured performance improvement is claimed.

--- a/src/ActionSystem/actionIds.ts
+++ b/src/ActionSystem/actionIds.ts
@@ -65,6 +65,7 @@ export const ACTION_ID = {
   SPOTLIGHT_OPEN_AGENT_SESSION_SEARCH: "spotlight.openAgentSessionSearch",
   SPOTLIGHT_OPEN_ALL_SESSIONS_SEARCH: "spotlight.openAllSessionsSearch",
   SPOTLIGHT_OPEN_AGENT_CONTROL: "spotlight.openAgentControl",
+  SPOTLIGHT_IMPORT_SESSION: "spotlight.importSession",
   SPOTLIGHT_OPEN_SESSION_CREATOR: "spotlight.openSessionCreator",
   SPOTLIGHT_OPEN_COLLAB_ORG: "spotlight.openCollabOrg",
   WORKSTATION_CREATE_PROJECT: "workstation.createProject",

--- a/src/ActionSystem/actions/spotlightActions.zod.ts
+++ b/src/ActionSystem/actions/spotlightActions.zod.ts
@@ -23,6 +23,7 @@ import {
   openCollabOrgSpotlight,
   openEditorSpotlight,
   openSessionCreatorSpotlight,
+  openSessionImportSpotlight,
   openWorkingDirectorySpotlight,
 } from "@src/scaffold/GlobalSpotlight/openSpotlight";
 import { spotlightOpenAtom } from "@src/store/ui/uiAtom";
@@ -258,6 +259,21 @@ const spotlightOpenAgentControl = defineZodAction(
   }
 );
 
+const spotlightImportSession = defineZodAction(
+  {
+    id: ACTION_ID.SPOTLIGHT_IMPORT_SESSION,
+    category: "spotlight",
+    description: "Open Spotlight's shared session import form",
+    params: z.object({}),
+    layer: "gui",
+    examples: ["import session", "import shared session"],
+  },
+  async () => {
+    openSessionImportSpotlight();
+    return { success: true, message: "Opened session import" };
+  }
+);
+
 const spotlightOpenSessionCreator = defineZodAction(
   {
     id: ACTION_ID.SPOTLIGHT_OPEN_SESSION_CREATOR,
@@ -319,6 +335,7 @@ export const spotlightZodActions: ZodAction<ZodTypeAny>[] = [
   spotlightOpenAllSessionsSearch,
   spotlightOpenAgentControl,
   spotlightOpenSessionCreator,
+  spotlightImportSession,
   spotlightOpenCollabOrg,
 ];
 

--- a/src/features/Org2Cloud/ImportSharedSessionDialog.test.ts
+++ b/src/features/Org2Cloud/ImportSharedSessionDialog.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+
+import ImportSharedSessionDialog from "./ImportSharedSessionDialog";
+import { org2CloudPendingShareAtom } from "./org2CloudPendingShareAtom";
+
+const input = vi.hoisted(() => ({ onChange: (_value: string) => {} }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/scaffold/GlobalSpotlight/shell", () => ({
+  SpotlightShell: ({
+    isOpen,
+    children,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+  }) =>
+    isOpen
+      ? createElement("div", { "data-testid": "spotlight-shell" }, children)
+      : null,
+}));
+vi.mock("@src/components/Textarea", () => ({
+  default: (props: { onChange: (value: string) => void }) => {
+    input.onChange = props.onChange;
+    return createElement("textarea", { "data-testid": "share-input" });
+  },
+}));
+
+const environment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+afterEach(() => {
+  delete environment.IS_REACT_ACT_ENVIRONMENT;
+});
+
+it("uses Spotlight chrome and preserves validation, import, and dismissal", () => {
+  environment.IS_REACT_ACT_ENVIRONMENT = true;
+  const store = createStore();
+  const onClose = vi.fn();
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const render = (visible: boolean) =>
+    root.render(
+      createElement(
+        Provider,
+        { store },
+        createElement(ImportSharedSessionDialog, { visible, onClose })
+      )
+    );
+  act(() => render(true));
+  expect(
+    container.querySelector('[data-testid="spotlight-shell"]')
+  ).not.toBeNull();
+  expect(container.querySelector('[data-icon="chevron-left"]')).not.toBeNull();
+  const submit = () =>
+    container.querySelector<HTMLButtonElement>(
+      '[data-testid="import-session-submit"]'
+    )!;
+  expect(submit().disabled).toBe(true);
+  act(() => input.onChange("invalid link"));
+  act(() => submit().click());
+  expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+    "cloud.share.importInvalidInput"
+  );
+  expect(store.get(org2CloudPendingShareAtom)).toBeNull();
+  act(() => input.onChange("a".repeat(64)));
+  expect(container.querySelector('[role="alert"]')).toBeNull();
+  act(() => submit().click());
+  expect(store.get(org2CloudPendingShareAtom)?.shareToken).toBe("a".repeat(64));
+  expect(onClose).toHaveBeenCalledOnce();
+  expect(submit().disabled).toBe(true);
+  act(() => render(false));
+  expect(container.childElementCount).toBe(0);
+  act(() => root.unmount());
+  container.remove();
+});
+
+it("embeds without another shell and uses the card label", () => {
+  environment.IS_REACT_ACT_ENVIRONMENT = true;
+  const onClose = vi.fn();
+  const onGoBack = vi.fn();
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  act(() =>
+    root.render(
+      createElement(
+        Provider,
+        {},
+        createElement(ImportSharedSessionDialog, {
+          visible: true,
+          asBody: true,
+          onClose,
+          onGoBack,
+        })
+      )
+    )
+  );
+  expect(container.querySelector('[data-testid="spotlight-shell"]')).toBeNull();
+  expect(
+    container.querySelector('[role="dialog"]')?.getAttribute("aria-label")
+  ).toBe("cloud.share.importEntry");
+  act(() =>
+    container
+      .querySelector('[data-icon="chevron-left"]')!
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }))
+  );
+  expect(onGoBack).toHaveBeenCalledOnce();
+  expect(onClose).not.toHaveBeenCalled();
+  act(() => root.unmount());
+});

--- a/src/features/Org2Cloud/ImportSharedSessionDialog.tsx
+++ b/src/features/Org2Cloud/ImportSharedSessionDialog.tsx
@@ -1,10 +1,17 @@
 /** Paste-a-share-link entry point: the parsed link is queued as a unique attempt; `CloudShareImportDialog` owns the registered-user resolve → import flow. */
-import Modal from "@/src/scaffold/ModalSystem";
 import { useSetAtom } from "jotai";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Textarea from "@src/components/Textarea";
+import { Download01Icon } from "@src/icons";
+import { PanelFooter } from "@src/modules/shared/layouts/blocks";
+import { SpotlightPillBar } from "@src/scaffold/GlobalSpotlight/components/SpotlightPillBar";
+import {
+  SpotlightFormBody,
+  SpotlightFormShell,
+} from "@src/scaffold/GlobalSpotlight/forms/shared";
+import { SpotlightShell } from "@src/scaffold/GlobalSpotlight/shell";
 
 import { parseCloudShareInput } from "./org2CloudOrgManagement";
 import { queueOrg2CloudPendingShareAtom } from "./org2CloudPendingShareAtom";
@@ -12,11 +19,15 @@ import { queueOrg2CloudPendingShareAtom } from "./org2CloudPendingShareAtom";
 interface ImportSharedSessionDialogProps {
   visible: boolean;
   onClose: () => void;
+  asBody?: boolean;
+  onGoBack?: () => void;
 }
 
 const ImportSharedSessionDialog: React.FC<ImportSharedSessionDialogProps> = ({
   visible,
   onClose,
+  asBody = false,
+  onGoBack,
 }) => {
   const { t } = useTranslation(["navigation", "common"]);
   const queuePendingShare = useSetAtom(queueOrg2CloudPendingShareAtom);
@@ -39,52 +50,96 @@ const ImportSharedSessionDialog: React.FC<ImportSharedSessionDialogProps> = ({
     handleClose();
   }, [handleClose, queuePendingShare, value]);
 
-  return (
-    <Modal
-      visible={visible}
-      title={t("cloud.share.importDialogTitle")}
-      onCancel={handleClose}
-      onOk={handleSubmit}
-      okText={t("cloud.share.importSubmit")}
-      cancelText={t("common:actions.cancel")}
-      okButtonProps={{ disabled: !value.trim() }}
-      size="large"
+  const body = (
+    <section
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("cloud.share.importEntry")}
     >
-      <div className="flex flex-col gap-2" data-testid="import-session-dialog">
-        <Textarea
-          value={value}
-          onChange={(next) => {
-            setValue(next);
-            setInvalid(false);
-          }}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-              event.preventDefault();
-              handleSubmit();
-            }
-          }}
-          placeholder={t("cloud.share.importInputPlaceholder")}
-          error={invalid}
-          aria-invalid={invalid}
-          aria-describedby={invalid ? "import-session-input-error" : undefined}
-          autoComplete="off"
-          spellCheck={false}
-          rows={3}
-          resize="vertical"
-          size="large"
-          data-testid="import-session-input"
-        />
-        {invalid && (
+      <SpotlightPillBar
+        path={[
+          {
+            type: "action",
+            id: "import-session",
+            label: t("cloud.share.importEntry"),
+            icon: Download01Icon,
+            color: "primary",
+          },
+        ]}
+        onRemoveSegment={() => {
+          setValue("");
+          setInvalid(false);
+          (onGoBack ?? onClose)();
+        }}
+      />
+      <SpotlightFormShell>
+        <SpotlightFormBody>
           <div
-            id="import-session-input-error"
-            role="alert"
-            className="text-xs text-danger-6"
+            className="flex flex-col gap-2"
+            data-testid="import-session-dialog"
           >
-            {t("cloud.share.importInvalidInput")}
+            <Textarea
+              value={value}
+              onChange={(next) => {
+                setValue(next);
+                setInvalid(false);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                  event.preventDefault();
+                  handleSubmit();
+                }
+              }}
+              placeholder={t("cloud.share.importInputPlaceholder")}
+              error={invalid}
+              aria-invalid={invalid}
+              aria-describedby={
+                invalid ? "import-session-input-error" : undefined
+              }
+              aria-label={t("cloud.share.importEntry")}
+              autoFocus
+              autoComplete="off"
+              spellCheck={false}
+              rows={3}
+              resize="vertical"
+              size="large"
+              data-testid="import-session-input"
+            />
+            {invalid && (
+              <div
+                id="import-session-input-error"
+                role="alert"
+                className="text-xs text-danger-6"
+              >
+                {t("cloud.share.importInvalidInput")}
+              </div>
+            )}
           </div>
-        )}
-      </div>
-    </Modal>
+        </SpotlightFormBody>
+        <PanelFooter
+          secondaryActions={[
+            { label: t("common:actions.cancel"), onClick: handleClose },
+          ]}
+          primaryAction={{
+            label: t("cloud.share.importSubmit"),
+            onClick: handleSubmit,
+            disabled: !value.trim(),
+            dataTestId: "import-session-submit",
+          }}
+        />
+      </SpotlightFormShell>
+    </section>
+  );
+  if (asBody) return visible ? body : null;
+  return (
+    <SpotlightShell
+      isOpen={visible}
+      onClose={handleClose}
+      hasActiveAction
+      hideFooter
+    >
+      {body}
+    </SpotlightShell>
   );
 };
 

--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "Dieser Freigabelink ist ungültig, abgelaufen oder wurde widerrufen.",
       "incomingRetryHint": "Der Import wurde nicht abgeschlossen. Die geteilte Session wird möglicherweise noch hochgeladen — versuchen Sie es erneut.",
       "importEntry": "Session importieren",
-      "importDialogTitle": "Geteilte Session importieren",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "Importieren",
       "importInvalidInput": "Das sieht nicht nach einem gültigen Freigabelink oder Token aus.",

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -711,7 +711,6 @@
       "incomingError": "This share link is invalid, expired, or has been revoked.",
       "incomingRetryHint": "Import didn't finish. The shared session may still be uploading — try again.",
       "importEntry": "Import Session",
-      "importDialogTitle": "Import a shared session",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "Import",
       "importInvalidInput": "This doesn't look like a valid share link or token.",

--- a/src/i18n/locales/es/navigation.json
+++ b/src/i18n/locales/es/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "Este enlace es inválido, ha caducado o fue revocado.",
       "incomingRetryHint": "La importación no terminó. Puede que la sesión compartida aún se esté subiendo — inténtalo de nuevo.",
       "importEntry": "Importar sesión",
-      "importDialogTitle": "Importar una sesión compartida",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "Importar",
       "importInvalidInput": "Esto no parece un enlace para compartir ni un token válido.",

--- a/src/i18n/locales/fr/navigation.json
+++ b/src/i18n/locales/fr/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "Ce lien de partage est invalide, expiré ou a été révoqué.",
       "incomingRetryHint": "L'import n'a pas abouti. La session partagée est peut-être encore en cours d'envoi — réessayez.",
       "importEntry": "Importer une session",
-      "importDialogTitle": "Importer une session partagée",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "Importer",
       "importInvalidInput": "Ceci ne ressemble pas à un lien de partage ou à un jeton valide.",

--- a/src/i18n/locales/ja/navigation.json
+++ b/src/i18n/locales/ja/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "この共有リンクは無効か、期限切れ、または取り消されています。",
       "incomingRetryHint": "インポートが完了しませんでした。共有セッションはまだアップロード中の可能性があります——もう一度お試しください。",
       "importEntry": "セッションをインポート",
-      "importDialogTitle": "共有セッションをインポート",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "インポート",
       "importInvalidInput": "有効な共有リンクまたはトークンではないようです。",

--- a/src/i18n/locales/ko/navigation.json
+++ b/src/i18n/locales/ko/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "이 공유 링크는 유효하지 않거나 만료되었거나 철회되었습니다.",
       "incomingRetryHint": "가져오기가 완료되지 않았습니다. 공유된 세션이 아직 업로드 중일 수 있습니다 — 다시 시도하세요.",
       "importEntry": "세션 가져오기",
-      "importDialogTitle": "공유된 세션 가져오기",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "가져오기",
       "importInvalidInput": "유효한 공유 링크나 토큰이 아닌 것 같습니다.",

--- a/src/i18n/locales/pl/navigation.json
+++ b/src/i18n/locales/pl/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "Ten link jest nieprawidłowy, wygasł lub został cofnięty.",
       "incomingRetryHint": "Import nie został ukończony. Udostępniona sesja może wciąż być przesyłana — spróbuj ponownie.",
       "importEntry": "Importuj sesję",
-      "importDialogTitle": "Importuj udostępnioną sesję",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "Importuj",
       "importInvalidInput": "To nie wygląda na prawidłowy link udostępniania ani token.",

--- a/src/i18n/locales/pt/navigation.json
+++ b/src/i18n/locales/pt/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "Este link é inválido, expirou ou foi revogado.",
       "incomingRetryHint": "A importação não foi concluída. A sessão compartilhada pode ainda estar sendo enviada — tente novamente.",
       "importEntry": "Importar sessão",
-      "importDialogTitle": "Importar uma sessão compartilhada",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "Importar",
       "importInvalidInput": "Isto não parece um link de compartilhamento ou token válido.",

--- a/src/i18n/locales/ru/navigation.json
+++ b/src/i18n/locales/ru/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "Эта ссылка недействительна, истекла или была отозвана.",
       "incomingRetryHint": "Импорт не завершился. Возможно, сессия ещё загружается — попробуйте ещё раз.",
       "importEntry": "Импортировать сессию",
-      "importDialogTitle": "Импортировать общую сессию",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "Импортировать",
       "importInvalidInput": "Это не похоже на действительную ссылку для доступа или токен.",

--- a/src/i18n/locales/tr/navigation.json
+++ b/src/i18n/locales/tr/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "Bu paylaşım bağlantısı geçersiz, süresi dolmuş veya iptal edilmiş.",
       "incomingRetryHint": "İçe aktarma tamamlanmadı. Paylaşılan oturum hâlâ yükleniyor olabilir — tekrar deneyin.",
       "importEntry": "Oturumu içe aktar",
-      "importDialogTitle": "Paylaşılan oturumu içe aktar",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "İçe aktar",
       "importInvalidInput": "Bu, geçerli bir paylaşım bağlantısı veya belirteç gibi görünmüyor.",

--- a/src/i18n/locales/vi/navigation.json
+++ b/src/i18n/locales/vi/navigation.json
@@ -657,7 +657,6 @@
       "incomingError": "Liên kết chia sẻ này không hợp lệ, đã hết hạn hoặc đã bị thu hồi.",
       "incomingRetryHint": "Nhập chưa hoàn tất. Phiên được chia sẻ có thể vẫn đang tải lên — hãy thử lại.",
       "importEntry": "Nhập phiên",
-      "importDialogTitle": "Nhập phiên được chia sẻ",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "Nhập",
       "importInvalidInput": "Đây có vẻ không phải là liên kết chia sẻ hoặc mã token hợp lệ.",

--- a/src/i18n/locales/zh-Hant/navigation.json
+++ b/src/i18n/locales/zh-Hant/navigation.json
@@ -656,7 +656,6 @@
       "incomingError": "此分享連結無效、已過期或已被撤銷。",
       "incomingRetryHint": "匯入未完成。分享的 session 可能仍在上傳——請再試一次。",
       "importEntry": "匯入 Session",
-      "importDialogTitle": "匯入分享的 session",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "匯入",
       "importInvalidInput": "這不是有效的分享連結或權杖。",

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -656,7 +656,6 @@
       "incomingError": "此分享链接无效、已过期或已被撤销。",
       "incomingRetryHint": "导入未完成。分享的 session 可能仍在上传——请重试。",
       "importEntry": "导入 Session",
-      "importDialogTitle": "导入分享的 session",
       "importInputPlaceholder": "orgii://cloud/session?share=…",
       "importSubmit": "导入",
       "importInvalidInput": "这不是有效的分享链接或令牌。",

--- a/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightActionDefinitions.navigation.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightActionDefinitions.navigation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   Add01Icon,
   FolderGitTwoIcon,
+  ImportIcon,
   Login01Icon,
   MessageAdd02Icon,
   Search01Icon,
@@ -76,5 +77,17 @@ describe("Spotlight action icons", () => {
         closeOnSuccess: false,
       }),
     ]);
+  });
+});
+
+it("offers session import using the same label and icon as the start-page card", () => {
+  expect(
+    AGENT_SESSION_ACTIONS.find((action) => action.id === "import-session")
+  ).toMatchObject({
+    labelKey: "navigation:cloud.share.importEntry",
+    icon: ImportIcon,
+    actionId: "spotlight.importSession",
+    opensSecondLevel: true,
+    closeOnSuccess: false,
   });
 });

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.navigation.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.navigation.ts
@@ -27,6 +27,7 @@ import {
   FolderLibraryIcon,
   GitPullRequestIcon,
   type IconSvgElement,
+  ImportIcon,
   KanbanIcon,
   Login01Icon,
   MessageAdd02Icon,
@@ -89,6 +90,22 @@ export const ALL_SESSIONS_SEARCH_ICON: IconSvgElement = [
 ];
 
 export const AGENT_SESSION_ACTIONS = [
+  {
+    id: "import-session",
+    labelKey: "navigation:cloud.share.importEntry",
+    icon: ImportIcon,
+    keywords: [
+      "import session",
+      "import shared session",
+      "share link",
+      "导入会话",
+    ],
+    actionId: ACTION_ID.SPOTLIGHT_IMPORT_SESSION,
+    payload: {},
+    fallback: "import-session",
+    opensSecondLevel: true,
+    closeOnSuccess: false,
+  },
   {
     id: "open-agent-control",
     labelKey: "common:adeManager.menuToggle",

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.types.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.types.ts
@@ -15,6 +15,7 @@ import type { SpotlightItem } from "../../types";
 // ============================================
 
 export type SpotlightStaticActionId =
+  | "import-session"
   | "open-session-creator"
   | "create-project"
   | "create-work-item"
@@ -55,6 +56,7 @@ export type SpotlightStaticActionId =
   | "detect-update";
 
 export type SpotlightStaticActionFallback =
+  | "import-session"
   | "open-session-creator"
   | "create-project"
   | "create-work-item"

--- a/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightEffects.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightEffects.ts
@@ -47,6 +47,7 @@ export interface UseSpotlightEffectsOptions {
   onOpenAllSessionsSearchLayer?: () => void;
   onOpenAgentControlLayer?: () => void;
   onOpenSessionCreatorLayer?: () => void;
+  onOpenSessionImportLayer?: () => void;
 }
 
 // ============================================
@@ -67,6 +68,7 @@ export function useSpotlightEffects(options: UseSpotlightEffectsOptions): void {
     onOpenAllSessionsSearchLayer,
     onOpenAgentControlLayer,
     onOpenSessionCreatorLayer,
+    onOpenSessionImportLayer,
   } = options;
 
   // Reset state on close
@@ -131,6 +133,8 @@ export function useSpotlightEffects(options: UseSpotlightEffectsOptions): void {
       onOpenAgentControlLayer?.();
     } else if (initialQuery.layer?.kind === "sessionCreator") {
       onOpenSessionCreatorLayer?.();
+    } else if (initialQuery.layer?.kind === "sessionImport") {
+      onOpenSessionImportLayer?.();
     } else if (initialQuery.query) {
       dispatch({
         type: "SET_SEARCH_QUERY",
@@ -152,6 +156,7 @@ export function useSpotlightEffects(options: UseSpotlightEffectsOptions): void {
     onOpenGitHubIssuesImportLayer,
     onOpenWorkingDirectoryLayer,
     onOpenSessionCreatorLayer,
+    onOpenSessionImportLayer,
     setInitialQuery,
     dispatch,
   ]);

--- a/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightOverlayLayers.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightOverlayLayers.ts
@@ -55,6 +55,7 @@ interface UseSpotlightOverlayLayersResult {
   allSessionsSearchOpen: boolean;
   agentControlOpen: boolean;
   sessionCreatorOpen: boolean;
+  sessionImportOpen: boolean;
   embeddedEditorPalette: EmbeddedEditorPaletteState | null;
   lastActivatedItemIdRef: RefObject<string | null>;
   pendingRestoreItemId: string | null;
@@ -71,6 +72,7 @@ interface UseSpotlightOverlayLayersResult {
   handleOpenAllSessionsSearch: () => void;
   handleOpenAgentControl: () => void;
   handleOpenSessionCreator: () => void;
+  handleOpenSessionImport: () => void;
   handleOpenEditorPalette: (query: string, mode?: EditorPaletteMode) => void;
   handleCloseWorkingDirectoryPicker: () => void;
   handleCloseCollabOrg: () => void;
@@ -81,6 +83,7 @@ interface UseSpotlightOverlayLayersResult {
   handleCloseAllSessionsSearch: () => void;
   handleCloseAgentControl: () => void;
   handleCloseSessionCreator: () => void;
+  handleCloseSessionImport: () => void;
   handleCloseEditorPalette: () => void;
 }
 
@@ -107,6 +110,7 @@ export function useSpotlightOverlayLayers(
   const [allSessionsSearchOpen, setAllSessionsSearchOpen] = useState(false);
   const [agentControlOpen, setAgentControlOpen] = useState(false);
   const [sessionCreatorOpen, setSessionCreatorOpen] = useState(false);
+  const [sessionImportOpen, setSessionImportOpen] = useState(false);
   const [embeddedEditorPalette, setEmbeddedEditorPalette] =
     useState<EmbeddedEditorPaletteState | null>(null);
   const lastActivatedItemIdRef = useRef<string | null>(null);
@@ -155,6 +159,11 @@ export function useSpotlightOverlayLayers(
   const handleOpenAgentControl = useCallback(() => {
     setAgentControlOpen(true);
   }, []);
+
+  const handleOpenSessionImport = useCallback(
+    () => setSessionImportOpen(true),
+    []
+  );
 
   const handleOpenSessionCreator = useCallback(() => {
     setSessionCreatorOpen(true);
@@ -214,6 +223,11 @@ export function useSpotlightOverlayLayers(
     restoreLastActivatedItem();
   }, [restoreLastActivatedItem]);
 
+  const handleCloseSessionImport = useCallback(() => {
+    setSessionImportOpen(false);
+    restoreLastActivatedItem();
+  }, [restoreLastActivatedItem]);
+
   const handleCloseSessionCreator = useCallback(() => {
     setSessionCreatorOpen(false);
     restoreLastActivatedItem();
@@ -239,6 +253,7 @@ export function useSpotlightOverlayLayers(
       setAllSessionsSearchOpen(false);
       setAgentControlOpen(false);
       setSessionCreatorOpen(false);
+      setSessionImportOpen(false);
       setEmbeddedEditorPalette(null);
       lastActivatedItemIdRef.current = null;
       setPendingRestoreItemId(null);
@@ -266,6 +281,7 @@ export function useSpotlightOverlayLayers(
     allSessionsSearchOpen,
     agentControlOpen,
     sessionCreatorOpen,
+    sessionImportOpen,
     embeddedEditorPalette,
     lastActivatedItemIdRef,
     pendingRestoreItemId,
@@ -280,6 +296,7 @@ export function useSpotlightOverlayLayers(
     handleOpenAllSessionsSearch,
     handleOpenAgentControl,
     handleOpenSessionCreator,
+    handleOpenSessionImport,
     handleOpenEditorPalette,
     handleCloseWorkingDirectoryPicker,
     handleCloseCollabOrg,
@@ -290,6 +307,7 @@ export function useSpotlightOverlayLayers(
     handleCloseAllSessionsSearch,
     handleCloseAgentControl,
     handleCloseSessionCreator,
+    handleCloseSessionImport,
     handleCloseEditorPalette,
   };
 }

--- a/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
@@ -33,6 +33,7 @@ import {
   openAgentControlSpotlight,
   openCollabOrgSpotlight,
   openSessionCreatorSpotlight,
+  openSessionImportSpotlight,
 } from "@src/scaffold/GlobalSpotlight/openSpotlight";
 import { AppViewService } from "@src/services/app";
 import { PanelService } from "@src/services/panel";
@@ -186,6 +187,7 @@ export function useSpotlight(
         () => void
       > = {
         "open-session-creator": openSessionCreatorSpotlight,
+        "import-session": openSessionImportSpotlight,
         "create-project": () => {
           void WorkStationViewService.openStationMode("my-station").then(
             async () => {

--- a/src/scaffold/GlobalSpotlight/index.tsx
+++ b/src/scaffold/GlobalSpotlight/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 
 import { ROUTES } from "@src/config/routes";
+import ImportSharedSessionDialog from "@src/features/Org2Cloud/ImportSharedSessionDialog";
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { useSelector as useSelectorKernel } from "@src/scaffold/GlobalSpotlight/hooks/selectors/useSelector";
 import { currentBranchAtom } from "@src/store/repo";
@@ -92,6 +93,7 @@ const GlobalSpotlightInner: React.FC<
     allSessionsSearchOpen,
     agentControlOpen,
     sessionCreatorOpen,
+    sessionImportOpen,
     embeddedEditorPalette,
     lastActivatedItemIdRef,
     pendingRestoreItemId,
@@ -106,6 +108,7 @@ const GlobalSpotlightInner: React.FC<
     handleOpenAllSessionsSearch,
     handleOpenAgentControl,
     handleOpenSessionCreator,
+    handleOpenSessionImport,
     handleOpenEditorPalette,
     handleCloseWorkingDirectoryPicker,
     handleCloseCollabOrg,
@@ -116,6 +119,7 @@ const GlobalSpotlightInner: React.FC<
     handleCloseAllSessionsSearch,
     handleCloseAgentControl,
     handleCloseSessionCreator,
+    handleCloseSessionImport,
     handleCloseEditorPalette,
   } = useSpotlightOverlayLayers(isOpen);
 
@@ -185,6 +189,7 @@ const GlobalSpotlightInner: React.FC<
       !agentSessionSearchOpen &&
       !allSessionsSearchOpen &&
       !agentControlOpen &&
+      !sessionImportOpen &&
       !sessionCreatorOpen,
     dispatch: spotlightDispatch,
     closeModal,
@@ -198,6 +203,7 @@ const GlobalSpotlightInner: React.FC<
     onOpenAllSessionsSearchLayer: handleOpenAllSessionsSearch,
     onOpenAgentControlLayer: handleOpenAgentControl,
     onOpenSessionCreatorLayer: handleOpenSessionCreator,
+    onOpenSessionImportLayer: handleOpenSessionImport,
   });
 
   // Default view kernel — same hook every palette uses. Owns the input
@@ -248,6 +254,7 @@ const GlobalSpotlightInner: React.FC<
       !agentSessionSearchOpen &&
       !allSessionsSearchOpen &&
       !agentControlOpen &&
+      !sessionImportOpen &&
       !sessionCreatorOpen &&
       !activeEditorPalette,
     onClose: closeModal,
@@ -276,6 +283,7 @@ const GlobalSpotlightInner: React.FC<
       agentSessionSearchOpen ||
       allSessionsSearchOpen ||
       agentControlOpen ||
+      sessionImportOpen ||
       sessionCreatorOpen ||
       !pendingRestoreItemId
     ) {
@@ -311,6 +319,7 @@ const GlobalSpotlightInner: React.FC<
     allSessionsSearchOpen,
     agentControlOpen,
     sessionCreatorOpen,
+    sessionImportOpen,
   ]);
 
   // ============ NORMAL MODE ============
@@ -359,6 +368,7 @@ const GlobalSpotlightInner: React.FC<
     agentSessionSearchOpen ||
     allSessionsSearchOpen ||
     agentControlOpen ||
+    sessionImportOpen ||
     sessionCreatorOpen ||
     !!activeEditorPalette ||
     spotlight.state.path.length > 0;
@@ -466,6 +476,13 @@ const GlobalSpotlightInner: React.FC<
       onGoBackToParent={handleCloseAgentControl}
       asBody
     />
+  ) : sessionImportOpen ? (
+    <ImportSharedSessionDialog
+      visible={isOpen}
+      onClose={closeModal}
+      onGoBack={handleCloseSessionImport}
+      asBody
+    />
   ) : sessionCreatorOpen ? (
     <SessionCreatorPalette
       isOpen={isOpen}
@@ -509,7 +526,12 @@ const GlobalSpotlightInner: React.FC<
       onClose={closeModal}
       hasActiveAction={hasActiveAction}
       activeActionChip={activeActionChip}
-      hideFooter={!!showConfirmation || agentControlOpen || sessionCreatorOpen}
+      hideFooter={
+        !!showConfirmation ||
+        agentControlOpen ||
+        sessionCreatorOpen ||
+        sessionImportOpen
+      }
     >
       {body}
     </SpotlightShell>

--- a/src/scaffold/GlobalSpotlight/openSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/openSpotlight.ts
@@ -192,3 +192,13 @@ export function openSessionCreatorSpotlight(): void {
   store.set(spotlightInitialQueryAtom, createSessionCreatorSpotlightRequest());
   store.set(spotlightOpenAtom, true);
 }
+
+export function openSessionImportSpotlight(): void {
+  if (!isStoreInitialized()) return;
+  const store = getInstrumentedStore();
+  store.set(spotlightInitialQueryAtom, {
+    query: "",
+    layer: { kind: "sessionImport" },
+  });
+  store.set(spotlightOpenAtom, true);
+}

--- a/src/store/ui/uiAtom.ts
+++ b/src/store/ui/uiAtom.ts
@@ -432,7 +432,8 @@ export type SpotlightInitialLayer =
   | { kind: "agentSessionSearch" }
   | { kind: "allSessionsSearch" }
   | { kind: "agentControl" }
-  | { kind: "sessionCreator" };
+  | { kind: "sessionCreator" }
+  | { kind: "sessionImport" };
 
 export interface SpotlightInitialQuery {
   query: string;


### PR DESCRIPTION
## Problem

Spotlight exposes session creation but no shared-session import command. The existing paste-link import dialog uses separate modal chrome and cannot be embedded as a Spotlight layer.

## Solution

Add the typed `spotlight.importSession` GUI action, navigation entry and initial overlay layer. Embed the shared-session form in Spotlight with back navigation, and reuse Spotlight form primitives for standalone use. Keep parsing and queueing at the existing pending-share boundary, preserving invalid-input feedback and disabled empty submission. Remove the obsolete modal-title translation from all 13 locales now that the form uses the shared import-entry label.

Includes only import entry, layer wiring, dialog composition, supporting tests and focused audit reports. Floating project/work-item creation is a separate PR.

## Potential risks

Standalone dialog chrome and embedded focus/back/Escape interactions change; native keyboard behavior, theme/viewport screenshots and live cloud resolve/import were not exercised. Component and queue tests cover input validation and queued attempts, but do not prove remote import success. The new GUI action is additive and uses an empty parameter object; there are no dependency, database or transport-format changes. Revert this commit to restore the prior dialog and remove the new action. Existing cloud import ownership and identity handling remain unchanged. Native lifecycle measurements remain unverified.

## Verification

- `pnpm test` — full suite passed: 1,751 files, 13,089 tests passed and 1 skipped.

- `pnpm run check:i18n-keys` — passed after removing the unused `navigation:cloud.share.importDialogTitle` key from every locale; zero new findings. This fixes the initial CI failure.

- `pnpm test src/features/Org2Cloud/ImportSharedSessionDialog.test.ts src/features/Org2Cloud/org2CloudPendingShareAtom.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightActionDefinitions.navigation.test.ts` — 12 tests passed in 3 files, covering standalone/embedded composition, validation, queueing, dismissal and the import command.
- `pnpm test src/scaffold/GlobalSpotlight/hooks/useSpotlight.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/useSpotlightEffects.test.ts src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/createWorkItemFromDraft.test.ts` — 11 tests passed in 3 files.
- `pnpm typecheck:fast` — passed across the full frontend.
- Commit hook `npx lint-staged` — passed (Oxlint, ESLint and Prettier); hook TypeScript check also passed.
- `pnpm check:test-placement` — passed, 540 directories.
- `pnpm check:circular` — fails on three existing cycles, reproduced identically on clean `origin/develop` at `cefceac8419a94f14b71f50eeffe33118409c049`: two SessionCore/composer/slash-command cycles and one SessionHoverCard cycle. No added cycle.
- `git diff --check` — passed. Final diff inspected for unrelated edits, secrets, personal paths and generated files.
- Native Tauri interaction, screenshots across themes/viewports, CPU/RSS measurements and full E2E were not run: computer control is not authorized. The full local unit suite passed; live cloud resolve/import was not exercised.

## Audit

UI review: 0 fix, 4 keep with reason, 0 abstract. Lifecycle evidence and native measurement gaps are recorded in `docs/org2-performance-guard-2026-09-10/ImportSharedSessionDialog.md`.

