### PR TITLE
fix(chat): collapse failed terminal activity groups

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/chatItemPipeline/__tests__/pipeline.grouping.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/chatItemPipeline/__tests__/pipeline.grouping.test.ts
@@ -271,6 +271,78 @@ describe("processChatItems", () => {
   });
 
   describe("terminal grouping", () => {
+    it.each([
+      { success: false, error: "Command failed" },
+      { is_error: true, content: "Command failed" },
+      { error_message: "Command failed" },
+    ])(
+      "groups consecutive failed commands without losing errors: %j",
+      (result) => {
+        const commands = ["python3", "from", "import"].map((command) =>
+          makeSessionEvent({
+            action_type: "tool_call",
+            function: "run_shell",
+            status: "failed",
+            args: { command },
+            result,
+          })
+        );
+        const { items } = processChatItems(
+          [...commands, makeSearchItem("done")],
+          {
+            preFilterEmptyActivities: false,
+          }
+        );
+
+        expect(items).toHaveLength(2);
+        expect(items[0].activityStackGroup).toEqual({
+          category: "terminal",
+          events: commands,
+          closedByBoundary: true,
+        });
+        expect(
+          items[0].activityStackGroup?.events.map((event) => event.result)
+        ).toEqual(commands.map(() => result));
+      }
+    );
+
+    it("keeps failed terminal follow-ups with successful commands", () => {
+      const events = [
+        makeShellItem("git status"),
+        {
+          ...makeAwaitItem("shell", "48291"),
+          result: { success: false, error: "Wait failed" },
+        },
+        {
+          ...makeInspectTerminalsItem(),
+          result: { success: false, error: "Inspection failed" },
+        },
+        makeShellItem("git diff", 1),
+      ];
+      const { items } = processChatItems(events, {
+        preFilterEmptyActivities: false,
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0].activityStackGroup?.events).toEqual(events);
+      expect(items[0].activityStackGroup?.closedByBoundary).toBe(false);
+    });
+
+    it("keeps non-terminal MCP failures standalone", () => {
+      const failure = makeSessionEvent({
+        action_type: "tool_call",
+        function: "mcp_service__lookup",
+        result: { success: false, error: "Service unavailable" },
+      });
+      const { items } = processChatItems(
+        [makeShellItem("git status"), failure, makeShellItem("git diff")],
+        { preFilterEmptyActivities: false }
+      );
+
+      expect(items).toHaveLength(3);
+      expect(items[1].event).toEqual(failure);
+    });
+
     it("groups a single terminal command", () => {
       const command = makeShellItem("git status");
 

--- a/src/engines/ChatPanel/ChatHistory/chatItemPipeline/pipeline.ts
+++ b/src/engines/ChatPanel/ChatHistory/chatItemPipeline/pipeline.ts
@@ -30,6 +30,7 @@ import {
   isManageTodoEvent,
   isMcpToolEvent,
   isReadFileEvent,
+  isTerminalActivityEvent,
   isTerminalCommandEvent,
 } from "./classifiers";
 import { buildDedupMaps } from "./dedup";
@@ -555,12 +556,12 @@ export function processChatItems(
     }
 
     // Buffer: consecutive shell commands, MCP calls, and terminal
-    // wait/monitor/inspect follow-ups. Explicit infrastructure failures remain
-    // standalone error cards, matching the exploration-group failure policy.
+    // wait/monitor/inspect follow-ups, including failures. Keep terminal error
+    // details inside the stack; non-terminal MCP failures remain standalone.
     if (
       opts.groupTerminalActivities &&
       isCommandGroupActivityEvent(event) &&
-      !isFailedToolCall(event)
+      (isTerminalActivityEvent(event) || !isFailedToolCall(event))
     ) {
       flushBrowserBuffer();
       flushPartialBuffer();

--- a/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { makeSessionEvent } from "@src/engines/SessionCore/rendering/props/__tests__/fixtures";
+
+import {
+  GroupItemRenderer,
+  type GroupItemRendererProps,
+} from "./GroupItemRenderer";
+
+vi.mock("./ChatItemRenderer", () => ({ ChatItemRenderer: () => null }));
+vi.mock("../components/TurnMetadataFooterSlot", () => ({
+  default: () => null,
+}));
+vi.mock("../hooks/useChatGroups", () => ({
+  getUnloadedTurnMeta: () => undefined,
+  isTurnPreviewItem: () => false,
+}));
+
+const compare = (
+  GroupItemRenderer as unknown as {
+    compare: (
+      left: GroupItemRendererProps,
+      right: GroupItemRendererProps
+    ) => boolean;
+  }
+).compare;
+
+describe("GroupItemRenderer terminal collapse updates", () => {
+  it.each([true, false])(
+    "updates the collapse boundary with failed=%s",
+    (failed) => {
+      const events = [
+        makeSessionEvent({
+          action_type: "tool_call",
+          function: "run_shell",
+          args: { command: "python3" },
+          result: { success: !failed },
+        }),
+      ];
+      const previous: GroupItemRendererProps = {
+        flatIndex: 0,
+        groupIndex: 0,
+        turnId: null,
+        chatItem: {
+          chunk_id: "terminal-group",
+          type: "activityStackGroup",
+          activityStackGroup: {
+            category: "terminal",
+            events,
+            closedByBoundary: false,
+          },
+        },
+        previousChatItem: undefined,
+        isLastItemInGroup: false,
+        isLastGroup: false,
+        isWpGeneWorking: false,
+        isExploring: false,
+        onSubmit: vi.fn(),
+        onSkip: vi.fn(),
+      };
+      expect(compare(previous, { ...previous })).toBe(true);
+      expect(
+        compare(previous, {
+          ...previous,
+          chatItem: {
+            ...previous.chatItem!,
+            activityStackGroup: {
+              category: "terminal",
+              events,
+              closedByBoundary: true,
+            },
+          },
+        })
+      ).toBe(false);
+    }
+  );
+});

--- a/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx
+++ b/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx
@@ -173,6 +173,9 @@ function sameChatItem(
     left.consolidatedParts === right.consolidatedParts &&
     left.actionSummaryClosedByBoundary ===
       right.actionSummaryClosedByBoundary &&
+    left.activityStackGroup?.category === right.activityStackGroup?.category &&
+    left.activityStackGroup?.closedByBoundary ===
+      right.activityStackGroup?.closedByBoundary &&
     sameEventSummary(left.event, right.event) &&
     sameEventList(left.readFileEvents, right.readFileEvents) &&
     sameEventList(

--- a/src/engines/ChatPanel/ChatItems/TerminalActivityGroup/TerminalActivityGroup.test.ts
+++ b/src/engines/ChatPanel/ChatItems/TerminalActivityGroup/TerminalActivityGroup.test.ts
@@ -1,4 +1,6 @@
-import { createElement } from "react";
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -11,6 +13,11 @@ vi.mock("@src/engines/ChatPanel/hooks/useChatEventReplay", () => ({
     replayEventById: vi.fn(),
     canReplay: false,
   }),
+}));
+
+vi.mock("@src/engines/SessionCore/rendering/registry/events", () => ({
+  getChatLazyComponent: () => () =>
+    createElement("div", null, "Failed command details"),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -35,6 +42,83 @@ const translateSummary = (
 };
 
 describe("buildGroupSummary", () => {
+  it("renders failed terminal groups collapsed with no individual error rows", () => {
+    const events = ["python3", "from", "import"].map((command) =>
+      makeSessionEvent({
+        action_type: "tool_call",
+        function: "run_shell",
+        status: "failed",
+        args: { command },
+        result: { success: false, error: "Command failed" },
+      })
+    );
+    const markup = renderToStaticMarkup(
+      createElement(TerminalActivityGroup, {
+        events,
+        closedByBoundary: true,
+      })
+    );
+    expect(markup).toContain("tools.runCommands");
+    expect(markup).not.toContain("Command failed");
+    expect(markup).not.toContain("overflow-y-auto");
+  });
+
+  it("collapses an open failed stack at the boundary and still allows manual expansion", () => {
+    const events = [
+      makeSessionEvent({
+        action_type: "tool_call",
+        function: "run_shell",
+        args: { command: "python3" },
+        result: { success: false, error: "Command failed" },
+      }),
+    ];
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const environment = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    const previousActEnvironment = environment.IS_REACT_ACT_ENVIRONMENT;
+    environment.IS_REACT_ACT_ENVIRONMENT = true;
+    try {
+      act(() =>
+        root.render(
+          createElement(TerminalActivityGroup, {
+            events,
+            closedByBoundary: false,
+          })
+        )
+      );
+      expect(container.textContent).toContain("Failed command details");
+      act(() =>
+        root.render(
+          createElement(TerminalActivityGroup, {
+            events,
+            closedByBoundary: true,
+          })
+        )
+      );
+      expect(container.textContent).not.toContain("Failed command details");
+      const header = container.querySelector(".chat-block-header");
+      expect(header).not.toBeNull();
+      act(() =>
+        header!.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+      );
+      expect(container.textContent).toContain("Failed command details");
+      act(() =>
+        root.render(
+          createElement(TerminalActivityGroup, {
+            events,
+            closedByBoundary: true,
+          })
+        )
+      );
+      expect(container.textContent).toContain("Failed command details");
+    } finally {
+      act(() => root.unmount());
+      environment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+    }
+  });
+
   it("summarizes mixed shell and MCP activity with MCP calls after commands", () => {
     const events = [
       makeSessionEvent({


### PR DESCRIPTION
## Problem

Failed shell calls were excluded from chat terminal groups, leaving repeated standalone rows. The memoized row comparison also ignored the terminal stack's collapse-boundary flag, so an open stack could miss its collapse update.

## Solution

Keep failed terminal commands and shell follow-ups in the ordinary collapsible stack, preserving their original results and order. Compare the stack category and collapse boundary when deciding whether to rerender. Non-terminal MCP failures retain their existing standalone behavior.

## Potential risks

Failed terminal details now require expanding the group. The current trailing group and explicit manual expansion retain their existing behavior. No stored data, protocol, or dependency changes are involved. Desktop light/dark screenshots and real-app interaction checks were not collected because desktop UI control was not authorized; rendered tests cover the collapse behavior.

## Verification

- `pnpm test src/engines/ChatPanel/ChatHistory/chatItemPipeline src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.test.ts src/engines/ChatPanel/ChatItems/TerminalActivityGroup/TerminalActivityGroup.test.ts`: 227 passed on the latest develop base
- Regression coverage includes failure payload variants, retained error details, memo invalidation, rendered boundary collapse, and manual reopening
- `git diff --check`: passed
- Normal commit hooks: lint-staged and TypeScript checks passed
