### PR TITLE
feat(terminal): share bounded command highlighting

### DIFF
--- a/docs/org2-performance-guard-2026-09-10/TerminalHighlight.md
+++ b/docs/org2-performance-guard-2026-09-10/TerminalHighlight.md
@@ -1,0 +1,18 @@
+# Lightweight terminal command highlighting
+
+Chat and Agent Station use one synchronous renderer. It decorates at most 256 source characters with at most 24 spans; the rest of the command remains exact plain text. Heredoc bodies remain plain. No HTML is interpreted. Existing `.prism-html .token.*` styles resolve to the same `--cm-syntax-*` variables used by CodeMirror in light and dark themes. No new stylesheet or highlighter library is loaded by this helper.
+
+Chat invokes it only inside the expanded body. The Agent Station command primitive no longer invokes the cached Prism hook. Durable and legacy replay enable the lightweight renderer. Existing explicitly plain and single-line ellipsis variants remain plain; output rendering is unchanged.
+
+| Area               | Verdict           | Evidence                                                   | Change or reason kept                                               | Verification                                                                                             |
+| ------------------ | ----------------- | ---------------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Background work    | keep              | Renderer has no effects, subscriptions, timers, or workers | Existing replay ownership unchanged                                 | Source inspection                                                                                        |
+| Memory             | bounded candidate | No token cache; capped character scan and spans            | At most 24 extra spans per visible command; arrays are render-local | 200,000-character input stays at 24 spans; 30 updates do not accumulate nodes; unmount removes all nodes |
+| Scope/isolation    | keep              | Pure function of caller-provided text                      | No global mutable/session state                                     | Repeated render and escaping tests                                                                       |
+| Rendering/hot path | bounded candidate | Expanded chat body and shared station primitive            | Reuse theme classes; remove command Prism hook                      | Rendered chat/station tests; heavy-highlighter hook is never invoked by primitive                        |
+
+Verification: 13 targeted tests passed, `pnpm typecheck:fast` passed, changed-file ESLint passed, and `git diff --check` passed. Tests cover text preservation, HTML escaping, Unicode, heredoc boundaries, token cap, repeated updates, unmount, collapsed chat, and Agent Station output remaining plain.
+
+No browser/WebView RAM measurement or real desktop visual verification was performed. DOM tests establish bounds and removal, not garbage collection or RSS behavior. Source inspection confirms shared color variables; it does not replace theme screenshots.
+
+Performance verdict: blocked for a literal zero-RAM guarantee. The implementation has small bounded markup overhead and no new persistent cache; net application RAM change is unmeasured.

--- a/src/engines/ChatPanel/blocks/TerminalBlock/index.tsx
+++ b/src/engines/ChatPanel/blocks/TerminalBlock/index.tsx
@@ -23,6 +23,7 @@ import type {
   ToolUsageMetadata,
 } from "@src/engines/SessionCore/core/types";
 import { ShellReplayOutput } from "@src/engines/SessionCore/replay/components/ShellReplayOutput";
+import { renderCommandHighlight } from "@src/engines/TerminalCore/components/TerminalDisplay/commandHighlight";
 import "@src/engines/TerminalCore/components/TerminalDisplay/index.scss";
 import { HugeiconsIcon, SquareIcon } from "@src/icons";
 import {
@@ -352,8 +353,8 @@ const TerminalBlock: React.FC<TerminalBlockProps> = memo(
                     <span className="terminal-command__prefix select-none">
                       $
                     </span>
-                    <span className="terminal-command__text">
-                      {commandPreview}
+                    <span className="terminal-command__text prism-html">
+                      {renderCommandHighlight(commandPreview)}
                     </span>
                   </div>
                 </div>

--- a/src/engines/ChatPanel/blocks/TerminalBlock/shellReplay.test.ts
+++ b/src/engines/ChatPanel/blocks/TerminalBlock/shellReplay.test.ts
@@ -9,6 +9,19 @@ vi.mock("react-i18next", () => ({
 }));
 
 describe("TerminalBlock shell replay", () => {
+  it("highlights commands only while the chat body is expanded", () => {
+    const command = "git status --short";
+    const expanded = renderToStaticMarkup(
+      createElement(TerminalBlock, { command, defaultCollapsed: false })
+    );
+    expect(expanded).toContain('class="token function">git</span>');
+    expect(expanded).toContain('class="token parameter">--short</span>');
+    const collapsed = renderToStaticMarkup(
+      createElement(TerminalBlock, { command, defaultCollapsed: true })
+    );
+    expect(collapsed).not.toContain('class="token');
+  });
+
   it("renders the bounded replay preview in the expanded chat body", () => {
     const markup = renderToStaticMarkup(
       createElement(TerminalBlock, {

--- a/src/engines/SessionCore/replay/components/ShellReplayOutput/index.tsx
+++ b/src/engines/SessionCore/replay/components/ShellReplayOutput/index.tsx
@@ -395,7 +395,6 @@ const ShellReplayOutputComponent: React.FC<ShellReplayOutputProps> = ({
           <TerminalCommand
             command={displayCommand}
             prefix="$"
-            highlighted={false}
             style={{ color: foreground, padding: 0, margin: 0 }}
           />
         </div>

--- a/src/engines/TerminalCore/components/TerminalDisplay/TerminalCommand.tsx
+++ b/src/engines/TerminalCore/components/TerminalDisplay/TerminalCommand.tsx
@@ -8,7 +8,7 @@
  * - TerminalCommandView
  *
  * Features:
- * - Prism syntax highlighting (shared lazy hook with caching)
+ * - Bounded shell highlighting using the shared CodeMirror token colors
  * - Customizable prompt prefix
  * - Optional highlighting disable
  * - Consistent styling across all contexts
@@ -16,8 +16,9 @@
  */
 import React, { memo } from "react";
 
-import { useSyntaxHighlight } from "@src/hooks/code/useSyntaxHighlight";
 import { HugeiconsIcon, SquareIcon } from "@src/icons";
+
+import { renderCommandHighlight } from "./commandHighlight";
 
 export interface TerminalCommandStopAction {
   /** Tooltip for the stop button */
@@ -77,9 +78,6 @@ export const TerminalCommand: React.FC<TerminalCommandProps> = memo(
   }) => {
     const useHighlight = highlighted && !singleLineEllipsis;
     // Single-line ellipsis needs plain text; token spans break text-overflow.
-    const highlightedHtml = useSyntaxHighlight(useHighlight ? command : "", {
-      lang: "bash",
-    });
 
     const rootClass = [
       "terminal-command",
@@ -97,11 +95,10 @@ export const TerminalCommand: React.FC<TerminalCommandProps> = memo(
         title={singleLineEllipsis ? command : undefined}
       >
         <span className="terminal-command__prefix select-none">{prefix}</span>
-        {useHighlight && highlightedHtml ? (
-          <span
-            className="terminal-command__text prism-html"
-            dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-          />
+        {useHighlight ? (
+          <span className="terminal-command__text prism-html">
+            {renderCommandHighlight(command)}
+          </span>
         ) : (
           <span className="terminal-command__text">{command}</span>
         )}

--- a/src/engines/TerminalCore/components/TerminalDisplay/commandHighlight.test.ts
+++ b/src/engines/TerminalCore/components/TerminalDisplay/commandHighlight.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { TerminalCommand } from "./TerminalCommand";
+import { renderCommandHighlight } from "./commandHighlight";
+
+const heavyHighlight = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("Command previews must not load the full highlighter");
+  })
+);
+vi.mock("@src/hooks/code/useSyntaxHighlight", () => ({
+  useSyntaxHighlight: heavyHighlight,
+}));
+
+function render(text: string) {
+  const element = document.createElement("div");
+  element.innerHTML = renderToStaticMarkup(
+    createElement(
+      "span",
+      { className: "prism-html" },
+      renderCommandHighlight(text)
+    )
+  );
+  return element;
+}
+
+describe("lightweight command highlighting", () => {
+  it("uses existing theme token classes while preserving the exact command", () => {
+    const command = "git status --short && printf '%s' $HOME";
+    const element = render(command);
+    expect(element.textContent).toBe(command);
+    expect(element.querySelector(".token.function")?.textContent).toBe("git");
+    expect(element.querySelector(".token.parameter")?.textContent).toBe(
+      "--short"
+    );
+    expect(element.querySelector(".token.string")?.textContent).toBe("'%s'");
+    expect(element.querySelector(".token.variable")?.textContent).toBe("$HOME");
+    expect(element.querySelector(".token.operator")?.textContent).toBe("&&");
+  });
+
+  it("does not parse heredoc bodies as shell or turn command text into HTML", () => {
+    const command = "python3 - <<'PY'\nprint('<script>bad()</script>')\nPY";
+    const element = render(command);
+    expect(element.textContent).toBe(command);
+    expect(element.querySelector("script")).toBeNull();
+    expect(
+      [...element.querySelectorAll(".token")].some((token) =>
+        token.textContent?.includes("print")
+      )
+    ).toBe(false);
+  });
+
+  it("bounds markup independently of script size without discarding text", () => {
+    const command = "a;".repeat(100_000);
+    const element = render(command);
+    expect(element.textContent).toBe(command);
+    expect(element.querySelectorAll(".token")).toHaveLength(24);
+    expect(render("echo 你好 😀").textContent).toBe("echo 你好 😀");
+  });
+
+  it("uses the same renderer in the station primitive without the full highlighter", () => {
+    const command = "git status --short";
+    const element = document.createElement("div");
+    element.innerHTML = renderToStaticMarkup(
+      createElement(TerminalCommand, { command })
+    );
+    expect(element.querySelector(".terminal-command__text")?.innerHTML).toBe(
+      render(command).firstElementChild?.innerHTML
+    );
+    expect(heavyHighlight).not.toHaveBeenCalled();
+    element.innerHTML = renderToStaticMarkup(
+      createElement(TerminalCommand, { command, highlighted: false })
+    );
+    expect(element.querySelector(".token")).toBeNull();
+  });
+
+  it("does not accumulate token nodes across updates or retain them after unmount", () => {
+    const element = document.createElement("div");
+    const root = createRoot(element);
+    const environment = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    const previous = environment.IS_REACT_ACT_ENVIRONMENT;
+    environment.IS_REACT_ACT_ENVIRONMENT = true;
+    try {
+      for (let i = 0; i < 30; i++) {
+        act(() =>
+          root.render(
+            createElement(TerminalCommand, {
+              command: `${i};${"a;".repeat(1000)}`,
+            })
+          )
+        );
+        expect(element.querySelectorAll(".token").length).toBeLessThanOrEqual(
+          24
+        );
+      }
+      act(() => root.unmount());
+      expect(element.childNodes).toHaveLength(0);
+    } finally {
+      environment.IS_REACT_ACT_ENVIRONMENT = previous;
+    }
+  });
+});

--- a/src/engines/TerminalCore/components/TerminalDisplay/commandHighlight.tsx
+++ b/src/engines/TerminalCore/components/TerminalDisplay/commandHighlight.tsx
@@ -1,0 +1,61 @@
+import { type ReactNode, createElement } from "react";
+
+// Decorate only a bounded prefix, even when Agent Station shows a full script.
+const MAX_CHARS = 256;
+const MAX_SPANS = 24;
+
+/** Small shell preview decoration: no grammar loader, HTML, cache, or state. */
+export function renderCommandHighlight(text: string): ReactNode {
+  if (!text) return text;
+  let end = Math.min(text.length, MAX_CHARS);
+  if (end < text.length && /[\uD800-\uDBFF]/.test(text[end - 1])) end--;
+
+  const tokens =
+    /#[^\n]*|"(?:\\[\s\S]|[^"\\])*(?:"|$)|'[^']*(?:'|$)|`[^`]*(?:`|$)|\$\{[^}]*\}?|\$[\w?@#*!$-]+|[|&;<>()[\]]+|\s+|\\[\s\S]?|[^\s"'`$|&;<>()[\]\\]+|./g;
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  let spans = 0;
+  let commandExpected = true;
+  let heredoc = false;
+  for (const match of text.slice(0, end).matchAll(tokens)) {
+    const token = match[0];
+    if (/^\s/.test(token)) {
+      if (token.includes("\n")) {
+        // A heredoc can contain any language. Do not guess shell tokens in it.
+        if (heredoc) break;
+        commandExpected = true;
+      }
+      continue;
+    }
+    let kind: string | undefined;
+    if (token.startsWith("#")) kind = "comment";
+    else if (/^["'`]/.test(token)) {
+      kind = "string";
+      commandExpected = false;
+    } else if (token.startsWith("$")) {
+      kind = "variable";
+      commandExpected = false;
+    } else if (/^[|&;<>()[\]]/.test(token)) {
+      kind = "operator";
+      heredoc ||= token.includes("<<");
+      commandExpected = /^[|&;(]/.test(token);
+    } else if (token.startsWith("-")) kind = "parameter";
+    else if (commandExpected && !/^[\w]+=/.test(token)) {
+      kind = "function";
+      commandExpected = false;
+    }
+    if (!kind) continue;
+    if (match.index > cursor) nodes.push(text.slice(cursor, match.index));
+    nodes.push(
+      createElement(
+        "span",
+        { key: match.index, className: `token ${kind}` },
+        token
+      )
+    );
+    cursor = match.index + token.length;
+    if (++spans === MAX_SPANS) break;
+  }
+  if (cursor < text.length) nodes.push(text.slice(cursor));
+  return nodes;
+}

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/ShellCssOutput.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/ShellCssOutput.tsx
@@ -1,7 +1,7 @@
 /**
  * Simulator shell replay using DOM + CSS, styled from the same terminal
  * settings as Workstation (theme palette + font atoms). Avoids xterm canvas/WebGL glitches.
- * Command and output render as plain terminal text without syntax highlighting.
+ * Commands use bounded highlighting; output remains plain terminal text.
  */
 import React, { memo, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -74,7 +74,6 @@ const SimulatorShellCssOutputComponent: React.FC<
           <TerminalCommand
             command={displayCommand}
             prefix="$"
-            highlighted={false}
             style={{
               color: foreground,
               padding: 0,

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/ShellCssOutput.test.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/ShellCssOutput.test.ts
@@ -1,0 +1,23 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { SimulatorShellCssOutput } from "../ShellCssOutput";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("Agent Station command highlighting", () => {
+  it("highlights the command with theme tokens and leaves output plain", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SimulatorShellCssOutput, {
+        command: "git status --short",
+        output: "ordinary output --plain",
+      })
+    );
+    expect(markup).toContain('class="token function">git</span>');
+    expect(markup).toContain('class="token parameter">--short</span>');
+    expect(markup).toContain("ordinary output --plain");
+  });
+});


### PR DESCRIPTION
## Problem

Chat command previews were plain, while Agent Station either disabled highlighting or used the full cached Prism path. The requested command-only styling needs consistent theme colors with bounded overhead.

## Solution

Use one lightweight shell decorator in chat and Agent Station, reusing the existing CodeMirror syntax CSS variables. Scan at most 256 characters and emit at most 24 colored spans; retain all remaining text as plain text and leave heredoc bodies and terminal output plain. Chat runs the decorator only while expanded. The station command primitive no longer invokes the Prism hook.

## Potential risks

This is basic shell decoration, not a full shell or embedded-language grammar. Only the bounded prefix is highlighted. It adds a small bounded amount of rendered markup; zero added RAM is not guaranteed or measured. Existing plain/ellipsis variants remain plain. No new dependency, cache, worker, storage, or wire format is introduced. Desktop theme screenshots and WebView memory profiling were not run because UI control was not authorized; light/dark/custom-theme support is source-verified through shared CSS tokens.

## Verification

- `pnpm test src/engines/TerminalCore/components/TerminalDisplay/commandHighlight.test.ts src/engines/ChatPanel/blocks/TerminalBlock src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/ShellCssOutput.test.ts`: 13 passed on latest develop
- Tests cover exact text and HTML escaping, Unicode, heredoc boundaries, a 200,000-character input with 24 spans, 30 updates without node accumulation, unmount cleanup, collapsed chat, and Agent Station output remaining plain
- `pnpm typecheck:fast`: passed in the original working checkout; isolated commit hooks rerun staged-file type checking
- `git diff --check`: passed
- Normal commit hooks: lint-staged and TypeScript checks passed
