### PR TITLE
refactor(my-station): remove unused configuration

### DIFF
--- a/docs/architecture-audit-2026-09-10/UnusedConfiguration.md
+++ b/docs/architecture-audit-2026-09-10/UnusedConfiguration.md
@@ -1,0 +1,7 @@
+# UnusedConfiguration architecture audit
+
+Traced editor sidebar rendering to CODE_EDITOR_CONFIG.defaultTreeWidth (resetSize). Preserve its value of 300. The other editor config fields have no consumers. Repo search uses SEARCH_CONSTANTS and direct icon imports; its local ICON_CONFIG is unconsumed. The shared TabBar renders its actual strip behavior without MAX_VISIBLE_TABS or STATUS_LABELS; their re-export chain has no consumers. Delete those declarations and exports only. The separate primary-sidebar ICON_CONFIG is live and stays.
+
+Covered layers: 1 compilation; 2 dead declarations and re-export chains; 3 remaining config names; 4 distinction between sidebar and search icon maps; 5 existing defaults preserved; 6 no new boundaries; 7 remove misleading inactive settings; 8 persistence and wire formats unchanged; 9 existing reset and initial sidebar widths preserved; 10 export/import symmetry. Rust and backend resolver behavior are outside scope.
+
+This changes no sidebar widths, search limits, debounce intervals, exclusions, overflow behavior, or rendered styles. Verification uses typecheck, changed-file lint, and type-aware lint; no implementation-mirroring tests are added for deleting unreferenced constants. See PR Verification for exact results.

--- a/docs/frontend-ui-audit-2026-09-10/UnusedConfiguration.md
+++ b/docs/frontend-ui-audit-2026-09-10/UnusedConfiguration.md
@@ -1,0 +1,9 @@
+# UnusedConfiguration UI audit
+
+| Line                                                  | Element                 | Verdict          | Reason                                                                           | Suggested change |
+| ----------------------------------------------------- | ----------------------- | ---------------- | -------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/WorkStation/shared/TabBar/index.tsx:547` | Configuration re-export | keep with reason | Only unused exports removed; no markup, tokens, layout or accessibility changed. | None.            |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.
+
+No visual changes are intended. Source inspection and focused automated coverage are used; native screenshots and UI automation were not run.

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/config.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/config.ts
@@ -1,28 +1,4 @@
-/**
- * RepoSearchPanel Configuration
- */
-import {
-  ArrowDown01Icon,
-  ArrowRight01Icon,
-  Cancel01Icon,
-  CaseSensitiveIcon,
-  Refresh04Icon,
-  RegexIcon,
-  Search01Icon,
-  WholeWordIcon,
-} from "@src/icons";
-
-export const ICON_CONFIG = {
-  search: Search01Icon,
-  caseSensitive: CaseSensitiveIcon,
-  wholeWord: WholeWordIcon,
-  regex: RegexIcon,
-  refresh: Refresh04Icon,
-  clear: Cancel01Icon,
-  chevronRight: ArrowRight01Icon,
-  chevronDown: ArrowDown01Icon,
-} as const;
-
+/** Repo search configuration. */
 export const SEARCH_CONSTANTS = {
   /** Debounce delay for search input (ms) - VSCode uses 150ms */
   DEBOUNCE_MS: 150,

--- a/src/modules/WorkStation/CodeEditor/config.ts
+++ b/src/modules/WorkStation/CodeEditor/config.ts
@@ -1,47 +1,4 @@
-/**
- * CodeEditor Configuration
- *
- * Configuration constants and icons for the CodeEditor component.
- */
-import { FileScriptIcon, FolderOpenIcon, Search01Icon } from "@src/icons";
-
-// ============================================
-// Icon Configuration
-// ============================================
-
-export const CODE_EDITOR_ICONS = {
-  fileCode: FileScriptIcon,
-  folderOpen: FolderOpenIcon,
-  search: Search01Icon,
-} as const;
-
-// ============================================
-// Default Configuration
-// ============================================
-
+/** Default file-tree width when resetting the editor sidebar. */
 export const CODE_EDITOR_CONFIG = {
-  // File tree
   defaultTreeWidth: 300,
-  minTreeWidth: 200,
-  maxTreeWidth: 500,
-
-  // Search
-  maxSearchResults: 50,
-  searchDebounceMs: 300,
-
-  // Excluded directories
-  excludeDirs: [
-    "node_modules",
-    ".git",
-    "dist",
-    "build",
-    ".next",
-    "target",
-    ".cache",
-    "coverage",
-    "__pycache__",
-    ".venv",
-    "venv",
-    ".DS_Store",
-  ],
 } as const;

--- a/src/modules/WorkStation/shared/TabBar/config.ts
+++ b/src/modules/WorkStation/shared/TabBar/config.ts
@@ -13,14 +13,3 @@ export const TAB_BAR_HEIGHT = 36;
  */
 export const TAB_STRIP_SECTION_RULE_CLASS =
   "pointer-events-none mx-1.5 shrink-0 self-center h-5 w-px bg-border-2";
-
-/** Maximum number of tabs to display before showing overflow */
-export const MAX_VISIBLE_TABS = 10;
-
-/** Status badge labels */
-export const STATUS_LABELS: Record<string, string> = {
-  modified: "M",
-  deleted: "D",
-  added: "A",
-  renamed: "R",
-};

--- a/src/modules/WorkStation/shared/TabBar/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/index.tsx
@@ -544,4 +544,4 @@ export default TabBar;
 
 // Re-export types and config
 export type { WorkStationTab } from "@src/store/workstation/tabs";
-export { TAB_BAR_HEIGHT, MAX_VISIBLE_TABS, STATUS_LABELS } from "./config";
+export { TAB_BAR_HEIGHT } from "./config";


### PR DESCRIPTION
## Problem

Unused editor/search icon maps and inactive editor and tab-bar settings suggest configuration that no production consumer reads. They duplicate the live settings used by the actual surfaces.

## Solution

Remove CODE_EDITOR_ICONS, unused CODE_EDITOR_CONFIG fields, the unused local search ICON_CONFIG, and MAX_VISIBLE_TABS/STATUS_LABELS plus their re-exports. Keep defaultTreeWidth at 300, every SEARCH_CONSTANTS value, the live primary-sidebar icon map, and tab-strip styles.

## Potential risks

Only unreferenced internal declarations and exports are removed. Sidebar reset and initial widths, search behavior, and overflow rendering are unchanged. No dependencies, persisted configuration or wire formats change. Revert the commit to restore the declarations.

## Verification

- `pnpm run typecheck:fast` — passed.
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm check:typed-lint` — passed: 1163 existing findings, 0 new or increased.
- `pnpm exec eslint src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/config.ts src/modules/WorkStation/CodeEditor/config.ts src/modules/WorkStation/shared/TabBar/config.ts src/modules/WorkStation/shared/TabBar/index.tsx --max-warnings 0` — passed.
- `git diff --check` — passed.
- Commit hooks (lint-staged, TypeScript check, commitlint) — passed.

## Audit

Architecture layers 1–10 covered within scope. UI audit: 0 fix, 1 keep with reason, 0 abstract. No new unit tests for dead constant deletion; native visual evidence is not useful because rendered code is unchanged.
