### PR TITLE
feat(mobile-remote): expose desktop identity

### DIFF
--- a/docs/org2-performance-guard-2026-09-09/MobileDesktopIdentity.md
+++ b/docs/org2-performance-guard-2026-09-09/MobileDesktopIdentity.md
@@ -1,0 +1,44 @@
+# Paired desktop identity restoration
+
+## Root cause and ownership
+
+The currently running desktop's authenticated `initialize` response omitted `desktopName` and `desktopIdentity`. The installed mobile app already supports those fields but fell back to the stable pairing identifier when neither was available. Pairing credentials were not lost or corrupted.
+
+The OS owns the display metadata. The desktop now collects native hostname, manufacturer model identifier and OS username and returns bounded optional fields through the authenticated bridge. No hardware UUID, serial number, home directory or Cloud account is collected. The Relay transports the response without new server schema or registration changes. Its `/v1/devices` labels describe phones and must not be reused as computer names.
+
+The installed mobile client's paired-desktop inventory owns cached display metadata scoped by the original pairing ID. Successful initialization enriches that existing record; reconnect and old-server responses preserve known metadata. No pairing ID, credentials, permissions or stored historical records are rewritten by this desktop patch.
+
+Dependency: the root desktop package now directly links the existing workspace `sysinfo` version for native queries; no new version is introduced. The lockfile only adds the existing dependency to the root package. Rollback removes the optional response fields, module and direct linkage; it does not require data migration.
+
+## Lifecycle contract
+
+- Successful authenticated initialization: collect native display fields off the async executor, sanitize and return additive optional metadata
+- Invalid protocol/disabled feature: retain existing rejection, without disclosing metadata
+- Missing or failed collection: initialize still works; absent data remains absent rather than fabricated
+- Reconnect: recollect native values so hostname changes can refresh without an app-lifetime cache
+- Read-only pairing: identity is readable; execution permissions are unchanged
+- Offline/scope switch: installed client retains metadata in the existing pairing-scoped inventory; no new background work
+
+Implementation scope is the current desktop plus the already-installed advanced mobile client from the relay-contract tree. Current-main mobile source consumes `desktopName` in the connection header but predates full device-inventory metadata support. Rebuilding iOS from current main would require a separate targeted consumer migration; this task does not rebuild or downgrade the phone app.
+
+## Review
+
+| Area | Verdict | Evidence | Change or reason kept | Verification |
+| --- | --- | --- | --- | --- |
+| Background work | keep | One native collection per valid initialize | No timers, scans, subprocesses or polling; off executor | sysinfo native implementation inspected |
+| Memory | keep | Three optional labels, each at most 128 characters | No new cache or retained registry | Bounds and serialization tests |
+| Scope/isolation | keep | Existing authenticated bridge and paired inventory | Original IDs/credentials unchanged; no cloud identity collection | RPC gating and installed-client scope tests |
+| Rendering/hot path | fix | Missing wire fields forced identifier fallback | Restore identity at producing boundary, not UI-only substitution | RPC contract and existing consumer tests |
+
+## Verification
+
+- Installed-client suites in relay-contract: `pnpm exec vitest run --config config/vitest.config.ts` targeting `mobileDesktopIdentity.test.ts`, `mobilePairedDesktopPresence.test.ts`, `MobileRemoteProviders.test.ts`, `tauriMobileRemotePlatform.test.ts`, `DevicesTab.test.ts`: 91 tests passed across five files
+- `cargo test -p org2 --lib api::mobile_bridge`: 101 passed, including the native initialized-response contract, metadata bounds, read-only responses and protocol rejection. Initial compilation identified a missing root-package dependency; the direct workspace linkage above fixed it
+- `git diff --check`: passed
+- No frontend files changed; post-rebase verification was scoped to the Rust producing boundary. The five previously recorded installed-client behavioral suites above passed
+- `cargo build -p org2 --bin org2`: passed with the existing large `__eh_frame` linker warning. Current-tree desktop restarted; no old desktop instance left running
+- Physical iPhone screenshot after automatic reconnect confirmed the online indicator and the native desktop hostname replaced the previous pairing UUID. Existing session workspace names remain visible. No new pairing or mobile reinstall occurred
+- The physical Devices tab model/username detail line was not captured; source/RPC contract and installed-client component/persistence suites cover those fields, but are not a substitute for that final screenshot
+- Windows/Linux native metadata and full visible/hidden CPU/RSS lifecycle not measured
+
+Performance verdict: blocked for steady-state visible/hidden lifecycle measurements. The executable build and physical connected-name display passed; no full-app performance or sustained connection-stability improvement is claimed.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5039,6 +5039,7 @@ dependencies = [
  "settings",
  "sha2",
  "shared_state",
+ "sysinfo",
  "system_services",
  "tar",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -206,6 +206,8 @@ flate2 = "1"
 tar = "0.4"
 plist = "1"
 tempfile = "3.13"
+# Authenticated mobile bridge host/model labels; reuse the workspace-pinned native queries.
+sysinfo = { workspace = true }
 
 # Shared cross-crate type definitions (Phase 1 of workspace migration).
 # See `docs/rust-backend/modularization-plan--0504.md`.

--- a/src-tauri/src/api/mobile_bridge/desktop_identity.rs
+++ b/src-tauri/src/api/mobile_bridge/desktop_identity.rs
@@ -1,0 +1,66 @@
+//! Display-only host metadata returned after the bridge authenticates a phone.
+//! Never collect hardware UUIDs, serial numbers, home paths, or Cloud accounts.
+
+use serde::Serialize;
+
+#[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct DesktopIdentity {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+}
+
+fn label(value: Option<String>) -> Option<String> {
+    let value = value?;
+    let value = value.trim();
+    if value.is_empty() || value.chars().any(char::is_control) {
+        return None;
+    }
+    Some(value.chars().take(128).collect())
+}
+
+/// One native query per successful initialize, off the async executor. This
+/// refreshes renamed hosts on reconnect without a process scan, subprocess,
+/// timer, or app-lifetime cache. Unavailable metadata is not invented.
+pub(super) fn collect() -> DesktopIdentity {
+    DesktopIdentity {
+        name: label(sysinfo::System::host_name()),
+        // Native manufacturer model identifier; do not guess a marketing name.
+        model: label(sysinfo::Product::name()),
+        username: label(std::env::var(if cfg!(windows) { "USERNAME" } else { "USER" }).ok()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_only_bounded_display_metadata() {
+        let identity = DesktopIdentity {
+            name: label(Some(" Work Mac ".into())),
+            model: label(Some("Mac14,7".into())),
+            username: label(Some("alex".into())),
+        };
+        assert_eq!(
+            serde_json::to_value(identity).unwrap(),
+            serde_json::json!({ "name": "Work Mac", "model": "Mac14,7", "username": "alex" })
+        );
+        assert_eq!(
+            serde_json::to_value(DesktopIdentity::default()).unwrap(),
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
+    fn unavailable_and_invalid_metadata_is_omitted_not_replaced_by_an_id() {
+        assert!(label(None).is_none());
+        assert!(label(Some("  ".into())).is_none());
+        assert!(label(Some("bad\nlabel".into())).is_none());
+        assert_eq!(label(Some("机".repeat(200))).unwrap().chars().count(), 128);
+    }
+}

--- a/src-tauri/src/api/mobile_bridge/mod.rs
+++ b/src-tauri/src/api/mobile_bridge/mod.rs
@@ -3,8 +3,9 @@
 pub mod adapters;
 pub mod auth;
 pub mod commands;
-pub mod org2_cloud_auth;
+mod desktop_identity;
 pub mod fanout;
+pub mod org2_cloud_auth;
 pub mod relay;
 pub mod rpc;
 pub mod ws_handler;

--- a/src-tauri/src/api/mobile_bridge/rpc.rs
+++ b/src-tauri/src/api/mobile_bridge/rpc.rs
@@ -103,7 +103,7 @@ async fn dispatch_method(
     params: &Value,
 ) -> Result<Value, RpcError> {
     match method {
-        "initialize" => handle_initialize(ctx, params),
+        "initialize" => handle_initialize(ctx, params).await,
         "session/list" => {
             require_initialized(ctx)?;
             session::session_list(params).await
@@ -197,7 +197,7 @@ fn require_full_tier(ctx: &RpcContext) -> Result<(), RpcError> {
     }
 }
 
-fn handle_initialize(ctx: &mut RpcContext, params: &Value) -> Result<Value, RpcError> {
+async fn handle_initialize(ctx: &mut RpcContext, params: &Value) -> Result<Value, RpcError> {
     if !ctx.settings.enabled {
         return Err(RpcError::feature_disabled());
     }
@@ -210,6 +210,9 @@ fn handle_initialize(ctx: &mut RpcContext, params: &Value) -> Result<Value, RpcE
         return Err(RpcError::invalid_params("unsupported protocolVersion"));
     }
 
+    let desktop_identity = tokio::task::spawn_blocking(super::desktop_identity::collect)
+        .await
+        .unwrap_or_default();
     ctx.initialized = true;
     let tier = match ctx.tier {
         MobileTier::Full => "full",
@@ -219,6 +222,8 @@ fn handle_initialize(ctx: &mut RpcContext, params: &Value) -> Result<Value, RpcE
     Ok(json!({
         "protocolVersion": 1,
         "desktopId": format!("desktop-{}", std::process::id()),
+        "desktopName": desktop_identity.name,
+        "desktopIdentity": desktop_identity,
         "orgiiVersion": env!("CARGO_PKG_VERSION"),
         "tier": tier,
         "capabilities": {
@@ -276,6 +281,15 @@ mod tests {
         });
         let response = dispatch(&mut ctx, &request).await.expect("response");
         assert!(response.get("result").is_some());
+        let expected_identity = super::super::desktop_identity::collect();
+        assert_eq!(
+            response["result"]["desktopIdentity"],
+            serde_json::to_value(&expected_identity).unwrap()
+        );
+        assert_eq!(
+            response["result"]["desktopName"],
+            serde_json::to_value(&expected_identity.name).unwrap()
+        );
         assert_eq!(
             response
                 .pointer("/result/capabilities/roundHistory")
@@ -323,6 +337,24 @@ mod tests {
             Some("read_only")
         );
         assert_eq!(ctx.tier, MobileTier::ReadOnly);
+        assert!(response["result"]["desktopIdentity"].is_object());
+    }
+
+    #[tokio::test]
+    async fn unsupported_initialize_does_not_disclose_desktop_metadata() {
+        let mut ctx = test_context(true);
+        let response = dispatch(
+            &mut ctx,
+            &json!({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": { "protocolVersion": 2 }
+            }),
+        )
+        .await
+        .expect("response");
+        assert!(response.get("result").is_none());
+        assert_eq!(response["error"]["message"], "unsupported protocolVersion");
+        assert!(!ctx.initialized);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The authenticated Mobile Remote `initialize` response exposes only a process-derived desktop ID. The installed mobile client therefore falls back to showing a pairing identifier instead of the computer's display identity, even though pairing credentials and connectivity remain valid.

## Solution

Collect bounded native hostname, product model, and OS username values after protocol validation, off the async executor, and return them as additive `desktopName` and `desktopIdentity` fields. Missing or invalid metadata is omitted, and the existing workspace-pinned `sysinfo` version is linked directly without introducing a new dependency version or persistence migration.

## Potential risks

Authenticated paired phones now receive hostname/model/username display metadata; hardware IDs, serial numbers, home paths, and cloud accounts remain excluded. Windows and Linux collection were not exercised at runtime. Rollback removes the optional fields, module, and direct dependency without touching pairing data. No new screenshot was captured in this pass, and visible/hidden CPU/RSS plus sustained reconnect behavior remain unmeasured.

## Audit

Architecture layers 1-10 were reviewed across the initialize entry point, module wiring, naming, defaults, authenticated wire payload, init parity, and fallback behavior. The performance review found one bounded `spawn_blocking` collection per valid initialize, with no timer, cache, scanner, or retained resource. Performance verdict: blocked on runtime lifecycle measurements.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml -p org2 --lib api::mobile_bridge::desktop_identity -- --test-threads=1` — 2 passed
- `cargo test --manifest-path src-tauri/Cargo.toml -p org2 --lib api::mobile_bridge::rpc::tests::initialize -- --test-threads=1` — 3 passed
- `rustfmt --edition 2021 --check src-tauri/src/api/mobile_bridge/desktop_identity.rs src-tauri/src/api/mobile_bridge/rpc.rs` — passed
- `git diff --check origin/develop..junyu/mobile-desktop-identity` — passed
- Added-line secret/personal-path pattern sweep — passed
- `node scripts/security/gitleaks.test.cjs` — blocked because the local `gitleaks` executable is not installed (`ENOENT`)

