### PR TITLE
fix(mobile-sidebar): publish canonical desktop roster

### DIFF
--- a/docs/org2-performance-guard-2026-09-10/MobileSidebarSync.md
+++ b/docs/org2-performance-guard-2026-09-10/MobileSidebarSync.md
@@ -1,0 +1,76 @@
+# Desktop/mobile sidebar synchronization
+
+## Cause and authoritative boundary
+
+The desktop connector renders the authoritative local/My Sessions projection,
+including locally backed pinned rows. The existing
+`mobile_remote_sync_sidebar_sessions` command had no production frontend caller.
+Consequently `session/list` used its database aggregation fallback instead of the
+desktop's scope, resolved labels, and loaded ordering. Those extra history rows
+are real stored records, not data to delete or hide by title pattern.
+
+The connector now publishes its final `sessionMenuItems` intersected with its
+session map. The existing Rust command validates and atomically replaces the
+snapshot, then emits `session/list_changed`. Mobile reads and replaces its roster;
+search remains an independent full-history query. No persisted history is edited.
+
+## Lifecycle and limits
+
+- Changes coalesce for 100 ms, with one in-flight IPC and one pending snapshot.
+- Identical snapshots produce no new IPC; one failure retry is bounded to 1 second.
+  Focus/online or later changes recover after the retry budget is exhausted.
+- Refresh within one scope retains successful data. Identity/org changes clear
+  the previous projection before replacement; unmount clears the backend snapshot.
+- Publishing continues when the desktop is backgrounded: a paired phone needs
+  current session state even when the desktop window is not foreground. No polling
+  or visibility-triggered scanner is introduced.
+- The existing backend contract caps snapshots at 200 rows. Desktop preserves the
+  first 200 projected rows; mobile explicitly requests 200 so older backends do
+  not silently return only their default 50. Cloud-only team rows and drafts have
+  no backing local session and remain outside this local-control contract.
+- A newly mounted publisher compares its pending scope with the last completed
+  publication, so an old in-flight completion is cleared before replacement.
+- Mobile invalidation uses one active read and one trailing refresh flag. Old
+  generations cannot overwrite a new connection/reset. Empty snapshots replace
+  old data; only explicit pagination appends.
+
+| Area | Verdict | Evidence | Change or reason | Verification |
+| --- | --- | --- | --- | --- |
+| Producer ownership | fix | Existing command had no production caller | Wire final connector projection to existing command | Hook tests inspect ordered IPC payloads; connector call inspected |
+| Idle work | fix | New publisher needs bounded lifecycle | No periodic timer; dedupe, coalescing, one retry | Fake-timer idle and failure tests |
+| Retained state | keep with reason | Phone needs a desktop process snapshot | Existing 200-row backend limit; one pending/in-flight snapshot | Projection bound and remount tests |
+| Request overlap | fix | Every mobile notification previously launched a read | Single-flight plus trailing invalidation | Provider notification burst tests |
+| Scope | fix | Previous rows must not survive org/account owner changes | Serialized clear/replacement, completed-scope check, and generation guards | Scope switch, in-flight remount, unmount, reset tests |
+| Runtime performance | unverified | Active app changed during validation | Do not infer CPU/RSS improvement from unit tests | Visible/hidden steady-state sampling not completed |
+
+## Architecture review coverage
+
+Compilation is covered by scoped lint/typecheck results reported at delivery.
+Call-chain/dead-code review found and connected the unused production API (layer
+2). Naming distinguishes roster from history search (3–4); fallback and empty
+snapshot semantics are preserved (5). Local projection policy stays in the
+desktop connector, transport remains generic (6–7). Existing wire fields and
+200-row limits were inspected with hook payload/consumer fixtures (8). Initial
+mount, refresh, reconnect, and unmount are covered separately (9). Row title,
+order, status, and workspace use the same canonical projection (10). No protocol
+schema, provider ingestion, database migration, or turn-state-machine rewrite is
+included.
+
+## Remaining runtime gate
+
+During verification the development Desktop process had exited, while the
+installed `/Applications/ORG2.app` instance was running. The simulator showed
+reconnecting. The user authorized a restart; the installed instance exited and
+the development instance started alone. Its health endpoint returned `ok` and
+the workstation accessibility tree loaded the current local session titles.
+A subsequent simulator screenshot still showed reconnecting, so runtime paired
+list verification and the performance verdict remain **blocked**, not passed.
+
+Earlier validation recorded 7 desktop mounted-hook tests and 69 mobile
+list/provider tests passing. In the post-rebase split, 8 desktop hook tests,
+targeted ESLint, whitespace checks, and desktop whole-project TypeScript check
+all passed. The final rebase added only the develop security baseline files.
+
+No historical remediation is necessary: no user sessions or pairing data were
+deleted. Rollback is to remove the connector publisher call and the scoped mobile
+request coordinator; persisted data and the existing protocol remain unchanged.

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -51,6 +51,7 @@ import { useWorkstationSidebarSelectionAndCollapse } from "./sidebarConnector.se
 import { useWorkstationSidebarSessionInteractionHandlers } from "./sidebarConnector.sessionInteractionHandlers";
 import { useSidebarSessionRefreshAction } from "./sidebarSessionRefresh";
 import type { SessionSidebarView } from "./types";
+import { useMobileSidebarSessions } from "./useMobileSidebarSessions";
 import { useSessionSidebarOrdering } from "./useSessionSidebarOrdering";
 import { useSessionSidebarRowActions } from "./useSessionSidebarRowActions";
 import { useSidebarStationNavigation } from "./useSidebarStationNavigation";
@@ -460,6 +461,14 @@ export const WorkstationSidebarConnector: React.FC = () => {
     cloudSessionMenuItems,
     sessionSidebarMenuItems,
     cloudMySessionsVisibleCount,
+  });
+
+  useMobileSidebarSessions({
+    scope: activeOrgId,
+    loading: sessionsLoading || orgSelectorLoading,
+    items: sessionMenuItems,
+    sessionMap,
+    repoPathToName,
   });
 
   const workItems = useWorkItemsSidebarSurface({

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/mobileSidebarPublisher.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/mobileSidebarPublisher.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+import { createMobileSidebarPublisher } from "./mobileSidebarPublisher";
+
+afterEach(() => vi.useRealTimers());
+
+it("bounds publication retries and stops scheduling after repeated rejection", async () => {
+  vi.useFakeTimers();
+  const error = new Error("IPC unavailable");
+  const publish = vi.fn().mockRejectedValue(error);
+  const onError = vi.fn();
+  const publisher = createMobileSidebarPublisher(publish, onError);
+  publisher.update(publisher.acquire(), "local", []);
+
+  await vi.runAllTimersAsync();
+
+  expect(publish).toHaveBeenCalledTimes(2);
+  expect(onError).toHaveBeenCalledTimes(2);
+  expect(onError).toHaveBeenCalledWith(error);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("handles a rejection escaping the scheduled flush", async () => {
+  vi.useFakeTimers();
+  const reportError = new Error("report failed");
+  const onError = vi.fn().mockImplementationOnce(() => {
+    throw reportError;
+  });
+  const publisher = createMobileSidebarPublisher(
+    vi.fn().mockRejectedValue(new Error("IPC unavailable")),
+    onError
+  );
+  publisher.update(publisher.acquire(), "local", []);
+
+  await vi.runAllTimersAsync();
+
+  expect(onError).toHaveBeenLastCalledWith(reportError);
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/mobileSidebarPublisher.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/mobileSidebarPublisher.ts
@@ -1,0 +1,102 @@
+import type { MobileSidebarSessionSnapshotRow } from "@src/api/tauri/mobileRemote";
+
+type Snapshot = readonly MobileSidebarSessionSnapshotRow[];
+interface Publication {
+  scope: string;
+  rows: Snapshot;
+  signature: string;
+}
+
+/** One in-flight IPC and one replaceable pending snapshot, including across remounts. */
+export function createMobileSidebarPublisher(
+  publish: (rows: Snapshot) => Promise<unknown>,
+  onError: (error: unknown) => void
+) {
+  let owner: symbol | null = null;
+  let latest: Publication | null = null;
+  let pending: Publication | null = null;
+  let published = "";
+  let publishedScope = "";
+  let inFlight = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let retries = 0;
+  let clearRequired = false;
+
+  const schedule = (delay: number) => {
+    if (timer !== undefined || inFlight) return;
+    timer = setTimeout(() => {
+      timer = undefined;
+      void flush();
+    }, delay);
+  };
+  const flush = async () => {
+    if (inFlight || !pending) return;
+    const next = pending;
+    pending = null;
+    if (next.signature === published) return;
+    if (publishedScope && next.scope !== publishedScope) clearRequired = true;
+    inFlight = true;
+    try {
+      if (clearRequired) {
+        clearRequired = false;
+        await publish([]);
+        published = "";
+        publishedScope = "";
+        if (latest !== next) return;
+      }
+      await publish(next.rows);
+      published = next.signature;
+      publishedScope = next.scope;
+      retries = 0;
+    } catch (error) {
+      onError(error);
+      clearRequired = true;
+      // One bounded retry. Subsequent changes/focus can recover; no idle poll loop.
+      const stillCurrent =
+        latest === next || (owner === null && next.signature === "released");
+      if (!pending && stillCurrent && retries < 1) {
+        retries += 1;
+        pending = next;
+      }
+    } finally {
+      inFlight = false;
+      if (pending) schedule(retries ? 1000 : 0);
+    }
+  };
+
+  return {
+    acquire() {
+      owner = Symbol("desktop-sidebar-publisher");
+      return owner;
+    },
+    update(token: symbol, scope: string, rows: Snapshot) {
+      if (token !== owner) return;
+      const signature = JSON.stringify([scope, rows]);
+      if (signature === latest?.signature) return;
+      if (latest && latest.scope !== scope) clearRequired = true;
+      latest = { scope, rows, signature };
+      pending = latest;
+      retries = 0;
+      schedule(100);
+    },
+    revalidate(token: symbol) {
+      if (token !== owner || !latest) return;
+      published = "";
+      pending = latest;
+      retries = 0;
+      schedule(0);
+    },
+    release(token: symbol) {
+      if (token !== owner) return;
+      owner = null;
+      if (timer !== undefined) clearTimeout(timer);
+      timer = undefined;
+      latest = null;
+      clearRequired = false;
+      // Do not leave a previous account/org's rows in the backend snapshot.
+      pending = { scope: "", rows: [], signature: "released" };
+      retries = 0;
+      schedule(0);
+    },
+  };
+}

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/mobileSidebarPublisher.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/mobileSidebarPublisher.ts
@@ -26,7 +26,7 @@ export function createMobileSidebarPublisher(
     if (timer !== undefined || inFlight) return;
     timer = setTimeout(() => {
       timer = undefined;
-      void flush();
+      void flush().catch(onError);
     }, delay);
   };
   const flush = async () => {

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useMobileSidebarSessions.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useMobileSidebarSessions.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
+import type { Session } from "@src/store/session";
+
+import { useMobileSidebarSessions } from "./useMobileSidebarSessions";
+
+const mocks = vi.hoisted(() => ({ publish: vi.fn() }));
+vi.mock("@src/api/tauri/mobileRemote", () => ({
+  syncSidebarSessions: mocks.publish,
+}));
+vi.mock("@src/features/Org2Cloud/org2CloudAuthAtom", async () => {
+  const { atom } = await import("jotai");
+  return {
+    org2CloudAuthAtom: atom(null),
+    org2CloudAuthIdentityKey: () => "identity",
+  };
+});
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ warn: vi.fn() }),
+}));
+
+const session = (id: string, extra: Partial<Session> = {}): Session => ({
+  session_id: id,
+  name: `Stored ${id}`,
+  status: "completed",
+  created_at: "2026-09-09T00:00:00Z",
+  updated_at: "2026-09-10T00:00:00Z",
+  repoPath: "/workspace/project/",
+  ...extra,
+});
+const item = (id: string): NavigationMenuItem => ({
+  id,
+  key: id,
+  label: `Desktop ${id}`,
+});
+type Params = Parameters<typeof useMobileSidebarSessions>[0];
+function Harness(props: Params) {
+  useMobileSidebarSessions(props);
+  return null;
+}
+
+describe("desktop connector's mobile sidebar publisher hook", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let props: Params;
+  const render = async (patch: Partial<Params> = {}) => {
+    props = { ...props, ...patch };
+    await act(async () => root.render(createElement(Harness, props)));
+  };
+  const flush = async (ms = 100) => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  };
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.useFakeTimers();
+    mocks.publish.mockReset().mockResolvedValue(true);
+    container = document.createElement("div");
+    root = createRoot(container);
+    props = {
+      scope: "org-a",
+      loading: false,
+      items: [item("pin"), item("local")],
+      sessionMap: new Map([
+        ["pin", session("pin", { pinned: true })],
+        ["local", session("local")],
+      ]),
+      repoPathToName: new Map([["/workspace/project", "Project"]]),
+    };
+  });
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    await flush(2000);
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("publishes final desktop order/titles, pinned/local rows and workspace/status metadata only", async () => {
+    await render({
+      items: [
+        item("separator"),
+        item("pin"),
+        item("cloud-remote"),
+        item("local"),
+        item("draft"),
+        item("pin"),
+      ],
+      sessionMap: new Map([
+        ["pin", session("pin", { pinned: true, status: "waiting_for_user" })],
+        ["local", session("local")],
+        ["not-rendered", session("not-rendered")],
+      ]),
+    });
+    await flush();
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    expect(mocks.publish.mock.calls[0][0]).toEqual([
+      {
+        id: "pin",
+        name: "Desktop pin",
+        status: "running",
+        repoPath: "/workspace/project",
+        repoName: "Project",
+        updatedAtMs: Date.parse("2026-09-10T00:00:00Z"),
+      },
+      {
+        id: "local",
+        name: "Desktop local",
+        status: "idle",
+        repoPath: "/workspace/project",
+        repoName: "Project",
+        updatedAtMs: Date.parse("2026-09-10T00:00:00Z"),
+      },
+    ]);
+  });
+
+  it("coalesces rename/reorder/status bursts and sends nothing while idle or unchanged", async () => {
+    await render();
+    await render({ items: [item("local")] });
+    await render({
+      items: [{ ...item("pin"), label: "Renamed" }],
+      sessionMap: new Map([["pin", session("pin", { status: "running" })]]),
+    });
+    await flush();
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    expect(mocks.publish.mock.calls[0][0][0]).toMatchObject({
+      name: "Renamed",
+      status: "running",
+    });
+    await render({ items: [{ ...item("pin"), label: "Renamed" }] });
+    await flush(60_000);
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the published window to the backend's 200-row contract", async () => {
+    const ids = Array.from({ length: 250 }, (_, index) => `row-${index}`);
+    await render({
+      items: ids.map(item),
+      sessionMap: new Map(ids.map((id) => [id, session(id)])),
+    });
+    await flush();
+    expect(mocks.publish.mock.calls[0][0]).toHaveLength(200);
+    expect(mocks.publish.mock.calls[0][0].at(-1).id).toBe("row-199");
+  });
+
+  it("retries a failed unmount clear and republishes the same rows on remount", async () => {
+    await render();
+    await flush();
+    mocks.publish.mockRejectedValueOnce(new Error("temporary IPC failure"));
+    await act(async () => root.unmount());
+    await flush(1500);
+    expect(mocks.publish.mock.calls.slice(-2).map(([rows]) => rows)).toEqual([
+      [],
+      [],
+    ]);
+    root = createRoot(container);
+    await render();
+    await flush();
+    expect(mocks.publish).toHaveBeenLastCalledWith(
+      expect.arrayContaining([expect.objectContaining({ id: "pin" })])
+    );
+  });
+
+  it("preserves rows while refreshing, publishes real empty, and clears old org before replacement", async () => {
+    await render();
+    await flush();
+    await render({ loading: true, items: [] });
+    await flush();
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    await render({ loading: false });
+    await flush();
+    expect(mocks.publish).toHaveBeenLastCalledWith([]);
+    await render({ scope: "org-b", items: [item("local")] });
+    await flush();
+    expect(
+      mocks.publish.mock.calls
+        .slice(-2)
+        .map(([rows]) => rows.map((row: { id: string }) => row.id))
+    ).toEqual([[], ["local"]]);
+  });
+
+  it("retries one failure, then waits for focus/online rather than polling", async () => {
+    mocks.publish.mockRejectedValue(new Error("unavailable"));
+    await render();
+    await flush(5000);
+    expect(mocks.publish).toHaveBeenCalledTimes(2);
+    await flush(60_000);
+    expect(mocks.publish).toHaveBeenCalledTimes(2);
+    mocks.publish.mockResolvedValue(true);
+    window.dispatchEvent(new Event("online"));
+    await flush();
+    expect(mocks.publish).toHaveBeenLastCalledWith(
+      expect.arrayContaining([expect.objectContaining({ id: "pin" })])
+    );
+  });
+
+  it("serializes in-flight work, discards superseded org rows and clears on unmount", async () => {
+    let finish: (() => void) | undefined;
+    mocks.publish.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        })
+    );
+    await render();
+    await flush();
+    await render({ scope: "org-b", items: [item("local")] });
+    await render({ scope: "org-c", items: [item("pin")] });
+    await flush();
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+    finish?.();
+    await flush();
+    expect(
+      mocks.publish.mock.calls
+        .slice(1)
+        .map(([rows]) => rows.map((row: { id: string }) => row.id))
+    ).toEqual([[], ["pin"]]);
+    await act(async () => root.unmount());
+    await flush();
+    expect(mocks.publish).toHaveBeenLastCalledWith([]);
+    root = createRoot(container);
+  });
+
+  it("clears an in-flight old scope before publishing an immediate remount", async () => {
+    let finish: (() => void) | undefined;
+    mocks.publish.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        })
+    );
+    await render({ scope: "org-a", items: [item("pin")] });
+    await flush();
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await render({ scope: "org-b", items: [item("local")] });
+    finish?.();
+    await flush();
+    expect(
+      mocks.publish.mock.calls
+        .slice(1)
+        .map(([rows]) => rows.map((row: { id: string }) => row.id))
+    ).toEqual([[], ["local"]]);
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useMobileSidebarSessions.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useMobileSidebarSessions.ts
@@ -1,0 +1,112 @@
+import { useAtomValue } from "jotai";
+import { useEffect, useMemo, useRef } from "react";
+
+import {
+  type MobileSidebarSessionSnapshotRow,
+  syncSidebarSessions,
+} from "@src/api/tauri/mobileRemote";
+import {
+  org2CloudAuthAtom,
+  org2CloudAuthIdentityKey,
+} from "@src/features/Org2Cloud/org2CloudAuthAtom";
+import { createLogger } from "@src/hooks/logger";
+import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
+import type { Session } from "@src/store/session";
+import { isSessionInProgress } from "@src/util/session/sessionInProgress";
+
+import { NO_WORKSPACE_KEY } from "../types";
+import { workspaceGroupKey } from "../workspaceGroupKey";
+import { createMobileSidebarPublisher } from "./mobileSidebarPublisher";
+
+const logger = createLogger("MobileSidebarPublisher");
+// Existing Rust snapshot contract; publish a usable prefix rather than rejecting the whole roster.
+const MAX_MOBILE_SIDEBAR_ROWS = 200;
+const publisher = createMobileSidebarPublisher(syncSidebarSessions, (error) =>
+  logger.warn("Failed to publish desktop session list", error)
+);
+
+interface Params {
+  scope: string;
+  loading: boolean;
+  items: readonly NavigationMenuItem[];
+  sessionMap: ReadonlyMap<string, Session>;
+  repoPathToName: ReadonlyMap<string, string>;
+}
+
+/** Copy only rows the desktop's final local/My Sessions projection actually exposes. */
+export function projectMobileSidebarSessions({
+  items,
+  sessionMap,
+  repoPathToName,
+}: Omit<Params, "scope" | "loading">): MobileSidebarSessionSnapshotRow[] {
+  const rows: MobileSidebarSessionSnapshotRow[] = [];
+  const seen = new Set<string>();
+  const visit = (item: NavigationMenuItem) => {
+    if (rows.length >= MAX_MOBILE_SIDEBAR_ROWS) return;
+    const session = sessionMap.get(item.id);
+    if (session && !seen.has(session.session_id)) {
+      seen.add(session.session_id);
+      const workspace = workspaceGroupKey(session);
+      const repoPath = workspace === NO_WORKSPACE_KEY ? null : workspace;
+      const timestamp = Date.parse(
+        session.updated_at || session.updated_time || session.created_at
+      );
+      rows.push({
+        id: session.session_id,
+        name: item.label,
+        status: isSessionInProgress(session.status, session)
+          ? "running"
+          : "idle",
+        repoPath,
+        repoName: repoPath
+          ? (repoPathToName.get(repoPath) ??
+            repoPath.split("/").pop() ??
+            repoPath)
+          : null,
+        updatedAtMs: Number.isFinite(timestamp) ? timestamp : null,
+      });
+    }
+    item.children?.forEach(visit);
+  };
+  items.forEach(visit);
+  return rows;
+}
+
+/** Mounted with the desktop connector, even when another sidebar view is visible. */
+export function useMobileSidebarSessions({
+  scope: orgScope,
+  loading,
+  items,
+  sessionMap,
+  repoPathToName,
+}: Params) {
+  const auth = useAtomValue(org2CloudAuthAtom);
+  const identity = auth ? org2CloudAuthIdentityKey(auth) : "local";
+  const scope = JSON.stringify([identity, orgScope]);
+  const rows = useMemo(
+    () => projectMobileSidebarSessions({ items, sessionMap, repoPathToName }),
+    [items, sessionMap, repoPathToName]
+  );
+  const owner = useRef<symbol | null>(null);
+  const previousScope = useRef<string | null>(null);
+  useEffect(() => {
+    const token = publisher.acquire();
+    owner.current = token;
+    const revalidate = () => publisher.revalidate(token);
+    window.addEventListener("focus", revalidate);
+    window.addEventListener("online", revalidate);
+    return () => {
+      window.removeEventListener("focus", revalidate);
+      window.removeEventListener("online", revalidate);
+      publisher.release(token);
+      owner.current = null;
+    };
+  }, []);
+  useEffect(() => {
+    if (!owner.current) return;
+    // Keep successful rows through same-scope refresh, but never across identity/org changes.
+    if (loading && previousScope.current === scope) return;
+    previousScope.current = scope;
+    publisher.update(owner.current, scope, loading ? [] : rows);
+  }, [scope, rows, loading]);
+}


### PR DESCRIPTION
## Problem

The backend supports an authoritative mobile sidebar snapshot, but the desktop connector never publishes its final local/My Sessions projection. Mobile therefore falls back to broader database aggregation and can show different ordering, labels, or rows than the desktop sidebar.

## Solution

Project the connector's final rendered session items into the existing 200-row snapshot contract and publish through a module-owned coordinator with 100 ms coalescing, one in-flight IPC, one replaceable pending snapshot, deduplication, and one bounded retry. Scope changes and unmount clear prior rows; a completed-scope check now also forces an old in-flight publication to clear before an immediate new-scope remount publishes.

Handle rejections from the scheduled flush promise explicitly without changing coalescing or retry limits.

## Potential risks

Only the first 200 projected local rows are published, matching the backend cap; cloud-only team rows and drafts remain outside this contract. Publishing intentionally continues while the desktop window is hidden because a paired phone needs current state. The module coordinator assumes one active connector owner and serializes remounts. The prerequisite `junyu/mobile-session-metadata` PR is merged; this PR now targets `develop`. No paired-mobile runtime, CPU/RSS baseline, or reconnect proof was completed.

## Audit

Architecture, React-performance, and lifecycle ownership were reviewed from connector projection through IPC. Timers/listeners have explicit cleanup, updates are bounded/coalesced/single-flight, identity plus org scope is part of the signature, old async completion cannot bypass the scope clear, and retained rows are capped. The TSX change only wires the hook and introduces no visual primitive, so a UI-consistency report was not required. Performance verdict: blocked on real runtime measurement and paired-device verification.

## Verification

- Scoped ESLint for the connector, publisher, hook, and hook tests — passed
- `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useMobileSidebarSessions.test.ts` — 8 passed
- `node node_modules/typescript/bin/tsc --noEmit --pretty false` — passed
- `git diff --check junyu/mobile-session-metadata..junyu/mobile-sidebar-sync` — passed
- Added-line secret/personal-path pattern sweep — passed
- `gitleaks` scan not run because the local executable is unavailable; the harness reports `ENOENT`
- No screenshot was captured because this PR adds no new desktop visual element; paired-mobile behavior remains unverified

- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/mobileSidebarPublisher.test.ts` — 2 passed, covering bounded failure retries and escaping rejection handling
- `pnpm typecheck:fast` — passed
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/mobileSidebarPublisher.ts --max-warnings 0` — passed
- `git diff --check` — passed
- `pnpm check:typed-lint` — passed, 0 new or increased findings
