### PR TITLE
fix(session-replay): retain the original external agent

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/ModelPill.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/ModelPill.test.ts
@@ -95,11 +95,12 @@ vi.mock("@src/components/ModelSelectorPill", async () => {
   return {
     default: forwardRef<
       HTMLButtonElement,
-      { onClick: () => void; dataTestId: string }
-    >(({ onClick, dataTestId }, ref) =>
+      { onClick: () => void; dataTestId: string; disabled?: boolean }
+    >(({ onClick, dataTestId, disabled }, ref) =>
       createElement("button", {
         ref,
         "data-testid": dataTestId,
+        disabled,
         onClick,
       })
     ),
@@ -246,6 +247,26 @@ describe("ModelPill disclosure ownership", () => {
       model: undefined,
     });
   }
+
+  it("opens the original agent's model picker before a complete target exists", () => {
+    const target = fixture.binding.target;
+    Reflect.set(fixture.binding, "target", null);
+    try {
+      act(() => renderCurrentSession());
+      const button = container.querySelector<HTMLButtonElement>(
+        '[data-testid="chat-model-pill-model"]'
+      )!;
+      expect(button.disabled).toBe(false);
+      click("chat-model-pill-model");
+      expect(
+        container
+          .querySelector('[data-testid="model-palette"]')
+          ?.getAttribute("data-cli-agent-type")
+      ).toBe("codex");
+    } finally {
+      fixture.binding.target = target;
+    }
+  });
 
   it("keeps the runtime and model palettes mutually exclusive", () => {
     click("chat-runtime-pill");

--- a/src/engines/ChatPanel/InputArea/components/ModelPill.tsx
+++ b/src/engines/ChatPanel/InputArea/components/ModelPill.tsx
@@ -368,6 +368,7 @@ const ModelPillComponent: React.FC = () => {
     !conversationBinding ||
     (conversationBinding.readiness === "ready" &&
       (Boolean(conversationBinding.target) ||
+        Boolean(conversationBinding.runtimeSelection) ||
         Boolean(pendingRuntimeSelection)));
   const modelDefaultLabel =
     conversationBinding?.readiness === "loading"

--- a/src/engines/ChatPanel/conversationTargetSelection.ts
+++ b/src/engines/ChatPanel/conversationTargetSelection.ts
@@ -4,10 +4,11 @@ import {
 } from "@src/api/tauri/rpc/schemas/validation";
 import { KEY_SOURCE, isHostedKey } from "@src/api/tauri/session";
 import { formatAgentType } from "@src/assets/providers";
-import type {
-  ConversationRootLocator,
-  ConversationSource,
-  LocalConversationTarget,
+import {
+  type ConversationRootLocator,
+  type ConversationSource,
+  type LocalConversationTarget,
+  NATIVE_CONVERSATION_CLI_TARGETS,
 } from "@src/engines/SessionCore/conversations/conversationTypes";
 import type { SessionCommentTarget } from "@src/features/Org2Cloud/sessionCommentTarget";
 import {
@@ -333,8 +334,20 @@ export function resolveConversationRuntimeSelection(params: {
   source: ConversationSource;
   definitions: readonly AgentDefinition[];
 }): AgentSelection | null {
-  if (!params.target) return null;
-  const parsed = CliAgentTypeSchema.safeParse(params.target.cliAgentType);
+  // Replay provenance owns its runtime identity even when a local account/model
+  // pair is still missing. Sharing moves the authority to Cloud without changing
+  // the original agent, so both replay authorities must preserve that identity.
+  const sourceRuntime =
+    (params.source.root.authority === "imported-history" ||
+      params.source.root.authority === "org2-cloud") &&
+    NATIVE_CONVERSATION_CLI_TARGETS.some(
+      (runtime) => runtime === params.source.cliAgentType
+    )
+      ? params.source.cliAgentType
+      : undefined;
+  const parsed = CliAgentTypeSchema.safeParse(
+    params.target ? params.target.cliAgentType : sourceRuntime
+  );
   if (parsed.success) {
     return {
       category: "cli_agent",
@@ -343,7 +356,7 @@ export function resolveConversationRuntimeSelection(params: {
       agentName: formatAgentType(parsed.data),
     };
   }
-  const agentDefinitionId = params.target.agentDefinitionId;
+  const agentDefinitionId = params.target?.agentDefinitionId;
   if (!agentDefinitionId) return null;
   const definition = params.definitions.find(
     (candidate) => candidate.id === agentDefinitionId

--- a/src/engines/ChatPanel/hooks/useConversationTargetBinding.test.ts
+++ b/src/engines/ChatPanel/hooks/useConversationTargetBinding.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { resolveConversationRuntimeSelection } from "@src/engines/ChatPanel/conversationTargetSelection";
+
 import {
   conversationExecutions,
   conversationRootForSession,
@@ -13,6 +15,36 @@ import {
 } from "./useConversationTargetBinding";
 
 describe("conversation target binding source", () => {
+  it.each([
+    ["codexapp-session-1", "codex"],
+    ["claudecodeapp-session-1", "claude_code"],
+  ])(
+    "preserves %s's original agent without a resolved model target",
+    (sessionId, cliAgentType) => {
+      const source = conversationSourceFromImportedHistory({ sessionId })!;
+      expect(
+        resolveConversationRuntimeSelection({
+          source,
+          target: null,
+          definitions: [],
+        })
+      ).toMatchObject({ category: "cli_agent", cliAgentType });
+    }
+  );
+
+  it("does not invent a native agent for unsupported imported history", () => {
+    const source = conversationSourceFromImportedHistory({
+      sessionId: "windsurfapp-session-1",
+    })!;
+    expect(
+      resolveConversationRuntimeSelection({
+        source,
+        target: null,
+        definitions: [],
+      })
+    ).toBeNull();
+  });
+
   it("keeps an installed shell-out Claude runtime without GUI launch support", () => {
     expect(
       resolveNativeConversationCliTargets(

--- a/src/engines/ChatPanel/hooks/useConversationTargetBinding.ts
+++ b/src/engines/ChatPanel/hooks/useConversationTargetBinding.ts
@@ -580,14 +580,14 @@ export function useConversationTargetBinding(
 
   const runtimeSelection = useMemo(
     () =>
-      source && readiness === "ready" && target
+      source && readiness === "ready"
         ? resolveConversationRuntimeSelection({
-            target,
+            target: target ?? preferredTarget ?? source.initialTarget,
             source,
             definitions,
           })
         : null,
-    [definitions, readiness, source, target]
+    [definitions, preferredTarget, readiness, source, target]
   );
 
   const applyModelPick = useCallback(

--- a/src/features/Org2Cloud/SessionConversation/useCloudConversationSource.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/useCloudConversationSource.test.ts
@@ -1,9 +1,46 @@
 import { describe, expect, it } from "vitest";
 
+import { resolveConversationRuntimeSelection } from "@src/engines/ChatPanel/conversationTargetSelection";
+
 import { cloudConversationAuthorityIsLive } from "./cloudConversationAuthority";
 import { conversationSourceFromCloudReplay } from "./useCloudConversationSource";
 
 describe("Cloud conversation source", () => {
+  it.each([
+    ["codexapp-rollout-session-1", "codex"],
+    ["claudecodeapp-session-1", "claude_code"],
+  ])(
+    "retains the original agent for shared external history %s without a model target",
+    (sessionId, cliAgentType) => {
+      const source = conversationSourceFromCloudReplay({
+        target: { orgId: "org-1", sessionId },
+        workspaceRepoPath: null,
+      })!;
+      expect(source.root.authority).toBe("org2-cloud");
+      expect(
+        resolveConversationRuntimeSelection({
+          source,
+          target: null,
+          definitions: [],
+        })
+      ).toMatchObject({ category: "cli_agent", cliAgentType });
+    }
+  );
+
+  it("keeps an explicit runtime choice ahead of shared external provenance", () => {
+    const source = conversationSourceFromCloudReplay({
+      target: { orgId: "org-1", sessionId: "codexapp-rollout-session-1" },
+      workspaceRepoPath: null,
+    })!;
+    expect(
+      resolveConversationRuntimeSelection({
+        source,
+        target: { cliAgentType: "claude_code", workspaceRepoPath: null },
+        definitions: [],
+      })
+    ).toMatchObject({ cliAgentType: "claude_code" });
+  });
+
   it("projects source runtime before the imported Session row exists", () => {
     expect(
       conversationSourceFromCloudReplay({


### PR DESCRIPTION
## Problem

Opening an externally created Codex or Claude Code session can show “Select agent” even though the imported source identifies its harness. The composer discards runtime identity when it cannot resolve a complete local account/model execution target. Cloud-shared external sessions additionally use org2-cloud authority, which the imported-history-only fallback misses.

## Solution

Preserve supported source runtime identity under imported-history and cloud authority when no complete target exists. Resolved, preferred, and initial targets retain precedence. Allow model selection for a known runtime without requiring a complete execution target; execution/account validation remains in place. Add Codex, Claude, unsupported-source, explicit-override, and model-picker regression coverage.

## Potential risks

Cloud replay runtime identity now remains visible before a complete execution target is available. This does not grant execution permission or bypass account validation. Unsupported sources and inventory/hydration gates remain unchanged. Live external-session continuation and cloud replay were not exercised in Tauri; UI screenshots were not captured because computer control was not authorized. No data migration, historical cleanup, wire changes, or additional background work is required.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/conversationTargetSelection.test.ts src/engines/ChatPanel/hooks/useConversationTargetBinding.test.ts src/engines/ChatPanel/InputArea/components/ModelPill.test.ts src/features/Org2Cloud/SessionConversation/useCloudConversationSource.test.ts` — 43 tests passed
- `pnpm typecheck:fast` — passed
- `pnpm exec eslint src/engines/ChatPanel/conversationTargetSelection.ts src/engines/ChatPanel/hooks/useConversationTargetBinding.ts src/engines/ChatPanel/hooks/useConversationTargetBinding.test.ts src/engines/ChatPanel/InputArea/components/ModelPill.tsx src/engines/ChatPanel/InputArea/components/ModelPill.test.ts src/features/Org2Cloud/SessionConversation/useCloudConversationSource.test.ts --max-warnings 0` — passed
- `git diff --check` — passed
- Read-only inspection confirmed the reported imported cache row retains its Codex source; the workstation trail already reads that descriptor correctly
- Reviewed the scoped diff for unrelated changes, personal paths, secrets, and generated artifacts
- Checks ran in an isolated worktree based on freshly pulled origin/develop; live app and provider-ingestion verification were not run

## Performance

| Area | Verdict | Evidence |
| --- | --- | --- |
| Background work | keep | Synchronous resolver/condition changes; no new timers, scans, requests, or workers |
| Memory | keep | One transient selection; no new retained collections |
| Scope/isolation | keep | Existing conversation source and explicit targets remain authoritative |
| Rendering | fix | Known runtime survives incomplete target resolution; regression tests cover model-picker access |

Performance verdict: pass for this synchronous projection change; no runtime performance improvement is claimed.
