### PR TITLE
fix(chat-picker): clarify empty and disabled selections

### DIFF
--- a/src/components/ModelSelectorPill/ModelSelectorPill.test.ts
+++ b/src/components/ModelSelectorPill/ModelSelectorPill.test.ts
@@ -37,8 +37,8 @@ vi.mock("react-i18next", () => ({
 vi.mock("@src/hooks/models", () => ({
   useModelAccountLookup: () => ({ accounts: [] }),
   resolveModelDisplaySelection: (selection: unknown) => selection,
-  useModelPillLabel: () => ({
-    label: "GPT 5.6 Sol",
+  useModelPillLabel: (selection: unknown, defaultLabel: string) => ({
+    label: selection ? "GPT 5.6 Sol" : defaultLabel,
     title: "GPT 5.6 Sol",
     displayParts: { label: "GPT 5.6 Sol" },
   }),
@@ -46,13 +46,13 @@ vi.mock("@src/hooks/models", () => ({
     selection,
     onApply,
   }: {
-    selection: { model: string };
+    selection: { model: string } | null;
     onApply?: (model: string) => void;
   }) => ({
     editable: fixture.models.length > 1 && Boolean(onApply),
     effortLabel: "Extra High",
     effortAriaLabel: "Effort",
-    modelId: selection.model,
+    modelId: selection?.model,
     variantOptions: buildVariantEditOptions(fixture.models),
     handleApply: onApply,
   }),
@@ -88,6 +88,43 @@ describe("ModelSelectorPill combined settings", () => {
     container.remove();
     vi.useRealTimers();
     Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("disables model and effort selection while explaining the prerequisite on focus", () => {
+    act(() =>
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(ModelSelectorPill, {
+            selection: null,
+            defaultLabel: "Select model",
+            active: false,
+            onClick: openModel,
+            onVariantApply: apply,
+            disabled: true,
+            disabledTooltip: "Select agent first",
+            dataTestId: "model-pill",
+          })
+        )
+      )
+    );
+    const button = element("model-pill") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toBe("Select model");
+    act(() => button.click());
+    expect(openModel).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="chat-model-pill-effort"]')
+    ).toBeNull();
+    const explanation = container.querySelector<HTMLElement>(
+      '[tabindex="0"][aria-disabled="true"]'
+    )!;
+    act(() => explanation.focus());
+    act(() => vi.advanceTimersByTime(500));
+    expect(document.body.textContent).toContain("Select agent first");
+    act(() => explanation.blur());
+    act(() => vi.runOnlyPendingTimers());
   });
 
   function render(

--- a/src/components/ModelSelectorPill/index.tsx
+++ b/src/components/ModelSelectorPill/index.tsx
@@ -20,6 +20,7 @@ import ModelPillTooltipContent from "@src/components/ModelPillTooltipContent";
 import ModelPropertiesDropdown from "@src/components/ModelPropertiesDropdown";
 import PillGroup, { type PillGroupSegment } from "@src/components/PillGroup";
 import SelectorPill from "@src/components/SelectorPill";
+import Tooltip from "@src/components/Tooltip";
 import {
   resolveModelDisplaySelection,
   useModelAccountLookup,
@@ -65,6 +66,8 @@ interface ModelSelectorPillProps {
   preferCombinedSettingsMenu?: boolean;
   /** Prevent opening a picker while its execution inventory is unresolved. */
   disabled?: boolean;
+  /** Explanation shown on hover or focus while the picker is disabled. */
+  disabledTooltip?: string;
 }
 
 const ModelSelectorPill = forwardRef<HTMLButtonElement, ModelSelectorPillProps>(
@@ -87,6 +90,7 @@ const ModelSelectorPill = forwardRef<HTMLButtonElement, ModelSelectorPillProps>(
       settingsMenuDefaultAdvanced = false,
       preferCombinedSettingsMenu = false,
       disabled = false,
+      disabledTooltip,
     },
     ref
   ) => {
@@ -97,6 +101,7 @@ const ModelSelectorPill = forwardRef<HTMLButtonElement, ModelSelectorPillProps>(
     );
 
     const [effortOpen, setEffortOpen] = useState(false);
+    const [disabledTooltipOpen, setDisabledTooltipOpen] = useState(false);
 
     const { accounts } = useModelAccountLookup();
     const displaySelection = useMemo(
@@ -168,7 +173,7 @@ const ModelSelectorPill = forwardRef<HTMLButtonElement, ModelSelectorPillProps>(
         ),
         label: resolvedModelLabel,
         title: modelTitle,
-        tooltip: (
+        tooltip: disabled ? undefined : (
           <ModelPillTooltipContent
             accountName={accountName}
             modelLabel={displayParts.rawValue ?? displayParts.label}
@@ -367,13 +372,37 @@ const ModelSelectorPill = forwardRef<HTMLButtonElement, ModelSelectorPillProps>(
       );
     }
 
-    return (
+    const pill = (
       <PillGroup
         segments={segments}
         className={`shrink-0 text-[13px] ${className ?? ""}`}
-        segmentClassName={`h-[28px] ${triggerClassName ?? ""}`.trim()}
+        segmentClassName={`h-[28px] ${disabled ? "cursor-not-allowed [&>span]:opacity-50" : ""} ${triggerClassName ?? ""}`.trim()}
       />
     );
+
+    if (disabled && disabledTooltip) {
+      return (
+        <Tooltip
+          content={disabledTooltip}
+          position="top"
+          open={disabledTooltipOpen}
+          onOpenChange={setDisabledTooltipOpen}
+        >
+          <span
+            tabIndex={0}
+            onFocus={() => setDisabledTooltipOpen(true)}
+            onBlur={() => setDisabledTooltipOpen(false)}
+            aria-label={`${ariaLabel ?? defaultLabel}: ${disabledTooltip}`}
+            aria-disabled="true"
+            className="inline-flex min-w-0 cursor-not-allowed"
+          >
+            {pill}
+          </span>
+        </Tooltip>
+      );
+    }
+
+    return pill;
   }
 );
 

--- a/src/components/SelectorPill/index.tsx
+++ b/src/components/SelectorPill/index.tsx
@@ -321,7 +321,9 @@ export const SelectorPill = forwardRef<HTMLButtonElement, SelectorPillProps>(
         ? ""
         : active
           ? PILL_CONTROL_ACTIVE_SURFACE_CLASS
-          : PILL_CONTROL_HOVER_CLASS;
+          : disabled
+            ? "hover:bg-surface-hover!"
+            : PILL_CONTROL_HOVER_CLASS;
 
     // Controlled tooltip visibility so that opening the dropdown (active=true)
     // immediately hides the tooltip instead of leaving it covering the panel.

--- a/src/engines/ChatPanel/InputArea/components/ModelPill.tsx
+++ b/src/engines/ChatPanel/InputArea/components/ModelPill.tsx
@@ -37,6 +37,7 @@ import { useSessionId } from "@src/engines/SessionCore/hooks/session";
 import type { AdvancedConfig } from "@src/features/SessionCreator/types";
 import { useValidatedLastPair } from "@src/hooks/models/useValidatedLastPair";
 import { useSessionModelField } from "@src/hooks/session/useSessionPatch";
+import { Infinity01Icon, HugeiconsIcon } from "@src/icons";
 import type { AgentSelection } from "@src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette";
 import { DispatchCategoryPicker } from "@src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/DispatchCategoryPicker";
 import { UnifiedModelPalette } from "@src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette";
@@ -372,7 +373,7 @@ const ModelPillComponent: React.FC = () => {
   const modelDefaultLabel =
     conversationBinding?.readiness === "loading"
       ? t("common:actions.loading")
-      : t("sessions:creator.model");
+      : t("sessions:creator.selectModel");
   const visiblePillSelection = conversationTargetReady ? pillSelection : null;
   const effectiveModelOpen = isModelOpen && conversationTargetReady;
   const runtimeSelection =
@@ -385,12 +386,14 @@ const ModelPillComponent: React.FC = () => {
       : (runtimeSelection?.agentName ?? t("sessions:creator.selectAgent"));
   const runtimeIcon = runtimeSelection?.cliAgentType ? (
     <ModelIcon agentType={runtimeSelection.cliAgentType} size={14} />
-  ) : (
+  ) : runtimeSelection ? (
     <AnyIcon
       icon={resolveAgentIcon(runtimeSelection?.agentIconId)}
       size={14}
       className="text-text-2"
     />
+  ) : (
+    <HugeiconsIcon icon={Infinity01Icon} size={14} className="text-text-2" />
   );
   const paletteAdvancedConfig = pendingRuntimeSelection
     ? {
@@ -420,6 +423,13 @@ const ModelPillComponent: React.FC = () => {
         ariaLabel={t("sessions:creator.selectModel")}
         isActiveSession={isActiveSession}
         disabled={!conversationTargetReady}
+        disabledTooltip={
+          conversationBinding?.readiness === "loading"
+            ? t("common:actions.loading")
+            : t("sessions:creator.selectAgentFirst", {
+                defaultValue: "Select agent first",
+              })
+        }
       />
     </div>
   );

--- a/src/features/SessionCreator/variants/ChatPanel/resolveSessionCreatorAgentHero.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/resolveSessionCreatorAgentHero.ts
@@ -17,8 +17,8 @@ export interface SessionCreatorAgentHeroContent {
   danger: boolean;
 }
 
-const NO_AGENT_NAME = "Select an agent";
-const NO_AGENT_DESCRIPTION = "Choose an agent to see what it can help you with";
+const NO_AGENT_NAME = "Select agent";
+const NO_AGENT_DESCRIPTION = "Select agent to see its capabilities";
 
 const GENERIC_DESCRIPTION =
   "Ready to help with your next task in this workspace";

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "Kurze Eingabe",
     "shortInputMessage": "Ihre Eingabe scheint sehr kurz zu sein. Möchten Sie wirklich eine Sitzung damit starten?",
     "selectModel": "Modell auswählen",
+    "selectAgentFirst": "Zuerst einen Agenten auswählen",
     "switchModel": "Modell wechseln",
     "switchMode": "Modus wechseln",
     "switchAgent": "Agent wechseln",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -1982,6 +1982,7 @@
     "shortInputTitle": "Short Input",
     "shortInputMessage": "Your input seems very short. Are you sure you want to start a session with this?",
     "selectModel": "Select model",
+    "selectAgentFirst": "Select agent first",
     "switchModel": "Switch model",
     "switchMode": "Switch mode",
     "switchAgent": "Switch Agent",
@@ -2002,7 +2003,7 @@
     "regionNoticeBodyProvider": "You are in {{location}}. Certain models may be unavailable in your region.",
     "regionNoticeBodySanctions": "You are in {{location}}. GitHub, npm, Docker Hub, and similar services may be unavailable.",
     "regionNoticeBodyBoth": "You are in {{location}}. Certain models and services like GitHub, npm, and Docker Hub may be unavailable due to regional policy and trade rules.",
-    "selectAgent": "Select an agent",
+    "selectAgent": "Select agent",
     "placeholderDefault": "Type a message, @ to add files, / to use skills",
     "wingmanPlaceholder": "Describe your mission — what should Wingman watch for?",
     "screenPicker": {

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "Entrada corta",
     "shortInputMessage": "Tu entrada parece muy corta. ¿Estás seguro de que deseas iniciar una sesión con esto?",
     "selectModel": "Seleccionar modelo",
+    "selectAgentFirst": "Selecciona primero un agente",
     "switchModel": "Cambiar modelo",
     "switchMode": "Cambiar modo",
     "switchAgent": "Cambiar Agent",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "Saisie courte",
     "shortInputMessage": "Votre saisie semble très courte. Êtes-vous sûr de vouloir démarrer une session avec ceci ?",
     "selectModel": "Sélectionner un modèle",
+    "selectAgentFirst": "Sélectionnez d’abord un agent",
     "switchModel": "Changer de modèle",
     "switchMode": "Changer de mode",
     "switchAgent": "Changer d'Agent",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "短い入力",
     "shortInputMessage": "入力内容が非常に短いようです。この内容でセッションを開始しますか？",
     "selectModel": "モデルを選択",
+    "selectAgentFirst": "先にエージェントを選択",
     "switchModel": "モデルを切り替え",
     "switchMode": "モードを切り替え",
     "switchAgent": "Agent を切り替え",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "짧은 입력",
     "shortInputMessage": "입력 내용이 매우 짧습니다. 이 내용으로 세션을 시작하시겠습니까?",
     "selectModel": "모델 선택",
+    "selectAgentFirst": "먼저 에이전트를 선택하세요",
     "switchModel": "모델 전환",
     "switchMode": "모드 전환",
     "switchAgent": "Agent 전환",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -1976,6 +1976,7 @@
     "shortInputTitle": "Krótki tekst",
     "shortInputMessage": "Twój tekst wygląda na bardzo krótki. Czy na pewno chcesz z tym rozpocząć sesję?",
     "selectModel": "Wybierz model",
+    "selectAgentFirst": "Najpierw wybierz agenta",
     "switchModel": "Zmień model",
     "switchMode": "Zmień tryb",
     "switchAgent": "Zmień Agenta",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -1976,6 +1976,7 @@
     "shortInputTitle": "Entrada curta",
     "shortInputMessage": "Sua entrada parece muito curta. Tem certeza de que quer iniciar uma sessão com isso?",
     "selectModel": "Selecionar modelo",
+    "selectAgentFirst": "Selecione primeiro um agente",
     "switchModel": "Alternar modelo",
     "switchMode": "Alternar modo",
     "switchAgent": "Alternar Agent",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "Короткий ввод",
     "shortInputMessage": "Ваш ввод кажется очень коротким. Вы уверены, что хотите начать сессию с этим?",
     "selectModel": "Выбрать модель",
+    "selectAgentFirst": "Сначала выберите агента",
     "switchModel": "Сменить модель",
     "switchMode": "Сменить режим",
     "switchAgent": "Сменить Agent",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "Kısa Giriş",
     "shortInputMessage": "Girişiniz çok kısa görünüyor. Bu içerikle bir oturum başlatmak istediğinizden emin misiniz?",
     "selectModel": "Model seç",
+    "selectAgentFirst": "Önce bir ajan seçin",
     "switchModel": "Model değiştir",
     "switchMode": "Mod değiştir",
     "switchAgent": "Agent değiştir",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "Nội dung ngắn",
     "shortInputMessage": "Nội dung nhập vào có vẻ rất ngắn. Bạn có chắc chắn muốn bắt đầu phiên với nội dung này không?",
     "selectModel": "Chọn mô hình",
+    "selectAgentFirst": "Chọn agent trước",
     "switchModel": "Chuyển mô hình",
     "switchMode": "Chuyển chế độ",
     "switchAgent": "Chuyển Agent",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -1957,6 +1957,7 @@
     "shortInputTitle": "輸入內容較短",
     "shortInputMessage": "您的輸入似乎非常簡短。確定要使用此內容啓動會話嗎？",
     "selectModel": "選擇模型",
+    "selectAgentFirst": "請先選擇 Agent",
     "switchModel": "切換模型",
     "switchMode": "切換模式",
     "switchAgent": "切換 Agent",
@@ -1977,7 +1978,7 @@
     "regionNoticeBodyProvider": "您所在位置：{{location}}。某些模型在您所在地區可能不可用。",
     "regionNoticeBodySanctions": "您所在位置：{{location}}。GitHub、npm、Docker Hub 等服務可能不可用。",
     "regionNoticeBodyBoth": "您所在位置：{{location}}。因地區政策與貿易規則，某些模型以及 GitHub、npm、Docker Hub 等服務可能不可用。",
-    "selectAgent": "選擇一個 Agent",
+    "selectAgent": "選擇 Agent",
     "placeholderDefault": "輸入訊息，使用 @ 加入檔案，使用 / 呼叫 skills",
     "wingmanPlaceholder": "描述你的任務 — Wingman 應該關注什麼？",
     "screenPicker": {

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -1963,6 +1963,7 @@
     "shortInputTitle": "输入内容较短",
     "shortInputMessage": "您的输入似乎非常简短。确定要使用此内容启动会话吗？",
     "selectModel": "选择模型",
+    "selectAgentFirst": "请先选择 Agent",
     "switchModel": "切换模型",
     "switchMode": "切换模式",
     "switchAgent": "切换 Agent",
@@ -1983,7 +1984,7 @@
     "regionNoticeBodyProvider": "您所在位置：{{location}}。某些模型在您所在地区可能不可用。",
     "regionNoticeBodySanctions": "您所在位置：{{location}}。GitHub、npm、Docker Hub 等服务可能不可用。",
     "regionNoticeBodyBoth": "您所在位置：{{location}}。因地区政策与贸易规则，某些模型以及 GitHub、npm、Docker Hub 等服务可能不可用。",
-    "selectAgent": "选择一个 Agent",
+    "selectAgent": "选择 Agent",
     "placeholderDefault": "输入消息，使用 @ 添加文件，使用 / 调用 skills",
     "wingmanPlaceholder": "描述你的任务 — Wingman 应该关注什么？",
     "screenPicker": {


### PR DESCRIPTION
## Problem

The composer uses verbose empty agent labels and a generic model label. Its disabled model picker looks actionable but gives no prerequisite explanation, while the shared enabled-only hover style suppresses the requested fill on disabled pills.

## Solution

Use the infinity icon for an empty agent selection and concise English and Chinese labels. Show “Select model” for an empty model selection. Add an optional disabledTooltip prop with a focusable wrapper, mute disabled content, and retain the normal hover fill while native disabled buttons continue to block clicks. Preserve the original Agent / Team chat switch dimensions. Translate the prerequisite tooltip in all 13 locales so the locale completeness check passes.

## Potential risks

The shared SelectorPill hover change affects other default-appearance disabled pills. The tooltip adds a keyboard focus stop while disabled. Live Tauri, light/dark themes, and narrow layouts have not been visually verified; no new screenshots are attached because computer control was not authorized. All locales define the new tooltip; native-speaker review of the added translations remains outstanding. No persistence, API, dependency, or background-worker changes are introduced.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/components/ModelSelectorPill/ModelSelectorPill.test.ts src/engines/ChatPanel/InputArea/components/ModelPill.test.ts` — 17 tests passed, including disabled interaction and keyboard tooltip coverage
- `pnpm typecheck:fast` — passed
- `pnpm exec eslint src/components/ModelSelectorPill/index.tsx src/components/ModelSelectorPill/ModelSelectorPill.test.ts src/components/SelectorPill/index.tsx src/engines/ChatPanel/InputArea/components/ModelPill.tsx src/features/SessionCreator/variants/ChatPanel/resolveSessionCreatorAgentHero.ts --max-warnings 0` — passed
- `git diff --check` — passed
- Reviewed the scoped diff for unrelated changes, personal paths, secrets, and generated artifacts
- Checks ran in an isolated worktree based on freshly pulled origin/develop; live app verification was not run


- `pnpm run test:i18n-keys` — all 27 tests passed after completing the tooltip translations
- `pnpm run check:i18n-keys` — passed with zero locale gaps, extras, or placeholder mismatches
- `git diff --check` — passed for the translation fix; the fix changes only 10 locale entries
