### PR TITLE
fix(model-selector): show effort dots and level tooltips on hover

### DIFF
--- a/src/components/ModelPropertiesDropdown/EffortSlider.scss
+++ b/src/components/ModelPropertiesDropdown/EffortSlider.scss
@@ -114,6 +114,8 @@
     transition: opacity 120ms ease-out;
   }
 
+  &:hover &__stages,
+  &:focus-within &__stages,
   &:has(input:active) &__stages {
     opacity: 1;
   }

--- a/src/components/ModelPropertiesDropdown/EffortSlider.test.ts
+++ b/src/components/ModelPropertiesDropdown/EffortSlider.test.ts
@@ -104,6 +104,56 @@ describe("EffortSlider", () => {
     act(() => range().dispatchEvent(event));
   }
 
+  it("shows each hovered level without changing the selection and clears on exit", () => {
+    const onChange = vi.fn();
+    const onPreviewChange = vi.fn();
+    render({ onChange, onPreviewChange });
+    const stages = container.querySelectorAll<HTMLElement>(
+      "[data-effort-stage]"
+    );
+    stages.forEach((stage, index) => {
+      vi.spyOn(stage, "getBoundingClientRect").mockReturnValue({
+        left: 10 + index * 100,
+        top: 10,
+        width: 4,
+        height: 4,
+        right: 14 + index * 100,
+        bottom: 14,
+        x: 10 + index * 100,
+        y: 10,
+        toJSON: () => ({}),
+      });
+    });
+    const move = (clientX: number) => {
+      act(() => {
+        range().dispatchEvent(
+          new MouseEvent("pointermove", {
+            bubbles: true,
+            clientX,
+            clientY: 12,
+          })
+        );
+      });
+    };
+    ["Light", "High", "Extra High"].forEach((label, index) => {
+      move(12 + index * 100);
+      expect(document.querySelector(".native-tooltip")?.textContent).toBe(
+        label
+      );
+    });
+    move(62);
+    expect(document.querySelector(".native-tooltip")).toBeNull();
+    move(12);
+    pointer("pointerout");
+    expect(document.querySelector(".native-tooltip")).toBeNull();
+    expect(range().value).toBe("1");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onPreviewChange).not.toHaveBeenCalled();
+    move(212);
+    act(() => root.render(null));
+    expect(document.querySelector(".native-tooltip")).toBeNull();
+  });
+
   it("leaves capture to the native thumb and commits the final preview once", () => {
     const onChange = vi.fn();
     render({ onChange });

--- a/src/components/ModelPropertiesDropdown/EffortSlider.tsx
+++ b/src/components/ModelPropertiesDropdown/EffortSlider.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import Tooltip from "@src/components/Tooltip";
 import {
   MODEL_REASONING_LEVEL,
   type ModelReasoningLevel,
@@ -48,6 +49,7 @@ export const EffortSlider: React.FC<EffortSliderProps> = ({
 }) => {
   const { t } = useTranslation();
   const sliderRef = useRef<HTMLDivElement>(null);
+  const [hoveredLevel, setHoveredLevel] = useState<ModelReasoningLevel>();
   const [preview, setPreview] = useState<{
     level: ModelReasoningLevel;
     sourceValue: ModelReasoningLevel | undefined;
@@ -145,10 +147,16 @@ export const EffortSlider: React.FC<EffortSliderProps> = ({
             </div>
             <div className="effort-slider__stages">
               {levels.map((level, index) => (
-                <span
+                <Tooltip
                   key={level}
-                  className={`h-1 w-1 rounded-full ${index < selectedIndex ? "bg-white/80" : "bg-text-3"}`}
-                />
+                  content={formatReasoningLevel(level)}
+                  open={hoveredLevel === level}
+                >
+                  <span
+                    data-effort-stage={level}
+                    className={`h-1 w-1 rounded-full ${index < selectedIndex ? "bg-white/80" : "bg-text-3"}`}
+                  />
+                </Tooltip>
               ))}
             </div>
           </div>
@@ -161,6 +169,28 @@ export const EffortSlider: React.FC<EffortSliderProps> = ({
             value={selectedIndex}
             aria-label={effortLabel}
             aria-valuetext={levelLabel}
+            onPointerMove={(event) => {
+              if (event.pointerType === "touch") return;
+              // Hit-test the painted dots through the native input so neither
+              // tooltips nor extra targets interfere with thumb dragging.
+              const stages = sliderRef.current?.querySelectorAll<HTMLElement>(
+                "[data-effort-stage]"
+              );
+              const index = stages
+                ? Array.from(stages).findIndex((stage) => {
+                    const rect = stage.getBoundingClientRect();
+                    return (
+                      Math.abs(event.clientX - (rect.left + rect.width / 2)) <=
+                        8 &&
+                      Math.abs(event.clientY - (rect.top + rect.height / 2)) <=
+                        8
+                    );
+                  })
+                : -1;
+              const nextLevel = levels[index];
+              if (nextLevel !== hoveredLevel) setHoveredLevel(nextLevel);
+            }}
+            onPointerLeave={() => setHoveredLevel(undefined)}
             onChange={(event) => {
               const nextLevel = levels[event.currentTarget.valueAsNumber];
               if (!nextLevel || nextLevel === selectedLevel) return;
@@ -180,6 +210,7 @@ export const EffortSlider: React.FC<EffortSliderProps> = ({
             // Let the native thumb own capture, including outside releases.
             // Capturing on the input prevents WebKit from dragging its thumb.
             onPointerDown={(event) => {
+              setHoveredLevel(undefined);
               if (event.button !== 0 || interactionRef.current) return;
               interactionRef.current = {
                 kind: "pointer",


### PR DESCRIPTION
## Problem

Both model menus hide effort-level dots until the range input is dragged, and the dots do not identify their levels on hover.

## Solution

Show the shared effort slider's dots on hover and keyboard focus as well as during dragging. Display the existing Tooltip component with each hovered dot's formatted level. Hit-test through the native range input to preserve thumb dragging and commit-on-release behavior; hovering does not change or preview the selected model level.

Add regression coverage for every level label, moving between dots, pointer exit, unmount cleanup, and unchanged selection callbacks.

## Potential risks

Native WebKit dragging, tooltip placement, light/dark themes, and narrow popover layouts have not been visually exercised. Desktop UI control was not authorized, so no updated screenshots or recordings are included. Synthetic pointer tests cover the component's callbacks but do not prove native thumb behavior. Hover hit-testing reads a bounded set of dot rectangles only on pointer movement; real runtime performance has not been measured. No persistence, dependencies, or API contracts change.

## Verification

- `pnpm test src/components/ModelPropertiesDropdown/EffortSlider.test.ts` — all 10 tests passed in the isolated worktree based on latest `origin/develop`.
- `pnpm exec eslint src/components/ModelPropertiesDropdown/EffortSlider.tsx src/components/ModelPropertiesDropdown/EffortSlider.test.ts` — passed.
- `pnpm exec prettier --check src/components/ModelPropertiesDropdown/EffortSlider.tsx src/components/ModelPropertiesDropdown/EffortSlider.scss src/components/ModelPropertiesDropdown/EffortSlider.test.ts` — passed.
- `git diff --check` — passed.
- Commit hooks: `npx lint-staged` (Oxlint, ESLint, Prettier), `npx tsgo --noEmit --pretty false`, and commitlint — passed. The successful full typecheck supersedes the interrupted initial implementation check.
- Desktop visual/native WebKit verification was not run, per the user's computer-control preference.
