### PR TITLE
fix(session-hover): dismiss details before opening row menus

### DIFF
--- a/src/components/SessionHoverCard/HoverCardBase.test.ts
+++ b/src/components/SessionHoverCard/HoverCardBase.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { jsx } from "react/jsx-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import HoverCardBase from "./HoverCardBase";
+import { dismissHoverCard } from "./singletonStore";
+
+describe("HoverCardBase action dismissal", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const action = vi.fn();
+  const capture = vi.fn();
+  const rowClick = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      }
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() =>
+      root.render(
+        jsx(HoverCardBase, {
+          cardId: "session",
+          position: "right-start",
+          mouseEnterDelay: 1000,
+          renderContent: () => "Session details",
+          children: createElement(
+            "div",
+            {
+              onClick: rowClick,
+              onClickCapture: capture,
+              onContextMenuCapture: capture,
+            },
+            createElement(
+              "button",
+              {
+                onClick: (event) => {
+                  event.stopPropagation();
+                  action();
+                },
+                onContextMenu: (event) => {
+                  event.stopPropagation();
+                  action();
+                },
+              },
+              "More"
+            )
+          ),
+        })
+      )
+    );
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    dismissHoverCard();
+    container.remove();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(["click", "contextmenu"])(
+    "%s dismisses visible and pending cards despite stopped bubbling",
+    (eventType) => {
+      const row = container.firstElementChild!;
+      const button = container.querySelector("button")!;
+      for (const delay of [1000, 100]) {
+        act(() =>
+          row.dispatchEvent(
+            new MouseEvent("mouseover", {
+              bubbles: true,
+              relatedTarget: document.body,
+            })
+          )
+        );
+        act(() => vi.advanceTimersByTime(delay));
+        expect(document.querySelectorAll("[data-hover-card]")).toHaveLength(
+          delay === 1000 ? 1 : 0
+        );
+        act(() =>
+          button.dispatchEvent(new MouseEvent(eventType, { bubbles: true }))
+        );
+        expect(document.querySelector("[data-hover-card]")).toBeNull();
+        expect(vi.getTimerCount()).toBe(0);
+        act(() => vi.advanceTimersByTime(2000));
+        expect(document.querySelector("[data-hover-card]")).toBeNull();
+        act(() =>
+          row.dispatchEvent(
+            new MouseEvent("mouseout", {
+              bubbles: true,
+              relatedTarget: document.body,
+            })
+          )
+        );
+      }
+      expect(action).toHaveBeenCalledTimes(2);
+      expect(capture).toHaveBeenCalledTimes(2);
+      expect(rowClick).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/components/SessionHoverCard/HoverCardBase.tsx
+++ b/src/components/SessionHoverCard/HoverCardBase.tsx
@@ -83,7 +83,8 @@ type ElementProps = {
   ref?: React.Ref<HTMLElement>;
   onMouseEnter?: (event: React.MouseEvent) => void;
   onMouseLeave?: (event: React.MouseEvent) => void;
-  onClick?: (event: React.MouseEvent) => void;
+  onClickCapture?: (event: React.MouseEvent) => void;
+  onContextMenuCapture?: (event: React.MouseEvent) => void;
   onFocus?: (event: React.FocusEvent) => void;
   onBlur?: (event: React.FocusEvent) => void;
   [key: string]: unknown;
@@ -247,10 +248,17 @@ const HoverCardTrigger: React.FC<HoverCardTriggerProps> = ({
       if (position === "right-or-bottom") handleLeave();
       originalProps.onBlur?.(event);
     },
-    onClick: (event: React.MouseEvent) => {
+    // Row actions stop bubbling so they do not select the row. Dismiss in
+    // capture, including pending opens, before an action opens its menu.
+    onClickCapture: (event: React.MouseEvent) => {
       clearEnterTimer();
       dismissHoverCard();
-      originalProps.onClick?.(event);
+      originalProps.onClickCapture?.(event);
+    },
+    onContextMenuCapture: (event: React.MouseEvent) => {
+      clearEnterTimer();
+      dismissHoverCard();
+      originalProps.onContextMenuCapture?.(event);
     },
   } as ElementProps);
 };


### PR DESCRIPTION
## Problem

Clicking a session sidebar row's ellipsis menu can leave its details hover card visible underneath the menu. The action button stops click propagation, so the hover trigger's bubbling handler never dismisses the card or cancels its pending open timer. Right-click menus have the same missing dismissal path.

## Solution

Dismiss the active hover card and cancel the trigger's pending open timer in click and context-menu capture handlers. Preserve existing capture callbacks and normal action handlers. Add regression coverage for visible and pending cards, stopped propagation, repeated interactions, and zero remaining timers after dismissal.

## Potential risks

The shared hover-card trigger also serves other hover-card surfaces, so descendant click and context-menu actions now dismiss their cards before running. Native Tauri menu behavior and visual appearance across themes/viewports have not been exercised; no after-fix screenshot is available. No persistence, dependency, or protocol changes are involved.

## Verification

Run on an isolated branch based on current `origin/develop`:

- `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/components/SessionHoverCard/HoverCardBase.test.ts src/components/SessionHoverCard/SessionHoverCard.test.ts` — 6 tests passed.
- `node node_modules/eslint/bin/eslint.js src/components/SessionHoverCard/HoverCardBase.tsx src/components/SessionHoverCard/HoverCardBase.test.ts` — passed.
- `node node_modules/@typescript/native-preview/bin/tsgo --noEmit --pretty false` — passed. The errors previously seen in the original dirty workspace do not occur on this isolated branch.
- `git diff --check` — passed.
- Initial pnpm entry-point attempts in the temporary worktree failed because dependency wrappers resolved relative paths incorrectly; direct Node entry points above completed successfully. The worktree was subsequently moved alongside the source checkout to restore wrapper resolution.
- Real Tauri interaction, screenshots, and runtime CPU/RSS measurements were not run.

## Performance review

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | fix | Trigger owns one delayed-open timer | Cancel before menu action even when bubbling stops | Click/right-click tests assert zero timers and no delayed reopen |
| Memory | keep | Existing singleton and trigger ownership | No new retained state | Diff inspection |
| Scope/isolation | keep | No cache, identity, or network changes | Existing ownership retained | Diff inspection |
| Rendering/hot path | keep | Event-driven dismissal | No polling or new subscriptions | Six component tests passed |

Performance verdict: blocked for real-machine measurement; timer cancellation is covered by component tests.
