### PR TITLE
fix(codex-import): preserve heredoc command result identity

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/desktop_exec.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/desktop_exec.rs
@@ -46,7 +46,8 @@ fn split_multiline_shell_script(command: &str) -> Vec<String> {
     let mut current = String::new();
     let mut quote = None;
     let mut escaped = false;
-    for ch in command.chars() {
+    let mut chars = command.chars().peekable();
+    while let Some(ch) = chars.next() {
         if escaped {
             current.push(ch);
             escaped = false;
@@ -63,6 +64,13 @@ fn split_multiline_shell_script(command: &str) -> Vec<String> {
                 quote = None;
             }
             continue;
+        }
+        // A here-document body is input to one shell invocation, not a list
+        // of shell commands. Keep the whole script (including any surrounding
+        // statements) together so its single process result has one owner.
+        // This also safely retains here-strings and tab-stripped heredocs.
+        if ch == '<' && chars.peek() == Some(&'<') {
+            return vec![command.to_string()];
         }
         if matches!(ch, '\'' | '"' | '`') {
             quote = Some(ch);

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -1511,6 +1511,109 @@ fn codex_write_stdin_cell_wait_still_merges_into_originating_command() {
 }
 
 #[test]
+fn codex_desktop_exec_keeps_heredoc_bodies_in_one_invocation() {
+    for command in [
+        "python3 - <<'PY'\nfrom pathlib import Path\nprint('done')\nPY",
+        "cat <<EOF\nhello\nEOF",
+        "cat <<-\"EOF\"\n\thello\n\tEOF\nprintf done",
+        "cat <<< 'hello'\nprintf done",
+    ] {
+        let payload = json!({
+            "name": "exec",
+            "call_id": "heredoc",
+            "input": format!("text(await tools.exec_command({{cmd:{}}}));", serde_json::to_string(command).unwrap()),
+        });
+        let (_, calls) =
+            pending_custom_tool_calls_from_payload(&payload, "2026-09-10T16:50:00Z").unwrap();
+        assert_eq!(calls.len(), 1, "{command}");
+        assert_eq!(
+            calls[0].canonical_name,
+            imported_history::FUNCTION_RUN_COMMAND_LINE
+        );
+        assert_eq!(calls[0].args["command"], command);
+    }
+}
+
+#[test]
+fn codex_desktop_background_heredoc_completion_pairs_with_batched_next_command() {
+    let temp_dir = std::env::temp_dir().join(format!("orgii-codex-heredoc-{}", std::process::id()));
+    std::fs::create_dir_all(&temp_dir).unwrap();
+    let path = temp_dir.join("rollout.jsonl");
+    let command = "python3 - <<'PY'\nfrom pathlib import Path\nprint('created')\nPY";
+    let next_command = "python3 - <<'PY'\nimport json\nprint('verified')\nPY";
+    let call = |id: &str, input: String| {
+        json!({
+            "timestamp": "2026-09-10T16:50:00Z", "type": "response_item",
+            "payload": {"type": "custom_tool_call", "name": "exec", "call_id": id, "input": input},
+        })
+    };
+    let output = |id: &str, results: Vec<Value>| {
+        json!({
+            "timestamp": "2026-09-10T16:50:01Z", "type": "response_item",
+            "payload": {"type": "custom_tool_call_output", "call_id": id, "output":
+                std::iter::once(json!({"type": "input_text", "text": "Script completed\nOutput:\n"}))
+                    .chain(results.into_iter().map(|result| json!({"type": "input_text", "text": result.to_string()})))
+                    .collect::<Vec<_>>()},
+        })
+    };
+    let start = [
+        call(
+            "start",
+            format!(
+                "text(await tools.exec_command({{cmd:{}}}));",
+                serde_json::to_string(command).unwrap()
+            ),
+        ),
+        output("start", vec![json!({"session_id": 65005, "output": ""})]),
+        call(
+            "poll",
+            "text(await tools.write_stdin({session_id:65005,chars:\"\"}));".to_string(),
+        ),
+        output(
+            "poll",
+            vec![json!({"session_id": 65005, "output": "created\n"})],
+        ),
+    ];
+    let completion = [
+        call("finish", format!("text(await tools.write_stdin({{session_id:65005,chars:\"\"}}));\ntext(await tools.exec_command({{cmd:{}}}));", serde_json::to_string(next_command).unwrap())),
+        output("finish", vec![json!({"exit_code": 0, "output": "finished\n"}), json!({"exit_code": 0, "output": "verified\n"})]),
+    ];
+    let encode = |rows: &[Value]| {
+        rows.iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    std::fs::write(&path, encode(&start)).unwrap();
+    let pending = load_codex_app_from_path("codexapp-heredoc", &path).unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].args["command"], command);
+    std::fs::write(
+        &path,
+        format!("{}\n{}", encode(&start), encode(&completion)),
+    )
+    .unwrap();
+    for _ in 0..2 {
+        let chunks = load_codex_app_from_path("codexapp-heredoc", &path).unwrap();
+        assert_eq!(chunks.len(), 2);
+        for (expected_command, expected_output) in [
+            (command, "created\nfinished\n"),
+            (next_command, "verified\n"),
+        ] {
+            let chunk = chunks
+                .iter()
+                .find(|chunk| chunk.args["command"] == expected_command)
+                .unwrap();
+            assert_eq!(chunk.result["exit_code"], 0);
+            assert_ne!(chunk.result["success"], false);
+            assert_ne!(chunk.result["status"], "interrupted");
+            assert_eq!(chunk.result["output"], expected_output);
+        }
+    }
+    std::fs::remove_dir_all(temp_dir).unwrap();
+}
+
+#[test]
 fn codex_desktop_exec_preserves_multiline_shell_script() {
     let command = "sed -n '1,180p' src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders.tsx\nsed -n '250,370p' src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx\nsed -n '1,180p' src/config/agentIcons.tsx\nrg -n \"interface.*MenuItem|type.*MenuItem|renderStatusDot|agentIconId\" src/scaffold/NavigationSidebar src/scaffold -g '*.tsx' -g '*.ts' | head -200";
     let script = format!(


### PR DESCRIPTION
## Problem

The Codex Desktop importer split Python heredoc bodies into synthetic shell commands. This could break result pairing when a background completion was batched with the next command, leaving successful scripts marked interrupted/failed and repeating their output. The reported source transcript had exit code 0.

## Solution

Preserve an entire shell invocation when it contains an unquoted heredoc or here-string operator. Its process result now retains one command owner. Add raw JSONL regression coverage for partial output, a batched completion plus the next script, and repeat reads.

## Potential risks

Heredoc-containing scripts no longer decompose into per-line exploration entries. This is deliberate because their body lines are input, not separate commands. No source transcript, database schema, or wire format is modified. Source-backed history regenerates when reloaded with the updated backend; no destructive cleanup is needed. Existing imported/cached copies elsewhere and cross-machine synchronization were not exercised. Reverting restores the former import behavior without modifying source history.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml -p orgtrack_core sources::codex --lib`: 86 passed, 1 opt-in fixture test ignored, on latest develop
- Read-only verification against the reported local transcript produced two intact scripts with success true and exit code 0
- Regression tests cover quoted/unquoted/tab-stripped heredocs, here-strings, a partial-output append followed by successful completion, and two final rereads
- `git diff --check`: passed
- This changes canonical import behavior; no UI layout changes or screenshots apply
- Normal commit hooks: lint-staged and scoped orgtrack_core Clippy checks passed
