### PR TITLE
fix(mobile-sessions): enforce workspace metadata projection

### DIFF
--- a/docs/org2-performance-guard-2026-09-09/MobileSessionMetadata.md
+++ b/docs/org2-performance-guard-2026-09-09/MobileSessionMetadata.md
@@ -1,0 +1,41 @@
+# Mobile session workspace metadata
+
+## Source and scope
+
+The authoritative workspace fields live in the session directory records, backed by the imported-history cache or native session storage. Read-only inspection confirmed the affected records still contained workspace paths and update timestamps. The desktop `session/list` projection reduced each record to id, name and status before serialization, losing workspace metadata. The installed mobile client only renders a workspace when `repoName` is present.
+
+Preserve `repoPath`, `repoName` and the RFC3339 update time converted to `updatedAtMs` at the RPC-producing boundary. Preserve the same optional fields through the sidebar snapshot ingestion and serialization path. Missing metadata remains null, not an invented label. No persistence migration, historical cleanup, re-pairing, title change, filter change or ordering change is needed.
+
+Compatibility: fields are additive and optional; legacy snapshot producers can omit them. Snapshot workspace strings and timestamps are validated before retention. Metadata-only changes participate in the existing equality/invalidation mechanism. Reverting the projection restores the previous response shape without modifying stored data.
+
+## Lifecycle and edge cases
+
+- Request: reuse the existing authenticated list path, status filter, bounded limit and send-capability lookup; serialize metadata only for requested rows
+- Snapshot update: validate up to 200 rows, reject oversized metadata/invalid dates, compare the complete row, invalidate through the existing event only when changed
+- Missing workspace/invalid directory time: return null; never infer workspace from a session title
+- Offline/reconnect/start/shutdown: no new timers, retries, listeners or persistent state; reconnect fetches canonical data through the existing lifecycle
+- Account/endpoint/secondary instance behavior is unchanged; this patch does not claim to repair existing app-lifetime snapshot isolation
+- Provider parsing, discovery, rewriting and compaction are untouched; no provider lifecycle improvements are claimed
+
+## Performance review
+
+| Area | Verdict | Evidence | Change or reason kept | Verification |
+| --- | --- | --- | --- | --- |
+| Background work | keep | Existing RPC request and snapshot invalidation own work | No added polling, scan, query or listener | Call-chain review |
+| Memory | keep | Snapshot remains capped at 200 rows | Optional path/name bounded to 4096/1024 bytes per row | Ingestion bound regression test |
+| Scope/isolation | keep | Existing authenticated RPC and process-owned snapshot | No new identity cache or async writer | Source review; account-switch runtime test not run |
+| Rendering/hot path | fix | Wire projection discarded existing metadata | Add three fields per requested row, preserve list semantics | Producing-boundary and snapshot serialization regressions |
+
+## Verification
+
+- `cargo test -p org2 --lib mobile_`: 98 passed, including directory wire serialization, sidebar metadata round-trip/bounds and existing order/status tests
+- `pnpm exec eslint src/api/tauri/mobileRemote/index.ts`: passed
+- `git diff --check`: passed
+- No frontend files changed; post-rebase verification was scoped to the Rust producing boundary
+- `cargo build -p org2 --bin org2`: passed; existing large `__eh_frame` linker warning remains
+- Restarted the current-tree desktop and the installed iPhone app without changing pairing data. Real-device screenshots before/after confirmed `ORGII` workspace labels and update dates restored for the same session rows. No mobile reinstall was required
+- The after screenshot still showed a desktop reconnect/offline banner despite having received the corrected list. Connection stability is a separate unresolved issue; this repair does not claim to fix it
+
+No performance improvement is claimed from code shape alone.
+
+Performance verdict: blocked for steady-state CPU/RSS across visible/hidden states and sustained reconnect stability. Functional metadata rendering is verified on the physical iPhone; no full-app performance or connection-stability pass is claimed.

--- a/src-tauri/src/api/mobile_bridge/adapters/session.rs
+++ b/src-tauri/src/api/mobile_bridge/adapters/session.rs
@@ -12,7 +12,9 @@ use crate::agent_sessions::event_pipeline::types::{
     EventDisplayVariant, EventSource, SessionEvent,
 };
 use crate::agent_sessions::session_directory::aggregation::list_all_sessions;
-use crate::agent_sessions::session_directory::types::{SessionCategory, SessionFilter};
+use crate::agent_sessions::session_directory::types::{
+    SessionAggregateRecord, SessionCategory, SessionFilter,
+};
 use crate::api::mobile_bridge::commands::{
     current_mobile_sidebar_sessions, MobileSidebarSessionSnapshotRow,
 };
@@ -166,6 +168,22 @@ fn is_mobile_list_category(category: SessionCategory) -> bool {
         category,
         SessionCategory::Agent | SessionCategory::Os | SessionCategory::Cli
     )
+}
+
+/// Keep directory metadata on the wire; do not reconstruct it from a title.
+fn mobile_directory_session_row(record: &SessionAggregateRecord, send_capability: &str) -> Value {
+    let updated_at_ms = chrono::DateTime::parse_from_rfc3339(&record.updated_at)
+        .ok()
+        .map(|date| date.timestamp_millis());
+    json!({
+        "id": record.session_id,
+        "name": mobile_session_name(&record.name, record.display_label.as_deref()),
+        "status": map_session_status_to_mobile(&record.status),
+        "repoPath": record.repo_path,
+        "repoName": record.repo_name,
+        "updatedAtMs": updated_at_ms,
+        "sendCapability": send_capability,
+    })
 }
 
 fn session_list_from_sidebar_snapshot(
@@ -405,23 +423,8 @@ pub async fn session_list(params: &Value) -> Result<Value, RpcError> {
         .sessions
         .into_iter()
         .filter(|record| is_mobile_list_category(record.category))
-        .filter_map(|record| {
-            let mobile_status = map_session_status_to_mobile(&record.status);
-            if status_filter == "running" && mobile_status != "running" {
-                return None;
-            }
-            let mobile_name = mobile_session_name(&record.name, record.display_label.as_deref());
-            let updated_at_ms = chrono::DateTime::parse_from_rfc3339(&record.updated_at)
-                .ok()
-                .map(|date| date.timestamp_millis());
-            Some((
-                record.session_id,
-                mobile_name,
-                mobile_status,
-                record.repo_path,
-                record.repo_name,
-                updated_at_ms,
-            ))
+        .filter(|record| {
+            status_filter != "running" || map_session_status_to_mobile(&record.status) == "running"
         })
         .take(limit)
         .collect::<Vec<_>>();
@@ -430,29 +433,25 @@ pub async fn session_list(params: &Value) -> Result<Value, RpcError> {
         crate::orgtrack::history_commands::external_history_mobile_writable_codex_session_ids(
             session_rows
                 .iter()
-                .filter(|(id, ..)| id.starts_with(orgtrack_core::sources::codex::SESSION_PREFIX))
-                .map(|(id, ..)| id.clone())
+                .filter(|record| {
+                    record
+                        .session_id
+                        .starts_with(orgtrack_core::sources::codex::SESSION_PREFIX)
+                })
+                .map(|record| record.session_id.clone())
                 .collect(),
         )
         .await
         .map_err(|err| RpcError::new(RpcErrorCode::InvalidRequest, err))?;
     let sessions = session_rows
         .into_iter()
-        .map(
-            |(session_id, mobile_name, mobile_status, repo_path, repo_name, updated_at_ms)| {
-                let send_capability =
-                    external_send::mobile_send_capability(&session_id, &writable_codex_session_ids);
-                json!({
-                    "id": session_id,
-                    "name": mobile_name,
-                    "repoPath": repo_path,
-                    "repoName": repo_name,
-                    "updatedAtMs": updated_at_ms,
-                    "status": mobile_status,
-                    "sendCapability": send_capability,
-                })
-            },
-        )
+        .map(|record| {
+            let send_capability = external_send::mobile_send_capability(
+                &record.session_id,
+                &writable_codex_session_ids,
+            );
+            mobile_directory_session_row(&record, send_capability)
+        })
         .collect::<Vec<_>>();
 
     Ok(
@@ -2100,6 +2099,32 @@ mod tests {
     }
 
     #[test]
+    fn directory_mobile_payload_retains_authoritative_workspace_and_timestamp() {
+        let mut record: SessionAggregateRecord = serde_json::from_value(json!({
+            "sessionId": "session-a", "name": "Raw name", "displayLabel": "Display name",
+            "status": "completed", "category": "cli", "keySource": "own_key",
+            "createdAt": "2026-09-09T00:00:00Z", "updatedAt": "2026-09-09T00:00:00Z",
+            "isActive": false, "repoPath": "/workspace/project", "repoName": "project"
+        }))
+        .unwrap();
+        let row = mobile_directory_session_row(&record, "read_only");
+        assert_eq!(row["repoPath"], "/workspace/project");
+        assert_eq!(row["repoName"], "project");
+        assert_eq!(row["updatedAtMs"], 1_788_912_000_000_i64);
+        assert_eq!(row["name"], "Display name");
+        assert_eq!(row["status"], "idle");
+        assert_eq!(row["sendCapability"], "read_only");
+
+        record.repo_name = None;
+        record.repo_path = None;
+        record.updated_at = "invalid".into();
+        let missing = mobile_directory_session_row(&record, "read_only");
+        assert!(missing["repoName"].is_null());
+        assert!(missing["repoPath"].is_null());
+        assert!(missing["updatedAtMs"].is_null());
+    }
+
+    #[test]
     fn sidebar_snapshot_list_preserves_desktop_order_and_running_filter() {
         let snapshot = vec![
             MobileSidebarSessionSnapshotRow {
@@ -2143,7 +2168,9 @@ mod tests {
             all.pointer("/sessions/0/repoPath"),
             Some(&json!("/projects/repo"))
         );
+        assert_eq!(all.pointer("/sessions/0/repoName"), Some(&json!("repo")));
         assert_eq!(all.pointer("/sessions/0/updatedAtMs"), Some(&json!(123)));
+        assert!(all["sessions"][1]["repoName"].is_null());
         let running = session_list_from_sidebar_snapshot(
             snapshot,
             "running",

--- a/src-tauri/src/api/mobile_bridge/commands.rs
+++ b/src-tauri/src/api/mobile_bridge/commands.rs
@@ -62,6 +62,12 @@ fn validate_mobile_sidebar_sessions(
         {
             return Err("mobile sidebar workspace metadata is too long".to_string());
         }
+        if session
+            .updated_at_ms
+            .is_some_and(|ms| !(-8_640_000_000_000_000..=8_640_000_000_000_000).contains(&ms))
+        {
+            return Err("mobile sidebar timestamp is outside the supported date range".to_string());
+        }
         if session.id.trim().is_empty() {
             return Err("mobile sidebar session id cannot be empty".to_string());
         }
@@ -404,5 +410,37 @@ mod tests {
             }])
             .is_err()
         );
+    }
+
+    #[test]
+    fn sidebar_metadata_is_optional_bounded_and_part_of_snapshot_identity() {
+        let legacy: MobileSidebarSessionSnapshotRow = serde_json::from_value(serde_json::json!({
+            "id": "a", "name": "Session A", "status": "idle"
+        }))
+        .unwrap();
+        assert_eq!(
+            validate_mobile_sidebar_sessions(std::slice::from_ref(&legacy)),
+            Ok(())
+        );
+        let mut enriched = legacy.clone();
+        enriched.repo_name = Some("project".into());
+        enriched.repo_path = Some("/workspace/project".into());
+        enriched.updated_at_ms = Some(1_788_912_000_000);
+        assert_ne!(legacy, enriched);
+        assert_eq!(
+            validate_mobile_sidebar_sessions(std::slice::from_ref(&enriched)),
+            Ok(())
+        );
+        let wire = serde_json::to_value(&enriched).unwrap();
+        assert_eq!(wire["repoName"], "project");
+        assert_eq!(
+            serde_json::from_value::<MobileSidebarSessionSnapshotRow>(wire).unwrap(),
+            enriched
+        );
+        enriched.updated_at_ms = Some(i64::MAX);
+        assert!(validate_mobile_sidebar_sessions(std::slice::from_ref(&enriched)).is_err());
+        enriched.updated_at_ms = None;
+        enriched.repo_path = Some("x".repeat(4097));
+        assert!(validate_mobile_sidebar_sessions(&[enriched]).is_err());
     }
 }


### PR DESCRIPTION
## Problem

The authoritative session directory already carries workspace path/name and update time, but the Mobile Remote `session/list` projection dropped that metadata. The sidebar snapshot boundary also lacked validation proving optional metadata remains bounded and participates in snapshot equality.

## Solution

Centralize directory-row projection so `repoPath`, `repoName`, and parsed `updatedAtMs` stay on the additive mobile wire shape, and validate sidebar snapshot workspace lengths plus the JavaScript-supported timestamp range. Missing or invalid source metadata remains null; no title inference, persistence rewrite, or historical cleanup is introduced.

## Potential risks

Older clients ignore the additive fields. Invalid dates now serialize as null and out-of-range snapshot timestamps are rejected. No schema migration is required, and rollback restores the prior response projection without touching stored sessions. Account-switch behavior, steady-state CPU/RSS, and sustained reconnect behavior were not run.

## Audit

Architecture layers 1-10 were reviewed across directory ownership, the shared projection helper, optional-field naming, status filtering, wire serialization, snapshot validation, and source symmetry. No new polling, scan, listener, cache, or async writer is added; the existing snapshot remains capped at 200 rows. Performance verdict: blocked on runtime measurements.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml -p org2 --lib directory_mobile_payload_retains_authoritative_workspace_and_timestamp -- --test-threads=1` — 1 passed
- `cargo test --manifest-path src-tauri/Cargo.toml -p org2 --lib sidebar_metadata_is_optional_bounded_and_part_of_snapshot_identity -- --test-threads=1` — 1 passed
- Targeted Rust formatting check for the changed adapter and command modules — passed
- `git diff --check origin/develop..junyu/mobile-session-metadata` — passed
- Added-line secret/personal-path pattern sweep — passed
- `gitleaks` scan not run because the local executable is unavailable; the harness reports `ENOENT`
- No frontend files or new visual surface are included

