### PR TITLE
refactor(session-replay): share sidebar state and configuration

### DIFF
--- a/docs/architecture-audit-2026-09-11/ReplaySidebar.md
+++ b/docs/architecture-audit-2026-09-11/ReplaySidebar.md
@@ -1,0 +1,41 @@
+# ReplaySidebar implementation review
+
+## Acceptance and ownership
+
+Code, Browser, Diff and Canvas replay surfaces independently bind the same sidebar atoms and duplicate width limits and setter wrappers.
+
+Use one useSimulatorReplaySidebar hook in all four owners. Memoize the shared config for their existing content memoization. Keep the same atom identities, width persistence, limits, reset values and station-specific preferences.
+
+Acceptance: replace all matching in-scope callers, preserve user behavior and persistence, pass focused tests and frontend checks, and keep changes isolated from unrelated working-tree edits.
+
+| Line                                                                           | Element          | Verdict | Reason                                                                                                                                                                                                                                | Suggested change                                  |
+| ------------------------------------------------------------------------------ | ---------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.ts:13` | Shared ownership | fix     | Use one useSimulatorReplaySidebar hook in all four owners. Memoize the shared config for their existing content memoization. Keep the same atom identities, width persistence, limits, reset values and station-specific preferences. | Implemented in this change; no unrelated cleanup. |
+
+## Architecture coverage
+
+Layers 1–7: frontend compilation/lint, caller sweep, naming, distinct station/host meanings, defaults, ownership boundaries, and readability reviewed. Layer 8: no serialized format, IPC or storage-key change; no real wire dump was needed for this internal refactor. Layer 9: existing station entry points retained and focused tests exercise changed ownership. Layer 10: preserve caller-specific visibility/selection policies rather than forcing false symmetry. Backend initialization and account/model resolvers are outside scope.
+
+## Lifecycle and performance
+
+| Area               | Verdict | Evidence                                       | Change or reason kept                                                                                                                                                                                                                 | Verification                        |
+| ------------------ | ------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Background work    | keep    | No new polling, listeners, workers or requests | Existing owner and mount/cleanup rules retained                                                                                                                                                                                       | Focused suites below                |
+| Memory             | keep    | No new app-lifetime collections or caches      | State stays with current atoms/components                                                                                                                                                                                             | Diff inspection; no RSS measurement |
+| Scope/isolation    | keep    | Existing station and store boundaries          | No shared cross-account/session cache introduced                                                                                                                                                                                      | Caller sweep                        |
+| Rendering/hot path | fix     | Common computation/config/action ownership     | Use one useSimulatorReplaySidebar hook in all four owners. Memoize the shared config for their existing content memoization. Keep the same atom identities, width persistence, limits, reset values and station-specific preferences. | Focused tests; no timing claim      |
+
+Applicable matrix: mount/unmount and station/visibility transitions at changed UI boundaries; existing online/offline, identity, transport and multi-instance ownership is unchanged. No provider ingestion or sync changes. Native Tauri pixels/CPU/RSS were not measured: Computer Use was not authorized. Performance verdict: blocked for live native measurement; no performance improvement is claimed. Automated correctness evidence is listed separately.
+
+## Risks
+
+Replay sidebar configuration affects four surfaces. Shared-state, reset, collapse, independent workstation dimensions, stable config identity, Canvas lifecycle/share and replay config tests pass. No native webview geometry code or station-position synchronization changes. Native visual drag/resize was not exercised. Rollback is a normal commit revert; no data migration or recovery is required.
+
+## Verification
+
+- `pnpm run typecheck:fast` — passed.
+- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.test.ts src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.ts src/engines/Simulator/apps/canvas/CanvasApp.tsx src/modules/WorkStation/Browser/SessionReplay/index.tsx src/modules/WorkStation/CodeEditor/SessionReplay/index.tsx src/modules/WorkStation/Diff/SessionReplay/index.tsx` — passed with zero warnings.
+- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.test.ts src/modules/WorkStation/shared/SessionReplay/ReplayShellLayout.test.ts src/engines/Simulator/apps/canvas/CanvasApp.test.ts src/engines/Simulator/apps/canvas/CanvasApp.share.test.ts src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/config.test.ts src/modules/WorkStation/Diff/SessionReplay/__tests__/config.test.ts` — 7 files, 23 tests passed.
+- `git diff --check` — passed.
+
+Focused suites may emit existing Vite/Sass/Jotai/React Router deprecation notices. Full Rust builds and native UI/CPU/RSS checks were not run; no backend code changed. Tests do not substitute for native visual verification.

--- a/docs/frontend-ui-audit-2026-09-11/ReplaySidebar.md
+++ b/docs/frontend-ui-audit-2026-09-11/ReplaySidebar.md
@@ -1,0 +1,9 @@
+# ReplaySidebar UI audit
+
+| Line                                                                           | Element                  | Verdict          | Reason                                                                                                                                                         | Suggested change                                          |
+| ------------------------------------------------------------------------------ | ------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.ts:13` | Existing visual boundary | keep with reason | This refactor preserves existing controls, sidebar content, caption presentation or browser status-bar ownership; no new design primitive or styling is needed | Retain existing DS components and owner-specific variants |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.
+
+The consolidation is implemented, with evidence in the architecture review of the same name. D1–D5 review of the changed diff found no new raw interactive HTML, arbitrary visual tokens/colors, accessibility semantics or repeated visual scaffolding needing another abstraction. No theme/viewport screenshots: behavior-preserving extraction, with native visual validation not performed because Computer Use was not authorized.

--- a/src/engines/Simulator/apps/canvas/CanvasApp.tsx
+++ b/src/engines/Simulator/apps/canvas/CanvasApp.tsx
@@ -15,12 +15,11 @@
  * - Diff uses a simple line-level diffLines utility (no external library)
  * - Source tab shows raw JSONL/HTML in a <pre> block
  */
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import React, { Suspense, lazy, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Placeholder } from "@src/components/Placeholder";
-import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
 import CanvasRevisionProgress from "@src/engines/ChatPanel/blocks/CanvasInlineCard/CanvasRevisionProgress";
 import { isCanvasRevisionDraftRelevant } from "@src/engines/ChatPanel/blocks/CanvasInlineCard/canvasRevisionProgressState";
 import { useCanvasRevisionDraftForSession } from "@src/engines/SessionCore";
@@ -35,13 +34,8 @@ import {
   WorkStationShell,
   buildPrimarySidebarConfig,
 } from "@src/modules/WorkStation/shared";
+import { useSimulatorReplaySidebar } from "@src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar";
 import { canvasPreviewAtom } from "@src/store/session/canvasPreviewAtom";
-import {
-  simulatorPrimarySidebarCollapsedAtom,
-  simulatorPrimarySidebarPositionAtom,
-  simulatorPrimarySidebarWidthAtom,
-  simulatorPrimarySidebarWidthPersistAtom,
-} from "@src/store/ui/simulatorAtom";
 
 import type { SimulatorAppProps } from "../core/types";
 import { useSimulatorAppState } from "../core/useSimulatorAppState";
@@ -93,23 +87,8 @@ const CanvasApp: React.FC<SimulatorAppProps> = () => {
   const canvasPreviewEntry = useAtomValue(canvasPreviewAtom);
 
   // ── sidebar atoms ────────────────────────────────────────────────────────
-  const primarySidebarCollapsed = useAtomValue(
-    simulatorPrimarySidebarCollapsedAtom
-  );
-  const primarySidebarPosition = useAtomValue(
-    simulatorPrimarySidebarPositionAtom
-  );
-  const primarySidebarWidth = useAtomValue(simulatorPrimarySidebarWidthAtom);
-  const setPrimarySidebarWidthPersist = useSetAtom(
-    simulatorPrimarySidebarWidthPersistAtom
-  );
-
-  const handlePrimarySidebarWidthChange = useCallback(
-    (width: number) => {
-      setPrimarySidebarWidthPersist(width);
-    },
-    [setPrimarySidebarWidthPersist]
-  );
+  const { layoutMode: primarySidebarPosition, sidebar } =
+    useSimulatorReplaySidebar();
 
   // ── selection state ──────────────────────────────────────────────────────
 
@@ -322,20 +301,13 @@ const CanvasApp: React.FC<SimulatorAppProps> = () => {
             t={t}
           />
         ),
-        collapsed: primarySidebarCollapsed,
-        size: primarySidebarWidth,
-        onSizeChange: handlePrimarySidebarWidthChange,
-        minSize: SIMULATOR_PRIMARY_SIDEBAR.minWidth,
-        maxSize: SIMULATOR_PRIMARY_SIDEBAR.maxWidth,
-        resetSize: SIMULATOR_PRIMARY_SIDEBAR.defaultWidth,
+        ...sidebar,
       }),
     [
       appEvents,
       selectedEventId,
       compareEventIds,
-      primarySidebarCollapsed,
-      primarySidebarWidth,
-      handlePrimarySidebarWidthChange,
+      sidebar,
       handleSelect,
       handleCompareToggle,
       t,
@@ -420,7 +392,7 @@ const CanvasApp: React.FC<SimulatorAppProps> = () => {
             primarySidebarConfig={primarySidebarConfig}
             content={mainContent}
             statusBar={null}
-            layoutMode={primarySidebarPosition === "right" ? "right" : "left"}
+            layoutMode={primarySidebarPosition}
             appClassName="canvas-app"
           />
         </div>

--- a/src/modules/WorkStation/Browser/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/Browser/SessionReplay/index.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import Message from "@src/components/Message";
 import { Placeholder } from "@src/components/Placeholder";
 import { TabBarTrailingIconButton } from "@src/components/TabPill/TabBarTrailingIconButton";
-import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
 import { useBrowserAutomation } from "@src/engines/BrowserCore/hooks/useBrowserAutomation";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 import { usePublishWorkstationTabHeader } from "@src/hooks/tabHost/useWorkstationTabHeader";
@@ -26,15 +25,10 @@ import {
   useSimulatorAwaitingAgentCaption,
   useSimulatorPlaceholderActions,
 } from "@src/modules/WorkStation/shared";
+import { useSimulatorReplaySidebar } from "@src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar";
 import { BrowserStatusBar } from "@src/modules/WorkStation/shared/StatusBar";
 import { addToAgentAtom } from "@src/store/ui/addToAgentAtom";
-import {
-  simulatorEffectiveDockAppAtom,
-  simulatorPrimarySidebarCollapsedAtom,
-  simulatorPrimarySidebarPositionAtom,
-  simulatorPrimarySidebarWidthAtom,
-  simulatorPrimarySidebarWidthPersistAtom,
-} from "@src/store/ui/simulatorAtom";
+import { simulatorEffectiveDockAppAtom } from "@src/store/ui/simulatorAtom";
 import {
   clearScreenshotCacheAtom,
   insertScreenshotCacheAtom,
@@ -83,16 +77,8 @@ const SessionReplayBrowserComponent: React.FC<SessionReplayBrowserProps> = ({
   const myTabsBrowserState = myTabsBrowser.browserState;
   const setMyTabsDevToolsCollapsed = myTabsBrowser.setDevToolsCollapsed;
   const setMyTabsDevToolsPosition = myTabsBrowser.setDevToolsPosition;
-  const primarySidebarCollapsed = useAtomValue(
-    simulatorPrimarySidebarCollapsedAtom
-  );
-  const primarySidebarPosition = useAtomValue(
-    simulatorPrimarySidebarPositionAtom
-  );
-  const primarySidebarWidth = useAtomValue(simulatorPrimarySidebarWidthAtom);
-  const setPrimarySidebarWidthPersist = useSetAtom(
-    simulatorPrimarySidebarWidthPersistAtom
-  );
+  const { layoutMode: primarySidebarPosition, sidebar } =
+    useSimulatorReplaySidebar();
   const setAddToAgent = useSetAtom(addToAgentAtom);
   const automation = useBrowserAutomation({ enabled: isBrowserReplayActive });
   const isAutomationActive = automation.isRunning;
@@ -113,13 +99,6 @@ const SessionReplayBrowserComponent: React.FC<SessionReplayBrowserProps> = ({
   const simulatorAwaitingAgentCaption = useSimulatorAwaitingAgentCaption();
 
   const [devToolsPanelHeight, setDevToolsPanelHeight] = useState(240);
-
-  const handlePrimarySidebarWidthChange = useCallback(
-    (width: number) => {
-      setPrimarySidebarWidthPersist(width);
-    },
-    [setPrimarySidebarWidthPersist]
-  );
 
   const handleCloseDevTools = useCallback(() => {
     setMyTabsDevToolsCollapsed(true);
@@ -292,12 +271,7 @@ const SessionReplayBrowserComponent: React.FC<SessionReplayBrowserProps> = ({
             </div>
           </div>
         ),
-        collapsed: primarySidebarCollapsed,
-        size: primarySidebarWidth,
-        onSizeChange: handlePrimarySidebarWidthChange,
-        minSize: SIMULATOR_PRIMARY_SIDEBAR.minWidth,
-        maxSize: SIMULATOR_PRIMARY_SIDEBAR.maxWidth,
-        resetSize: SIMULATOR_PRIMARY_SIDEBAR.defaultWidth,
+        ...sidebar,
       }),
     [
       browserEntries,
@@ -313,9 +287,7 @@ const SessionReplayBrowserComponent: React.FC<SessionReplayBrowserProps> = ({
       handleNewMyTabsSession,
       handleNewPrivateMyTabsSession,
       handleSelectAgentEntry,
-      primarySidebarCollapsed,
-      primarySidebarWidth,
-      handlePrimarySidebarWidthChange,
+      sidebar,
     ]
   );
 
@@ -582,7 +554,7 @@ const SessionReplayBrowserComponent: React.FC<SessionReplayBrowserProps> = ({
         primarySidebarConfig,
         secondaryPanelConfig,
         statusBar: myTabsStatusBar,
-        layoutMode: primarySidebarPosition === "right" ? "right" : "left",
+        layoutMode: primarySidebarPosition,
         appClassName: "session-replay-browser",
       }}
     >

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/index.tsx
@@ -8,7 +8,7 @@
  * Uses WorkStationShell for consistent layout with the interactive CodeEditor.
  * Integrated with SimulatorApps framework for replay-aware state management.
  */
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import React, {
   memo,
   useCallback,
@@ -18,15 +18,9 @@ import React, {
   useState,
 } from "react";
 
-import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
 import { getIDEEventType } from "@src/engines/SessionCore/rendering/registry/toolRegistryDomain";
-import {
-  simulatorIdeTerminalRevealRequestAtom,
-  simulatorPrimarySidebarCollapsedAtom,
-  simulatorPrimarySidebarPositionAtom,
-  simulatorPrimarySidebarWidthAtom,
-  simulatorPrimarySidebarWidthPersistAtom,
-} from "@src/store/ui/simulatorAtom";
+import { useSimulatorReplaySidebar } from "@src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar";
+import { simulatorIdeTerminalRevealRequestAtom } from "@src/store/ui/simulatorAtom";
 import type { BackendEvent } from "@src/types/session/steps";
 
 import {
@@ -82,23 +76,8 @@ const SessionReplayIDEComponent: React.FC<SimulatorIDEProps> = ({
   const terminalRevealRequest = useAtomValue(
     simulatorIdeTerminalRevealRequestAtom
   );
-  const primarySidebarCollapsed = useAtomValue(
-    simulatorPrimarySidebarCollapsedAtom
-  );
-  const primarySidebarPosition = useAtomValue(
-    simulatorPrimarySidebarPositionAtom
-  );
-  const primarySidebarWidth = useAtomValue(simulatorPrimarySidebarWidthAtom);
-  const setPrimarySidebarWidthPersist = useSetAtom(
-    simulatorPrimarySidebarWidthPersistAtom
-  );
-
-  const handlePrimarySidebarWidthChange = useCallback(
-    (width: number) => {
-      setPrimarySidebarWidthPersist(width);
-    },
-    [setPrimarySidebarWidthPersist]
-  );
+  const { layoutMode: primarySidebarPosition, sidebar } =
+    useSimulatorReplaySidebar();
 
   const {
     fileViewMode,
@@ -307,12 +286,7 @@ const SessionReplayIDEComponent: React.FC<SimulatorIDEProps> = ({
           currentEventId={eventId}
         />
       ),
-      collapsed: primarySidebarCollapsed,
-      size: primarySidebarWidth,
-      onSizeChange: handlePrimarySidebarWidthChange,
-      minSize: SIMULATOR_PRIMARY_SIDEBAR.minWidth,
-      maxSize: SIMULATOR_PRIMARY_SIDEBAR.maxWidth,
-      resetSize: SIMULATOR_PRIMARY_SIDEBAR.defaultWidth,
+      ...sidebar,
     });
   }, [
     fileViewMode,
@@ -331,9 +305,7 @@ const SessionReplayIDEComponent: React.FC<SimulatorIDEProps> = ({
     handleShellSelect,
     handleToolSelect,
     eventId,
-    primarySidebarCollapsed,
-    primarySidebarWidth,
-    handlePrimarySidebarWidthChange,
+    sidebar,
   ]);
 
   // Build a UNIFIED newest-first timeline across every op kind. Each kind
@@ -489,7 +461,7 @@ const SessionReplayIDEComponent: React.FC<SimulatorIDEProps> = ({
       eventWrapper={{ event: currentEvent as unknown as BackendEvent, mode }}
       workstation={{
         primarySidebarConfig,
-        layoutMode: primarySidebarPosition === "right" ? "right" : "left",
+        layoutMode: primarySidebarPosition,
         appClassName: "session-replay-ide",
       }}
     >

--- a/src/modules/WorkStation/Diff/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/Diff/SessionReplay/index.tsx
@@ -13,14 +13,13 @@
  * `TurnMetadataFooter` "Review"/file click still scrolls the cumulative list to
  * the clicked file, but never filters it down to a single round.
  */
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import { Placeholder } from "@src/components/Placeholder";
 import TabPill from "@src/components/TabPill";
-import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
 import { simulatorEventsAtom } from "@src/engines/SessionCore/derived/simulatorEvents";
 import type { SimulatorAppProps } from "@src/engines/Simulator/apps/core/types";
 import { useFileReviewBatchActions } from "@src/hooks/fileReview/useFileReview";
@@ -42,16 +41,13 @@ import {
 } from "@src/modules/WorkStation/shared";
 import { PrimarySidebarLayoutWithSections } from "@src/modules/WorkStation/shared/PrimarySidebarLayout";
 import type { ReplayTab } from "@src/modules/WorkStation/shared/SessionReplay/ReplayTabBar";
+import { useSimulatorReplaySidebar } from "@src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar";
 import { reposAtom } from "@src/store/repo/atoms";
 import { sessionByIdAtom } from "@src/store/session";
 import {
   simulatorDiffCommitNavigationRequestAtom,
   simulatorDiffRefreshNonceAtom,
   simulatorDiffScopeRequestAtom,
-  simulatorPrimarySidebarCollapsedAtom,
-  simulatorPrimarySidebarPositionAtom,
-  simulatorPrimarySidebarWidthAtom,
-  simulatorPrimarySidebarWidthPersistAtom,
 } from "@src/store/ui/simulatorAtom";
 import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
@@ -155,22 +151,8 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
 
   const consolidatedSections = sidebarItems;
 
-  const primarySidebarCollapsed = useAtomValue(
-    simulatorPrimarySidebarCollapsedAtom
-  );
-  const primarySidebarPosition = useAtomValue(
-    simulatorPrimarySidebarPositionAtom
-  );
-  const primarySidebarWidth = useAtomValue(simulatorPrimarySidebarWidthAtom);
-  const setPrimarySidebarWidthPersist = useSetAtom(
-    simulatorPrimarySidebarWidthPersistAtom
-  );
-  const handlePrimarySidebarWidthChange = useCallback(
-    (width: number) => {
-      setPrimarySidebarWidthPersist(width);
-    },
-    [setPrimarySidebarWidthPersist]
-  );
+  const { layoutMode: primarySidebarPosition, sidebar } =
+    useSimulatorReplaySidebar();
 
   const simulatorPlaceholderActions = useSimulatorPlaceholderActions(mode);
   const simulatorAwaitingAgentCaption = useSimulatorAwaitingAgentCaption();
@@ -400,20 +382,9 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
             hideTabs
           />
         ),
-        collapsed: primarySidebarCollapsed,
-        size: primarySidebarWidth,
-        onSizeChange: handlePrimarySidebarWidthChange,
-        minSize: SIMULATOR_PRIMARY_SIDEBAR.minWidth,
-        maxSize: SIMULATOR_PRIMARY_SIDEBAR.maxWidth,
-        resetSize: SIMULATOR_PRIMARY_SIDEBAR.defaultWidth,
+        ...sidebar,
       }),
-    [
-      sidebarTab,
-      noopTabChange,
-      primarySidebarCollapsed,
-      primarySidebarWidth,
-      handlePrimarySidebarWidthChange,
-    ]
+    [sidebarTab, noopTabChange, sidebar]
   );
 
   const detailContent = useDiffDetailContent({
@@ -476,7 +447,7 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
       onTabClick={handleTabClick}
       workstation={{
         primarySidebarConfig,
-        layoutMode: primarySidebarPosition === "right" ? "right" : "left",
+        layoutMode: primarySidebarPosition,
         appClassName: "session-replay-diff",
       }}
     >

--- a/src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.test.ts
+++ b/src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it } from "vitest";
+
+import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
+import {
+  simulatorPrimarySidebarCollapsedAtom,
+  simulatorPrimarySidebarPositionAtom,
+  simulatorPrimarySidebarWidthAtom,
+} from "@src/store/ui/simulatorAtom";
+import { workStationPrimarySidebarWidthAtom } from "@src/store/ui/workStationLayout/primarySidebarAtoms";
+
+import { useSimulatorReplaySidebar } from "./useSimulatorReplaySidebar";
+
+it("shares replay resize/collapse state without changing My Station dimensions", () => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  const store = createStore();
+  const root = createRoot(document.createElement("div"));
+  const values: ReturnType<typeof useSimulatorReplaySidebar>[] = [];
+  function Consumer({ index }: { index: number }) {
+    const value = useSimulatorReplaySidebar();
+    useEffect(() => {
+      values[index] = value;
+    }, [index, value]);
+    return null;
+  }
+  const myWidth = store.get(workStationPrimarySidebarWidthAtom);
+  try {
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          [0, 1].map((index) => createElement(Consumer, { index, key: index }))
+        )
+      )
+    );
+    expect(values[0].sidebar.minSize).toBe(SIMULATOR_PRIMARY_SIDEBAR.minWidth);
+    expect(values[0].sidebar.maxSize).toBe(SIMULATOR_PRIMARY_SIDEBAR.maxWidth);
+    act(() =>
+      values[0].sidebar.onSizeChange(SIMULATOR_PRIMARY_SIDEBAR.minWidth + 25)
+    );
+    expect(values[1].sidebar.size).toBe(
+      SIMULATOR_PRIMARY_SIDEBAR.minWidth + 25
+    );
+    act(() => values[1].sidebar.onSizeChange(values[1].sidebar.resetSize));
+    expect(store.get(simulatorPrimarySidebarWidthAtom)).toBe(
+      SIMULATOR_PRIMARY_SIDEBAR.defaultWidth
+    );
+    act(() => {
+      store.set(simulatorPrimarySidebarCollapsedAtom, true);
+      store.set(simulatorPrimarySidebarPositionAtom, "right");
+    });
+    expect(
+      values.every(
+        (value) => value.sidebar.collapsed && value.layoutMode === "right"
+      )
+    ).toBe(true);
+    expect(store.get(workStationPrimarySidebarWidthAtom)).toBe(myWidth);
+    const previous = values[0].sidebar;
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          [0, 1].map((index) => createElement(Consumer, { index, key: index }))
+        )
+      )
+    );
+    expect(values[0].sidebar).toBe(previous);
+  } finally {
+    act(() => root.unmount());
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  }
+});

--- a/src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.ts
+++ b/src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.ts
@@ -1,0 +1,31 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import { useMemo } from "react";
+
+import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
+import {
+  simulatorPrimarySidebarCollapsedAtom,
+  simulatorPrimarySidebarPositionAtom,
+  simulatorPrimarySidebarWidthAtom,
+  simulatorPrimarySidebarWidthPersistAtom,
+} from "@src/store/ui/simulatorAtom";
+
+/** Shared replay preferences; live workstation dimensions remain independent. */
+export function useSimulatorReplaySidebar() {
+  const collapsed = useAtomValue(simulatorPrimarySidebarCollapsedAtom);
+  const layoutMode = useAtomValue(simulatorPrimarySidebarPositionAtom);
+  const size = useAtomValue(simulatorPrimarySidebarWidthAtom);
+  const onSizeChange = useSetAtom(simulatorPrimarySidebarWidthPersistAtom);
+  // Stable across cursor/selection renders so each app can memoize its content.
+  const sidebar = useMemo(
+    () => ({
+      collapsed,
+      size,
+      onSizeChange,
+      minSize: SIMULATOR_PRIMARY_SIDEBAR.minWidth,
+      maxSize: SIMULATOR_PRIMARY_SIDEBAR.maxWidth,
+      resetSize: SIMULATOR_PRIMARY_SIDEBAR.defaultWidth,
+    }),
+    [collapsed, size, onSizeChange]
+  );
+  return { layoutMode, sidebar };
+}


### PR DESCRIPTION
## Problem

Code, Browser, Diff and Canvas replay surfaces independently bind the same sidebar atoms and duplicate width limits and setter wrappers.

## Solution

Use one useSimulatorReplaySidebar hook in all four owners. Memoize the shared config for their existing content memoization. Keep the same atom identities, width persistence, limits, reset values and station-specific preferences.

## Potential risks

Replay sidebar configuration affects four surfaces. Shared-state, reset, collapse, independent workstation dimensions, stable config identity, Canvas lifecycle/share and replay config tests pass. No native webview geometry code or station-position synchronization changes. Native visual drag/resize was not exercised. No dependency, schema, storage-key or wire-format changes; rollback is a normal revert.

## Verification

- `pnpm run typecheck:fast` — passed.
- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.test.ts src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.ts src/engines/Simulator/apps/canvas/CanvasApp.tsx src/modules/WorkStation/Browser/SessionReplay/index.tsx src/modules/WorkStation/CodeEditor/SessionReplay/index.tsx src/modules/WorkStation/Diff/SessionReplay/index.tsx` — passed, zero warnings.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/shared/SessionReplay/useSimulatorReplaySidebar.test.ts src/modules/WorkStation/shared/SessionReplay/ReplayShellLayout.test.ts src/engines/Simulator/apps/canvas/CanvasApp.test.ts src/engines/Simulator/apps/canvas/CanvasApp.share.test.ts src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/config.test.ts src/modules/WorkStation/Diff/SessionReplay/__tests__/config.test.ts` — 7 files, 23 tests passed.
- `git diff --check` — passed.

No native screenshots, actual webview interaction, CPU/RSS profiling or Rust checks were run. This is a behavior-preserving TypeScript refactor; native visual verification remains unclaimed. Architecture/lifecycle review and applicable UI audit are included under `docs/`.
