### PR TITLE
fix(typed-lint): stabilize switch finding fingerprints

### DIFF
--- a/scripts/quality/typed-lint/findings.mjs
+++ b/scripts/quality/typed-lint/findings.mjs
@@ -1,6 +1,33 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
 
+// TypeScript can reorder literal unions when import traversal changes. The
+// missing-case set is the finding; its diagnostic display order is not.
+function findingKey({ file, rule, message, source }) {
+  const prefix = "Switch is not exhaustive. Cases not matched: ";
+  if (
+    rule === "@typescript-eslint/switch-exhaustiveness-check" &&
+    message.startsWith(prefix)
+  ) {
+    const cases = message.slice(prefix.length);
+    // Only normalize a complete list of quoted literals. Do not split inside
+    // literals containing a pipe or an escaped quote, or reinterpret other
+    // TypeScript diagnostic syntax.
+    const literalList = /^"(?:[^"\\]|\\.)*"(?: \| "(?:[^"\\]|\\.)*")*$/;
+    if (literalList.test(cases)) {
+      message =
+        prefix +
+        cases
+          .match(/"(?:[^"\\]|\\.)*"/g)
+          .sort()
+          .join(" | ");
+    }
+  }
+  return createHash("sha256")
+    .update(JSON.stringify([file, rule, message, source]))
+    .digest("hex");
+}
+
 export function collectFindings(results, root) {
   const grouped = new Map();
   for (const result of results) {
@@ -26,9 +53,12 @@ export function collectFindings(results, root) {
         selected[0] = selected[0].slice(message.column - 1);
       }
       const source = selected.join("\n").replace(/\s+/g, " ").trim();
-      const key = createHash("sha256")
-        .update(JSON.stringify([file, message.ruleId, message.message, source]))
-        .digest("hex");
+      const key = findingKey({
+        file,
+        rule: message.ruleId,
+        message: message.message,
+        source,
+      });
       const finding = grouped.get(key) ?? {
         key,
         file,
@@ -50,13 +80,16 @@ export function newFindings(current, baseline) {
   if (!Array.isArray(baseline)) throw new Error("Baseline must be an array");
   const limits = new Map();
   for (const entry of baseline) {
+    // Recompute legacy keys with the same normalization; no baseline rewrite
+    // or extra allowance is needed when only diagnostic ordering changes.
+    const key = findingKey(entry);
     if (
-      limits.has(entry.key) ||
+      limits.has(key) ||
       !Number.isSafeInteger(entry.count) ||
       entry.count < 1
     )
       throw new Error("Invalid or duplicate baseline entry");
-    limits.set(entry.key, entry.count);
+    limits.set(key, entry.count);
   }
   return current.filter((entry) => entry.count > (limits.get(entry.key) ?? 0));
 }

--- a/scripts/quality/typed-lint/findings.test.mjs
+++ b/scripts/quality/typed-lint/findings.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 
 import { collectFindings, newFindings } from "./findings.mjs";
@@ -51,5 +52,54 @@ test("parser/configuration failures cannot be baselined", () => {
       ],
       "/repo"
     )
+  );
+});
+
+function switchFindings(cases) {
+  const results = result("tab.type");
+  results[0].messages[0].ruleId =
+    "@typescript-eslint/switch-exhaustiveness-check";
+  results[0].messages[0].message =
+    "Switch is not exhaustive. Cases not matched: " + cases;
+  return collectFindings(results, "/repo");
+}
+
+test("reordered literal cases match an unchanged legacy baseline", () => {
+  const baseline = switchFindings('"project" | "browser" | "code"');
+  const entry = baseline[0];
+  entry.key = createHash("sha256")
+    .update(
+      JSON.stringify([entry.file, entry.rule, entry.message, entry.source])
+    )
+    .digest("hex");
+  assert.deepEqual(
+    newFindings(switchFindings('"code" | "project" | "browser"'), baseline),
+    []
+  );
+  assert.equal(
+    newFindings(
+      switchFindings('"code" | "project" | "browser" | "new"'),
+      baseline
+    ).length,
+    1
+  );
+  const doubled = switchFindings('"code" | "project" | "browser"');
+  doubled[0].count = 2;
+  assert.equal(newFindings(doubled, baseline).length, 1);
+});
+
+test("literal contents and unfamiliar diagnostics retain their identity", () => {
+  const baseline = switchFindings('"a | b" | "c"');
+  assert.deepEqual(newFindings(switchFindings('"c" | "a | b"'), baseline), []);
+  assert.equal(
+    newFindings(switchFindings('"a" | "b" | "c"'), baseline).length,
+    1
+  );
+  assert.equal(
+    newFindings(
+      switchFindings('Some.Type | "c"'),
+      switchFindings('"c" | Some.Type')
+    ).length,
+    1
   );
 });


### PR DESCRIPTION
## Problem

The typed-lint baseline hashes the diagnostic's full message. TypeScript can reorder the same missing literal cases when an import graph changes, so a host-state refactor reports four existing switch findings as new even though their files, expressions, missing cases, and occurrence counts are unchanged.

## Solution

Canonicalize the ordering of complete quoted-literal lists for switch-exhaustiveness diagnostics when computing finding keys. Apply the same normalization to existing baseline entries at comparison time, preserving the checked-in baseline and its allowances. Keep other diagnostic syntax unchanged. Add regressions for legacy keys, reordered cases, added cases, increased counts, and literals containing a pipe.

## Potential risks

This changes CI finding identity, not application behavior. Normalization is restricted to one rule and a complete quoted-literal list; distinct cases, source expressions, files and occurrence increases still fail. Unknown diagnostic formats retain their original identity. No baseline entries or allowances are added. Reverting restores the old ordering-sensitive comparison; it requires no data recovery.

## Verification

- `pnpm test:typed-lint` — 6 tests passed, including the real type-aware rule fixture.
- `node --check scripts/quality/typed-lint/findings.mjs` and `node --check scripts/quality/typed-lint/findings.test.mjs` — passed.
- `git diff --check` — passed.
- Existing baseline loaded through the normalized comparator without collisions.
- Ordinary ESLint ignores these `.mjs` quality scripts; the attempted scoped lint reported ignored-file warnings, so Node syntax checks and the script test suite are the applicable checks.
- No UI changes; native screenshots and Rust checks are inapplicable.
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm check:typed-lint` on the stacked canonical-host branch — 1163 existing findings, 0 new or increased; the previously observed four ordering-only mismatches no longer trigger the gate.
