### PR TITLE
fix(chat-header): align full-width tab controls with effective layout

### DIFF
--- a/src/engines/ChatPanel/header/ChatPanelCollapsedTabHeading.tsx
+++ b/src/engines/ChatPanel/header/ChatPanelCollapsedTabHeading.tsx
@@ -10,6 +10,7 @@ import {
   ListTodoIcon,
   MessageAdd02Icon,
   PencilEdit02Icon,
+  Settings02Icon,
 } from "@src/icons";
 import { type ChatPanelTab } from "@src/store/chatPanel/chatPanelTabsModel";
 import { activeChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsState";
@@ -39,7 +40,9 @@ const CollapsedTabHeadingLabel: React.FC<{ tab: ChatPanelTab }> = ({ tab }) => {
             ? tab.managementSection === WORK_MANAGEMENT_SECTION.KANBAN
               ? KanbanIcon
               : ListTodoIcon
-            : undefined;
+            : tab.type === "organization"
+              ? Settings02Icon
+              : undefined;
 
   return (
     <span className="flex min-w-0 items-center gap-2 px-1 text-[13px] font-medium text-text-1">

--- a/src/hooks/ui/workbench/usePinnedWorkbenchChrome.ts
+++ b/src/hooks/ui/workbench/usePinnedWorkbenchChrome.ts
@@ -12,6 +12,8 @@ import { useAtomValue } from "jotai";
 import { useLocation } from "react-router-dom";
 
 import { ROUTES, isWorkbenchPath } from "@src/config/routes";
+import { resolveChatPanelMaximizedForLayout } from "@src/store/chatPanel/chatPanelTabsModel";
+import { activeChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsState";
 import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
 import { stationChatVisibilityAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
@@ -145,7 +147,12 @@ export function useWorkbenchRightEdgeReservation(): WorkbenchRightEdgeReservatio
   const pinned = usePinnedWorkbenchChromeVisible();
   const chatVisible = useCurrentStationChatVisible();
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
-  const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
+  const userMaximized = useAtomValue(chatPanelMaximizedAtom);
+  const activeTab = useAtomValue(activeChatPanelTabAtom);
+  const chatPanelMaximized = resolveChatPanelMaximizedForLayout(
+    userMaximized,
+    activeTab
+  );
   if (!pinned) return { owner: null, reservedRight: 0 };
   const owner: WorkbenchRightEdgeOwner =
     chatPanelMaximized || (chatVisible && chatPanelPosition === "right")

--- a/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts
+++ b/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { Provider } from "jotai";
-import { act, createElement } from "react";
+import { Fragment, act, createElement } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import {
@@ -20,8 +20,11 @@ import {
   isPinnedWorkbenchChromePath,
   resolvePinnedWorkbenchChromeSlots,
   shouldShowPinnedWorkbenchChrome,
+  useWorkbenchRightEdgeReservation,
 } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
+import { chatPanelTabsAtom } from "@src/store/chatPanel/chatPanelTabsState";
 import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
+import { settingsAtom } from "@src/store/settings";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
 import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
 import { chatWidthAtom } from "@src/store/ui/chatPanel/widthAtoms";
@@ -51,6 +54,15 @@ vi.mock("@src/services/workStation/WorkStationViewService", () => ({
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
+
+function RightEdgeReservationProbe() {
+  const reservation = useWorkbenchRightEdgeReservation();
+  return createElement("div", {
+    "data-testid": "right-edge-reservation",
+    "data-owner": reservation.owner,
+    "data-reserved-right": reservation.reservedRight,
+  });
+}
 
 describe("PinnedWorkbenchChrome", () => {
   let container: HTMLDivElement;
@@ -91,7 +103,12 @@ describe("PinnedWorkbenchChrome", () => {
           createElement(
             MemoryRouter,
             { initialEntries: [pathname] },
-            createElement(PinnedWorkbenchChrome)
+            createElement(
+              Fragment,
+              null,
+              createElement(PinnedWorkbenchChrome),
+              createElement(RightEdgeReservationProbe)
+            )
           )
         )
       );
@@ -218,6 +235,39 @@ describe("PinnedWorkbenchChrome", () => {
     expect(query("pinned-workbench-chrome-maximize-chat")).toBeNull();
     expect(query("pinned-workbench-chrome")?.childElementCount).toBe(1);
   });
+
+  it.each(["organization", "team-inbox", "work-management"] as const)(
+    "reserves one disabled sidebar control for full-width %s tabs with a saved split layout",
+    (type) => {
+      render();
+      act(() => {
+        store.set(activeStationChatVisibleAtom, "my-station", true);
+        store.set(chatWidthAtom, 360);
+        store.set(settingsAtom, {
+          ...store.get(settingsAtom),
+          "general.chatPanelPosition": "left",
+        });
+        store.set(chatPanelMaximizedAtom, false);
+        store.set(chatPanelTabsAtom, {
+          activeTabId: "full-width-tab",
+          tabs: [{ id: "full-width-tab", type, title: "Full-width page" }],
+        });
+      });
+
+      expect(query("pinned-workbench-chrome-chat-visibility")).toBeNull();
+      expect(query("pinned-workbench-chrome-maximize-chat")).toBeNull();
+      const sidebarButton = query("pinned-workbench-chrome-show-workstation");
+      expect(sidebarButton).toBeInstanceOf(HTMLButtonElement);
+      expect((sidebarButton as HTMLButtonElement).disabled).toBe(true);
+      expect(query("pinned-workbench-chrome")?.childElementCount).toBe(1);
+      expect(query("right-edge-reservation")?.dataset.owner).toBe("chat");
+      expect(query("right-edge-reservation")?.dataset.reservedRight).toBe(
+        String(getPinnedWorkbenchChromeReservedRight(1))
+      );
+      click("pinned-workbench-chrome-show-workstation");
+      expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    }
+  );
 
   it("follows the station on screen: Agent Station keeps its maximize toggle", () => {
     render();

--- a/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx
+++ b/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx
@@ -30,7 +30,10 @@ import {
 } from "@src/icons";
 import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { toggleActiveChatPanelMaximizedAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
-import { isChatPanelTabStationAvailable } from "@src/store/chatPanel/chatPanelTabsModel";
+import {
+  isChatPanelTabStationAvailable,
+  resolveChatPanelMaximizedForLayout,
+} from "@src/store/chatPanel/chatPanelTabsModel";
 import { activeChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsState";
 import {
   chatPanelMaximizedAtom,
@@ -45,8 +48,12 @@ const PinnedWorkbenchChromeComponent: React.FC = () => {
   const visible = usePinnedWorkbenchChromeVisible();
   const isChatPanelVisible = useCurrentStationChatVisible();
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
-  const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
+  const userMaximized = useAtomValue(chatPanelMaximizedAtom);
   const activeTab = useAtomValue(activeChatPanelTabAtom);
+  const chatPanelMaximized = resolveChatPanelMaximizedForLayout(
+    userMaximized,
+    activeTab
+  );
   const toggleChatPanelMaximized = useSetAtom(toggleChatPanelMaximizedAtom);
   const toggleActiveChatMaximized = useSetAtom(
     toggleActiveChatPanelMaximizedAtom

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -1298,11 +1298,16 @@ describe("ChatPanel navigation tabs", () => {
   it("opens org management in its own singleton tab and restores the selected org", async () => {
     const {
       activateChatPanelTabAtom,
+      activeChatPanelTabAtom,
       activeChatPanelSurfaceAtom,
       CHAT_PANEL_SURFACE_KIND,
+      chatPanelMaximizedAtom,
       chatPanelTabsAtom,
+      isChatPanelTabStationAvailable,
       openOrganizationInChatPanelTabAtom,
+      resolveChatPanelMaximizedForLayout,
       store,
+      toggleActiveChatPanelMaximizedAtom,
     } = await loadChatPanelTabAtoms();
     const consumedLaunchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
 
@@ -1317,6 +1322,16 @@ describe("ChatPanel navigation tabs", () => {
       },
       title: "Manage ORG",
     });
+
+    const expectStationUnavailable = () => {
+      const tab = store.get(activeChatPanelTabAtom);
+      expect(isChatPanelTabStationAvailable(tab)).toBe(false);
+      expect(resolveChatPanelMaximizedForLayout(false, tab)).toBe(true);
+      const savedMaximized = store.get(chatPanelMaximizedAtom);
+      expect(store.set(toggleActiveChatPanelMaximizedAtom)).toBe(false);
+      expect(store.get(chatPanelMaximizedAtom)).toBe(savedMaximized);
+    };
+    expectStationUnavailable();
 
     expect(store.get(chatPanelTabsAtom)).toMatchObject({
       activeTabId: managementTabId,
@@ -1378,6 +1393,7 @@ describe("ChatPanel navigation tabs", () => {
       title: "Manage ORG",
     });
     expect(switchedTabId).toBe(managementTabId);
+    expectStationUnavailable();
     expect(
       store
         .get(chatPanelTabsAtom)


### PR DESCRIPTION
## Problem

Manage Organization and other full-width tabs could show an extra maximize control overlapping the new-tab (+) button on macOS. The pinned controls and their right-edge reservation read the saved maximize preference, while the page layout enforced full width through the active tab's Station-access policy. Manage Organization also lacked its settings icon in the collapsed title.

## Solution

Use the existing effective-layout resolver for both pinned controls and their reserved space. Full-width tabs retain + and one disabled sidebar button, without the extra maximize control. Add the organization tab's existing settings icon to its collapsed heading. Cover organization, Inbox, and Work Management controls and reservation together, and verify Station access remains blocked when opening cloud and local organization management.

## Potential risks

The shared pinned macOS chrome also serves session and hidden-chat layouts; existing regression tests for those states pass. Live macOS rendering, themes, and viewport layouts have not been visually verified, so pixel-level alignment remains unverified. No persistence, dependency, IPC, or schema changes are included; the saved maximize preference is preserved. Reverting this commit restores the prior behavior.

## Verification

Run in an isolated worktree based on the latest `origin/develop`:

- `pnpm test src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/engines/ChatPanel/ChatPanelHeader.test.ts src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts` — 4 files, 86 tests passed
- `pnpm typecheck:fast` — passed
- `pnpm exec eslint src/engines/ChatPanel/header/ChatPanelCollapsedTabHeading.tsx src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/hooks/ui/workbench/usePinnedWorkbenchChrome.ts src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts --max-warnings 0` — passed
- `git diff --check` — passed
- Inspected the five-file diff for scope, secrets, personal paths, debug logs, and generated churn
- No live UI checks or new screenshots: desktop control was not authorized under the user's explicit opt-in preference. DOM regression tests verify the disabled control, absence of maximize controls, and reservation of the correct pane and width; they do not establish visual alignment
