### PR TITLE
fix(dropdown): render separators only between populated sections

### DIFF
--- a/src/components/Dropdown/tokens.ts
+++ b/src/components/Dropdown/tokens.ts
@@ -404,8 +404,10 @@ export const DROPDOWN_CLASSES = {
     "text-text-1",
   ].join(" "),
 
-  /** Inset rule between menu-item groups with a tight 2px local offset. */
+  /** Inset rule between populated groups; never draw at a menu edge. */
   menuGroupSeparator: [
+    "first:hidden",
+    "last:hidden",
     "mx-1.5",
     "my-0.5",
     "shrink-0",

--- a/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts
+++ b/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts
@@ -4,6 +4,7 @@ import { act, createElement } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
 import { activeOverlayCountAtom } from "@src/store/ui/overlayLayerAtom";
 
 import {
@@ -123,6 +124,63 @@ afterEach(() => {
 });
 
 describe("FileHeaderMoreMenu", () => {
+  it("renders no divider when page display is the only section", () => {
+    render({
+      showSaveAction: false,
+      showDiscardAction: false,
+      showSearchAction: false,
+      showGoToLineAction: false,
+      showCopyRelativePathAction: false,
+      showRevealInFileManagerAction: false,
+      showReloadButton: false,
+    });
+    const menu = element("file-header-more-menu");
+    expect(menu.textContent).toContain("common:actions.uiSettings");
+    expect(
+      [...menu.children].filter(
+        (child) => child.className === DROPDOWN_CLASSES.menuGroupSeparator
+      )
+    ).toHaveLength(0);
+    expect(menu.children).toHaveLength(1);
+    render({ showSearchAction: true });
+    expect(
+      [...menu.children].filter(
+        (child) => child.className === DROPDOWN_CLASSES.menuGroupSeparator
+      )
+    ).toHaveLength(1);
+  });
+
+  it("does not surround an isolated save section or lone more-settings action with dividers", () => {
+    render({
+      showDiscardAction: false,
+      showSearchAction: false,
+      showGoToLineAction: false,
+      showCopyRelativePathAction: false,
+      showRevealInFileManagerAction: false,
+      showReloadButton: false,
+      showLineNumbersToggle: false,
+      showWordWrapToggle: false,
+      showMinimapToggle: false,
+      showHighlightActiveLineToggle: false,
+      showGitBlameToggle: false,
+      showMoreSettingsAction: false,
+    });
+    const menu = element("file-header-more-menu");
+    expect(menu.children).toHaveLength(1);
+    render({ showMoreSettingsAction: true });
+    expect(
+      [...menu.children].filter(
+        (child) => child.className === DROPDOWN_CLASSES.menuGroupSeparator
+      )
+    ).toHaveLength(1);
+    const panel = openSettings();
+    expect(
+      [...panel.children].filter(
+        (child) => child.className === DROPDOWN_CLASSES.menuGroupSeparator
+      )
+    ).toHaveLength(0);
+  });
+
   it("keeps file actions at the first level and moves display controls into UI settings", () => {
     render();
     const menu = element("file-header-more-menu");

--- a/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.tsx
+++ b/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.tsx
@@ -163,6 +163,24 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
   const revealInFileManagerDisabled = !showRevealInFileManagerAction;
   const reloadDisabled = !showReloadButton || loading || reloadMenuCoolingDown;
 
+  const hasFileChangeActions = !saveDisabled || !discardDisabled;
+  const hasNavigationActions =
+    !searchDisabled ||
+    !goToLineDisabled ||
+    !copyRelativePathDisabled ||
+    !revealInFileManagerDisabled ||
+    !reloadDisabled;
+  const hasDisplayToggles =
+    showLineNumbersToggle ||
+    showWordWrapToggle ||
+    showMinimapToggle ||
+    showHighlightActiveLineToggle ||
+    showGitBlameToggle;
+  const hasDisplaySettings = hasDisplayToggles || showMoreSettingsAction;
+  const fileActions =
+    menuVisible && isPositioned ? renderFileActions?.(close) : null;
+  const hasFileActions = React.Children.toArray(fileActions).length > 0;
+
   const renderToggleRow = useCallback(
     ({
       label,
@@ -312,9 +330,10 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
               </DropdownItem>
             )}
 
-            {(!saveDisabled || !discardDisabled) && (
-              <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
-            )}
+            {hasFileChangeActions &&
+              (hasNavigationActions || hasFileActions) && (
+                <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
+              )}
 
             {!searchDisabled && (
               <DropdownItem
@@ -428,22 +447,14 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
               </DropdownItem>
             )}
 
-            {(showLineNumbersToggle ||
-              showWordWrapToggle ||
-              showMinimapToggle ||
-              showHighlightActiveLineToggle ||
-              showGitBlameToggle ||
-              showMoreSettingsAction) && (
-              <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
-            )}
-
-            {renderFileActions?.(close)}
-            {(showLineNumbersToggle ||
-              showWordWrapToggle ||
-              showMinimapToggle ||
-              showHighlightActiveLineToggle ||
-              showGitBlameToggle ||
-              showMoreSettingsAction) && (
+            {fileActions}
+            {hasDisplaySettings &&
+              (hasFileChangeActions ||
+                hasNavigationActions ||
+                hasFileActions) && (
+                <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
+              )}
+            {hasDisplaySettings && (
               <ActionSubmenu
                 label={t("common:actions.uiSettings")}
                 icon={
@@ -490,7 +501,7 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
                   onChange: onGitBlameChange,
                 })}
 
-                {showMoreSettingsAction && (
+                {hasDisplayToggles && showMoreSettingsAction && (
                   <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
                 )}
 


### PR DESCRIPTION
## Problem

My Station's file-header menu inserts a separator whenever display settings are available, even if there are no actions above them. Similar conditions can leave trailing or duplicate dividers when other sections are empty, including a lone More settings action.

## Solution

Derive section visibility from the actions actually rendered and add dividers only between populated sections. Reuse the shared dropdown separator token and make that token hide leading and trailing dividers across its consumers. Keep the display-label change in the separate chat-display PR.

## Potential risks

The shared token affects all dropdowns that use it: edge dividers are intentionally hidden while interior dividers remain visible. Custom menu content that renders no DOM is also protected by the edge rules, but final desktop visual checks across all consumers were not performed because computer control was not authorized. No dependencies, persistence formats, data, or APIs change; reverting this commit restores the prior rendering rules.

## Verification

On an isolated branch based on the latest `origin/develop`:

- `pnpm test src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts src/components/Dropdown/tokens.test.ts src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts` — 49 tests passed, including single-section, isolated-save, lone-settings, and populated-section cases
- `pnpm run typecheck:fast` — passed
- `git diff --cached --check` — passed
- Repository commit hooks ran lint-staged (ESLint and Prettier), TypeScript checking, and commitlint — passed
- Final diff inspected for scope, credential patterns, personal paths, generated artifacts, and unrelated changes

No final screenshots or desktop theme/viewport checks were captured. Rust checks were not run because no Rust files changed.
