### PR TITLE
refactor(workstation): derive host routing from tab categories

### DIFF
--- a/docs/architecture-audit-2026-09-10/WorkstationHostRouting.md
+++ b/docs/architecture-audit-2026-09-10/WorkstationHostRouting.md
@@ -1,0 +1,7 @@
+# WorkstationHostRouting
+
+Use one exhaustive default tab-category map for both factory construction and category-less tab routing. Export the existing mapping from the pure factory module and derive `tabTypeToTabHost` through `categoryToTabHost`. Explicit category overrides retain precedence; all current category/host assignments remain unchanged.
+
+Architecture layers 1–7: typecheck, per-type fresh/restored parity tests, no duplicate type switch, and explicit category overrides retained. Layer 8: no serialization or IPC changes. Layer 9: newly created and restored tabs resolve through the same mapping. Layer 10: category-absent tabs derive defaults from the factory authority; category-present tabs retain overrides. Rust and runtime transport checks are outside scope.
+
+No timers, subscriptions, caches, renderer structure, or resource ownership changes. Source revert is sufficient for rollback. Unit tests establish routing behavior, not native rendering or performance.

--- a/src/store/workstation/tabHost.test.ts
+++ b/src/store/workstation/tabHost.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { categoryToTabHost, tabToHost, tabTypeToTabHost } from "./tabHost";
+import { DEFAULT_CATEGORY_BY_TYPE, defineTabFactory } from "./tabs/tabFactory";
+import type { WorkStationTabType } from "./tabs/types";
+
+describe("tab host routing", () => {
+  it.each(Object.keys(DEFAULT_CATEGORY_BY_TYPE) as WorkStationTabType[])(
+    "routes restored %s tabs to the same host as freshly created tabs",
+    (type) => {
+      const factory = defineTabFactory<Record<string, never>>({
+        tabType: type,
+        idStrategy: { type: "singleton", id: "routing-test" },
+        getTitle: () => "Routing test",
+      });
+      const tab = factory({});
+      const restored = { ...tab, category: undefined };
+      expect(tabToHost(restored)).toBe(tabToHost(tab));
+      expect(tabTypeToTabHost(type)).toBe(categoryToTabHost(tab.category));
+    }
+  );
+
+  it("preserves explicit category overrides", () => {
+    expect(
+      tabToHost({
+        id: "custom",
+        type: "file",
+        category: "browser",
+        title: "Custom",
+        data: {},
+      })
+    ).toBe("browser");
+    expect(tabTypeToTabHost("file")).toBe("code");
+    expect(tabTypeToTabHost("browser-session")).toBe("browser");
+    expect(tabTypeToTabHost("project-workitems")).toBe("project");
+  });
+});

--- a/src/store/workstation/tabHost.ts
+++ b/src/store/workstation/tabHost.ts
@@ -11,6 +11,7 @@
 import { atom } from "jotai";
 
 import { activeWorkStationTabAtom, mainPaneTabsAtom } from "./tabs";
+import { DEFAULT_CATEGORY_BY_TYPE } from "./tabs/tabFactory";
 import type {
   WorkStationTab,
   WorkStationTabCategory,
@@ -42,28 +43,11 @@ export function categoryToTabHost(
 
 /**
  * Map a tab type onto its host. Convenience for callers that have the raw
- * `tab.type` literal rather than the category. Mirrors `categoryToTabHost` via
+ * `tab.type` literal rather than the category. Uses `categoryToTabHost` with
  * the tab-type → category default mapping in `tabFactory.ts`.
  */
 export function tabTypeToTabHost(type: WorkStationTabType): WorkstationTabHost {
-  switch (type) {
-    case "browser-session":
-    case "devtools":
-      return "browser";
-    case "project-dashboard":
-    case "project-work-items":
-    case "project-linear-projects":
-    case "project-linear-work-items":
-    case "project-settings":
-    case "project-org":
-    case "project-org-settings":
-    case "project-git-sync-review":
-    case "project-workitems":
-    case "workItem-detail":
-      return "project";
-    default:
-      return "code";
-  }
+  return categoryToTabHost(DEFAULT_CATEGORY_BY_TYPE[type]);
 }
 
 /** Convenience: derive host from a tab. */

--- a/src/store/workstation/tabs/tabFactory.ts
+++ b/src/store/workstation/tabs/tabFactory.ts
@@ -66,7 +66,7 @@ export interface TabFactoryConfig<TData> {
  * `category` field when a tab type wants its own mount slot (e.g. a
  * read-only viewer that should not share state with the editor).
  */
-const DEFAULT_CATEGORY_BY_TYPE: Record<
+export const DEFAULT_CATEGORY_BY_TYPE: Record<
   WorkStationTabType,
   WorkStationTabCategory
 > = {


### PR DESCRIPTION
## Problem

Category-less restored tabs use a manually maintained type-to-host switch while new tabs use the factory category map. The default code branch can silently route a newly added project/browser type incorrectly if only the factory map is updated.

## Solution

Export the existing exhaustive default category map from the pure factory module and derive type-to-host routing through it. Preserve explicit category overrides. Add parity coverage for every supported type and representative host expectations.

## Potential risks

Current category/host assignments and serialized formats are unchanged. The factory module has no runtime atom dependency, so the shared mapping does not introduce a store cycle. Native rendering was not exercised; tests verify the routing boundary. No JSX change, so screenshots are not useful. Revert the commit for rollback.

## Verification

- `pnpm run typecheck:fast` — passed
- `pnpm exec vitest run --config config/vitest.config.ts src/store/workstation/tabHost.test.ts src/store/workstation/tabs/__tests__/tabFactory.test.ts` — 2 files, 71 tests passed
- `pnpm exec eslint $(git diff --name-only --diff-filter=ACM origin/develop...HEAD -- '*.ts' '*.tsx') --max-warnings 0` — passed
- Repository pre-commit hooks run lint-staged (Oxlint, ESLint and Prettier), TypeScript checking and commitlint
- `git diff --check` — passed
- Source/diff review checked caller reachability, scope and generated/private content
- Full application build, Rust checks and native UI tests were not run for this frontend scope

Combined integration check (all four changes applied together): `pnpm run typecheck:fast` passed; `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell src/store/workstation/tabs/__tests__/tabFactory.test.ts src/store/workstation/tabs/__tests__/storage.test.ts src/store/workstation/tabs/__tests__/workspaceState.test.ts src/hooks/tabHost/useWorkStationTabs.test.ts src/hooks/tabHost/useWorkStationTabs.removal.test.ts src/store/workstation/tabRegistry/atoms.test.ts src/store/workstation/tabHost.test.ts` — 21 files, 180 tests passed.
