### PR TITLE
fix(sidebar): hide header actions after pointer focus

### DIFF
--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts
@@ -119,7 +119,7 @@ describe("NavigationSidebar", () => {
     expect(markup).toContain('data-testid="sidebar-sessions-refresh"');
     expect(markup).toContain('title="Refresh"');
     expect(markup).toContain(
-      '<span class="hidden group-focus-within/section-title:inline-flex group-hover/section-title:inline-flex"><button type="button" aria-label="More"'
+      '<span class="hidden group-hover/section-title:inline-flex group-focus-visible/section-title:inline-flex group-has-[:focus-visible]/section-title:inline-flex"><button type="button" aria-label="More"'
     );
     expect(markup.indexOf('data-testid="section-more"')).toBeLessThan(
       markup.indexOf('data-testid="sidebar-sessions-search"')

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -433,8 +433,8 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
                                 )
                                   ? "inline-flex"
                                   : action.showOnSidebarHover
-                                    ? "hidden group-focus-within/section-title:inline-flex group-hover/sidebar:inline-flex"
-                                    : "hidden group-focus-within/section-title:inline-flex group-hover/section-title:inline-flex"
+                                    ? "hidden group-hover/sidebar:inline-flex group-focus-visible/section-title:inline-flex group-has-[:focus-visible]/section-title:inline-flex"
+                                    : "hidden group-hover/section-title:inline-flex group-focus-visible/section-title:inline-flex group-has-[:focus-visible]/section-title:inline-flex"
                               }
                             >
                               <NavigationMenuRowActionButton


### PR DESCRIPTION
## Problem

Sidebar section headers reveal their menu and Start actions using `focus-within`. A mouse click can leave the header or an action focused after the pointer leaves, keeping the buttons displayed.

## Solution

Use `focus-visible` on the header and its descendants to reveal actions for keyboard navigation while retaining the existing hover rules. Active-filter visibility is unchanged. Update the existing sidebar markup assertion for the new selectors.

## Potential risks

Keyboard focus and pointer-focus behavior depend on the desktop WebView's `:focus-visible` and `:has()` support. Live desktop hover, menu dismissal, and keyboard traversal were not verified. No dependencies, persistence, or APIs change; reverting this commit restores the previous selectors.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts` — passed, 5 tests, in the isolated branch based on the latest `origin/develop`.
- `pnpm exec eslint src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts --max-warnings 0` — passed.
- `git diff --check` — passed.
- Reviewed the diff: only the sidebar component and its existing test changed; no secrets or unrelated changes included.
- Full-suite tests and live UI verification were not run for this scoped CSS fix. No new screenshots or recordings were captured because desktop control was not authorized; the markup tests do not verify browser focus behavior.
