### PR TITLE
feat(wiki): add searchable English feature guide

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/WikiModal.md
+++ b/docs/frontend-ui-audit-2026-09-10/WikiModal.md
@@ -1,0 +1,15 @@
+# Wiki modal UI audit
+
+| Line                                                                      | Element            | Verdict          | Reason                                                                                                                                                 | Suggested change |
+| ------------------------------------------------------------------------- | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `src/features/Wiki/WikiModal.tsx:13`                                      | Dialog shell       | keep with reason | Reuses Modal for focus trapping and Escape. A bounded 80dvh height and hidden body overflow make the article the only scroll owner                     | None             |
+| `src/features/Wiki/WikiBrowser.tsx:30`                                    | Search             | keep with reason | Shared labeled Input in the fixed sidebar header; no result count or extra introductory copy                                                           | None             |
+| `src/features/Wiki/WikiBrowser.tsx:42`                                    | Article navigation | keep with reason | Native buttons reuse SESSION_ROW_PRESENTATION, SIDEBAR_STYLE.rowHeight and sidebar selection tokens, matching sidebar rows without form-button styling | None             |
+| `src/features/Wiki/WikiBrowser.tsx:61`                                    | Article pane       | keep with reason | Shared border token separates the fixed sidebar from a keyboard-focusable scroll region; article identity resets scroll on navigation                  | None             |
+| `src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx:381` | Wiki menu action   | keep with reason | Matches sibling dropdown tokens and closes the dropdown before opening the separate modal                                                              | None             |
+
+Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.
+
+English-only content is explicitly requested. Articles contain category, title, summary and instructions; interactive demonstrations and simulated credential validation are excluded.
+
+Verification: rendered jsdom tests cover search, no results, article navigation, Escape/reopen, independent menu access outside developer mode and preserved onboarding actions. Desktop visual inspection and screenshots were not performed because computer control was not authorized. Small viewport layout, actual scrolling, and light/dark appearance remain visually unverified.

--- a/docs/org2-performance-guard-2026-09-10/WikiModal.md
+++ b/docs/org2-performance-guard-2026-09-10/WikiModal.md
@@ -1,0 +1,16 @@
+# Wiki modal lifecycle review
+
+Production entry: account-menu Wiki action → lazily imported WikiModal → WikiBrowser. Existing onboarding event, host and developer-mode gate are unchanged. Wiki is available independently of developer mode.
+
+| Area               | Verdict | Evidence                                                                           | Change or reason kept                                            | Verification                                    |
+| ------------------ | ------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------- |
+| Background work    | keep    | No timers, effects, listeners, network requests or provider controllers introduced | Mount only when opened                                           | Menu open/dismiss test                          |
+| Memory             | keep    | Ten static articles; local query and selected article ID                           | Close unmounts the modal and resets local state                  | Escape/reopen test                              |
+| Scope/isolation    | keep    | Public English text only; no account data, keys or persistent state                | Independent per mounted menu                                     | Signed-out/non-dev menu test                    |
+| Rendering/hot path | keep    | Search scans the fixed-size catalog on input; one article renders                  | Fixed sidebar and one article scroll region; no scroll listeners | Search and navigation tests; typecheck and lint |
+
+Visible/hidden idle performs no new scheduled work. Network, account, endpoint, provider ingestion and multi-instance transport lifecycles are inapplicable to this public local documentation. Existing shared Modal/Input lifecycle behavior is reused. No runtime CPU/RSS improvement is claimed.
+
+Verification: targeted wiki, onboarding and menu tests; TypeScript typecheck; scoped ESLint; diff whitespace check. Actual Tauri rendering, scroll behavior and CPU/RSS were not measured because computer control was not authorized.
+
+Performance verdict: pass for the bounded local UI resource surface; actual visual layout remains unverified.

--- a/src/features/Onboarding/OnboardingModal.test.ts
+++ b/src/features/Onboarding/OnboardingModal.test.ts
@@ -66,6 +66,9 @@ describe("OnboardingModal", () => {
     expect(button?.tagName).toBe("BUTTON");
     act(() => button!.click());
   }
+  it("does not contain the wiki", () => {
+    expect(document.querySelector('[aria-label="Search the wiki"]')).toBeNull();
+  });
   it.each([
     ["onboarding-start-session", "openSessionCreatorSpotlight", []],
     [

--- a/src/features/Wiki/WikiBrowser.tsx
+++ b/src/features/Wiki/WikiBrowser.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+
+import Button from "@src/components/Button";
+import Input from "@src/components/Input";
+import { SESSION_ROW_PRESENTATION } from "@src/components/SessionRowPresentation";
+import { SIDEBAR_STYLE } from "@src/scaffold/NavigationSidebar/config";
+
+import { searchWikiArticles } from "./wikiArticles";
+
+export default function WikiBrowser() {
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState("keys");
+  const results = searchWikiArticles(query);
+  const article =
+    results.find((entry) => entry.id === selectedId) ?? results[0];
+  return (
+    <section
+      lang="en"
+      aria-label="Feature wiki"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+    >
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <nav
+          aria-label="Wiki articles"
+          className="flex w-44 shrink-0 flex-col gap-1 border-r border-border-2 px-3 py-2 sm:w-60"
+        >
+          <div className="flex shrink-0 flex-col gap-2 pb-3">
+            <Input
+              type="search"
+              aria-label="Search the wiki"
+              placeholder="Search wiki…"
+              value={query}
+              onChange={setQuery}
+              allowClear
+            />
+          </div>
+          {results.map((entry) => (
+            <button
+              type="button"
+              key={entry.id}
+              aria-current={article?.id === entry.id ? "page" : undefined}
+              onClick={() => setSelectedId(entry.id)}
+              title={`${entry.category}: ${entry.title}`}
+              style={{ height: SIDEBAR_STYLE.rowHeight }}
+              className={`${SESSION_ROW_PRESENTATION.row} shrink-0 px-2 text-left text-text-1 hover:bg-sidebar-selected focus-visible:outline focus-visible:outline-primary-6 ${article?.id === entry.id ? "bg-sidebar-selected" : ""}`}
+              data-testid={`wiki-${entry.id}`}
+            >
+              <span className={SESSION_ROW_PRESENTATION.title}>
+                {entry.title}
+              </span>
+            </button>
+          ))}
+        </nav>
+        <div
+          key={article?.id ?? "empty"}
+          role="region"
+          aria-label="Wiki article content"
+          tabIndex={0}
+          className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain p-4"
+        >
+          {article ? (
+            <article
+              aria-labelledby="wiki-article-title"
+              className="flex min-w-0 flex-col gap-4"
+            >
+              <div>
+                <p className="text-xs text-text-3">{article.category}</p>
+                <h2
+                  id="wiki-article-title"
+                  className="text-lg font-semibold text-text-1"
+                >
+                  {article.title}
+                </h2>
+              </div>
+              <p className="text-sm text-text-2">{article.summary}</p>
+              <ol className="flex list-decimal flex-col gap-3 pl-5 text-sm text-text-2">
+                {article.steps.map((step) => (
+                  <li key={step}>{step}</li>
+                ))}
+              </ol>
+            </article>
+          ) : (
+            <div className="flex flex-col items-start gap-3">
+              <p className="text-sm text-text-2">
+                No articles match “{query}”. Try a provider name, “keys” or
+                “imports”.
+              </p>
+              <Button onClick={() => setQuery("")}>Clear search</Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/Wiki/WikiModal.test.ts
+++ b/src/features/Wiki/WikiModal.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React, { act, useState } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import WikiModal from "./WikiModal";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("WikiModal", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    function Host() {
+      const [open, setOpen] = useState(true);
+      return React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(
+          "button",
+          { onClick: () => setOpen(true), "data-testid": "reopen" },
+          "Reopen"
+        ),
+        React.createElement(WikiModal, {
+          open,
+          onClose: () => setOpen(false),
+        })
+      );
+    }
+    act(() =>
+      root.render(
+        React.createElement(
+          Provider,
+          { store: createStore() },
+          React.createElement(Host)
+        )
+      )
+    );
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.resetAllMocks();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+  function click(id: string) {
+    const button = document.querySelector<HTMLButtonElement>(
+      `[data-testid="${id}"]`
+    );
+    expect(button?.tagName).toBe("BUTTON");
+    act(() => button!.click());
+  }
+  function search(value: string) {
+    const input = document.querySelector<HTMLInputElement>(
+      '[aria-label="Search the wiki"]'
+    )!;
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value"
+      )!.set!.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+  it("searches body content, selects an article and handles no results", () => {
+    expect(document.querySelector("#wiki-article-title")?.textContent).toBe(
+      "Adding keys: choose a method"
+    );
+    search("device authorization");
+    expect(document.querySelector("#wiki-article-title")?.textContent).toBe(
+      "Authentication by provider"
+    );
+    search("not-a-wiki-topic");
+    expect(document.body.textContent).toContain("No articles match");
+    search("");
+    click("wiki-editor");
+    expect(document.querySelector("#wiki-article-title")?.textContent).toBe(
+      "Code Editor & source control"
+    );
+  });
+  it("resets the wiki search after closing and reopening", () => {
+    search("not-a-wiki-topic");
+    act(() =>
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+      )
+    );
+    click("reopen");
+    expect(
+      document.querySelector<HTMLInputElement>('[aria-label="Search the wiki"]')
+        ?.value
+    ).toBe("");
+  });
+});

--- a/src/features/Wiki/WikiModal.tsx
+++ b/src/features/Wiki/WikiModal.tsx
@@ -1,0 +1,25 @@
+import Modal from "@src/scaffold/ModalSystem";
+
+import WikiBrowser from "./WikiBrowser";
+
+export default function WikiModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  return (
+    <Modal
+      visible={open}
+      onCancel={onClose}
+      title="ORG2 Wiki"
+      footer={null}
+      width={1040}
+      className="h-[80dvh]"
+      bodyClassName="flex min-h-0 flex-col overflow-hidden! p-0"
+    >
+      {open && <WikiBrowser />}
+    </Modal>
+  );
+}

--- a/src/features/Wiki/wikiArticles.test.ts
+++ b/src/features/Wiki/wikiArticles.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { WIKI_ARTICLES, searchWikiArticles } from "./wikiArticles";
+
+describe("wiki search", () => {
+  it("searches article bodies with case-insensitive AND terms", () => {
+    expect(searchWikiArticles("  CLAUDE oauth ").map(({ id }) => id)).toContain(
+      "provider-auth"
+    );
+    expect(
+      searchWikiArticles("device authorization").map(({ id }) => id)
+    ).toContain("provider-auth");
+    expect(searchWikiArticles("extract config").map(({ id }) => id)).toContain(
+      "keys"
+    );
+  });
+  it("returns the catalog for whitespace and no results for unknown terms", () => {
+    expect(searchWikiArticles("   ")).toEqual(WIKI_ARTICLES);
+    expect(searchWikiArticles("not-a-wiki-topic")).toEqual([]);
+  });
+});

--- a/src/features/Wiki/wikiArticles.ts
+++ b/src/features/Wiki/wikiArticles.ts
@@ -1,0 +1,157 @@
+/** English product guide. Keep authentication instructions aligned with KeyVault setup components. */
+export interface WikiArticle {
+  id: string;
+  category: string;
+  title: string;
+  summary: string;
+  steps: string[];
+}
+
+export const WIKI_ARTICLES: WikiArticle[] = [
+  {
+    id: "sessions",
+    category: "Workspace",
+    title: "Agent sessions & chat",
+    summary:
+      "Start a conversation, choose an agent and model, and follow the work in the Chat Panel.",
+    steps: [
+      "Use Start a session to open the session creator and choose a working directory and available account.",
+      "Send instructions in the Chat Panel, inspect tool activity, and follow up in the same session.",
+      "Use session search to return to earlier work; imports bring supported external CLI histories into the app.",
+    ],
+  },
+  {
+    id: "projects",
+    category: "Workspace",
+    title: "Projects, work items & directories",
+    summary:
+      "Organize repositories and work items, and connect sessions to the work they belong to.",
+    steps: [
+      "Switch working directories to choose the repository or folder for your next task.",
+      "Use Projects and Work Items to organize work and attach related sessions.",
+      "Choose a branch or worktree when work needs its own checkout; review changes before integrating them.",
+    ],
+  },
+  {
+    id: "editor",
+    category: "Apps",
+    title: "Code Editor & source control",
+    summary:
+      "Open files, terminals and diffs alongside agent work, then review Git changes and history.",
+    steps: [
+      "Open the Code Editor from the station dock and choose a file or tab.",
+      "Use Source Control to inspect diffs, stage or unstage changes, and commit.",
+      "Use Git History to inspect previous commits, or use Spotlight to open repository branches.",
+    ],
+  },
+  {
+    id: "browser",
+    category: "Apps",
+    title: "Browser & replay",
+    summary:
+      "Keep web pages and recorded browser sessions within your workspace.",
+    steps: [
+      "Open Browser from the station dock to work with web tabs.",
+      "Use the browser sidebar to find sessions and open available replays.",
+      "Review captured activity alongside the agent conversation for context.",
+    ],
+  },
+  {
+    id: "extensions",
+    category: "Apps",
+    title: "Skills, rules, MCP & agents",
+    summary:
+      "Configure reusable instructions and tool integrations from Integrations.",
+    steps: [
+      "Choose the relevant Skills, Rules, MCP or Agents section in Integrations.",
+      "Create an entry or use the supported external import flow to reuse an existing configuration.",
+      "Review the entry and its scope before enabling it for your workflow. MCP servers may need their own credentials.",
+    ],
+  },
+  {
+    id: "cloud",
+    category: "Collaboration",
+    title: "Cloud workspaces, sharing & mobile remote",
+    summary:
+      "Sign in to ORG2 Cloud to access collaboration features available to your account.",
+    steps: [
+      "Sign in from the account menu, then connect or choose a cloud workspace.",
+      "Use session sharing to share work and the shared-session import flow to bring shared context into your workspace.",
+      "Use Mobile Remote to access supported remote session controls. Workspace membership and access permissions still apply.",
+      "ORG2 Cloud sign-in is separate from model-provider authentication: it does not add a model API key.",
+    ],
+  },
+  {
+    id: "usage",
+    category: "Apps",
+    title: "Runtime, usage & settings",
+    summary:
+      "Inspect runtime activity and quota information, then tailor appearance and layout.",
+    steps: [
+      "Open Runtime to inspect usage and available account quota information.",
+      "In a cloud workspace, inspect member runtime and sync status where access permits.",
+      "Use Settings for appearance and layout preferences; the account menu also exposes appearance, layout and RAM tools.",
+    ],
+  },
+  {
+    id: "keys",
+    category: "Keys & authentication",
+    title: "Adding keys: choose a method",
+    summary:
+      "Open Integrations → Key Vault, add an account and choose a provider. Available methods depend on that provider.",
+    steps: [
+      "Direct API key: paste a provider-issued key, choose the endpoint and protocol where offered, validate, then complete the account wizard.",
+      "Sign in: complete the provider authorization flow. This adds provider account credentials rather than an ORG2 Cloud login.",
+      "Autodetect: sign in or configure the supported CLI locally first, then detect its existing credentials and review the result.",
+      "Enter token: paste a supported session token or key only where the selected provider offers this method.",
+      "Extract config: for supported generic providers, paste configuration text, extract the credentials, review the key and base URL, then validate.",
+      "Import credentials from other apps: expand the import panel, select supported discovered entries, import them and review any per-item failures.",
+      "Local model: choose the local runtime, configure its base URL and model, supply a key if the server requires one, then validate.",
+    ],
+  },
+  {
+    id: "provider-auth",
+    category: "Keys & authentication",
+    title: "Authentication by provider",
+    summary:
+      "The wizard exposes different setup choices for each provider; methods are not interchangeable.",
+    steps: [
+      "Claude Code: Sign in or Autodetect an existing OAuth login. Saving requires OAuth credentials; a plain API key is not a Claude Code login.",
+      "Codex: Sign in, Autodetect, or Enter token. The manual field accepts supported OAuth session tokens or API keys; validate before saving.",
+      "Cursor: Guided setup, Autodetect, or Enter token. The setup also offers API key entry; review the credential type selected by the wizard.",
+      "GitHub Copilot: enter an existing token and validate, or use the guided token-creation browser flow.",
+      "Kiro: Autodetect credentials from kiro-cli or Sign in through its device authorization flow.",
+      "Direct API providers: enter a key, with official/custom base URL and protocol options only where supported.",
+      "Other providers: use only the methods offered by their configuration. Autodetect, manual entry and config extraction are provider-dependent.",
+    ],
+  },
+  {
+    id: "key-troubleshooting",
+    category: "Keys & authentication",
+    title: "Validation, endpoints & troubleshooting",
+    summary:
+      "Validate credentials against the intended provider and endpoint before completing setup.",
+    steps: [
+      "If detection finds nothing, check that the supported CLI is installed and signed in on this machine, then retry detection.",
+      "If validation fails, check the credential, selected provider, base URL, protocol and network connection. An account login is not necessarily an API key.",
+      "For custom endpoints, confirm the server supports the selected protocol and model. Changing an endpoint can change where requests are sent.",
+      "If authorization expires, return to the account setup and sign in again. For failed imports, inspect individual errors before retrying.",
+      "After saving, choose the account and an available model in your session setup. Provider usage and ORG2 Cloud membership are separate.",
+    ],
+  },
+];
+
+export function searchWikiArticles(query: string): WikiArticle[] {
+  const terms = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+  return WIKI_ARTICLES.filter((article) => {
+    const text = [
+      article.title,
+      article.category,
+      article.summary,
+      ...article.steps,
+    ]
+      .join(" ")
+      .toLowerCase();
+    return terms.every((term) => text.includes(term));
+  });
+}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts
@@ -154,6 +154,40 @@ describe("SidebarSettingsMenuButton", () => {
     expect(adeManagerButton).toBeUndefined();
   });
 
+  it("opens and dismisses the separate wiki outside dev mode without opening onboarding", async () => {
+    act(() => store.set(devModeEnabledAtom, false));
+    const onOnboarding = vi.fn();
+    window.addEventListener(TUTORIALS_OPEN_EVENT, onOnboarding);
+    try {
+      const button = document.querySelector<HTMLButtonElement>(
+        '[data-testid="sidebar-menu-wiki"]'
+      );
+      expect(button?.textContent).toBe("Wiki");
+      await act(async () => {
+        button!.click();
+        await import("@src/features/Wiki/WikiModal");
+      });
+      expect(mocks.closeDropdown).toHaveBeenCalledOnce();
+      expect(
+        document.querySelector('[aria-label="Search the wiki"]')
+      ).not.toBeNull();
+      expect(
+        document.querySelector('[data-testid="onboarding-modal"]')
+      ).toBeNull();
+      expect(onOnboarding).not.toHaveBeenCalled();
+      act(() =>
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+        )
+      );
+      expect(
+        document.querySelector('[aria-label="Search the wiki"]')
+      ).toBeNull();
+    } finally {
+      window.removeEventListener(TUTORIALS_OPEN_EVENT, onOnboarding);
+    }
+  });
+
   it("hides onboarding when dev mode is disabled", () => {
     act(() => store.set(devModeEnabledAtom, false));
     expect(

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -38,6 +38,7 @@ import {
 import { useAppNavigation } from "@src/hooks/navigation";
 import {
   ArrowRight01Icon,
+  BookOpen01Icon,
   CircleIcon,
   ContrastIcon,
   GaugeIcon,
@@ -63,6 +64,8 @@ import {
   SidebarSettingsMenuSubmenus,
   type SubmenuPosition,
 } from "./SidebarSettingsMenuSubmenus";
+
+const WikiModal = React.lazy(() => import("@src/features/Wiki/WikiModal"));
 
 const MENU_ICON_CLASS_NAME = "shrink-0 text-text-2";
 const MENU_ARROW_CLASS_NAME = "text-text-3";
@@ -104,6 +107,7 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
   const { t: tSettings } = useTranslation("settings");
   const { t: tOnboarding } = useTranslation("onboarding");
   const { goToSettings } = useAppNavigation();
+  const [showWiki, setShowWiki] = useState(false);
   const [showSignInModal, setShowSignInModal] = useState(false);
   const [showSignOutConfirmation, setShowSignOutConfirmation] = useState(false);
   const signedIn = useAtomValue(org2CloudAuthAtom) !== null;
@@ -364,6 +368,25 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
                   <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
                 </>
               )}
+              <button
+                type="button"
+                className={`${DROPDOWN_CLASSES.menuActionItem} gap-2`}
+                onMouseEnter={() => setActiveSubmenu(null)}
+                onFocus={() => setActiveSubmenu(null)}
+                onClick={() => {
+                  flushSync(closeAll);
+                  setShowWiki(true);
+                }}
+                aria-haspopup="dialog"
+                data-testid="sidebar-menu-wiki"
+              >
+                <HugeiconsIcon
+                  icon={BookOpen01Icon}
+                  size={DROPDOWN_ITEM.iconSize}
+                  className={MENU_ICON_CLASS_NAME}
+                />
+                <span className="truncate">Wiki</span>
+              </button>
               {devModeEnabled && (
                 <button
                   type="button"
@@ -533,6 +556,11 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
           </div>,
           document.body
         )}
+      {showWiki && (
+        <React.Suspense fallback={null}>
+          <WikiModal open onClose={() => setShowWiki(false)} />
+        </React.Suspense>
+      )}
       {showSignInModal && onSignIn && (
         <SignInModal
           onClose={() => setShowSignInModal(false)}


### PR DESCRIPTION
## Problem

The app has onboarding cards and tours but no searchable in-app reference for major features or the provider-specific ways to add keys and authenticate.

## Solution

Add a separate, lazily loaded English Wiki modal from the account menu, available outside developer mode. Ten articles cover the main apps and workflows, with dedicated guides for key setup methods, provider authentication and troubleshooting. Search matches article titles and content.

The sidebar uses existing navigation tokens, contains search in its header, and stays fixed beside a vertical divider. Only the article pane scrolls. The guide contains plain instructions without result counts or interactive demonstrations. Existing onboarding behavior is unchanged.

## Potential risks

Desktop screenshots and real-app visual checks were not run because computer control was not authorized. Actual scrolling, light/dark appearance, and compact viewport layout remain visually unverified; the fixed sidebar may need further adaptation on very short windows. English copy is intentional and provider instructions will need maintenance as setup flows evolve.

No dependencies, persistence formats, authentication behavior, API/IPC contracts or background resources change. The modal is unmounted on close. Reverting this PR removes the menu entry and guide without data recovery work.

## Verification

Run in an isolated checkout based on the latest `origin/develop`:

- `pnpm test src/features/Onboarding src/features/Wiki src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts` — 27 tests passed. Covers search, empty results, article selection, Escape/reopen, independent Wiki access outside developer mode, and unchanged onboarding actions.
- `pnpm typecheck:fast` — passed.
- `pnpm exec eslint src/features/Wiki src/features/Onboarding/OnboardingModal.test.ts src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts --ext .ts,.tsx --max-warnings 0` — passed.
- `git diff --check` — passed.
- Reviewed the scoped diff for unrelated changes, credentials, personal paths and generated artifacts; none included.
- Tauri visual/E2E checks and screenshots were not run under the user's no-computer-control preference. Rust tests were not run because no backend code changes.

## Audit

UI audit: 0 fix, 5 keep with reason, 0 abstract. Lifecycle review passes for bounded local state with no new background work. Reports are included in the PR.
