### PR TITLE
fix(launchpad): remove the empty right-side rail

### DIFF
--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
@@ -8,7 +8,6 @@ import {
   resolveFocusedChatWorkstationRailTrackClass,
   resolveFocusedChatWorkstationSectionOrder,
   shouldMountFocusedChatWorkstationControls,
-  shouldReserveFocusedChatWorkstationPlaceholder,
 } from "./focusedChatWorkstationLayout";
 import { CHAT_PANEL_HEADER_STACK_HEIGHT_PX } from "./header/chatPanelHeaderLayout";
 
@@ -41,38 +40,6 @@ describe("shouldMountFocusedChatWorkstationControls", () => {
     },
   ])("stays unmounted outside the focused session lifecycle", (input) => {
     expect(shouldMountFocusedChatWorkstationControls(input)).toBe(false);
-  });
-});
-
-describe("shouldReserveFocusedChatWorkstationPlaceholder", () => {
-  it("reserves the collapsed rail track for a focused visible Launchpad", () => {
-    expect(
-      shouldReserveFocusedChatWorkstationPlaceholder({
-        activeTabType: "start-page",
-        isChatFocus: true,
-        startPageOpen: true,
-      })
-    ).toBe(true);
-  });
-
-  it.each([
-    {
-      activeTabType: "start-page" as const,
-      isChatFocus: false,
-      startPageOpen: true,
-    },
-    {
-      activeTabType: "start-page" as const,
-      isChatFocus: true,
-      startPageOpen: false,
-    },
-    {
-      activeTabType: "session" as const,
-      isChatFocus: true,
-      startPageOpen: true,
-    },
-  ])("does not reserve the track outside Launchpad focus", (input) => {
-    expect(shouldReserveFocusedChatWorkstationPlaceholder(input)).toBe(false);
   });
 });
 

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
@@ -76,12 +76,6 @@ interface FocusedChatWorkstationMountInput {
   showSessionContent: boolean;
 }
 
-interface FocusedChatWorkstationPlaceholderInput {
-  activeTabType: ChatPanelTab["type"] | null;
-  isChatFocus: boolean;
-  startPageOpen: boolean;
-}
-
 /**
  * The environment rail owns a live working-tree subscription, so it only
  * mounts while a maximized session is actually presenting session content.
@@ -92,18 +86,6 @@ export function shouldMountFocusedChatWorkstationControls({
   showSessionContent,
 }: FocusedChatWorkstationMountInput): boolean {
   return isChatFocus && activeTabType === "session" && showSessionContent;
-}
-
-/**
- * Keep focused Launchpad content aligned with a session using the collapsed
- * workstation track, without mounting the rail's live data or controls.
- */
-export function shouldReserveFocusedChatWorkstationPlaceholder({
-  activeTabType,
-  isChatFocus,
-  startPageOpen,
-}: FocusedChatWorkstationPlaceholderInput): boolean {
-  return isChatFocus && activeTabType === "start-page" && startPageOpen;
 }
 
 /**

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -60,11 +60,7 @@ import {
   SessionRawToolbarActions,
 } from "./components/SessionViewSwitcher";
 import SessionWorkstationRail from "./components/SessionWorkstationRail";
-import {
-  resolveFocusedChatWorkstationRailTrackClass,
-  shouldMountFocusedChatWorkstationControls,
-  shouldReserveFocusedChatWorkstationPlaceholder,
-} from "./focusedChatWorkstationLayout";
+import { shouldMountFocusedChatWorkstationControls } from "./focusedChatWorkstationLayout";
 import { FocusedChatWorkstationMinimapPortalContext } from "./focusedChatWorkstationMinimapPortal";
 import {
   resolveChatPanelChromeTopInsetPx,
@@ -279,12 +275,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         isChatFocus,
         showSessionContent: contentState.showSessionContent,
       });
-    const reserveFocusedWorkstationPlaceholder =
-      shouldReserveFocusedChatWorkstationPlaceholder({
-        activeTabType: activeTab?.type ?? null,
-        isChatFocus,
-        startPageOpen,
-      });
 
     const {
       handleMoveToWorkstation,
@@ -486,13 +476,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
                 session={currentSession}
                 sessionId={currentSessionId}
                 topInset={chromeTopInsetPx}
-              />
-            ) : reserveFocusedWorkstationPlaceholder ? (
-              <div
-                aria-hidden
-                data-testid="launchpad-workstation-rail-placeholder"
-                data-workstation-trail-track
-                className={`h-full shrink-0 ${resolveFocusedChatWorkstationRailTrackClass(true)}`}
               />
             ) : null
           }


### PR DESCRIPTION
## Problem

Focused Launchpad reserved an empty workstation rail track on the right, leaving a 44 px gap at wide pane sizes. The placeholder existed solely to align Launchpad with session content.

## Solution

Remove the Launchpad-only placeholder, its predicate, and the obsolete predicate tests. Launchpad can use the full available width; session workstation controls and minimap tracks retain their existing behavior.

## Potential risks

The change affects focused Launchpad geometry, including the former intermediate 36 px track. Desktop visual behavior across pane widths and themes has not been checked through the GUI because computer control was not authorized. No persistence, dependencies, IPC, or background lifecycle changes are involved. Reverting this commit restores the old spacing.

## Verification

- `pnpm test src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts src/engines/ChatPanel/ChatPanelShell.test.ts` — passed, 21 tests across 2 files.
- `pnpm exec eslint src/engines/ChatPanel/index.tsx src/engines/ChatPanel/focusedChatWorkstationLayout.ts src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts` — passed.
- `pnpm run typecheck:fast` — passed in the isolated branch.
- `git diff --check` — passed.
- Source review confirms the rail is supplied only for visible focused session content. The diff contains only the placeholder removal and its obsolete helper/tests.
- Full application build, E2E, screenshots, and GUI checks were not run. Targeted tests cover the layout helpers and shell; screenshots remain a visual verification gap.
