### PR TITLE
fix(chat): simplify turn file activity controls

### DIFF
--- a/docs/frontend-ui-audit-2026-09-10/TurnMetadataFooter.md
+++ b/docs/frontend-ui-audit-2026-09-10/TurnMetadataFooter.md
@@ -1,0 +1,11 @@
+# TurnMetadataFooter UI audit
+
+| Line                                                                            | Element                                | Verdict          | Reason                                                                                                                                                                                              | Suggested change |
+| ------------------------------------------------------------------------------- | -------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.tsx:292` | Read/write tabs                        | keep with reason | Reuses TabPill with the browser dev tools' simple variant and no active dot; keeps chat typography and counts, with a fixed 28px height and centered line boxes                                     | None             |
+| `src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.tsx:263` | Container disclosure                   | keep with reason | Reuses Button with a directional chevron, localized accessible label, expanded state, and body association; keyboard activation comes from the native button; its 16px column aligns with row icons | None             |
+| `src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.tsx:321` | Bounded list and existing row controls | keep with reason | Preserves the existing chat/composer tokens, 320px list cap, and show-more behavior; body unmounts while collapsed; overflow scrollbar stays visible using the shared thumb color                   | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+Scope: changed footer UI; reviewed design-system use, theme tokens, sizes, accessibility, and duplication. No cross-file sweep proposed. Desktop visual verification was not run because computer control was not requested.

--- a/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__/TurnMetadataFooter.actions.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__/TurnMetadataFooter.actions.test.ts
@@ -78,3 +78,55 @@ describe("TurnMetadataFooter PR row", () => {
     await root.unmount();
   });
 });
+
+describe("TurnMetadataFooter container disclosure", () => {
+  it("collapses and reopens the body while keeping tabs and counts available", async () => {
+    const root = createSmokeRoot();
+    await root.render(
+      React.createElement(TurnMetadataFooter, {
+        summary: SUMMARY,
+        sessionId: SUMMARY.sessionId,
+        turnId: SUMMARY.turnId,
+      })
+    );
+    const toggle = root.container.querySelector<HTMLButtonElement>(
+      '[data-testid="turn-metadata-collapse-toggle"]'
+    )!;
+    const tab = root.container.querySelector<HTMLButtonElement>(
+      '[data-testid="turn-metadata-edits-tab"]'
+    )!;
+    expect(toggle).not.toBeNull();
+    expect(tab.className).toContain("bg-transparent");
+    expect(tab.querySelector(".rounded-full")).toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      root.container.querySelector('[data-testid="turn-metadata-pr"]')
+    ).not.toBeNull();
+
+    for (let cycle = 0; cycle < 2; cycle += 1) {
+      await dispatch(() => toggle.click());
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      expect(
+        root.container.querySelector(
+          '[data-testid="turn-metadata-scroll-area"]'
+        )
+      ).toBeNull();
+      expect(root.container.contains(tab)).toBe(true);
+      expect(
+        root.container.querySelector(
+          '[data-testid="turn-metadata-edits-count"]'
+        )?.textContent
+      ).toBe("1");
+
+      await dispatch(() => toggle.click());
+      expect(toggle.getAttribute("aria-expanded")).toBe("true");
+      expect(
+        root.container.querySelector('[data-testid="turn-metadata-pr"]')
+      ).not.toBeNull();
+      expect(
+        document.getElementById(toggle.getAttribute("aria-controls")!)
+      ).not.toBeNull();
+    }
+    await root.unmount();
+  });
+});

--- a/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__/TurnMetadataFooter.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__/TurnMetadataFooter.test.ts
@@ -86,7 +86,7 @@ describe("TurnMetadataFooter tabs", () => {
     );
   });
 
-  it("keeps the larger expansion control pinned outside the hidden-scroll list", () => {
+  it("keeps the larger expansion control pinned outside the visible-scrollbar list", () => {
     const summary: TurnSummary = {
       ...BASE_SUMMARY,
       resourceInteractions: Array.from({ length: 6 }, (_, index) => ({
@@ -110,7 +110,10 @@ describe("TurnMetadataFooter tabs", () => {
       'data-testid="turn-metadata-pinned-controls"'
     );
 
-    expect(markup).toContain("scrollbar-hide min-h-0 flex-1 overflow-y-auto");
+    expect(markup).toContain(
+      "turn-metadata-scroll-area min-h-0 flex-1 overflow-y-auto pr-2"
+    );
+    expect(markup).not.toContain("scrollbar-hide");
     expect(
       markup.match(/data-testid="turn-metadata-read"/g) ?? []
     ).toHaveLength(4);

--- a/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.scss
+++ b/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.scss
@@ -1,0 +1,12 @@
+// Keep the overflow affordance visible even when this list is idle.
+.turn-metadata-scroll-area {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb-color) transparent;
+
+  &::-webkit-scrollbar-thumb,
+  &::-webkit-scrollbar-thumb:hover,
+  &::-webkit-scrollbar-thumb:active {
+    background: var(--scrollbar-thumb-color);
+    background-clip: padding-box;
+  }
+}

--- a/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.tsx
@@ -1,5 +1,12 @@
 import { useSetAtom } from "jotai";
-import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
@@ -21,6 +28,7 @@ import type {
 } from "@src/engines/SessionCore/storage/sqliteCache";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 import {
+  ArrowRight01Icon,
   GitCommitHorizontalIcon,
   GitPullRequestIcon,
   HugeiconsIcon,
@@ -38,6 +46,7 @@ import {
 } from "@src/store/ui/simulatorAtom";
 import { getFileName } from "@src/util/file/pathUtils";
 
+import "./index.scss";
 import { mapTurnModifiedFilesToFileChanges } from "./turnFilesMapping";
 
 const DEFAULT_VISIBLE_FILES = 4;
@@ -78,6 +87,8 @@ const TurnMetadataFooter: React.FC<TurnMetadataFooterProps> = memo(
   ({ summary, sessionId, turnId, isPagedHistoryRound = false }) => {
     const { t } = useTranslation("sessions");
     const [expanded, setExpanded] = useState(false);
+    const [collapsed, setCollapsed] = useState(false);
+    const bodyId = useId();
     const [activeTab, setActiveTab] = useState<MetadataTab>(() =>
       summary.modifiedFiles.length > 0 || summary.gitArtifacts.length > 0
         ? "edits"
@@ -129,7 +140,7 @@ const TurnMetadataFooter: React.FC<TurnMetadataFooterProps> = memo(
           label: t("chat.turnMetadata.editsTab"),
           badge: (
             <span
-              className="chat-block-xs text-text-3"
+              className="chat-block-xs leading-none text-text-3"
               data-testid="turn-metadata-edits-count"
             >
               {editCount}
@@ -144,7 +155,7 @@ const TurnMetadataFooter: React.FC<TurnMetadataFooterProps> = memo(
           label: t("chat.turnMetadata.readsTab"),
           badge: (
             <span
-              className="chat-block-xs text-text-3"
+              className="chat-block-xs leading-none text-text-3"
               data-testid="turn-metadata-reads-count"
             >
               {readCount}
@@ -248,7 +259,31 @@ const TurnMetadataFooter: React.FC<TurnMetadataFooterProps> = memo(
       <div className="px-3 pt-2" data-testid="turn-metadata-footer">
         <div className="overflow-hidden rounded-lg border border-solid border-border-2">
           <div className="flex min-h-9 items-center justify-between gap-2 px-2.5 py-1">
-            <div className="flex min-w-0 items-center gap-2">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <Button
+                variant="tertiary"
+                appearance="ghost"
+                size="small"
+                iconOnly
+                style={{ width: 16 }}
+                aria-label={t(
+                  collapsed
+                    ? "common:actions.expand"
+                    : "common:actions.collapse"
+                )}
+                aria-expanded={!collapsed}
+                aria-controls={bodyId}
+                onClick={() => setCollapsed((previous) => !previous)}
+                data-testid="turn-metadata-collapse-toggle"
+                icon={
+                  <HugeiconsIcon
+                    icon={ArrowRight01Icon}
+                    size={14}
+                    className={collapsed ? "" : "rotate-90"}
+                    aria-hidden
+                  />
+                }
+              />
               {isPagedHistoryRound && (
                 <span className="chat-block-xs shrink-0 text-text-3">
                   {t("chat.turnMetadata.earlierRound")}
@@ -258,10 +293,12 @@ const TurnMetadataFooter: React.FC<TurnMetadataFooterProps> = memo(
                 tabs={tabs}
                 activeTab={activeTab}
                 onChange={handleTabChange}
-                variant="pill"
-                appearance="ghost"
+                variant="simple"
+                showActiveIndicator={false}
                 fillWidth={false}
                 size="chatPanel"
+                height={28}
+                className="[&_button]:leading-none"
               />
             </div>
             {activeTab === "edits" && files.length > 0 && (
@@ -278,138 +315,144 @@ const TurnMetadataFooter: React.FC<TurnMetadataFooterProps> = memo(
             )}
           </div>
 
-          <div
-            className={`${CHAT_COMPOSER_STACK_BAR_INNER_PADDING_X_CLASS} flex max-h-[320px] min-h-0 flex-col pb-1`}
-          >
+          {!collapsed && (
             <div
-              className="scrollbar-hide min-h-0 flex-1 overflow-y-auto"
-              data-testid="turn-metadata-scroll-area"
+              id={bodyId}
+              className={`${CHAT_COMPOSER_STACK_BAR_INNER_PADDING_X_CLASS} flex max-h-[320px] min-h-0 flex-col pb-1`}
             >
-              {activeTab === "edits" &&
-                commits.map((artifact) => (
-                  <button
-                    key={`commit-${artifact.sha ?? artifact.url}`}
-                    type="button"
-                    onClick={() => openCommit(artifact)}
-                    disabled={!artifact.sha && !artifact.shortSha}
-                    title={artifact.sha ?? artifact.url}
-                    className={STACK_ROW_BUTTON_CLASSES}
-                    data-testid="turn-metadata-commit"
-                  >
-                    <HugeiconsIcon
-                      icon={GitCommitHorizontalIcon}
-                      data-icon="git-commit-horizontal"
-                      {...ARTIFACT_ICON_PROPS}
-                    />
-                    <span className="chat-block-title min-w-0 flex-1 truncate text-text-2">
-                      {artifactLabel(artifact)}
-                    </span>
-                    {artifact.shortSha && (
-                      <span className="chat-block-xs shrink-0 font-mono text-text-3">
-                        {artifact.shortSha}
-                      </span>
-                    )}
-                  </button>
-                ))}
-              {activeTab === "edits" &&
-                pullRequests.map((artifact) => (
-                  <button
-                    key={`pr-${artifact.url ?? artifact.prNumber}`}
-                    type="button"
-                    onClick={() => openPullRequest(artifact)}
-                    disabled={!artifact.url}
-                    title={artifact.url}
-                    className={STACK_ROW_BUTTON_CLASSES}
-                    data-testid="turn-metadata-pr"
-                  >
-                    <HugeiconsIcon
-                      icon={GitPullRequestIcon}
-                      data-icon="git-pull-request"
-                      {...ARTIFACT_ICON_PROPS}
-                    />
-                    <span className="chat-block-title min-w-0 flex-1 truncate text-text-2">
-                      {artifactLabel(artifact)}
-                    </span>
-                    <HugeiconsIcon
-                      icon={InternetIcon}
-                      data-icon="chrome"
-                      size={14}
-                      strokeWidth={1.75}
-                      className="shrink-0 text-text-3"
-                      aria-hidden
-                    />
-                  </button>
-                ))}
-              {activeTab === "edits" &&
-                visibleFiles.map((file) => (
-                  <EventFileHoverPreview key={file.path} path={file.path}>
-                    <FileChangeRow
-                      file={file}
-                      fileIconSize="medium"
-                      onFileClick={openDiff}
-                    />
-                  </EventFileHoverPreview>
-                ))}
-              {activeTab === "reads" &&
-                visibleResources.map((interaction: TurnResourceInteraction) => {
-                  const displayName =
-                    interaction.fileName ||
-                    getFileName(interaction.path) ||
-                    interaction.path;
-                  return (
-                    <EventFileHoverPreview
-                      key={`${interaction.outcome}-${interaction.path}`}
-                      path={interaction.path}
-                    >
-                      <div
-                        className={COMPOSER_STACK_ROW_BASE}
-                        data-testid="turn-metadata-read"
-                      >
-                        <FileTypeIcon fileName={displayName} size="medium" />
-                        <span className="chat-block-title min-w-0 flex-1 truncate text-text-2">
-                          {displayName}
-                        </span>
-                        <span className="chat-block-xs shrink-0 text-text-3">
-                          {interaction.outcome === "failed"
-                            ? t("chat.turnMetadata.failed")
-                            : interaction.count > 1
-                              ? `×${interaction.count}`
-                              : t("chat.turnMetadata.reads", { count: 1 })}
-                        </span>
-                      </div>
-                    </EventFileHoverPreview>
-                  );
-                })}
-            </div>
-            {hiddenCount > 0 || expanded ? (
               <div
-                className="shrink-0"
-                data-testid="turn-metadata-pinned-controls"
+                className="turn-metadata-scroll-area min-h-0 flex-1 overflow-y-auto pr-2"
+                data-testid="turn-metadata-scroll-area"
               >
-                <button
-                  type="button"
-                  onClick={() => setExpanded((previous) => !previous)}
-                  className={`${STACK_ROW_BUTTON_CLASSES} text-text-3`}
-                  data-testid="turn-metadata-expansion-toggle"
-                  aria-expanded={expanded}
-                >
-                  <HugeiconsIcon
-                    icon={MoreHorizontalIcon}
-                    data-icon="ellipsis"
-                    size={16}
-                    className="shrink-0"
-                  />
-                  <span className="chat-block-title truncate">
-                    {expanded
-                      ? t("chat.turnMetadata.showLess")
-                      : t("chat.turnMetadata.showMore", {
-                          count: hiddenCount,
-                        })}
-                  </span>
-                </button>
+                {activeTab === "edits" &&
+                  commits.map((artifact) => (
+                    <button
+                      key={`commit-${artifact.sha ?? artifact.url}`}
+                      type="button"
+                      onClick={() => openCommit(artifact)}
+                      disabled={!artifact.sha && !artifact.shortSha}
+                      title={artifact.sha ?? artifact.url}
+                      className={STACK_ROW_BUTTON_CLASSES}
+                      data-testid="turn-metadata-commit"
+                    >
+                      <HugeiconsIcon
+                        icon={GitCommitHorizontalIcon}
+                        data-icon="git-commit-horizontal"
+                        {...ARTIFACT_ICON_PROPS}
+                      />
+                      <span className="chat-block-title min-w-0 flex-1 truncate text-text-2">
+                        {artifactLabel(artifact)}
+                      </span>
+                      {artifact.shortSha && (
+                        <span className="chat-block-xs shrink-0 font-mono text-text-3">
+                          {artifact.shortSha}
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                {activeTab === "edits" &&
+                  pullRequests.map((artifact) => (
+                    <button
+                      key={`pr-${artifact.url ?? artifact.prNumber}`}
+                      type="button"
+                      onClick={() => openPullRequest(artifact)}
+                      disabled={!artifact.url}
+                      title={artifact.url}
+                      className={STACK_ROW_BUTTON_CLASSES}
+                      data-testid="turn-metadata-pr"
+                    >
+                      <HugeiconsIcon
+                        icon={GitPullRequestIcon}
+                        data-icon="git-pull-request"
+                        {...ARTIFACT_ICON_PROPS}
+                      />
+                      <span className="chat-block-title min-w-0 flex-1 truncate text-text-2">
+                        {artifactLabel(artifact)}
+                      </span>
+                      <HugeiconsIcon
+                        icon={InternetIcon}
+                        data-icon="chrome"
+                        size={14}
+                        strokeWidth={1.75}
+                        className="shrink-0 text-text-3"
+                        aria-hidden
+                      />
+                    </button>
+                  ))}
+                {activeTab === "edits" &&
+                  visibleFiles.map((file) => (
+                    <EventFileHoverPreview key={file.path} path={file.path}>
+                      <FileChangeRow
+                        file={file}
+                        fileIconSize="medium"
+                        onFileClick={openDiff}
+                      />
+                    </EventFileHoverPreview>
+                  ))}
+                {activeTab === "reads" &&
+                  visibleResources.map(
+                    (interaction: TurnResourceInteraction) => {
+                      const displayName =
+                        interaction.fileName ||
+                        getFileName(interaction.path) ||
+                        interaction.path;
+                      return (
+                        <EventFileHoverPreview
+                          key={`${interaction.outcome}-${interaction.path}`}
+                          path={interaction.path}
+                        >
+                          <div
+                            className={COMPOSER_STACK_ROW_BASE}
+                            data-testid="turn-metadata-read"
+                          >
+                            <FileTypeIcon
+                              fileName={displayName}
+                              size="medium"
+                            />
+                            <span className="chat-block-title min-w-0 flex-1 truncate text-text-2">
+                              {displayName}
+                            </span>
+                            {interaction.outcome === "failed" && (
+                              <span className="chat-block-xs shrink-0 text-text-3">
+                                {t("chat.turnMetadata.failed")}
+                              </span>
+                            )}
+                          </div>
+                        </EventFileHoverPreview>
+                      );
+                    }
+                  )}
               </div>
-            ) : null}
-          </div>
+              {hiddenCount > 0 || expanded ? (
+                <div
+                  className="shrink-0"
+                  data-testid="turn-metadata-pinned-controls"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setExpanded((previous) => !previous)}
+                    className={`${STACK_ROW_BUTTON_CLASSES} text-text-3`}
+                    data-testid="turn-metadata-expansion-toggle"
+                    aria-expanded={expanded}
+                  >
+                    <HugeiconsIcon
+                      icon={MoreHorizontalIcon}
+                      data-icon="ellipsis"
+                      size={16}
+                      className="shrink-0"
+                    />
+                    <span className="chat-block-title truncate">
+                      {expanded
+                        ? t("chat.turnMetadata.showLess")
+                        : t("chat.turnMetadata.showMore", {
+                            count: hiddenCount,
+                          })}
+                    </span>
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          )}
         </div>
       </div>
     );


### PR DESCRIPTION
## Problem

The turn file activity card used filled read/write pills, lacked a whole-container collapse control, and hid its scrollbar. Per-file read counts crowded the right edge, while header alignment and scrollbar spacing made the list harder to scan.

## Solution

Use the browser dev tools' simple, dot-free TabPill style with vertically centered labels and counts. Add an accessible disclosure chevron aligned with the file icon column, preserving the existing show-more control. Keep the overflow scrollbar visible and add right padding. Show right-side status text only for failed reads, retaining the aggregate count in the tab.

## Potential risks

Scrollbar appearance and precise alignment across desktop platforms, themes, and narrow viewports have not been visually verified. Collapsing unmounts the body and reopening can reset its scroll position. This is a local UI change with no database, API, dependency, or persistence changes; reverting the commit restores the previous presentation.

## Verification

Run on the isolated branch based on the latest origin/develop:

- `pnpm test src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__` — 4 files, 13 tests passed, including repeated collapse/reopen and existing row actions.
- `pnpm exec eslint src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.tsx src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__/TurnMetadataFooter.actions.test.ts src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__/TurnMetadataFooter.test.ts` — passed.
- `pnpm typecheck:fast` — passed.
- `git diff --check` — passed.
- Reviewed the scoped diff for unrelated changes, secrets, personal paths, debug logs, and generated files.

Desktop visual checks and final screenshots were not captured because computer control was not authorized. The user-provided screenshots guided the changes but predate the final read-status simplification. Rust checks were not run because no backend code changed.

## Audit

UI consistency report: `docs/frontend-ui-audit-2026-09-10/TurnMetadataFooter.md` — 0 fix, 3 keep with reason, 0 abstract.
