### PR TITLE
refactor(workstation): consolidate tab removal ownership

### DIFF
--- a/docs/architecture-audit-2026-09-10/WorkstationCloseOwnership.md
+++ b/docs/architecture-audit-2026-09-10/WorkstationCloseOwnership.md
@@ -1,0 +1,24 @@
+# WorkstationCloseOwnership
+
+Retire the unused navigation, reorder, bulk-close and tab-bar contract from `useWorkStationTabs`. Its live programmatic removal now delegates to `closeWorkstationTabAtom` with the workspace key captured by the hook. Project deletion callbacks keep removal semantics without adding deleted content to recents. The project close control uses the existing `useCloseTabWithGuard`, including confirmation and registry-owned recent history, instead of maintaining a second prompt/projection mutation.
+
+The authoritative source is `workstationTabsStateAtom`; `workstationLayoutAtom` is a compatibility projection. The prior hook used that projection to remove a tab, bypassing canonical resource deletion. The existing canonical store action removes Browser/Terminal resource records and persists the result. Host teardown remains owned by the existing resource owners. No new timer, listener, worker or teardown implementation is introduced.
+
+Architecture layers 1–7: typecheck, real hook/store tests, removed duplicate mutation paths and unused contracts, named programmatic removal, existing close guards retained. Layer 8: persistence schema unchanged; tests read back resource storage. Layer 9: user dismissal and programmatic removal deliberately have different recent-history semantics; both use canonical close actions. Layer 10: captured session key prevents delayed programmatic removal from targeting the newly selected workspace. Rust/session resolver internals are outside scope.
+
+Tests cover cancelled and confirmed dirty dismissal, recent history, deletion exclusion, Browser/Terminal record removal, repeated removal, and a delayed callback after session switching. No historical data cleanup is performed. Source revert restores the old hook behavior; resources intentionally closed during normal use must be reopened normally.
+
+## Lifecycle evidence
+
+| Area               | Verdict | Evidence                                                                  | Change or reason kept                               | Verification                                             |
+| ------------------ | ------- | ------------------------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------- |
+| Background work    | keep    | Existing Browser/Terminal owners react to canonical resource records      | No extra polling or teardown owner                  | Store removal tests; native PTY/webview teardown not run |
+| Memory             | fix     | Projection removal previously left global resource records                | Delegate to existing explicit close atom            | Browser/Terminal record and idempotence tests            |
+| Scope/isolation    | keep    | Hook captures presented workspace key                                     | Delayed callback remains scoped to original session | Same-ID tabs across two session workspaces               |
+| Rendering/hot path | keep    | Existing guarded close hook reads registry; no streaming or timer changes | Removed unused callbacks; no measured speed claim   | Real React hook tests and typecheck                      |
+
+Lifecycle matrix: active removal and repeat removal tested; session switching tested; unmount performed by each hook test. Idle/hidden/focus-return behavior does not acquire new work. Network, auth, endpoint and external-provider transitions are unchanged. Native startup/shutdown and process counts were not measured because computer control was not authorized.
+
+Performance verdict: blocked for native PTY/webview teardown and CPU/RSS measurement. State-level removal and session-isolation checks pass; no native performance claim is made. This limitation is disclosed rather than blocking the authorized PR delivery.
+
+No JSX structure or styling changes; the frontend skill excludes type/control-flow work. Prompt behavior is tested with a mocked native dialog.

--- a/src/hooks/tabHost/useWorkStationTabs.removal.test.ts
+++ b/src/hooks/tabHost/useWorkStationTabs.removal.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
+import {
+  type WorkStationTab,
+  recentWorkstationTabsAtom,
+  workstationLayoutAtom,
+  workstationTabsStateAtom,
+} from "@src/store/workstation/tabs";
+import {
+  WORKSTATION_V4_SHARED_KEY,
+  emptyWorkstationTabsState,
+} from "@src/store/workstation/tabs/storage";
+
+import { useCloseTabWithGuard } from "./useCloseTabWithGuard";
+import { useWorkStationTabs } from "./useWorkStationTabs";
+
+const { ask } = vi.hoisted(() => ({ ask: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ ask }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+let dismiss: ReturnType<typeof useCloseTabWithGuard>;
+let root: Root;
+let container: HTMLDivElement;
+let api: ReturnType<typeof useWorkStationTabs>;
+let store: ReturnType<typeof createStore>;
+function Probe() {
+  const nextApi = useWorkStationTabs();
+  const nextDismiss = useCloseTabWithGuard();
+  useEffect(() => {
+    api = nextApi;
+    dismiss = nextDismiss;
+  }, [nextApi, nextDismiss]);
+  return null;
+}
+function tab(
+  id: string,
+  type: WorkStationTab["type"] = "file"
+): WorkStationTab {
+  return { id, type, title: id, data: {} };
+}
+function mount() {
+  act(() =>
+    root.render(createElement(Provider, { store }, createElement(Probe)))
+  );
+}
+beforeEach(() => {
+  Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  localStorage.clear();
+  ask.mockReset();
+  store = createStore();
+  store.set(workstationTabsStateAtom, emptyWorkstationTabsState());
+  container = document.createElement("div");
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+});
+
+describe("programmatic workstation tab removal", () => {
+  it("removes deleted content without putting it in recent history", () => {
+    const deleted = tab("deleted", "project-workitems");
+    store.set(workstationLayoutAtom, {
+      mainPane: { tabs: [deleted], activeTabId: deleted.id },
+    });
+    mount();
+    act(() => api.removeTab(deleted.id));
+    expect(store.get(workstationLayoutAtom).mainPane.tabs).toEqual([]);
+    expect(store.get(recentWorkstationTabsAtom)).toEqual([]);
+  });
+
+  it.each(["browser-session", "terminal"] as const)(
+    "releases a %s resource and persists the removal",
+    (type) => {
+      const resource = tab("resource", type);
+      store.set(workstationLayoutAtom, {
+        mainPane: { tabs: [resource], activeTabId: resource.id },
+      });
+      mount();
+      act(() => api.removeTab(resource.id));
+      expect(store.get(workstationTabsStateAtom).shared.tabs).toEqual([]);
+      expect(
+        JSON.parse(localStorage.getItem(WORKSTATION_V4_SHARED_KEY)!).tabs
+      ).toEqual([]);
+      expect(store.get(recentWorkstationTabsAtom)).toEqual([]);
+      act(() => api.removeTab(resource.id));
+      expect(store.get(workstationTabsStateAtom).shared.tabs).toEqual([]);
+    }
+  );
+
+  it("keeps a captured removal scoped to its original session", () => {
+    mount();
+    act(() => {
+      store.set(workstationActiveSessionIdAtom, "session-a");
+      store.set(workstationLayoutAtom, {
+        mainPane: { tabs: [tab("same-id")], activeTabId: "same-id" },
+      });
+    });
+    const removeFromA = api.removeTab;
+    act(() => {
+      store.set(workstationActiveSessionIdAtom, "session-b");
+      store.set(workstationLayoutAtom, {
+        mainPane: { tabs: [tab("same-id")], activeTabId: "same-id" },
+      });
+    });
+    act(() => removeFromA("same-id"));
+    expect(store.get(workstationLayoutAtom).mainPane.tabs).toHaveLength(1);
+    act(() => store.set(workstationActiveSessionIdAtom, "session-a"));
+    expect(store.get(workstationLayoutAtom).mainPane.tabs).toEqual([]);
+  });
+});
+
+describe("user tab dismissal", () => {
+  it("records a dismissed tab in recents", async () => {
+    const file = tab("file:a");
+    store.set(workstationLayoutAtom, {
+      mainPane: { tabs: [file], activeTabId: file.id },
+    });
+    mount();
+    await act(async () => {
+      await dismiss({ tabId: file.id });
+    });
+    expect(store.get(workstationLayoutAtom).mainPane.tabs).toEqual([]);
+    expect(store.get(recentWorkstationTabsAtom)).toEqual([file]);
+    expect(ask).not.toHaveBeenCalled();
+  });
+
+  it("preserves dirty content on cancel and closes only after confirmation", async () => {
+    const file = { ...tab("dirty"), hasUnsavedChanges: true };
+    store.set(workstationLayoutAtom, {
+      mainPane: { tabs: [file], activeTabId: file.id },
+    });
+    mount();
+    ask.mockResolvedValueOnce(false);
+    await act(async () => {
+      await dismiss({ tabId: file.id });
+    });
+    expect(store.get(workstationLayoutAtom).mainPane.tabs).toEqual([file]);
+    expect(store.get(recentWorkstationTabsAtom)).toEqual([]);
+    ask.mockResolvedValueOnce(true);
+    await act(async () => {
+      await dismiss({ tabId: file.id });
+    });
+    expect(store.get(workstationLayoutAtom).mainPane.tabs).toEqual([]);
+    expect(store.get(recentWorkstationTabsAtom)).toHaveLength(1);
+    expect(ask).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/tabHost/useWorkStationTabs.test.ts
+++ b/src/hooks/tabHost/useWorkStationTabs.test.ts
@@ -5,14 +5,12 @@
  * than reproducing the mutation tests (covered in tabMutations.test.ts),
  * this file tests the thin pure logic that lives inside the hook itself:
  *
- *   • The `closeAllTabs` guard: if `tabs === []` and `activeTabId === null`
- *     the updater is a no-op (returns the same state reference).
  *   • The `updateTabMeta` early-exit: no state change when title+icon
  *     are unchanged.
  *   • The `setTabUnsaved` early-exit: no state change when the flag is
  *     already at the requested value.
  *
- * All three are inline anonymous functions inside the hook; we extract
+ * Both are inline anonymous functions inside the hook; we extract
  * their equivalent logic here as named helpers so they can be unit tested
  * without React.
  */
@@ -32,34 +30,6 @@ function tab(
     ...overrides,
   };
 }
-
-// ── closeAllTabs guard ────────────────────────────────────────────────────────
-
-function closeAllTabsGuard(state: PanelState): PanelState {
-  if (state.tabs.length === 0 && state.activeTabId === null) return state;
-  return { tabs: [], activeTabId: null };
-}
-
-describe("closeAllTabs guard", () => {
-  it("returns the same reference when already empty", () => {
-    const state: PanelState = { tabs: [], activeTabId: null };
-    expect(closeAllTabsGuard(state)).toBe(state);
-  });
-
-  it("clears tabs when there are tabs", () => {
-    const state: PanelState = { tabs: [tab("a")], activeTabId: "a" };
-    const next = closeAllTabsGuard(state);
-    expect(next.tabs).toHaveLength(0);
-    expect(next.activeTabId).toBeNull();
-  });
-
-  it("clears when activeTabId is set but tabs array is empty", () => {
-    const state: PanelState = { tabs: [], activeTabId: "orphaned" };
-    const next = closeAllTabsGuard(state);
-    expect(next.tabs).toHaveLength(0);
-    expect(next.activeTabId).toBeNull();
-  });
-});
 
 // ── updateTabMeta early-exit ──────────────────────────────────────────────────
 

--- a/src/hooks/tabHost/useWorkStationTabs.ts
+++ b/src/hooks/tabHost/useWorkStationTabs.ts
@@ -13,15 +13,11 @@ import {
   type WorkStationLayoutState,
   type WorkStationTab,
   claimLegacyWorkstationSeedAtom,
-  closeOtherTabs as closeOtherTabsMutation,
-  closeSavedTabs as closeSavedTabsMutation,
-  closeTab as closeTabMutation,
+  closeWorkstationTabAtom,
   mainPaneActiveTabIdAtom,
   mainPaneTabsAtom,
   openTab as openTabMutation,
   presentedWorkstationWorkspaceKeyAtom,
-  reorderTabs as reorderTabsMutation,
-  switchTab as switchTabMutation,
   updateTabData as updateTabDataMutation,
   workstationLayoutAtom,
 } from "@src/store/workstation/tabs";
@@ -36,13 +32,8 @@ export interface UseWorkStationTabsReturn {
   activeTab: WorkStationTab | null;
 
   openTab: (tab: WorkStationTab) => void;
-  closeTab: (tabId: string) => void;
-  switchTab: (tabId: string) => void;
-  reorderTabs: (startIndex: number, endIndex: number) => void;
-
-  closeOtherTabs: (keepTabId: string) => void;
-  closeSavedTabs: () => void;
-  closeAllTabs: () => void;
+  /** Programmatic removal: release resources without offering deleted data in recents. */
+  removeTab: (tabId: string) => void;
 
   updateTabData: (
     tabId: string,
@@ -53,16 +44,6 @@ export interface UseWorkStationTabsReturn {
     meta: Partial<Pick<WorkStationTab, "title" | "icon">>
   ) => void;
   setTabUnsaved: (tabId: string, hasUnsavedChanges: boolean) => void;
-
-  tabBarProps: {
-    tabs: WorkStationTab[];
-    activeTabId: string | null;
-    onTabClick: (tabId: string) => void;
-    onTabClose: (tabId: string) => void;
-    onTabReorder: (startIndex: number, endIndex: number) => void;
-    onCloseOtherTabs: (tabId: string) => void;
-    onCloseSavedTabs: () => void;
-  };
 }
 
 const EMPTY_PANE_STATE: PanelState = { tabs: [], activeTabId: null };
@@ -76,6 +57,7 @@ export function useWorkStationTabs(): UseWorkStationTabsReturn {
   const activeTabId = useAtomValue(mainPaneActiveTabIdAtom);
   const workspaceKey = useAtomValue(presentedWorkstationWorkspaceKeyAtom);
   const setLayout = useSetAtom(workstationLayoutAtom);
+  const removeWorkstationTab = useSetAtom(closeWorkstationTabAtom);
   const claimLegacySeed = useSetAtom(claimLegacyWorkstationSeedAtom);
 
   // A legacy v2 task workspace is claimed only after a user has explicitly
@@ -109,40 +91,9 @@ export function useWorkStationTabs(): UseWorkStationTabsReturn {
     [updatePane]
   );
 
-  const closeTab = useCallback(
-    (tabId: string) => updatePane((state) => closeTabMutation(state, tabId)),
-    [updatePane]
-  );
-
-  const switchTab = useCallback(
-    (tabId: string) => updatePane((state) => switchTabMutation(state, tabId)),
-    [updatePane]
-  );
-
-  const reorderTabs = useCallback(
-    (startIndex: number, endIndex: number) =>
-      updatePane((state) => reorderTabsMutation(state, startIndex, endIndex)),
-    [updatePane]
-  );
-
-  const closeOtherTabs = useCallback(
-    (keepTabId: string) =>
-      updatePane((state) => closeOtherTabsMutation(state, keepTabId)),
-    [updatePane]
-  );
-
-  const closeSavedTabs = useCallback(
-    () => updatePane((state) => closeSavedTabsMutation(state)),
-    [updatePane]
-  );
-
-  const closeAllTabs = useCallback(
-    () =>
-      updatePane((state) => {
-        if (state.tabs.length === 0 && state.activeTabId === null) return state;
-        return { tabs: [], activeTabId: null };
-      }),
-    [updatePane]
+  const removeTab = useCallback(
+    (tabId: string) => removeWorkstationTab({ workspace: workspaceKey, tabId }),
+    [removeWorkstationTab, workspaceKey]
   );
 
   const updateTabData = useCallback(
@@ -193,41 +144,14 @@ export function useWorkStationTabs(): UseWorkStationTabsReturn {
     [updatePane]
   );
 
-  const tabBarProps = useMemo(
-    () => ({
-      tabs,
-      activeTabId,
-      onTabClick: switchTab,
-      onTabClose: closeTab,
-      onTabReorder: reorderTabs,
-      onCloseOtherTabs: closeOtherTabs,
-      onCloseSavedTabs: closeSavedTabs,
-    }),
-    [
-      tabs,
-      activeTabId,
-      switchTab,
-      closeTab,
-      reorderTabs,
-      closeOtherTabs,
-      closeSavedTabs,
-    ]
-  );
-
   return {
     tabs,
     activeTabId,
     activeTab,
     openTab,
-    closeTab,
-    switchTab,
-    reorderTabs,
-    closeOtherTabs,
-    closeSavedTabs,
-    closeAllTabs,
+    removeTab,
     updateTabData,
     updateTabMeta,
     setTabUnsaved,
-    tabBarProps,
   };
 }

--- a/src/modules/ProjectManager/ProjectManagerLayout/hooks/useProjectTabActions.ts
+++ b/src/modules/ProjectManager/ProjectManagerLayout/hooks/useProjectTabActions.ts
@@ -53,7 +53,6 @@ interface UseProjectTabActionsOptions {
   tabs: WorkStationTab[];
   activeTab: WorkStationTab | null;
   openTab: (tab: WorkStationTab) => void;
-  closeTab: (tabId: string) => void;
   primarySidebarCollapsed: boolean;
 }
 
@@ -61,7 +60,6 @@ export function useProjectTabActions({
   tabs,
   activeTab,
   openTab,
-  closeTab: _closeTab,
   primarySidebarCollapsed,
 }: UseProjectTabActionsOptions) {
   const { t } = useTranslation();

--- a/src/modules/ProjectManager/ProjectManagerLayout/index.tsx
+++ b/src/modules/ProjectManager/ProjectManagerLayout/index.tsx
@@ -1,6 +1,5 @@
 import { useSetAtom } from "jotai";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { PROJECT_ORG_SYNC_PROVIDER } from "@src/api/http/project";
@@ -9,6 +8,7 @@ import {
   buildIntegrationsPath,
   buildWizardPath,
 } from "@src/config/mainAppPaths";
+import { useCloseTabWithGuard } from "@src/hooks/tabHost/useCloseTabWithGuard";
 import { usePrimarySidebarState } from "@src/hooks/tabHost/useWorkStationPanels";
 import { useWorkStationTabShortcutBridge } from "@src/hooks/tabHost/useWorkStationTabShortcutBridge";
 import { useWorkStationTabs } from "@src/hooks/tabHost/useWorkStationTabs";
@@ -39,7 +39,6 @@ import type { ProjectManagerLayoutProps } from "./types";
 
 export const ProjectManagerLayout: React.FC<ProjectManagerLayoutProps> = memo(
   ({ repoPath, repoName }) => {
-    const { t } = useTranslation();
     const navigate = useNavigate();
 
     const {
@@ -55,31 +54,16 @@ export const ProjectManagerLayout: React.FC<ProjectManagerLayoutProps> = memo(
       tabs,
       activeTab,
       openTab,
-      closeTab,
+      removeTab,
       setTabUnsaved,
       updateTabData,
       updateTabMeta,
     } = useWorkStationTabs();
 
+    const dismissTab = useCloseTabWithGuard();
     const handleCloseTab = useCallback(
-      async (tabId: string) => {
-        const tabToClose = tabs.find((tab) => tab.id === tabId);
-        if (tabToClose?.hasUnsavedChanges) {
-          const { ask } = await import("@tauri-apps/plugin-dialog");
-          const confirmed = await ask(
-            `"${tabToClose.title}" has unsaved changes. Discard them and close?`,
-            {
-              title: t("workstation.unsavedChangesTitle"),
-              kind: "warning",
-              okLabel: t("actions.discard"),
-              cancelLabel: t("actions.cancel"),
-            }
-          );
-          if (!confirmed) return;
-        }
-        closeTab(tabId);
-      },
-      [tabs, closeTab, t]
+      (tabId: string) => dismissTab({ tabId }),
+      [dismissTab]
     );
 
     const activeProjectSlug =
@@ -156,7 +140,6 @@ export const ProjectManagerLayout: React.FC<ProjectManagerLayoutProps> = memo(
       tabs,
       activeTab,
       openTab,
-      closeTab,
       primarySidebarCollapsed,
     });
 
@@ -268,7 +251,7 @@ export const ProjectManagerLayout: React.FC<ProjectManagerLayoutProps> = memo(
         onOpenRepoSettings: handleOpenRepoSettings,
         onExpandWorkItemToTab: handleExpandWorkItemToTab,
         onOpenChatSession: handleOpenChatSession,
-        onCloseTab: closeTab,
+        onCloseTab: removeTab,
         onUpdateTabData: updateTabData,
         onUpdateTabMeta: updateTabMeta,
         onSetTabUnsaved: setTabUnsaved,
@@ -288,7 +271,7 @@ export const ProjectManagerLayout: React.FC<ProjectManagerLayoutProps> = memo(
         handleOpenRepoSettings,
         handleExpandWorkItemToTab,
         handleOpenChatSession,
-        closeTab,
+        removeTab,
         updateTabData,
         updateTabMeta,
         setTabUnsaved,
@@ -311,7 +294,7 @@ export const ProjectManagerLayout: React.FC<ProjectManagerLayoutProps> = memo(
         onOpenRepoSettings={handleOpenRepoSettings}
         onExpandWorkItemToTab={handleExpandWorkItemToTab}
         onOpenChatSession={handleOpenChatSession}
-        onCloseTab={closeTab}
+        onCloseTab={removeTab}
         onUpdateTabData={updateTabData}
         onUpdateTabMeta={updateTabMeta}
         onSetTabUnsaved={setTabUnsaved}


### PR DESCRIPTION
## Problem

useWorkStationTabs removes tabs through the layout projection instead of the canonical close action and exposes unused navigation/bulk-close/tab-bar APIs. Project dismissal also duplicates the native confirmation logic. Projection removal and explicit resource closure differ in resource cleanup and recent-history semantics.

## Solution

Remove the unused hook APIs. Expose programmatic removeTab through the canonical closeWorkstationTabAtom with a captured workspace key. Preserve deletion semantics without adding deleted content to recents. Route the project user-close control through the existing useCloseTabWithGuard and registry-owned dismissal path. Add real React-hook/store tests for removal, resource records, session scope, recents and confirmation.

## Potential risks

Programmatic removal now clears Browser/Terminal resource records through the existing canonical owner. State and persisted-record removal are tested, but native PTY/webview teardown, process counts and CPU/RSS were not measured because computer control was not authorized. Performance verdict: native verification blocked; no runtime speed claim. Dirty prompts use a mocked native dialog. No persistence format changes or historical cleanup. Revert for source rollback; normally closed resources must be reopened. JSX structure/styling is unchanged, so screenshots add no evidence.

## Verification

- `pnpm run typecheck:fast` — passed
- `pnpm exec vitest run --config config/vitest.config.ts src/hooks/tabHost/useWorkStationTabs.test.ts src/hooks/tabHost/useWorkStationTabs.removal.test.ts src/store/workstation/tabRegistry/atoms.test.ts src/store/workstation/tabs/__tests__/workspaceState.test.ts` — 4 files, 34 tests passed
- `pnpm exec eslint $(git diff --name-only --diff-filter=ACM origin/develop...HEAD -- '*.ts' '*.tsx') --max-warnings 0` — passed
- Repository pre-commit hooks run lint-staged (Oxlint, ESLint and Prettier), TypeScript checking and commitlint
- `git diff --check` — passed
- Source/diff review checked caller reachability, scope and generated/private content
- Full application build, Rust checks and native UI tests were not run for this frontend scope

Combined integration check (all four changes applied together): `pnpm run typecheck:fast` passed; `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell src/store/workstation/tabs/__tests__/tabFactory.test.ts src/store/workstation/tabs/__tests__/storage.test.ts src/store/workstation/tabs/__tests__/workspaceState.test.ts src/hooks/tabHost/useWorkStationTabs.test.ts src/hooks/tabHost/useWorkStationTabs.removal.test.ts src/store/workstation/tabRegistry/atoms.test.ts src/store/workstation/tabHost.test.ts` — 21 files, 180 tests passed.
