### PR TITLE
fix(chat): distinguish comment composer actions

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/InputActions.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputActions.tsx
@@ -28,6 +28,7 @@ import {
   ArrowUp02Icon,
   HugeiconsIcon,
   RotateLeft01Icon,
+  SendIcon,
   SquareIcon,
 } from "@src/icons";
 import { chatAppearanceAtom } from "@src/store/config/configAtom";
@@ -60,6 +61,7 @@ interface InputActionsProps {
   onResume: () => Promise<void>;
   tone?: "primary" | "warning";
   submitDisabled?: boolean;
+  commentMode?: boolean;
 }
 
 const InputActions: React.FC<InputActionsProps> = memo(
@@ -76,6 +78,7 @@ const InputActions: React.FC<InputActionsProps> = memo(
     onResume,
     tone = "primary",
     submitDisabled = false,
+    commentMode = false,
   }) => {
     const { t } = useTranslation();
     const { sendOnEnter } = useAtomValue(chatAppearanceAtom);
@@ -153,12 +156,14 @@ const InputActions: React.FC<InputActionsProps> = memo(
     // layer-promotion shake explanation. `transition-colors` keeps the
     // 200ms animation limited to the background swap.
     const baseClass = `flex ${INPUT_AREA_BUTTONS.iconButtonSizeClass} shrink-0 items-center justify-center rounded-full transition-colors duration-200 focus:outline-none`;
-    const activeButtonClass =
-      tone === "warning"
+    const activeButtonClass = commentMode
+      ? "cursor-pointer border-none bg-purple-6 text-white hover:bg-purple-5"
+      : tone === "warning"
         ? "cursor-pointer border-none bg-warning-6 text-white hover:bg-warning-5"
         : INPUT_AREA_BUTTONS.iconButtonActive;
-    const inactiveButtonClass =
-      tone === "warning"
+    const inactiveButtonClass = commentMode
+      ? "border-none bg-purple-6 text-white opacity-50"
+      : tone === "warning"
         ? "border-none bg-warning-6 text-white opacity-50"
         : INPUT_AREA_BUTTONS.iconButtonInactive;
 
@@ -233,8 +238,8 @@ const InputActions: React.FC<InputActionsProps> = memo(
           />
         ) : (
           <HugeiconsIcon
-            icon={ArrowUp02Icon}
-            data-icon="arrow-up"
+            icon={commentMode ? SendIcon : ArrowUp02Icon}
+            data-icon={commentMode ? "send" : "arrow-up"}
             size={INPUT_AREA_BUTTONS.iconSize}
             strokeWidth={2}
             className="block text-[#fff]"

--- a/src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx
@@ -265,6 +265,7 @@ interface NormalComposerContentProps extends SharedComposerBarProps {
   onBlur: () => void;
   onSubmit: (capturedText?: string) => void;
   placeholder?: string;
+  commentMode?: boolean;
   /** Inline ghost hint after the last content node (see ComposerInput) */
   trailingHint?: string | null;
   currentInputEmpty: boolean;
@@ -321,6 +322,7 @@ export const NormalComposerContent: React.FC<NormalComposerContentProps> = ({
   contextualPanel = false,
   inlineLeadingContent,
   placeholder,
+  commentMode = false,
   trailingHint,
   currentInputEmpty,
   stopSuppressedForEmptyInput,
@@ -437,6 +439,7 @@ export const NormalComposerContent: React.FC<NormalComposerContentProps> = ({
                 onInterrupt={onInterrupt}
                 onResume={onResume}
                 submitDisabled={submitDisabled}
+                commentMode={commentMode}
               />
             </div>
           }

--- a/src/engines/ChatPanel/InputArea/index.tsx
+++ b/src/engines/ChatPanel/InputArea/index.tsx
@@ -621,7 +621,10 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
                 currentRepoPath={currentRepoPath}
                 contextualPanel={isContextualPanel}
                 inlineLeadingContent={isContextual ? topRowPills : undefined}
-                placeholder={placeholder}
+                placeholder={
+                  teamChatActive ? t("input.commentPlaceholder") : placeholder
+                }
+                commentMode={teamChatActive}
                 trailingHint={
                   compactHintVisible
                     ? t("input.compactArgHint")

--- a/src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx
+++ b/src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx
@@ -62,7 +62,7 @@ export function ConversationModePill({
               data-icon="messages-square"
               size={PILL_SM_ICON_SIZE}
               strokeWidth={1.75}
-              className="block"
+              className={mode === "team_chat" ? "block text-purple-6" : "block"}
               aria-hidden
             />
           ),

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Nachricht bearbeiten...",
     "defaultPlaceholder": "Mit Agent chatten",
+    "commentPlaceholder": "Kommentar schreiben…",
     "editingQueuedMessage": "Warteschlangennachricht bearbeiten",
     "editingSentMessage": "Gesendete Nachricht bearbeiten",
     "voiceErrorPermission": "Mikrofonzugriff verweigert. Aktivieren Sie ihn in den Systemeinstellungen.",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Edit your message...",
     "defaultPlaceholder": "Chat with Agent",
+    "commentPlaceholder": "Leave a comment…",
     "editingQueuedMessage": "Editing queued message",
     "editingSentMessage": "Editing sent message",
     "voiceErrorPermission": "Microphone permission denied. Enable it in your OS settings.",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Editar tu mensaje...",
     "defaultPlaceholder": "Chatear con el Agent",
+    "commentPlaceholder": "Escribe un comentario…",
     "editingQueuedMessage": "Editando mensaje en cola",
     "editingSentMessage": "Editando mensaje enviado",
     "voiceErrorPermission": "Permiso de micrófono denegado. Actívalo en la configuración del sistema.",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Modifier votre message...",
     "defaultPlaceholder": "Discuter avec l'Agent",
+    "commentPlaceholder": "Laissez un commentaire…",
     "editingQueuedMessage": "Modification du message en file",
     "editingSentMessage": "Modification du message envoyé",
     "voiceErrorPermission": "Permission micro refusée. Activez-la dans les paramètres système.",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "メッセージを編集...",
     "defaultPlaceholder": "Agent とチャット",
+    "commentPlaceholder": "コメントを入力…",
     "editingQueuedMessage": "キューメッセージを編集中",
     "editingSentMessage": "送信済みメッセージを編集中",
     "voiceErrorPermission": "マイクの権限が拒否されました。OS の設定で有効にしてください。",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "메시지 편집...",
     "defaultPlaceholder": "Agent와 채팅",
+    "commentPlaceholder": "댓글을 남겨 보세요…",
     "editingQueuedMessage": "대기 메시지 편집 중",
     "editingSentMessage": "보낸 메시지 편집 중",
     "voiceErrorPermission": "마이크 권한이 거부되었습니다. OS 설정에서 활성화하세요.",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Edytuj wiadomość...",
     "defaultPlaceholder": "Czat z Agentem",
+    "commentPlaceholder": "Napisz komentarz…",
     "editingQueuedMessage": "Edycja wiadomości w kolejce",
     "editingSentMessage": "Edycja wysłanej wiadomości",
     "voiceErrorPermission": "Brak uprawnień do mikrofonu. Włącz je w ustawieniach systemu.",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Edite sua mensagem...",
     "defaultPlaceholder": "Conversar com o Agent",
+    "commentPlaceholder": "Deixe um comentário…",
     "editingQueuedMessage": "Editando mensagem na fila",
     "editingSentMessage": "Editando mensagem enviada",
     "voiceErrorPermission": "Permissão do microfone negada. Ative nas configurações do sistema.",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Редактировать сообщение...",
     "defaultPlaceholder": "Чат с Agent",
+    "commentPlaceholder": "Оставьте комментарий…",
     "editingQueuedMessage": "Редактирование сообщения в очереди",
     "editingSentMessage": "Редактирование отправленного сообщения",
     "voiceErrorPermission": "Доступ к микрофону запрещён. Включите его в настройках системы.",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Mesajınızı düzenleyin...",
     "defaultPlaceholder": "Agent ile sohbet edin",
+    "commentPlaceholder": "Bir yorum yazın…",
     "editingQueuedMessage": "Sıradaki mesaj düzenleniyor",
     "editingSentMessage": "Gönderilmiş mesaj düzenleniyor",
     "voiceErrorPermission": "Mikrofon izni reddedildi. İşletim sistemi ayarlarından etkinleştirin.",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "Chỉnh sửa tin nhắn...",
     "defaultPlaceholder": "Trò chuyện với Agent",
+    "commentPlaceholder": "Để lại bình luận…",
     "editingQueuedMessage": "Đang chỉnh sửa tin nhắn trong hàng đợi",
     "editingSentMessage": "Đang chỉnh sửa tin nhắn đã gửi",
     "voiceErrorPermission": "Quyền truy cập micrô bị từ chối. Bật trong cài đặt hệ thống.",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "編輯消息...",
     "defaultPlaceholder": "與 Agent 對話",
+    "commentPlaceholder": "留下評論…",
     "editingQueuedMessage": "編輯排隊消息",
     "editingSentMessage": "編輯已發送消息",
     "voiceErrorPermission": "麥克風權限被拒絕。請在系統設定中啟用。",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -577,6 +577,7 @@
   "input": {
     "editPlaceholder": "编辑消息...",
     "defaultPlaceholder": "与 Agent 对话",
+    "commentPlaceholder": "留下评论…",
     "editingQueuedMessage": "编辑排队消息",
     "editingSentMessage": "编辑已发送消息",
     "voiceErrorPermission": "麦克风权限被拒绝。请在系统设置中启用。",

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -444,3 +444,5 @@ export { default as WorkflowCircle05Icon } from "@hugeicons/core-free-icons/Work
 export { default as Wrench01Icon } from "@hugeicons/core-free-icons/Wrench01Icon";
 export { default as ZoomInAreaIcon } from "@hugeicons/core-free-icons/ZoomInAreaIcon";
 export { default as ZoomOutAreaIcon } from "@hugeicons/core-free-icons/ZoomOutAreaIcon";
+
+export { default as SendIcon } from "@hugeicons/core-free-icons/SendIcon";


### PR DESCRIPTION
## Problem

Comment mode reuses the agent composer’s send icon, blue action color, and agent placeholder, making the target of a message unclear.

## Solution

Use the existing team-chat mode to display SendIcon, purple active/inactive send styling, a purple selected comment icon, and a localized “Leave a comment…” placeholder in all 13 locales. Agent submission, stop, and retry behavior stay unchanged.

## Potential risks

Purple contrast and placeholder fit across themes, narrow viewports, and locales have not been visually verified. No persistence, dependency, or protocol changes are involved; reverting this commit restores the previous presentation.

## Verification

Passed on the isolated branch based on latest develop:
- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/InputArea/components/InputComposerBars.test.ts src/features/Org2Cloud/SessionConversation/ConversationModePill.test.ts src/engines/ChatPanel/InputArea/components/inputActionClickGuard.test.ts` — 16 tests passed
- `pnpm exec eslint src/icons.ts src/engines/ChatPanel/InputArea/components/InputActions.tsx src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx src/engines/ChatPanel/InputArea/index.tsx src/features/Org2Cloud/SessionConversation/ConversationModePill.tsx` — passed
- `pnpm typecheck:fast` — passed
- `git diff --check` — passed
- Python JSON parsing verified all 13 locales contain the comment placeholder

Reviewed the diff for scope, secrets, private paths, debug output, and generated churn. Desktop visual checks and after-change screenshots were not performed because computer control was not authorized. Existing automated tests do not verify pixel appearance.
