### PR TITLE
refactor(station-chrome): share pane control actions and buttons

### DIFF
--- a/docs/architecture-audit-2026-09-11/StationPaneControls.md
+++ b/docs/architecture-audit-2026-09-11/StationPaneControls.md
@@ -1,0 +1,41 @@
+# StationPaneControls implementation review
+
+## Acceptance and ownership
+
+My Station, Agent Station and pinned window chrome repeat the same chat visibility and maximize actions and button presentation.
+
+Share StationPaneControls and action callbacks across all three owners. Preserve each owner’s visibility gates, both pane restore affordances, Settings control, pinned availability, and the Agent header’s static directional icon.
+
+Acceptance: replace all matching in-scope callers, preserve user behavior and persistence, pass focused tests and frontend checks, and keep changes isolated from unrelated working-tree edits.
+
+| Line                                                        | Element          | Verdict | Reason                                                                                                                                                                                                                                | Suggested change                                  |
+| ----------------------------------------------------------- | ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `src/modules/WorkStation/shared/StationPaneControls.tsx:21` | Shared ownership | fix     | Share StationPaneControls and action callbacks across all three owners. Preserve each owner’s visibility gates, both pane restore affordances, Settings control, pinned availability, and the Agent header’s static directional icon. | Implemented in this change; no unrelated cleanup. |
+
+## Architecture coverage
+
+Layers 1–7: frontend compilation/lint, caller sweep, naming, distinct station/host meanings, defaults, ownership boundaries, and readability reviewed. Layer 8: no serialized format, IPC or storage-key change; no real wire dump was needed for this internal refactor. Layer 9: existing station entry points retained and focused tests exercise changed ownership. Layer 10: preserve caller-specific visibility/selection policies rather than forcing false symmetry. Backend initialization and account/model resolvers are outside scope.
+
+## Lifecycle and performance
+
+| Area               | Verdict | Evidence                                       | Change or reason kept                                                                                                                                                                                                                 | Verification                        |
+| ------------------ | ------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Background work    | keep    | No new polling, listeners, workers or requests | Existing owner and mount/cleanup rules retained                                                                                                                                                                                       | Focused suites below                |
+| Memory             | keep    | No new app-lifetime collections or caches      | State stays with current atoms/components                                                                                                                                                                                             | Diff inspection; no RSS measurement |
+| Scope/isolation    | keep    | Existing station and store boundaries          | No shared cross-account/session cache introduced                                                                                                                                                                                      | Caller sweep                        |
+| Rendering/hot path | fix     | Common computation/config/action ownership     | Share StationPaneControls and action callbacks across all three owners. Preserve each owner’s visibility gates, both pane restore affordances, Settings control, pinned availability, and the Agent header’s static directional icon. | Focused tests; no timing claim      |
+
+Applicable matrix: mount/unmount and station/visibility transitions at changed UI boundaries; existing online/offline, identity, transport and multi-instance ownership is unchanged. No provider ingestion or sync changes. Native Tauri pixels/CPU/RSS were not measured: Computer Use was not authorized. Performance verdict: blocked for live native measurement; no performance improvement is claimed. Automated correctness evidence is listed separately.
+
+## Risks
+
+The main risk is chrome availability or icon drift across station modes and chat positions. Existing rendered tests and added dispatch/icon coverage pass. No persistence, IPC, native webview, or lifecycle policy changes. Native visual screenshots were not collected; this is intended to preserve appearance. Rollback is a normal commit revert; no data migration or recovery is required.
+
+## Verification
+
+- `pnpm run typecheck:fast` — passed.
+- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/shared/StationPaneControls.test.ts src/modules/WorkStation/shared/StationPaneControls.tsx src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.tsx src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.visibility.test.ts` — passed with zero warnings.
+- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.visibility.test.ts src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts src/modules/WorkStation/shared/StationPaneControls.test.ts` — 4 files, 23 tests passed.
+- `git diff --check` — passed.
+
+Focused suites may emit existing Vite/Sass/Jotai/React Router deprecation notices. Full Rust builds and native UI/CPU/RSS checks were not run; no backend code changed. Tests do not substitute for native visual verification.

--- a/docs/frontend-ui-audit-2026-09-11/StationPaneControls.md
+++ b/docs/frontend-ui-audit-2026-09-11/StationPaneControls.md
@@ -1,0 +1,9 @@
+# StationPaneControls UI audit
+
+| Line                                                        | Element                  | Verdict          | Reason                                                                                                                                                         | Suggested change                                          |
+| ----------------------------------------------------------- | ------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `src/modules/WorkStation/shared/StationPaneControls.tsx:21` | Existing visual boundary | keep with reason | This refactor preserves existing controls, sidebar content, caption presentation or browser status-bar ownership; no new design primitive or styling is needed | Retain existing DS components and owner-specific variants |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.
+
+The consolidation is implemented, with evidence in the architecture review of the same name. D1–D5 review of the changed diff found no new raw interactive HTML, arbitrary visual tokens/colors, accessibility semantics or repeated visual scaffolding needing another abstraction. No theme/viewport screenshots: behavior-preserving extraction, with native visual validation not performed because Computer Use was not authorized.

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts
@@ -28,6 +28,11 @@ import {
 
 import AgentStationTopHeader from "./AgentStationTopHeader";
 
+const { logError } = vi.hoisted(() => ({ logError: vi.fn() }));
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ error: logError }),
+}));
+
 vi.mock("@src/util/platform/tauri", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@src/util/platform/tauri")>()),
   isMacOS: () => true,
@@ -146,6 +151,28 @@ describe("AgentStationTopHeader", () => {
     expect(WorkStationViewService.showWorkStation).toHaveBeenCalledTimes(1);
     act(() => buttons[1].click());
     expect(WorkStationViewService.showWorkStation).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles a rejected visibility action without an unhandled rejection", async () => {
+    renderHeader();
+    act(() => {
+      store.set(stationModeAtom, "agent-station");
+      store.set(workstationActiveSessionIdAtom, "session-a");
+      store.set(activeStationChatVisibleAtom, "agent-station", false);
+    });
+    const error = new Error("Station module failed to load");
+    vi.mocked(WorkStationViewService.showWorkStation).mockRejectedValueOnce(
+      error
+    );
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[title="chat.restoreChatPanel"]'
+    );
+    expect(button).not.toBeNull();
+    await act(async () => button!.click());
+    expect(logError).toHaveBeenCalledWith(
+      "Failed to toggle station chat visibility:",
+      error
+    );
   });
 
   it("leaves the controls to pinned chrome while Agent Station is empty", () => {

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts
@@ -15,6 +15,7 @@ import {
 } from "vitest";
 
 import { ROUTES } from "@src/config/routes";
+import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
 import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
@@ -127,6 +128,24 @@ describe("AgentStationTopHeader", () => {
     expect(
       container.querySelector('button[title="chat.hideWorkstation"]')
     ).not.toBeNull();
+  });
+
+  it("preserves both restore affordances and their single dispatch", () => {
+    renderHeader();
+    act(() => {
+      store.set(stationModeAtom, "agent-station");
+      store.set(workstationActiveSessionIdAtom, "session-a");
+      store.set(activeStationChatVisibleAtom, "agent-station", false);
+    });
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      'button[title="chat.restoreChatPanel"]'
+    );
+    expect(buttons).toHaveLength(2);
+    vi.mocked(WorkStationViewService.showWorkStation).mockClear();
+    act(() => buttons[0].click());
+    expect(WorkStationViewService.showWorkStation).toHaveBeenCalledTimes(1);
+    act(() => buttons[1].click());
+    expect(WorkStationViewService.showWorkStation).toHaveBeenCalledTimes(2);
   });
 
   it("leaves the controls to pinned chrome while Agent Station is empty", () => {

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
@@ -5,8 +5,8 @@
  * Contains: station mode chip, chat panel toggle, caption toggle,
  * layout settings dropdown, and a separate caption row below the top bar.
  */
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import React, { memo, startTransition, useCallback, useEffect } from "react";
+import { useAtom, useAtomValue } from "jotai";
+import React, { memo, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 
@@ -15,7 +15,6 @@ import { NoDragRegion } from "@src/components/WindowChrome";
 import { matchesShortcut } from "@src/config/keyboard/shortcutBindings";
 import { CHROME_TOOLTIP_HOVER_DELAY } from "@src/config/tooltip";
 import { TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX } from "@src/config/workstation/tokens";
-import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import CaptionBar from "@src/engines/Simulator/components/CaptionBar";
 import { useCurrentTurnLastAgentMessage } from "@src/engines/Simulator/hooks/useCurrentTurnLastAgentMessage";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
@@ -27,23 +26,13 @@ import {
   usePinnedWorkbenchChromeVisible,
   useWorkbenchRightEdgeReservation,
 } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
-import {
-  ArrowExpand01Icon,
-  ArrowShrink01Icon,
-  BubbleChatIcon,
-  Cancel01Icon,
-  CaptionsIcon,
-  HugeiconsIcon,
-  PanelRightIcon,
-} from "@src/icons";
+import { CaptionsIcon, HugeiconsIcon } from "@src/icons";
 import { CHROME_INSET_TRANSITION_CLASSES } from "@src/modules/shared/layouts/viewContainerTokens";
 import { CollapsedSidebarButton } from "@src/scaffold/NavigationSidebar/CollapsedSidebarButton";
-import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import {
   sessionMapAtom,
   workstationActiveSessionIdAtom,
 } from "@src/store/session";
-import { toggleChatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
 import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
 import { chatWidthAtom } from "@src/store/ui/chatPanel/widthAtoms";
 import {
@@ -54,6 +43,11 @@ import { chatPanelPositionAtom } from "@src/store/ui/workStationLayout/chatPosit
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import { SimulatorAgentChip, StationModeChip } from "../shared";
+import {
+  StationChatVisibilityButton,
+  StationMaximizeChatButton,
+  useStationPaneActions,
+} from "../shared/StationPaneControls";
 
 const AgentStationTopHeader: React.FC = memo(() => {
   const { t } = useTranslation("sessions");
@@ -64,7 +58,6 @@ const AgentStationTopHeader: React.FC = memo(() => {
   const getStationChatVisible = useAtomValue(activeStationChatVisibleAtom);
   const chatWidth = useAtomValue(chatWidthAtom);
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
-  const toggleChatPanelMaximized = useSetAtom(toggleChatPanelMaximizedAtom);
   const isChatPanelVisible =
     getStationChatVisible("agent-station") && chatWidth > 0;
   const location = useLocation();
@@ -101,11 +94,6 @@ const AgentStationTopHeader: React.FC = memo(() => {
         )
     : captionMessage?.text;
   const captionToggleLabel = t("simulator.captionBarToggleTooltip");
-  const chatPanelLabel = isChatPanelVisible
-    ? t("chat.maximizeWorkStation")
-    : t("chat.restoreChatPanel");
-  const hideWorkstationLabel = t("chat.hideWorkstation");
-
   const showCaptionBar =
     captionEnabled && !!captionMessage && !!workstationActiveSessionId;
 
@@ -133,15 +121,8 @@ const AgentStationTopHeader: React.FC = memo(() => {
     };
   }, []);
 
-  const handleToggleChatPanel = useCallback(() => {
-    startTransition(() => {
-      void WorkStationViewService.showWorkStation();
-    });
-  }, []);
-
-  const handleToggleChatPanelMaximized = useCallback(() => {
-    toggleChatPanelMaximized();
-  }, [toggleChatPanelMaximized]);
+  const { handleToggleChatPanel, handleToggleChatPanelMaximized } =
+    useStationPaneActions();
 
   return (
     <div className="flex shrink-0 flex-col">
@@ -191,70 +172,24 @@ const AgentStationTopHeader: React.FC = memo(() => {
             />
           </TabBarTrailingIconButton>
           {showPaneControls && !isChatPanelVisible && (
-            <TabBarTrailingIconButton
-              title={chatPanelLabel}
-              shortcutId="maximize_work_station"
-              tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+            <StationChatVisibilityButton
+              visible={false}
+              restoreIcon="shrink"
               onClick={handleToggleChatPanel}
-            >
-              <HugeiconsIcon
-                icon={ArrowShrink01Icon}
-                data-icon="minimize-2"
-                size={14}
-                strokeWidth={2}
-              />
-            </TabBarTrailingIconButton>
+            />
           )}
-          {/* Empty macOS stations leave these actions to the pinned window
-              chrome. Once a session populates Agent Station, this header
-              owns them so the controls do not disappear with that chrome. */}
           {showPaneControls && (
-            <TabBarTrailingIconButton
-              title={chatPanelLabel}
-              shortcutId="maximize_work_station"
-              tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+            <StationChatVisibilityButton
+              visible={isChatPanelVisible}
               onClick={handleToggleChatPanel}
-            >
-              {isChatPanelVisible ? (
-                <HugeiconsIcon
-                  icon={ArrowExpand01Icon}
-                  data-icon="maximize-2"
-                  size={14}
-                  strokeWidth={2}
-                />
-              ) : (
-                <HugeiconsIcon
-                  icon={BubbleChatIcon}
-                  data-icon="message-circle"
-                  size={14}
-                  strokeWidth={2}
-                />
-              )}
-            </TabBarTrailingIconButton>
+            />
           )}
           {showPaneControls && isChatPanelVisible && (
-            <TabBarTrailingIconButton
-              title={hideWorkstationLabel}
-              shortcutId="maximize_chat"
-              tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+            <StationMaximizeChatButton
+              chatPanelPosition={chatPanelPosition}
+              directionalHover={false}
               onClick={handleToggleChatPanelMaximized}
-            >
-              {chatPanelPosition === "left" ? (
-                <HugeiconsIcon
-                  icon={PanelRightIcon}
-                  data-icon="panel-right"
-                  size={HEADER_ICON_SIZE.md}
-                  strokeWidth={2}
-                />
-              ) : (
-                <HugeiconsIcon
-                  icon={Cancel01Icon}
-                  data-icon="x"
-                  size={HEADER_ICON_SIZE.md}
-                  strokeWidth={1.75}
-                />
-              )}
-            </TabBarTrailingIconButton>
+            />
           )}
         </NoDragRegion>
       </div>

--- a/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx
+++ b/src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx
@@ -8,7 +8,7 @@
  * covered. The counterpart of `PinnedSidebarChrome` on the left.
  */
 import { useAtomValue, useSetAtom } from "jotai";
-import React, { memo, startTransition, useCallback } from "react";
+import React, { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
@@ -21,22 +21,22 @@ import {
   usePinnedWorkbenchChromeVisible,
 } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
 import {
-  ArrowExpand01Icon,
-  BubbleChatIcon,
   HugeiconsIcon,
   LayoutAlignRightIcon,
   PanelRightIcon,
   PanelRightOpenIcon,
 } from "@src/icons";
-import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { effectiveChatPanelMaximizedAtom } from "@src/store/chatPanel/chatPanelLayoutAtoms";
 import { toggleActiveChatPanelMaximizedAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { isChatPanelTabStationAvailable } from "@src/store/chatPanel/chatPanelTabsModel";
 import { activeChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsState";
-import { toggleChatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
 import { chatPanelPositionAtom } from "@src/store/ui/workStationLayout/chatPositionAtoms";
 
-import { WorkstationMaximizeChatIcon } from "./useWorkstationTrailingSlot";
+import {
+  StationChatVisibilityButton,
+  StationMaximizeChatButton,
+  useStationPaneActions,
+} from "../shared/StationPaneControls";
 
 const PinnedWorkbenchChromeComponent: React.FC = () => {
   const { t } = useTranslation("sessions");
@@ -45,19 +45,12 @@ const PinnedWorkbenchChromeComponent: React.FC = () => {
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
   const activeTab = useAtomValue(activeChatPanelTabAtom);
   const chatPanelMaximized = useAtomValue(effectiveChatPanelMaximizedAtom);
-  const toggleChatPanelMaximized = useSetAtom(toggleChatPanelMaximizedAtom);
   const toggleActiveChatMaximized = useSetAtom(
     toggleActiveChatPanelMaximizedAtom
   );
 
-  const handleToggleChatPanel = useCallback(() => {
-    startTransition(() => {
-      void WorkStationViewService.showWorkStation();
-    });
-  }, []);
-  const handleMaximizeChat = useCallback(() => {
-    toggleChatPanelMaximized();
-  }, [toggleChatPanelMaximized]);
+  const { handleToggleChatPanel, handleToggleChatPanelMaximized } =
+    useStationPaneActions();
   const handleShowWorkstation = useCallback(() => {
     toggleActiveChatMaximized();
   }, [toggleActiveChatMaximized]);
@@ -69,33 +62,11 @@ const PinnedWorkbenchChromeComponent: React.FC = () => {
   // Slot A: hide / restore the chat pane. Meaningless while the chat is
   // maximized (there is no workstation to grow), so it is dropped outright.
   const chatVisibilityControl = chatPanelMaximized ? null : (
-    <TabBarTrailingIconButton
-      title={
-        isChatPanelVisible
-          ? t("chat.maximizeWorkStation")
-          : t("chat.restoreChatPanel")
-      }
-      shortcutId="maximize_work_station"
-      tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+    <StationChatVisibilityButton
+      visible={isChatPanelVisible}
       onClick={handleToggleChatPanel}
-      data-testid="pinned-workbench-chrome-chat-visibility"
-    >
-      {isChatPanelVisible ? (
-        <HugeiconsIcon
-          icon={ArrowExpand01Icon}
-          data-icon="maximize-2"
-          size={14}
-          strokeWidth={2}
-        />
-      ) : (
-        <HugeiconsIcon
-          icon={BubbleChatIcon}
-          data-icon="message-circle"
-          size={14}
-          strokeWidth={2}
-        />
-      )}
-    </TabBarTrailingIconButton>
+      testId="pinned-workbench-chrome-chat-visibility"
+    />
   );
 
   // Slot B: maximize chat while the workstation shows; show the workstation
@@ -153,16 +124,11 @@ const PinnedWorkbenchChromeComponent: React.FC = () => {
     );
   } else {
     maximizeControl = (
-      <TabBarTrailingIconButton
-        title={t("chat.hideWorkstation")}
-        shortcutId="maximize_chat"
-        tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
-        onClick={handleMaximizeChat}
-        className={chatPanelPosition === "left" ? "group" : undefined}
-        data-testid="pinned-workbench-chrome-maximize-chat"
-      >
-        <WorkstationMaximizeChatIcon chatPanelPosition={chatPanelPosition} />
-      </TabBarTrailingIconButton>
+      <StationMaximizeChatButton
+        chatPanelPosition={chatPanelPosition}
+        onClick={handleToggleChatPanelMaximized}
+        testId="pinned-workbench-chrome-maximize-chat"
+      />
     );
   }
 

--- a/src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.tsx
+++ b/src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.tsx
@@ -7,35 +7,28 @@
  * Project trailing bar) from the
  * main tab-bar component.
  */
-import { useAtomValue, useSetAtom } from "jotai";
-import { type ReactNode, startTransition, useCallback, useMemo } from "react";
+import { useAtomValue } from "jotai";
+import { type ReactNode, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
 import { CHROME_TOOLTIP_HOVER_DELAY } from "@src/config/tooltip";
-import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import { usePinnedWorkbenchChromeVisible } from "@src/hooks/ui/workbench/usePinnedWorkbenchChrome";
-import {
-  ArrowExpand01Icon,
-  ArrowShrink01Icon,
-  BubbleChatIcon,
-  Cancel01Icon,
-  HugeiconsIcon,
-  LayoutAlignRightIcon,
-  PanelRightIcon,
-} from "@src/icons";
+import { Cancel01Icon, HugeiconsIcon } from "@src/icons";
 import ProjectManagerWorkItemsTabBarTrailing from "@src/modules/ProjectManager/ProjectManagerLayout/components/ProjectManagerWorkItemsTabBarTrailing";
 import { TabBarPlusMenu } from "@src/modules/WorkStation/AppShell/TabBarPlusMenu";
-import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
-import { toggleChatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
 import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
 import { chatWidthAtom } from "@src/store/ui/chatPanel/widthAtoms";
 import { chatPanelPositionAtom } from "@src/store/ui/workStationLayout/chatPositionAtoms";
-import type { ChatPanelPosition } from "@src/store/ui/workStationLayout/chatPositionAtoms";
 import { workstationProjectTabBarAtom } from "@src/store/workstation";
 import type { WorkstationTabHost } from "@src/store/workstation/tabHost";
 
+import {
+  StationChatVisibilityButton,
+  StationMaximizeChatButton,
+  useStationPaneActions,
+} from "../shared/StationPaneControls";
 import type { UseWorkstationTabListReturn } from "./useWorkstationTabList";
 
 export interface UseWorkstationTrailingSlotOptions {
@@ -48,42 +41,6 @@ export interface UseWorkstationTrailingSlotReturn {
   handleToggleChatPanel: () => void;
 }
 
-export function WorkstationMaximizeChatIcon({
-  chatPanelPosition,
-}: {
-  chatPanelPosition: ChatPanelPosition;
-}): ReactNode {
-  if (chatPanelPosition === "right") {
-    return (
-      <HugeiconsIcon
-        icon={Cancel01Icon}
-        data-icon="x"
-        size={HEADER_ICON_SIZE.md}
-        strokeWidth={1.75}
-      />
-    );
-  }
-
-  return (
-    <span className="flex h-4 w-4 items-center justify-center">
-      <HugeiconsIcon
-        icon={PanelRightIcon}
-        data-icon="panel-right"
-        size={HEADER_ICON_SIZE.md}
-        strokeWidth={2}
-        className="group-hover:hidden"
-      />
-      <HugeiconsIcon
-        icon={LayoutAlignRightIcon}
-        data-icon="layout-align-right"
-        size={HEADER_ICON_SIZE.md}
-        strokeWidth={2}
-        className="hidden group-hover:block"
-      />
-    </span>
-  );
-}
-
 export function useWorkstationTrailingSlot({
   host,
   visible,
@@ -94,7 +51,6 @@ export function useWorkstationTrailingSlot({
   const chatWidth = useAtomValue(chatWidthAtom);
   const chatPanelPosition = useAtomValue(chatPanelPositionAtom);
   const projectTabBar = useAtomValue(workstationProjectTabBarAtom);
-  const toggleChatPanelMaximized = useSetAtom(toggleChatPanelMaximizedAtom);
   const pinnedChrome = usePinnedWorkbenchChromeVisible();
 
   const isChatPanelVisible =
@@ -105,15 +61,8 @@ export function useWorkstationTrailingSlot({
   const isSettingsRoute = location.pathname.startsWith("/orgii/app/settings");
   const showPaneControls = !isSettingsRoute && !pinnedChrome;
 
-  const handleToggleChatPanel = useCallback(() => {
-    startTransition(() => {
-      void WorkStationViewService.showWorkStation();
-    });
-  }, []);
-
-  const handleToggleChatPanelMaximized = useCallback(() => {
-    toggleChatPanelMaximized();
-  }, [toggleChatPanelMaximized]);
+  const { handleToggleChatPanel, handleToggleChatPanelMaximized } =
+    useStationPaneActions();
 
   const trailingSlot = useMemo((): ReactNode => {
     // Unified surface: the "+" (new-tab) menu always renders. There are no
@@ -121,64 +70,27 @@ export function useWorkstationTrailingSlot({
     // tab type.
     const plusMenuControl = <TabBarPlusMenu />;
 
-    const chatPanelLabel = isChatPanelVisible
-      ? t("sessions:chat.maximizeWorkStation")
-      : t("sessions:chat.restoreChatPanel");
     const chatPanelControl = showPaneControls ? (
-      <TabBarTrailingIconButton
-        title={chatPanelLabel}
-        shortcutId="maximize_work_station"
-        tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+      <StationChatVisibilityButton
+        visible={isChatPanelVisible}
         onClick={handleToggleChatPanel}
-      >
-        {isChatPanelVisible ? (
-          <HugeiconsIcon
-            icon={ArrowExpand01Icon}
-            data-icon="maximize-2"
-            size={14}
-            strokeWidth={2}
-          />
-        ) : (
-          <HugeiconsIcon
-            icon={BubbleChatIcon}
-            data-icon="message-circle"
-            size={14}
-            strokeWidth={2}
-          />
-        )}
-      </TabBarTrailingIconButton>
+      />
     ) : null;
-
-    const hideWorkstationLabel = t("sessions:chat.hideWorkstation");
     const maximizeChatControl =
       showPaneControls && isChatPanelVisible ? (
-        <TabBarTrailingIconButton
-          title={hideWorkstationLabel}
-          shortcutId="maximize_chat"
-          tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+        <StationMaximizeChatButton
+          chatPanelPosition={chatPanelPosition}
           onClick={handleToggleChatPanelMaximized}
-          className={chatPanelPosition === "left" ? "group" : undefined}
-        >
-          <WorkstationMaximizeChatIcon chatPanelPosition={chatPanelPosition} />
-        </TabBarTrailingIconButton>
+        />
       ) : null;
-
-    const shrinkWorkstationControl = showPaneControls &&
-      !isChatPanelVisible && (
-        <TabBarTrailingIconButton
-          title={chatPanelLabel}
-          shortcutId="maximize_work_station"
-          tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+    const shrinkWorkstationControl =
+      showPaneControls && !isChatPanelVisible ? (
+        <StationChatVisibilityButton
+          visible={false}
+          restoreIcon="shrink"
           onClick={handleToggleChatPanel}
-        >
-          <HugeiconsIcon
-            icon={ArrowShrink01Icon}
-            data-icon="minimize-2"
-            size={14}
-            strokeWidth={2}
-          />
-        </TabBarTrailingIconButton>
-      );
+        />
+      ) : null;
 
     // X close button shown only while the Settings slot is mounted:
     // hides the workstation surface and maximizes Settings. The

--- a/src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.visibility.test.ts
+++ b/src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.visibility.test.ts
@@ -117,12 +117,10 @@ describe("useWorkstationTrailingSlot pane controls", () => {
 
   function expectPaneControls(): void {
     expect(
-      container.querySelector(
-        'button[title="sessions:chat.maximizeWorkStation"]'
-      )
+      container.querySelector('button[title="chat.maximizeWorkStation"]')
     ).not.toBeNull();
     expect(
-      container.querySelector('button[title="sessions:chat.hideWorkstation"]')
+      container.querySelector('button[title="chat.hideWorkstation"]')
     ).not.toBeNull();
   }
 
@@ -143,12 +141,10 @@ describe("useWorkstationTrailingSlot pane controls", () => {
     renderHost("code");
 
     expect(
-      container.querySelector(
-        'button[title="sessions:chat.maximizeWorkStation"]'
-      )
+      container.querySelector('button[title="chat.maximizeWorkStation"]')
     ).toBeNull();
     expect(
-      container.querySelector('button[title="sessions:chat.hideWorkstation"]')
+      container.querySelector('button[title="chat.hideWorkstation"]')
     ).toBeNull();
   });
 

--- a/src/modules/WorkStation/shared/StationPaneControls.test.ts
+++ b/src/modules/WorkStation/shared/StationPaneControls.test.ts
@@ -2,7 +2,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { WorkstationMaximizeChatIcon } from "./useWorkstationTrailingSlot";
+import { WorkstationMaximizeChatIcon } from "../shared/StationPaneControls";
 
 describe("WorkstationMaximizeChatIcon", () => {
   it("keeps the X unchanged when the workstation is left of the chat panel", () => {
@@ -15,6 +15,18 @@ describe("WorkstationMaximizeChatIcon", () => {
     expect(markup).toContain('data-icon="x"');
     expect(markup).not.toContain("group-hover");
     expect(markup).not.toContain('data-icon="panel-left-close"');
+  });
+
+  it("keeps Agent Station's left-side icon static", () => {
+    const markup = renderToStaticMarkup(
+      createElement(WorkstationMaximizeChatIcon, {
+        chatPanelPosition: "left",
+        directionalHover: false,
+      })
+    );
+    expect(markup).toContain('data-icon="panel-right"');
+    expect(markup).not.toContain("group-hover");
+    expect(markup).not.toContain('data-icon="layout-align-right"');
   });
 
   it("preserves the directional hover affordance when the chat panel is left", () => {

--- a/src/modules/WorkStation/shared/StationPaneControls.tsx
+++ b/src/modules/WorkStation/shared/StationPaneControls.tsx
@@ -1,0 +1,156 @@
+import { useSetAtom } from "jotai";
+import { type ReactNode, startTransition, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+
+import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
+import { CHROME_TOOLTIP_HOVER_DELAY } from "@src/config/tooltip";
+import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
+import {
+  ArrowExpand01Icon,
+  ArrowShrink01Icon,
+  BubbleChatIcon,
+  Cancel01Icon,
+  HugeiconsIcon,
+  LayoutAlignRightIcon,
+  PanelRightIcon,
+} from "@src/icons";
+import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
+import { toggleChatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
+import type { ChatPanelPosition } from "@src/store/ui/workStationLayout/chatPositionAtoms";
+
+export function useStationPaneActions() {
+  const toggleMaximized = useSetAtom(toggleChatPanelMaximizedAtom);
+  const handleToggleChatPanel = useCallback(() => {
+    startTransition(() => {
+      void WorkStationViewService.showWorkStation();
+    });
+  }, []);
+  const handleToggleChatPanelMaximized = useCallback(() => {
+    toggleMaximized();
+  }, [toggleMaximized]);
+  return { handleToggleChatPanel, handleToggleChatPanelMaximized };
+}
+
+export function WorkstationMaximizeChatIcon({
+  chatPanelPosition,
+  directionalHover = true,
+}: {
+  chatPanelPosition: ChatPanelPosition;
+  directionalHover?: boolean;
+}): ReactNode {
+  if (chatPanelPosition === "right") {
+    return (
+      <HugeiconsIcon
+        icon={Cancel01Icon}
+        data-icon="x"
+        size={HEADER_ICON_SIZE.md}
+        strokeWidth={1.75}
+      />
+    );
+  }
+
+  if (!directionalHover) {
+    return (
+      <HugeiconsIcon
+        icon={PanelRightIcon}
+        data-icon="panel-right"
+        size={HEADER_ICON_SIZE.md}
+        strokeWidth={2}
+      />
+    );
+  }
+
+  return (
+    <span className="flex h-4 w-4 items-center justify-center">
+      <HugeiconsIcon
+        icon={PanelRightIcon}
+        data-icon="panel-right"
+        size={HEADER_ICON_SIZE.md}
+        strokeWidth={2}
+        className="group-hover:hidden"
+      />
+      <HugeiconsIcon
+        icon={LayoutAlignRightIcon}
+        data-icon="layout-align-right"
+        size={HEADER_ICON_SIZE.md}
+        strokeWidth={2}
+        className="hidden group-hover:block"
+      />
+    </span>
+  );
+}
+
+export function StationChatVisibilityButton({
+  visible,
+  restoreIcon = "chat",
+  onClick,
+  testId,
+}: {
+  visible: boolean;
+  restoreIcon?: "chat" | "shrink";
+  onClick: () => void;
+  testId?: string;
+}) {
+  const { t } = useTranslation("sessions");
+  return (
+    <TabBarTrailingIconButton
+      title={
+        visible ? t("chat.maximizeWorkStation") : t("chat.restoreChatPanel")
+      }
+      shortcutId="maximize_work_station"
+      tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+      onClick={onClick}
+      data-testid={testId}
+    >
+      <HugeiconsIcon
+        icon={
+          visible
+            ? ArrowExpand01Icon
+            : restoreIcon === "shrink"
+              ? ArrowShrink01Icon
+              : BubbleChatIcon
+        }
+        data-icon={
+          visible
+            ? "maximize-2"
+            : restoreIcon === "shrink"
+              ? "minimize-2"
+              : "message-circle"
+        }
+        size={14}
+        strokeWidth={2}
+      />
+    </TabBarTrailingIconButton>
+  );
+}
+
+export function StationMaximizeChatButton({
+  chatPanelPosition,
+  directionalHover = true,
+  onClick,
+  testId,
+}: {
+  chatPanelPosition: ChatPanelPosition;
+  directionalHover?: boolean;
+  onClick: () => void;
+  testId?: string;
+}) {
+  const { t } = useTranslation("sessions");
+  return (
+    <TabBarTrailingIconButton
+      title={t("chat.hideWorkstation")}
+      shortcutId="maximize_chat"
+      tooltipMouseEnterDelay={CHROME_TOOLTIP_HOVER_DELAY}
+      onClick={onClick}
+      className={
+        directionalHover && chatPanelPosition === "left" ? "group" : undefined
+      }
+      data-testid={testId}
+    >
+      <WorkstationMaximizeChatIcon
+        chatPanelPosition={chatPanelPosition}
+        directionalHover={directionalHover}
+      />
+    </TabBarTrailingIconButton>
+  );
+}

--- a/src/modules/WorkStation/shared/StationPaneControls.tsx
+++ b/src/modules/WorkStation/shared/StationPaneControls.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
 import { CHROME_TOOLTIP_HOVER_DELAY } from "@src/config/tooltip";
 import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
+import { createLogger } from "@src/hooks/logger";
 import {
   ArrowExpand01Icon,
   ArrowShrink01Icon,
@@ -18,11 +19,15 @@ import { WorkStationViewService } from "@src/services/workStation/WorkStationVie
 import { toggleChatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
 import type { ChatPanelPosition } from "@src/store/ui/workStationLayout/chatPositionAtoms";
 
+const logger = createLogger("StationPaneControls");
+
 export function useStationPaneActions() {
   const toggleMaximized = useSetAtom(toggleChatPanelMaximizedAtom);
   const handleToggleChatPanel = useCallback(() => {
     startTransition(() => {
-      void WorkStationViewService.showWorkStation();
+      void WorkStationViewService.showWorkStation().catch((error: unknown) => {
+        logger.error("Failed to toggle station chat visibility:", error);
+      });
     });
   }, []);
   const handleToggleChatPanelMaximized = useCallback(() => {


### PR DESCRIPTION
## Problem

My Station, Agent Station and pinned window chrome repeat the same chat visibility and maximize actions and button presentation.

## Solution

Share StationPaneControls and action callbacks across all three owners. Handle and log visibility-action rejections at the shared callback so they do not become unhandled promises; a rendered regression test covers this failure path. Preserve each owner’s visibility gates, both pane restore affordances, Settings control, pinned availability, and the Agent header’s static directional icon.

## Potential risks

The main risk is chrome availability or icon drift across station modes and chat positions. Existing rendered tests and added dispatch/icon coverage pass. No persistence, IPC, native webview, or lifecycle policy changes. Native visual screenshots were not collected; this is intended to preserve appearance. No dependency, schema, storage-key or wire-format changes; rollback is a normal revert.

## Verification

- `pnpm run typecheck:fast` — passed.
- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/shared/StationPaneControls.test.ts src/modules/WorkStation/shared/StationPaneControls.tsx src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.tsx src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.tsx src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.visibility.test.ts` — passed, zero warnings.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/modules/WorkStation/AppShell/useWorkstationTrailingSlot.visibility.test.ts src/modules/WorkStation/AppShell/PinnedWorkbenchChrome.test.ts src/modules/WorkStation/shared/StationPaneControls.test.ts` — 4 files, 23 tests passed.
- `git diff --check` — passed.

No native screenshots, actual webview interaction, CPU/RSS profiling or Rust checks were run. This is a behavior-preserving TypeScript refactor; native visual verification remains unclaimed. Architecture/lifecycle review and applicable UI audit are included under `docs/`.

### CI follow-up

- `pnpm test:typed-lint` — 6 tests passed.
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm check:typed-lint` — passed, zero new or increased findings; baseline unchanged.
- `pnpm test src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/modules/WorkStation/shared/StationPaneControls.test.ts` — 7 tests passed, including rejected visibility action.
- Normal commit hooks passed lint-staged and TypeScript checks.
- An initial direct Vitest invocation omitted the repository config and failed import resolution; rerunning with `pnpm test` passed as above.
