### PR TITLE
style(model-selector): tighten settings popover spacing

### DIFF
--- a/src/components/ModelSelectorPill/ModelSettingsMenu.tsx
+++ b/src/components/ModelSelectorPill/ModelSettingsMenu.tsx
@@ -322,8 +322,8 @@ export default function ModelSettingsMenu({
                 </div>
               </ActionMenuSurface>
             ) : (
-              <div className={`${DROPDOWN_CLASSES.menuPanelBase} p-2`}>
-                <div className="mb-2 flex items-center justify-between gap-2">
+              <div className={`${DROPDOWN_CLASSES.menuPanelBase} p-1`}>
+                <div className="flex items-center justify-between gap-2">
                   <Button
                     size="small"
                     variant="tertiary"


### PR DESCRIPTION
## Problem

The compact model settings popover has excessive space between the switch-model row and effort slider, plus more outer padding than needed.

## Solution

Remove the row’s 8px bottom margin and reduce the compact popover padding from 8px to 4px on all sides using existing spacing classes.

## Potential risks

The tighter spacing has not been visually verified across themes and narrow viewports. The change only affects the compact popover layout; no control behavior, dependencies, or persisted data change. Revert this commit to restore the previous spacing.

## Verification

Passed on the isolated branch based on latest develop:
- `pnpm exec vitest run --config config/vitest.config.ts src/components/ModelSelectorPill/ModelSelectorPill.test.ts` — 14 tests passed
- `pnpm exec eslint src/components/ModelSelectorPill/ModelSettingsMenu.tsx` — passed
- `git diff --check` — passed

Reviewed the two-line diff for scope, secrets, private paths, debug output, and generated churn. Desktop visual checks and after-change screenshots were not performed because computer control was not authorized. Component tests verify interaction behavior, not pixel spacing.
