### PR TITLE
perf(codex-import): reduce command parsing allocations

### DIFF
--- a/docs/org2-performance-guard-2026-09-10/CodexParsing.md
+++ b/docs/org2-performance-guard-2026-09-10/CodexParsing.md
@@ -1,0 +1,49 @@
+# Codex command and output parsing
+
+Scope: the Codex Desktop wrapper scanner, multiline shell decomposition, and output partitioning. These are synchronous helpers invoked by the existing transcript reader; no new cache, subscription, timer, task, or persistence format is introduced.
+
+## Changes
+
+- Borrow wrapper names, argument expressions, and command-line slices instead of constructing intermediate strings. Single-line commands skip the shell scan.
+- Preserve heredocs, compound commands, continued pipelines, and incomplete quoted scripts as one invocation. Backslashes inside single quotes remain literal.
+- Partition bounded read output with a forward iterator and byte offsets. Copy the final remainder directly instead of indexing every output line.
+
+The scanner remains a conservative recognizer, not a complete JavaScript or shell grammar. Unrecognized complex shell syntax should remain an intact command. Existing exploration decomposition tests remain covered.
+
+## Measurements
+
+Local optimized Rust microbenchmark, extracted before/after helper implementations, counting allocations with the same allocator wrapper. Time is the median of five batches of 1,000 calls. Inputs and outputs were compared for the unchanged split/partition cases. Concurrent desktop/build activity makes small timing differences inconclusive.
+
+| Case                                                          | Allocations before / after | Allocated bytes before / after | Time per call before / after  |
+| ------------------------------------------------------------- | -------------------------- | ------------------------------ | ----------------------------- |
+| Split 1,000 printf lines                                      | 1,012 / 9                  | 66,002 / 32,704                | 63.24 / 39.63 microseconds    |
+| Extract one wrapper carrying those lines                      | 3 / 1                      | 19,102 / 128                   | 12.45 / 11.94 microseconds    |
+| Partition 100,000 Unicode output lines after a 10-line prefix | 20 / 4                     | 6,094,320 / 1,900,080          | 1,971.85 / 44.97 microseconds |
+
+The last case benefits particularly from avoiding a scan of the large final remainder. Allocated bytes are cumulative allocator requests, not peak RSS. No whole-app latency or CPU improvement is claimed.
+
+## Performance guard
+
+| Area               | Verdict | Evidence                                                           | Change or reason kept                      | Verification                                  |
+| ------------------ | ------- | ------------------------------------------------------------------ | ------------------------------------------ | --------------------------------------------- |
+| Background work    | keep    | Existing command handler owns synchronous parsing in blocking work | No scheduling/lifecycle change             | Call-chain inspection                         |
+| Memory             | fix     | Per-call strings and full output-line vector                       | Borrow slices; eliminate line index        | Allocation benchmark; byte-exact output tests |
+| Scope/isolation    | keep    | Helpers receive one caller-owned string; no shared mutable state   | No identity/cache change                   | Source inspection; repeat-read tests          |
+| Rendering/hot path | fix     | Transcript parsing feeds canonical activity chunks                 | Preserve shell structure and reduce copies | Parser regression suite and microbenchmark    |
+
+| Provider      | Raw transition                                  | App/UI state                     | Topology/boundary      | Expected invariant                                               | Observed evidence                               |
+| ------------- | ----------------------------------------------- | -------------------------------- | ---------------------- | ---------------------------------------------------------------- | ----------------------------------------------- |
+| Codex Desktop | Call, partial output, batched completion append | Parser reads before/after append | Local JSONL ingestion  | One command per heredoc; successful completion paired correctly  | Regression fixture, including two final rereads |
+| Codex Desktop | Multiline command/output parse                  | Parser-only                      | Local normalization    | Quoted newlines, Unicode, CRLF, empty/truncated output preserved | Targeted tests                                  |
+| Codex         | Rotation, compaction, turn windows              | Parser-only                      | Existing local readers | Existing reader behavior retained                                | Existing Codex suite                            |
+
+Desktop rendering, remote synchronization, and other providers were not exercised; their code is unchanged. No destructive historical remediation is needed. Reloading source-backed history with the updated backend applies the new projection.
+
+## Verification
+
+- `cargo test --manifest-path src-tauri/Cargo.toml -p orgtrack_core sources::codex --lib`: 88 passed, 1 opt-in fixture test ignored
+- The final isolated PR worktree reran the complete Codex suite after the continued-pipeline guard: 88 passed, 1 opt-in fixture test ignored.
+- `cargo clippy --manifest-path src-tauri/Cargo.toml -p orgtrack_core --lib -- -D warnings`: passed
+- `git diff --check`: passed
+
+Performance verdict: pass for the local parser helpers. No desktop or cross-machine performance claim is made.

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/desktop_exec.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/desktop_exec.rs
@@ -16,8 +16,8 @@ pub(super) fn normalize_codex_exec_tool_calls(input: &str) -> Vec<(String, Value
     calls
         .into_iter()
         .flat_map(|(name, expression)| {
-            let args = tool_args(input, &name, &expression);
-            if is_codex_shell_tool_key(&normalize_tool_name_key(&name)) {
+            let args = tool_args(input, name, expression);
+            if is_codex_shell_tool_key(&normalize_tool_name_key(name)) {
                 let statements = args
                     .get("command")
                     .and_then(Value::as_str)
@@ -29,37 +29,46 @@ pub(super) fn normalize_codex_exec_tool_calls(input: &str) -> Vec<(String, Value
                         .flat_map(|command| {
                             let mut statement_args = args.clone();
                             if let Some(object) = statement_args.as_object_mut() {
-                                object.insert("command".to_string(), Value::String(command));
+                                object.insert(
+                                    "command".to_string(),
+                                    Value::String(command.to_string()),
+                                );
                             }
-                            normalize_codex_tool_calls(&name, statement_args)
+                            normalize_codex_tool_calls(name, statement_args)
                         })
                         .collect::<Vec<_>>();
                 }
             }
-            normalize_codex_tool_calls(&name, args)
+            normalize_codex_tool_calls(name, args)
         })
         .collect()
 }
 
-fn split_multiline_shell_script(command: &str) -> Vec<String> {
+fn split_multiline_shell_script(command: &str) -> Vec<&str> {
+    if !command.contains('\n') {
+        let statement = command.trim();
+        return if statement.is_empty() {
+            Vec::new()
+        } else {
+            vec![statement]
+        };
+    }
     let mut statements = Vec::new();
-    let mut current = String::new();
+    let mut start = 0;
     let mut quote = None;
     let mut escaped = false;
-    let mut chars = command.chars().peekable();
-    while let Some(ch) = chars.next() {
+    let mut chars = command.char_indices().peekable();
+    while let Some((index, ch)) = chars.next() {
         if escaped {
-            current.push(ch);
             escaped = false;
             continue;
         }
-        if ch == '\\' {
-            current.push(ch);
+        // Backslashes are literal inside single quotes.
+        if ch == '\\' && quote != Some('\'') {
             escaped = true;
             continue;
         }
         if let Some(active) = quote {
-            current.push(ch);
             if ch == active {
                 quote = None;
             }
@@ -69,25 +78,40 @@ fn split_multiline_shell_script(command: &str) -> Vec<String> {
         // of shell commands. Keep the whole script (including any surrounding
         // statements) together so its single process result has one owner.
         // This also safely retains here-strings and tab-stripped heredocs.
-        if ch == '<' && chars.peek() == Some(&'<') {
-            return vec![command.to_string()];
+        if ch == '<' && chars.peek().is_some_and(|(_, next)| *next == '<') {
+            return vec![command];
+        }
+        // Compound shell syntax cannot be decomposed using line boundaries.
+        if matches!(ch, '(' | ')' | '{' | '}') {
+            return vec![command];
         }
         if matches!(ch, '\'' | '"' | '`') {
             quote = Some(ch);
-            current.push(ch);
         } else if ch == '\n' {
-            let statement = current.trim();
-            if !statement.is_empty() {
-                statements.push(statement.to_string());
+            let statement = command[start..index].trim();
+            if statement.ends_with(['|', '&']) {
+                return vec![command];
             }
-            current.clear();
-        } else {
-            current.push(ch);
+            if !statement.is_empty() {
+                statements.push(statement);
+            }
+            start = index + 1;
         }
     }
-    let statement = current.trim();
+    if quote.is_some() || escaped {
+        return vec![command];
+    }
+    let statement = command[start..].trim();
     if !statement.is_empty() {
-        statements.push(statement.to_string());
+        statements.push(statement);
+    }
+    if statements.iter().any(|line| {
+        matches!(
+            line.split_whitespace().next(),
+            Some("if" | "for" | "while" | "until" | "case" | "select" | "function")
+        )
+    }) {
+        return vec![command];
     }
     statements
 }
@@ -123,7 +147,7 @@ fn tool_args(script: &str, name: &str, expression: &str) -> Value {
 }
 
 /// Scan source-order calls while ignoring tool-looking text inside strings.
-fn tool_invocations(script: &str) -> Vec<(String, String)> {
+fn tool_invocations(script: &str) -> Vec<(&str, &str)> {
     let bytes = script.as_bytes();
     let mut calls = Vec::new();
     let mut index = 0usize;
@@ -170,10 +194,7 @@ fn tool_invocations(script: &str) -> Vec<(String, String)> {
         };
         let name = &script[name_start..name_end];
         if !matches!(name, "text" | "image" | "generatedImage" | "notify") {
-            calls.push((
-                name.to_string(),
-                script[(open + 1)..close].trim().to_string(),
-            ));
+            calls.push((name, script[(open + 1)..close].trim()));
         }
         index = close + 1;
     }
@@ -343,4 +364,54 @@ pub(super) fn codex_tool_output_failed(output: &str, exit_code: Option<i64>) -> 
                 "Script failed" | "Script error:" | "Script error"
             )
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_multiline_shell_script;
+
+    #[test]
+    fn splits_only_unquoted_lines_without_copying_the_command() {
+        for (command, expected) in [
+            (
+                "printf '你好'\r\nprintf done\r\n",
+                vec!["printf '你好'", "printf done"],
+            ),
+            (
+                "printf 'a\nb'\nprintf done",
+                vec!["printf 'a\nb'", "printf done"],
+            ),
+            (
+                "printf 'a\\'\nprintf done",
+                vec!["printf 'a\\'", "printf done"],
+            ),
+            (
+                "printf a\\\nb\nprintf done",
+                vec!["printf a\\\nb", "printf done"],
+            ),
+            ("\n  \nprintf done\n", vec!["printf done"]),
+        ] {
+            let actual = split_multiline_shell_script(command);
+            assert_eq!(actual, expected);
+            let source = command.as_bytes().as_ptr_range();
+            assert!(actual.iter().all(|part| source.contains(&part.as_ptr())));
+        }
+    }
+
+    #[test]
+    fn preserves_compound_and_incomplete_shell_scripts() {
+        for command in [
+            "for x in a b; do\nprintf '%s' \"$x\"\ndone",
+            "if true; then\nprintf done\nfi",
+            "(\nprintf done\n)",
+            "value=$(printf a\nprintf b)\nprintf '%s' \"$value\"",
+            "printf done |\nwc -c",
+            "true &&\nprintf done",
+            "echo before\nprintf 'unterminated",
+            "echo before\nprintf trailing\\",
+            "python3 - <<'PY'\nprint('done')\nPY",
+        ] {
+            assert_eq!(split_multiline_shell_script(command), vec![command]);
+        }
+    }
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript/tool_calls/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript/tool_calls/mod.rs
@@ -388,21 +388,23 @@ pub(crate) fn output_parts_for_tool_calls(calls: &[ImportedToolCall], output: &s
         return vec![output.to_string(); calls.len()];
     };
 
-    let lines = output.split_inclusive('\n').collect::<Vec<_>>();
+    let mut lines = output.split_inclusive('\n');
     let mut cursor = 0usize;
     calls
         .iter()
         .enumerate()
         .map(|(index, _)| {
-            let remaining = lines.len().saturating_sub(cursor);
-            let take = if index + 1 == calls.len() {
-                remaining
+            let start = cursor;
+            if index + 1 == calls.len() {
+                cursor = output.len();
             } else {
-                limits[index].min(remaining)
-            };
-            let part = lines[cursor..cursor.saturating_add(take)].concat();
-            cursor = cursor.saturating_add(take);
-            part
+                cursor += lines
+                    .by_ref()
+                    .take(limits[index])
+                    .map(str::len)
+                    .sum::<usize>();
+            }
+            output[start..cursor].to_string()
         })
         .collect()
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -1674,6 +1674,13 @@ fn codex_desktop_exec_preserves_multiline_shell_script() {
     assert_eq!(parts[1].lines().count(), 121);
     assert_eq!(parts[2].lines().count(), 180);
     assert_eq!(parts[3].lines().count(), 2);
+
+    for output in ["", "你好\r\n\nlast line", "first\n", "\n\n"] {
+        let parts = output_parts_for_tool_calls(&calls, output);
+        assert_eq!(parts.concat(), output);
+        assert_eq!(parts[0], output);
+        assert!(parts[1..].iter().all(String::is_empty));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Codex Desktop command parsing allocates intermediate strings for wrapper arguments and each command line, while output partitioning indexes every output line even when only a short prefix needs separation. Newline decomposition also needs to preserve compound shell syntax rather than treating its lines as independent commands.

## Solution

Borrow bounded source slices for wrapper arguments and line segments, fast-path single-line commands, and preserve compound/incomplete shell commands and continued pipelines. Partition output using a forward line iterator and byte offsets, copying the final remainder directly. #1560 is merged, and this PR now targets develop with only the allocation/decomposition changes remaining in its diff.

## Potential risks

The scanner is a conservative recognizer, not a complete shell grammar. Complex scripts remain whole rather than producing synthetic per-line exploration entries. Existing output contents are preserved exactly, including Unicode, CRLF, empty output and a missing final newline. No dependencies, retained cache, background scheduling, persistence schema, or wire format change. Microbenchmark results are helper-level measurements, not whole-app RAM or latency claims. Remote synchronization and real desktop profiling were not exercised. Reverting this PR restores allocation/decomposition behavior without changing source transcripts.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml -p orgtrack_core sources::codex --lib`: 88 passed, 1 opt-in fixture test ignored in the final isolated stacked worktree
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p orgtrack_core --lib -- -D warnings`: passed in the original checkout; normal commit hooks also passed scoped Clippy
- Regression tests cover borrowed slices, quotes, Unicode, CRLF, heredocs, incomplete scripts, loops/subshells, continued pipelines, byte-exact output partitions, and existing raw transcript lifecycle fixtures
- Optimized Rust helper microbenchmark, median of five 1,000-call batches: 1,000-line splitting 63.24 to 39.63 microseconds/call and 1,012 to 9 allocations; 100,000-line output partition with a 10-line prefix 1,971.85 to 44.97 microseconds/call
- `git diff --check`: passed
- No UI layout changes; no screenshots apply. Scope, measurement method, and limitations are documented in the included performance report
