### PR TITLE
feat(mobile-sessions): add indexed title search

### DIFF
--- a/docs/org2-performance-guard-2026-09-10/MobileSessionSearchIntegration.md
+++ b/docs/org2-performance-guard-2026-09-10/MobileSessionSearchIntegration.md
@@ -1,0 +1,45 @@
+# Mobile session search integration
+
+## Contract and ownership
+
+The running desktop checkout lacked the mobile search implementation present in the mobile feature checkout. `initialize` now advertises `sessionSearch` together with an implemented `session/list(query, offset, limit)` path. No-query listing is unchanged. Search reads the existing `orgtrack_core_sessions` title index, hydrates through the same native/imported-history directory boundary, and returns existing mobile row projection plus `nextOffset`/`hasMore`. No schema, credentials, pairing, history writes or historical cleanup are needed.
+
+Mobile owns transient query intent and the existing latest-only request generation. Desktop owns the authoritative indexed records. Search is literal substring matching (SQLite lower for ASCII case folding), not full-message search or an external-history rescan. Source providers retain their existing ingestion/visibility rules.
+
+## State and verification matrix
+
+| State / transition | Contract | Evidence |
+| --- | --- | --- |
+| Old desktop / unavailable | Show unsupported warning and Cancel; do not claim indexed search scope | SessionsScreen.features regression |
+| Initialize / supported | Capability corresponds to a real implementation behind initialized connection | RPC initialize and read-only validation tests |
+| Query / loading / results | Query database before pagination, not the loaded sidebar snapshot | SQL fixture finds row 151 with page size 50; request path bypasses snapshot |
+| Empty / terminal page | Return explicit empty rows and cursor/exhaustion | SQL exhausted-page and hydration-page tests |
+| Hidden or deleted result | Cursor consumes candidate rows even if hydration drops them; lookahead is not hydrated | Hydration cursor regression |
+| Invalid query / cursor | Reject before database access; cursor stays JavaScript-safe | Real RPC dispatcher tests |
+| Database failure | Propagate failure, do not report empty success | Hydration failure regression |
+| Cancel / retry / switch / offline | Retain existing mobile generation and latest-only scheduler policies | 21 useMobileSessionSearch tests plus 18 screen tests |
+| Desktop restart / phone reconnect | Negotiate new capability and exercise real phone search | After approved restart, iPhone 17 Pro simulator automatically reconnected; the real search field opened and `chat` returned matching history including August entries |
+
+## Performance guard
+
+| Area | Verdict | Evidence | Change or reason kept | Verification |
+| --- | --- | --- | --- | --- |
+| Background work | keep | Search runs only on explicit requests, within spawn_blocking | No new timer, subscription, history scan or background task | Call-chain review; mobile lifecycle tests |
+| Memory | keep | SQL LIMIT page size + 1; request maximum 200; only page rows hydrated | No cache or app-lifetime collection added | SQL page-size test; lookahead hydration test |
+| Scope/isolation | keep | Same paired desktop/database and existing auth initialization gate | No new identity, credentials or storage scope | RPC initialize/read-only tests; mobile switch/stale-result coverage |
+| Rendering/hot path | keep | Existing response validation and generation guard | Unsupported scope text follows capability; no per-stream work | Screen tests; typecheck |
+
+Performance verdict: blocked for remaining measurement only. Restart recovery and real search response are now verified through the simulator's user-visible UI. Physical-phone latency and hidden-idle CPU were not measured. Query uses a bounded result set but substring matching may scan eligible indexed titles; no latency improvement is claimed. Offset ordering is stable for equal timestamps, but concurrent index mutations can move rows between pages as with ordinary offset pagination.
+
+## Architecture review
+
+Layers 1–10 considered within the search integration only: compilation; one shared hydration boundary rather than duplicated converters; explicit name-search naming; distinction between indexed history and sidebar snapshot; absent query preserves existing behavior; directory access stays in aggregation; request path documented; additive capability/query/cursor contract; LAN/Relay both dispatch through initialize; list and search reuse the same field hydration/projection. No unrelated queue, provider-ingestion, session-startup or schema refactors. Raw-provider transition and dual-machine sync tests are outside this read-only search change and are not claimed.
+
+## Checks
+
+- `cargo test --lib agent_sessions::session_directory::aggregation -- --test-threads=1`
+- `cargo test --lib api::mobile_bridge::rpc -- --test-threads=1`
+- `cargo build --bin org2` (existing macOS linker unwind-size warning)
+- Mobile checkout: targeted screen/search-hook tests, `pnpm typecheck:fast`, scoped ESLint, `pnpm build:mobile-native`, `git diff --check`
+
+Rollback removes the additive desktop search integration and leaves old clients/listing intact; mobile detects the absent capability. No persisted migration or data rollback is required. Do not replace the modern desktop with the older feature checkout just to enable search.

--- a/src-tauri/src/agent_sessions/session_directory/aggregation.rs
+++ b/src-tauri/src/agent_sessions/session_directory/aggregation.rs
@@ -25,6 +25,7 @@ mod merge;
 mod native_page;
 mod native_sidebar;
 mod pagination;
+mod search;
 mod sorting;
 #[cfg(test)]
 mod test_support;
@@ -32,3 +33,4 @@ mod test_support;
 pub use external_history::resync_external_history_source;
 pub use merge::list_all_sessions;
 pub use native_sidebar::{list_native_sidebar_sessions, NATIVE_SIDEBAR_PAGE_MAX_LIMIT};
+pub use search::search_session_names;

--- a/src-tauri/src/agent_sessions/session_directory/aggregation/native_page.rs
+++ b/src-tauri/src/agent_sessions/session_directory/aggregation/native_page.rs
@@ -253,48 +253,8 @@ fn plain_directory_page(
             if sessions.len() >= limit {
                 break;
             }
-            match source.as_str() {
-                s if s == orgtrack_core::canonical::SOURCE_ORGII_CLI_SESSIONS => {
-                    if let Some(session) = cli_session_persistence::get_session(&session_id)
-                        .map_err(|err| format!("hydrate cli session: {err}"))?
-                    {
-                        sessions.push(cli_session_to_aggregate_record(session));
-                    }
-                }
-                s if s == orgtrack_core::canonical::SOURCE_ORGII_RUST_AGENTS => {
-                    let Some(record) = session_persistence::get_session(&session_id)
-                        .map_err(|err| format!("hydrate agent session: {err}"))?
-                    else {
-                        continue;
-                    };
-                    match record.session_type.as_str() {
-                        t if t == session_type::CODING || t == session_type::ORG_MEMBER => {
-                            sessions.push(sde_session_to_aggregate_record(record, &mut resolver));
-                        }
-                        t if t == session_type::DESKTOP => {
-                            sessions.push(os_session_to_aggregate_record(record, &mut resolver));
-                        }
-                        t if t == session_type::HUMAN => {
-                            sessions.push(human_session_to_aggregate_record(record));
-                        }
-                        // Gateway/subagent/custom sessions are infrastructure
-                        // the merge path never lists either.
-                        _ => continue,
-                    }
-                }
-                _ => {
-                    if let Some((cached_source, session)) =
-                        imported_history_cache::query_cached_session_by_session_id_from_conn(
-                            &conn,
-                            &session_id,
-                        )?
-                    {
-                        sessions.push(imported_history_to_aggregate_record(
-                            session.to_row(),
-                            &cached_source,
-                        ));
-                    }
-                }
+            if let Some(row) = hydrate_directory_row(&conn, &session_id, &source, &mut resolver)? {
+                sessions.push(row);
             }
         }
 
@@ -307,6 +267,45 @@ fn plain_directory_page(
     annotate_agent_org_root_rows(&mut sessions)?;
     apply_sorting(&mut sessions, Some(filter));
     Ok(Some(SessionListResponse { sessions }))
+}
+
+/// One hydration boundary shared by the directory and name-search pages.
+pub(super) fn hydrate_directory_row(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+    source: &str,
+    resolver: &mut AgentMetadataResolver,
+) -> Result<Option<SessionAggregateRecord>, String> {
+    Ok(match source {
+        s if s == orgtrack_core::canonical::SOURCE_ORGII_CLI_SESSIONS => {
+            cli_session_persistence::get_session(session_id)
+                .map_err(|err| err.to_string())?
+                .map(cli_session_to_aggregate_record)
+        }
+        s if s == orgtrack_core::canonical::SOURCE_ORGII_RUST_AGENTS => {
+            let Some(record) =
+                session_persistence::get_session(session_id).map_err(|err| err.to_string())?
+            else {
+                return Ok(None);
+            };
+            match record.session_type.as_str() {
+                t if t == session_type::CODING || t == session_type::ORG_MEMBER => {
+                    Some(sde_session_to_aggregate_record(record, resolver))
+                }
+                t if t == session_type::DESKTOP => {
+                    Some(os_session_to_aggregate_record(record, resolver))
+                }
+                t if t == session_type::HUMAN => Some(human_session_to_aggregate_record(record)),
+                _ => None,
+            }
+        }
+        _ => {
+            imported_history_cache::query_cached_session_by_session_id_from_conn(conn, session_id)?
+                .map(|(cached_source, session)| {
+                    imported_history_to_aggregate_record(session.to_row(), &cached_source)
+                })
+        }
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agent_sessions/session_directory/aggregation/search.rs
+++ b/src-tauri/src/agent_sessions/session_directory/aggregation/search.rs
@@ -1,0 +1,163 @@
+//! Demand-driven name search over the Desktop's indexed directory, not its
+//! currently rendered sidebar. The cursor counts source rows, including rows
+//! removed while hydrating, so a missing/hidden row cannot repeat a page.
+
+use database::db::get_connection;
+use rusqlite::{params_from_iter, types::Value, Connection};
+
+use super::external_history::EXTERNAL_HISTORY_SOURCE_LOADERS;
+use super::native_page::hydrate_directory_row;
+use crate::agent_sessions::session_directory::conversion::AgentMetadataResolver;
+use crate::agent_sessions::session_directory::types::SessionAggregateRecord;
+
+pub struct SessionNameSearchPage {
+    pub sessions: Vec<SessionAggregateRecord>,
+    pub next_offset: usize,
+    pub has_more: bool,
+}
+
+fn candidates(
+    conn: &Connection,
+    query: &str,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<(String, String)>, String> {
+    let sources = [
+        orgtrack_core::canonical::SOURCE_ORGII_CLI_SESSIONS,
+        orgtrack_core::canonical::SOURCE_ORGII_RUST_AGENTS,
+    ]
+    .into_iter()
+    .chain(
+        EXTERNAL_HISTORY_SOURCE_LOADERS
+            .iter()
+            .map(|loader| loader.source),
+    );
+    let mut values = sources
+        .map(|source| Value::Text(source.to_string()))
+        .collect::<Vec<_>>();
+    let placeholders = vec!["?"; values.len()].join(",");
+    // instr treats %, _ and backslashes literally. Query values never become SQL.
+    let sql = format!(
+        "SELECT session_id, source FROM orgtrack_core_sessions
+        WHERE source IN ({placeholders}) AND instr(lower(title), lower(?)) > 0
+        ORDER BY updated_at DESC, session_id ASC LIMIT ? OFFSET ?"
+    );
+    values.extend([
+        Value::Text(query.to_string()),
+        Value::Integer((limit + 1) as i64),
+        Value::Integer(offset as i64),
+    ]);
+    let mut statement = conn.prepare(&sql).map_err(|err| err.to_string())?;
+    let rows = statement
+        .query_map(params_from_iter(values), |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .map_err(|err| err.to_string())?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|err| err.to_string())
+}
+
+pub fn search_session_names(
+    query: &str,
+    limit: usize,
+    offset: usize,
+) -> Result<SessionNameSearchPage, String> {
+    let limit = limit.clamp(1, 200);
+    let offset = offset.min(i64::MAX as usize - 201);
+    let conn = get_connection().map_err(|err| err.to_string())?;
+    let rows = candidates(&conn, query, limit, offset)?;
+    let mut resolver = AgentMetadataResolver::new();
+    hydrate_page(rows, limit, offset, |id, source| {
+        hydrate_directory_row(&conn, id, source, &mut resolver)
+    })
+}
+
+fn hydrate_page(
+    rows: Vec<(String, String)>,
+    limit: usize,
+    offset: usize,
+    mut hydrate: impl FnMut(&str, &str) -> Result<Option<SessionAggregateRecord>, String>,
+) -> Result<SessionNameSearchPage, String> {
+    let has_more = rows.len() > limit;
+    let consumed = rows.len().min(limit);
+    let mut sessions = Vec::with_capacity(consumed);
+    for (id, source) in rows.into_iter().take(limit) {
+        if let Some(row) = hydrate(&id, &source)? {
+            sessions.push(row);
+        }
+    }
+    Ok(SessionNameSearchPage {
+        sessions,
+        next_offset: offset + consumed,
+        has_more,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn search_cursor_consumes_missing_rows_without_hydrating_lookahead() {
+        let rows = (0..3)
+            .map(|n| (n.to_string(), "source".to_string()))
+            .collect();
+        let mut calls = 0;
+        let page = hydrate_page(rows, 2, 50, |_, _| {
+            calls += 1;
+            Ok(None)
+        })
+        .unwrap();
+        assert_eq!(calls, 2);
+        assert!(page.sessions.is_empty());
+        assert_eq!(page.next_offset, 52);
+        assert!(page.has_more);
+        let empty =
+            hydrate_page(vec![], 2, 52, |_, _| panic!("empty page must not hydrate")).unwrap();
+        assert_eq!(empty.next_offset, 52);
+        assert!(!empty.has_more);
+    }
+
+    #[test]
+    fn search_hydration_failure_is_not_reported_as_empty_success() {
+        let page = hydrate_page(vec![("id".into(), "source".into())], 2, 0, |_, _| {
+            Err("read failure".into())
+        });
+        assert_eq!(page.err().as_deref(), Some("read failure"));
+    }
+
+    #[test]
+    fn searches_history_before_paging_with_literal_queries_and_stable_ties() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("CREATE TABLE orgtrack_core_sessions (session_id TEXT, source TEXT, title TEXT, updated_at TEXT)").unwrap();
+        for i in 0..151 {
+            conn.execute(
+                "INSERT INTO orgtrack_core_sessions VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![
+                    format!("s-{i:03}"),
+                    orgtrack_core::canonical::SOURCE_ORGII_CLI_SESSIONS,
+                    if i == 150 {
+                        "old 认证_100%"
+                    } else {
+                        "ordinary"
+                    },
+                    "2026-09-08"
+                ],
+            )
+            .unwrap();
+        }
+        assert_eq!(candidates(&conn, "认证_100%", 50, 0).unwrap()[0].0, "s-150");
+        assert!(candidates(&conn, "' OR 1=1 --", 50, 0).unwrap().is_empty());
+        assert_eq!(candidates(&conn, "ORDINARY", 50, 0).unwrap().len(), 51);
+        assert_eq!(candidates(&conn, "ordinary", 50, 50).unwrap()[0].0, "s-050");
+        assert_eq!(candidates(&conn, "ordinary", 50, 100).unwrap().len(), 50);
+        assert!(candidates(&conn, "ordinary", 50, 150).unwrap().is_empty());
+        conn.execute("INSERT INTO orgtrack_core_sessions VALUES ('foreign', 'unrelated-source', 'ordinary', '9999')", []).unwrap();
+        assert_eq!(candidates(&conn, "ordinary", 200, 0).unwrap().len(), 150);
+        assert_eq!(
+            conn.query_row("SELECT count(*) FROM orgtrack_core_sessions", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            152
+        );
+    }
+}

--- a/src-tauri/src/api/mobile_bridge/adapters/session.rs
+++ b/src-tauri/src/api/mobile_bridge/adapters/session.rs
@@ -359,7 +359,22 @@ pub fn parse_session_round_params(params: &Value) -> Result<SessionRoundParams, 
 
 /// List sessions from the cross-backend directory, mapped to the mobile wire shape.
 pub async fn session_list(params: &Value) -> Result<Value, RpcError> {
-    let offset = params.get("offset").and_then(Value::as_u64).unwrap_or(0) as usize;
+    let query = parse_session_search_query(params)?;
+    let offset = if query.is_some() {
+        // Leave room for one page while keeping the response cursor exactly
+        // representable by JavaScript clients.
+        match params.get("offset") {
+            None => 0,
+            Some(value) => value
+                .as_u64()
+                .filter(|offset| *offset <= 9_007_199_254_740_991 - 200)
+                .ok_or_else(|| {
+                    RpcError::invalid_params("offset must be a non-negative safe page cursor")
+                })? as usize,
+        }
+    } else {
+        params.get("offset").and_then(Value::as_u64).unwrap_or(0) as usize
+    };
     let limit = params
         .get("limit")
         .and_then(|value| value.as_u64())
@@ -377,9 +392,31 @@ pub async fn session_list(params: &Value) -> Result<Value, RpcError> {
         ));
     }
 
-    if let Some(snapshot) = current_mobile_sidebar_sessions()
-        .map_err(|err| RpcError::new(RpcErrorCode::InvalidRequest, err))?
-    {
+    let search_page = if let Some(query) = query {
+        Some(
+            tokio::task::spawn_blocking(move || {
+                crate::agent_sessions::session_directory::aggregation::search_session_names(
+                    &query, limit, offset,
+                )
+            })
+            .await
+            .map_err(|err| {
+                RpcError::new(RpcErrorCode::InvalidRequest, format!("task join: {err}"))
+            })?
+            .map_err(|err| RpcError::new(RpcErrorCode::InvalidRequest, err))?,
+        )
+    } else {
+        None
+    };
+
+    // The sidebar only contains loaded rows. Search must use the indexed
+    // directory even when a sidebar snapshot is available.
+    if let Some(snapshot) = if search_page.is_none() {
+        current_mobile_sidebar_sessions()
+            .map_err(|err| RpcError::new(RpcErrorCode::InvalidRequest, err))?
+    } else {
+        None
+    } {
         let candidate_ids = snapshot
             .iter()
             .filter(|session| status_filter != "running" || session.status == "running")
@@ -413,14 +450,20 @@ pub async fn session_list(params: &Value) -> Result<Value, RpcError> {
         ..Default::default()
     };
 
-    let response = tokio::task::spawn_blocking(move || list_all_sessions(Some(&filter)))
-        .await
-        .map_err(|err| RpcError::new(RpcErrorCode::InvalidRequest, format!("task join: {err}")))?
-        .map_err(|err| RpcError::new(RpcErrorCode::InvalidRequest, err))?;
+    let (source_sessions, cursor) = if let Some(page) = search_page {
+        (page.sessions, Some((page.next_offset, page.has_more)))
+    } else {
+        let response = tokio::task::spawn_blocking(move || list_all_sessions(Some(&filter)))
+            .await
+            .map_err(|err| {
+                RpcError::new(RpcErrorCode::InvalidRequest, format!("task join: {err}"))
+            })?
+            .map_err(|err| RpcError::new(RpcErrorCode::InvalidRequest, err))?;
+        (response.sessions, None)
+    };
 
-    let consumed = response.sessions.len();
-    let session_rows = response
-        .sessions
+    let consumed = source_sessions.len();
+    let session_rows = source_sessions
         .into_iter()
         .filter(|record| is_mobile_list_category(record.category))
         .filter(|record| {
@@ -454,9 +497,31 @@ pub async fn session_list(params: &Value) -> Result<Value, RpcError> {
         })
         .collect::<Vec<_>>();
 
-    Ok(
-        json!({ "sessions": sessions, "nextOffset": offset.saturating_add(consumed), "hasMore": consumed == limit }),
-    )
+    let mut result = json!({ "sessions": sessions });
+    if let Some((next_offset, has_more)) = cursor {
+        result["nextOffset"] = json!(next_offset);
+        result["hasMore"] = json!(has_more);
+    } else {
+        result["nextOffset"] = json!(offset.saturating_add(consumed));
+        result["hasMore"] = json!(consumed == limit);
+    }
+    Ok(result)
+}
+
+fn parse_session_search_query(params: &Value) -> Result<Option<String>, RpcError> {
+    let Some(query) = params.get("query") else {
+        return Ok(None);
+    };
+    let query = query
+        .as_str()
+        .ok_or_else(|| RpcError::invalid_params("query must be a string"))?
+        .trim();
+    if query.is_empty() || query.chars().count() > 200 {
+        return Err(RpcError::invalid_params(
+            "query must contain 1 to 200 characters",
+        ));
+    }
+    Ok(Some(query.to_owned()))
 }
 
 /// Submit a user message from mobile — enqueues a turn and returns immediately.

--- a/src-tauri/src/api/mobile_bridge/rpc.rs
+++ b/src-tauri/src/api/mobile_bridge/rpc.rs
@@ -227,6 +227,7 @@ fn handle_initialize(ctx: &mut RpcContext, params: &Value) -> Result<Value, RpcE
             "roundHistory": true,
             "openSessionFile": true,
             "modelSelection": true,
+            "sessionSearch": true,
         }
     }))
 }
@@ -288,7 +289,40 @@ mod tests {
                 .and_then(Value::as_bool),
             Some(true)
         );
+        assert_eq!(response["result"]["capabilities"]["sessionSearch"], true);
         assert!(ctx.initialized);
+    }
+
+    #[tokio::test]
+    async fn session_search_validates_query_for_read_only_clients() {
+        let mut ctx = test_context(true);
+        ctx.initialized = true;
+        ctx.tier = MobileTier::ReadOnly;
+        for query in [json!(null), json!(123), json!(" "), json!("x".repeat(201))] {
+            let response = dispatch(
+                &mut ctx,
+                &json!({
+                    "jsonrpc": "2.0", "id": 30, "method": "session/list",
+                    "params": {"query": query}
+                }),
+            )
+            .await
+            .unwrap();
+            // Read-only search reaches input validation, not write-tier denial.
+            assert_eq!(response["error"]["code"], -32602);
+        }
+        for offset in [json!(-1), json!(1.5), json!("50"), json!(u64::MAX)] {
+            let response = dispatch(
+                &mut ctx,
+                &json!({
+                    "jsonrpc": "2.0", "id": 31, "method": "session/list",
+                    "params": {"query": "history", "offset": offset}
+                }),
+            )
+            .await
+            .unwrap();
+            assert_eq!(response["error"]["code"], -32602);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Mobile title search cannot use the desktop sidebar snapshot because that snapshot contains only currently loaded rows. Falling back to the existing aggregate list would search after pagination or materialize broader history, producing incomplete or unnecessarily expensive results.

## Solution

Add explicit bounded `query` support to `session/list`, search the indexed session directory before pagination, hydrate only the selected page through the shared directory-row boundary, and return a stable source-row cursor. Search bypasses the loaded-sidebar snapshot and runs blocking SQLite work through `spawn_blocking`; ordinary list behavior is unchanged. The `sessionSearch` capability advertises the additive contract.

## Potential risks

Case-insensitive substring matching can scan eligible indexed titles, and offset pagination can shift under concurrent index mutation. Query length, page size, and JavaScript-safe offsets are bounded, but no latency benchmark or hidden-idle measurement was performed. The prerequisite `junyu/mobile-session-metadata` PR is merged and this PR now targets `develop`; older clients simply omit `query`.

## Audit

Architecture layers 1-10 were reviewed across capability naming, directory/search ownership, hydration deduplication, explicit default branches, wire cursors, and list/search symmetry. The performance path is demand-driven, capped at 200 rows plus one lookahead, holds no app-lifetime cache, and performs no background scan or timer. Performance verdict: blocked on real-data latency and runtime measurement.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml -p org2 --lib agent_sessions::session_directory::aggregation::search -- --test-threads=1` — 3 passed
- `cargo test --manifest-path src-tauri/Cargo.toml -p org2 --lib session_search_validates_query_for_read_only_clients -- --test-threads=1` — 1 passed
- Targeted `rustfmt --check` for search, aggregation, adapter, and RPC files — passed
- `git diff --check junyu/mobile-session-metadata..junyu/mobile-session-search` — passed
- Added-line secret/personal-path pattern sweep — passed
- `gitleaks` scan not run because the local executable is unavailable; the harness reports `ENOENT`
- No frontend files or new visual surface are included

