### PR TITLE
fix(chat): make turn collapse row reliably clickable

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.test.ts
@@ -14,10 +14,16 @@ import {
 
 import TurnCollapsePinBar from "./TurnCollapsePinBar";
 
+const { setOverride, replayEventById, replayState } = vi.hoisted(() => ({
+  setOverride: vi.fn(),
+  replayEventById: vi.fn(),
+  replayState: { canReplay: false },
+}));
+
 vi.mock("jotai", async (importOriginal) => ({
   ...(await importOriginal<typeof import("jotai")>()),
   useAtomValue: () => new Map(),
-  useSetAtom: () => vi.fn(),
+  useSetAtom: () => setOverride,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -28,7 +34,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("@src/engines/ChatPanel/hooks/useChatEventReplay", () => ({
-  useChatEventReplay: () => ({ canReplay: false, replayEventById: vi.fn() }),
+  useChatEventReplay: () => ({ ...replayState, replayEventById }),
 }));
 
 describe("TurnCollapsePinBar", () => {
@@ -43,6 +49,8 @@ describe("TurnCollapsePinBar", () => {
   });
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    replayState.canReplay = false;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -51,6 +59,7 @@ describe("TurnCollapsePinBar", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    window.getSelection()?.removeAllRanges();
   });
 
   afterAll(() => {
@@ -113,6 +122,76 @@ describe("TurnCollapsePinBar", () => {
     expect(
       divider?.classList.contains("peer-hover/turn-collapse:opacity-0")
     ).toBe(true);
+  });
+
+  it.each([true, false])(
+    "toggles on the first click outside the chevron with selected transcript text (collapsed=%s)",
+    async (defaultCollapsed) => {
+      act(() => {
+        root.render(
+          createElement(TurnCollapsePinBar, {
+            turnId: "turn-1",
+            durationMs: 42_000,
+            startMs: 1_000,
+            endMs: 43_000,
+            defaultCollapsed,
+            turnCollapseInteractionAtRef: { current: 0 },
+          })
+        );
+      });
+      const transcript = document.createElement("p");
+      transcript.textContent = "Previously selected transcript text";
+      container.appendChild(transcript);
+      const range = document.createRange();
+      range.selectNodeContents(transcript);
+      window.getSelection()?.addRange(range);
+      expect(window.getSelection()?.isCollapsed).toBe(false);
+
+      const button = container.querySelector<HTMLButtonElement>("button")!;
+      const label = button.querySelector<HTMLSpanElement>("span > span")!;
+      await act(async () => {
+        label.click();
+      });
+      expect(setOverride).toHaveBeenCalledOnce();
+      expect(setOverride).toHaveBeenCalledWith({
+        turnId: "turn-1",
+        collapsed: !defaultCollapsed,
+      });
+      expect(button.classList.contains("h-full")).toBe(true);
+      expect(button.classList.contains("px-2")).toBe(true);
+    }
+  );
+
+  it("reserves a fixed right-side replay slot and keeps replay clicks separate", async () => {
+    replayState.canReplay = true;
+    for (const defaultCollapsed of [true, false]) {
+      act(() => {
+        root.render(
+          createElement(TurnCollapsePinBar, {
+            turnId: "turn-1",
+            durationMs: 42_000,
+            startMs: 1_000,
+            endMs: 43_000,
+            defaultCollapsed,
+            turnCollapseInteractionAtRef: { current: 0 },
+          })
+        );
+      });
+      const navigate = container.querySelector<HTMLButtonElement>(
+        '[data-testid="event-navigate"]'
+      )!;
+      expect(navigate.classList.contains("w-5")).toBe(true);
+      expect(navigate.classList.contains("w-0")).toBe(false);
+      expect(navigate.parentElement?.classList.contains("absolute")).toBe(true);
+      expect(navigate.parentElement?.classList.contains("right-2")).toBe(true);
+      expect(navigate.parentElement?.classList.contains("w-5")).toBe(true);
+      await act(async () => {
+        navigate.click();
+      });
+    }
+    expect(replayEventById).toHaveBeenCalledTimes(2);
+    expect(replayEventById).toHaveBeenCalledWith("turn-1");
+    expect(setOverride).not.toHaveBeenCalled();
   });
 
   it("shows a loading indicator after the time range while expanding", async () => {

--- a/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx
+++ b/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx
@@ -2,7 +2,7 @@
  * TurnCollapsePinBar — "Agent worked for xxx" collapse control.
  *
  * Rendered inside the group header (`GroupHeaderRenderer`), positioned below
- * the user message for every completed turn that has body items. Clicking the chevron
+ * the user message for every completed turn that has body items. Clicking the row
  * toggles the collapse state in `turnCollapseOverrideAtom`; when
  * collapsed, `GroupItemRenderer` hides every non-final-assistant item
  * in the group so only the closing agent message remains visible —
@@ -173,15 +173,13 @@ const TurnCollapsePinBar: React.FC<TurnCollapsePinBarProps> = memo(
 
     return (
       <div className="mt-1 pb-2">
-        <div className="peer/turn-collapse group/turn-collapse group/chat-block-header chat-block-header flex h-8 w-full items-center gap-1 rounded-lg px-2 transition-colors hover:bg-fill-2">
+        <div className="peer/turn-collapse group/turn-collapse group/chat-block-header chat-block-header relative flex h-8 w-full items-center rounded-lg transition-colors hover:bg-fill-2">
           <button
             type="button"
             aria-expanded={expanded}
-            className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 border-0 bg-transparent px-0 text-left focus-visible:ring-2 focus-visible:ring-primary-6/30 focus-visible:outline-none"
+            className={`flex h-full min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg border-0 bg-transparent px-2 text-left select-none focus-visible:ring-2 focus-visible:ring-primary-6/30 focus-visible:outline-none ${showReplayNavigate ? "pr-9" : ""}`}
             onClick={(event) => {
               event.stopPropagation();
-              const selection = window.getSelection();
-              if (selection && !selection.isCollapsed) return;
               void handleToggle();
             }}
           >
@@ -213,10 +211,13 @@ const TurnCollapsePinBar: React.FC<TurnCollapsePinBarProps> = memo(
             </span>
           </button>
           {showReplayNavigate ? (
-            <EventNavigateIcon
-              onClick={handleReplayNavigate}
-              ariaLabel={t("tools.replay.title")}
-            />
+            <div className="absolute right-2 flex h-5 w-5 items-center justify-center opacity-0 transition-opacity group-focus-within/turn-collapse:opacity-100 group-hover/turn-collapse:opacity-100">
+              <EventNavigateIcon
+                variant="footer"
+                onClick={handleReplayNavigate}
+                ariaLabel={t("tools.replay.title")}
+              />
+            </div>
           ) : null}
         </div>
         <div


### PR DESCRIPTION
## Problem

The completed-turn “Agent worked” row can ignore a click outside the chevron: its button does not cover the full row height and padding, and a selection anywhere in the transcript blocks toggling. The replay icon also expands from zero width on hover, shifting the row layout.

## Solution

Make the toggle button fill the row, including its padding, and remove the unrelated transcript-selection guard. Place the replay action in a fixed right-side slot with opacity-only hover/focus visibility. Replay clicks remain separate from collapse toggles. Add component regression coverage for first-click toggling in both states with selected transcript text and for the replay slot/action.

## Potential risks

The fixed replay slot reserves some text width even when the icon is hidden. Actual browser hit testing, narrow viewport truncation, themes, and visual alignment remain unverified in the desktop app. No persistence, dependencies, background lifecycle, or public interfaces change; rollback is a revert of this commit.

## Verification

- `pnpm test src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.test.ts` — all 7 tests pass on the branch based on latest `develop`.
- `pnpm exec eslint src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.test.ts` — passes.
- `git diff --check` — passes.
- Commit hooks: `oxlint -c .oxlintrc.json --max-warnings 0`, `eslint --fix`, `prettier --write`, and the staged-file TypeScript check — pass.
- Inspected the two-file diff for scope, secrets, personal paths, debug output, and generated artifacts; no unrelated changes included.
- Desktop visual checks and screenshots were not produced because computer control requires explicit user opt-in. The jsdom assertions cover event behavior and layout classes, not rendered geometry. Full test suite and desktop E2E were not run for this localized component fix.
