### PR TITLE
refactor(station-caption): select caption once in the app shell

### DIFF
--- a/docs/architecture-audit-2026-09-11/StationCaption.md
+++ b/docs/architecture-audit-2026-09-11/StationCaption.md
@@ -1,0 +1,43 @@
+# StationCaption implementation review
+
+## Acceptance and ownership
+
+AppShell and AgentStationTopHeader each select the current caption and independently decide whether its row is visible.
+
+AppShell selects the caption once and passes the message and its existing visibility decision to AgentStationTopHeader. The frame and header now use the same visibility result. Keep user, assistant and thought channel notices and caption-toggle behavior.
+
+Acceptance: replace all matching in-scope callers, preserve user behavior and persistence, pass focused tests and frontend checks, and keep changes isolated from unrelated working-tree edits.
+
+| Line                                                            | Element          | Verdict | Reason                                                                                                                                                                                                                                                         | Suggested change                                  |
+| --------------------------------------------------------------- | ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx:55` | Shared ownership | fix     | AppShell selects the caption once and passes the message and its existing visibility decision to AgentStationTopHeader. The frame and header now use the same visibility result. Keep user, assistant and thought channel notices and caption-toggle behavior. | Implemented in this change; no unrelated cleanup. |
+
+## Architecture coverage
+
+Layers 1–7: frontend compilation/lint, caller sweep, naming, distinct station/host meanings, defaults, ownership boundaries, and readability reviewed. Layer 8: no serialized format, IPC or storage-key change; no real wire dump was needed for this internal refactor. Layer 9: existing station entry points retained and focused tests exercise changed ownership. Layer 10: preserve caller-specific visibility/selection policies rather than forcing false symmetry. Backend initialization and account/model resolvers are outside scope.
+
+## Lifecycle and performance
+
+| Area               | Verdict | Evidence                                       | Change or reason kept                                                                                                                                                                                                                                          | Verification                        |
+| ------------------ | ------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Background work    | keep    | No new polling, listeners, workers or requests | Existing owner and mount/cleanup rules retained                                                                                                                                                                                                                | Focused suites below                |
+| Memory             | keep    | No new app-lifetime collections or caches      | State stays with current atoms/components                                                                                                                                                                                                                      | Diff inspection; no RSS measurement |
+| Scope/isolation    | keep    | Existing station and store boundaries          | No shared cross-account/session cache introduced                                                                                                                                                                                                               | Caller sweep                        |
+| Rendering/hot path | fix     | Common computation/config/action ownership     | AppShell selects the caption once and passes the message and its existing visibility decision to AgentStationTopHeader. The frame and header now use the same visibility result. Keep user, assistant and thought channel notices and caption-toggle behavior. | Focused tests; no timing claim      |
+
+Applicable matrix: mount/unmount and station/visibility transitions at changed UI boundaries; existing online/offline, identity, transport and multi-instance ownership is unchanged. No provider ingestion or sync changes. Native Tauri pixels/CPU/RSS were not measured: Computer Use was not authorized. Performance verdict: blocked for live native measurement; no performance improvement is claimed. Automated correctness evidence is listed separately.
+
+## Risks
+
+This PR is based on `dev/station-pane-controls` (PR #1567) because both changes edit the header. Merge that PR first, then retarget this PR to develop.
+
+A mismatch in parent/header props could affect caption spacing or notices. A rendered AppShell test with the real header verifies one selector call and aligned visibility, plus all three channel notices. No replay cursor, event payload, persistence or native webview behavior changes. Native pixels and runtime timing were not profiled. Rollback is a normal commit revert; no data migration or recovery is required.
+
+## Verification
+
+- `pnpm run typecheck:fast` — passed.
+- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/AppShell/AppShell.caption.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx src/modules/WorkStation/AppShell/index.tsx` — passed with zero warnings.
+- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell/AppShell.caption.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts` — 2 files, 9 tests passed.
+- `git diff --check` — passed.
+
+Focused suites may emit existing Vite/Sass/Jotai/React Router deprecation notices. Full Rust builds and native UI/CPU/RSS checks were not run; no backend code changed. Tests do not substitute for native visual verification.

--- a/docs/frontend-ui-audit-2026-09-11/StationCaption.md
+++ b/docs/frontend-ui-audit-2026-09-11/StationCaption.md
@@ -1,0 +1,9 @@
+# StationCaption UI audit
+
+| Line                                                            | Element                  | Verdict          | Reason                                                                                                                                                         | Suggested change                                          |
+| --------------------------------------------------------------- | ------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx:55` | Existing visual boundary | keep with reason | This refactor preserves existing controls, sidebar content, caption presentation or browser status-bar ownership; no new design primitive or styling is needed | Retain existing DS components and owner-specific variants |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.
+
+The consolidation is implemented, with evidence in the architecture review of the same name. D1–D5 review of the changed diff found no new raw interactive HTML, arbitrary visual tokens/colors, accessibility semantics or repeated visual scaffolding needing another abstraction. No theme/viewport screenshots: behavior-preserving extraction, with native visual validation not performed because Computer Use was not authorized.

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts
@@ -105,7 +105,10 @@ describe("AgentStationTopHeader", () => {
           createElement(
             MemoryRouter,
             { initialEntries: [ROUTES.workStation.base.path] },
-            createElement(AgentStationTopHeader)
+            createElement(AgentStationTopHeader, {
+              captionMessage: null,
+              captionVisible: false,
+            })
           )
         )
       );

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
@@ -16,7 +16,7 @@ import { matchesShortcut } from "@src/config/keyboard/shortcutBindings";
 import { CHROME_TOOLTIP_HOVER_DELAY } from "@src/config/tooltip";
 import { TAB_BAR_CONTROLS_ROW_TRAILING_PADDING_PX } from "@src/config/workstation/tokens";
 import CaptionBar from "@src/engines/Simulator/components/CaptionBar";
-import { useCurrentTurnLastAgentMessage } from "@src/engines/Simulator/hooks/useCurrentTurnLastAgentMessage";
+import type { CurrentTurnLastAgentMessage } from "@src/engines/Simulator/hooks/useCurrentTurnLastAgentMessage";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 import {
   useCollapsedSidebarChromeOffset,
@@ -49,7 +49,15 @@ import {
   useStationPaneActions,
 } from "../shared/StationPaneControls";
 
-const AgentStationTopHeader: React.FC = memo(() => {
+interface AgentStationTopHeaderProps {
+  captionMessage: CurrentTurnLastAgentMessage | null;
+  captionVisible: boolean;
+}
+
+const AgentStationTopHeaderComponent = ({
+  captionMessage,
+  captionVisible,
+}: AgentStationTopHeaderProps) => {
   const { t } = useTranslation("sessions");
   const shouldOffsetLeftChrome = useShouldOffsetWorkStationTopBar();
   const collapsedSidebarChromeOffset = useCollapsedSidebarChromeOffset();
@@ -70,7 +78,6 @@ const AgentStationTopHeader: React.FC = memo(() => {
   const [captionEnabled, setCaptionEnabled] = useAtom(
     simulatorCaptionBarEnabledAtom
   );
-  const captionMessage = useCurrentTurnLastAgentMessage();
   const workstationActiveSessionId = useAtomValue(
     workstationActiveSessionIdAtom
   );
@@ -94,8 +101,6 @@ const AgentStationTopHeader: React.FC = memo(() => {
         )
     : captionMessage?.text;
   const captionToggleLabel = t("simulator.captionBarToggleTooltip");
-  const showCaptionBar =
-    captionEnabled && !!captionMessage && !!workstationActiveSessionId;
 
   const handleToggleCaption = useCallback(() => {
     setCaptionEnabled((prev) => !prev);
@@ -193,7 +198,7 @@ const AgentStationTopHeader: React.FC = memo(() => {
           )}
         </NoDragRegion>
       </div>
-      {showCaptionBar && captionMessage ? (
+      {captionVisible && captionMessage ? (
         <NoDragRegion className="flex h-10 min-h-10 shrink-0 items-center justify-start px-3">
           <div className="w-full min-w-0">
             <CaptionBar
@@ -206,7 +211,9 @@ const AgentStationTopHeader: React.FC = memo(() => {
       ) : null}
     </div>
   );
-});
+};
+
+const AgentStationTopHeader = memo(AgentStationTopHeaderComponent);
 
 AgentStationTopHeader.displayName = "AgentStationTopHeader";
 

--- a/src/modules/WorkStation/AppShell/AppShell.caption.test.ts
+++ b/src/modules/WorkStation/AppShell/AppShell.caption.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppType } from "@src/engines/Simulator/types/appTypes";
+import { workstationActiveSessionIdAtom } from "@src/store/session";
+import {
+  simulatorCaptionBarEnabledAtom,
+  simulatorEffectiveDockAppAtom,
+} from "@src/store/ui/simulatorAtom";
+
+import AppShell from "./index";
+
+const { captionHook, frameSpy, station } = vi.hoisted(() => ({
+  captionHook: vi.fn(),
+  frameSpy: vi.fn(),
+  station: { agent: true },
+}));
+vi.mock("@src/engines/Simulator/hooks/useCurrentTurnLastAgentMessage", () => ({
+  useCurrentTurnLastAgentMessage: captionHook,
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset", () => ({
+  useCollapsedSidebarChromeOffset: () => 0,
+  useShouldOffsetWorkStationTopBar: () => false,
+}));
+vi.mock("@src/hooks/ui/workbench/usePinnedWorkbenchChrome", () => ({
+  usePinnedWorkbenchChromeVisible: () => false,
+  useWorkbenchRightEdgeReservation: () => ({ owner: null, reservedRight: 0 }),
+}));
+vi.mock("../shared", () => ({
+  SimulatorAgentChip: () => null,
+  StationModeChip: () => null,
+}));
+vi.mock("@src/engines/Simulator/components/CaptionBar", () => ({
+  default: ({ text }: { text: string }) =>
+    createElement("span", { "data-caption": true }, text),
+}));
+vi.mock("./AgentStationChromeFrame", () => ({
+  default: (props: { children: React.ReactNode; captionVisible: boolean }) => {
+    frameSpy(props);
+    return props.children;
+  },
+}));
+vi.mock("./AppShellContent", () => ({ AppShellContent: () => null }));
+vi.mock("./WorkstationTabBar", () => ({ default: () => null }));
+vi.mock("./WorkstationTabHeader", () => ({ default: () => null }));
+vi.mock("../shared/StatusBar/StatusBarRenderer", () => ({
+  StatusBarRenderer: () => null,
+}));
+vi.mock("../shared/StatusBar/WorkspacePortScanner", () => ({
+  WorkspacePortScanner: () => null,
+}));
+vi.mock("../shared/StatusBar/utils/useWorkspacePortAdvertisedUrls", () => ({
+  useWorkspacePortAdvertisedUrls: () => undefined,
+}));
+vi.mock("@src/hooks/tabHost/useWorkStationPanels", () => ({
+  useWorkStationPanels: () => ({ layoutMode: "left" }),
+}));
+vi.mock("./hooks/useAppShellActions", () => ({
+  useAppShellActions: () => ({
+    handleSelectRepo: vi.fn(),
+    handleOpenSettings: vi.fn(),
+  }),
+}));
+vi.mock("./hooks/useAppShellDerivedState", () => ({
+  useAppShellDerivedState: () => ({
+    activeHost: "code",
+    isCodeMode: true,
+    isBrowserMode: false,
+    isProjectMode: false,
+  }),
+}));
+vi.mock("./hooks/useAppShellDock", () => ({
+  useAppShellDock: () => ({ visitedModes: new Set() }),
+}));
+vi.mock("./hooks/useAppShellRepo", () => ({
+  useAppShellRepo: () => ({
+    repoPath: "",
+    repoName: "",
+    pathExists: true,
+    lastSeenPath: "",
+  }),
+}));
+vi.mock("./hooks/useAppShellSimulatorPanelSync", () => ({
+  useAppShellSimulatorPanelSync: () => undefined,
+}));
+vi.mock("./hooks/useAppShellStationMode", () => ({
+  useAppShellStationMode: () => ({
+    isAgentStation: station.agent,
+    illuminateAgentStationChrome: false,
+  }),
+}));
+vi.mock("./hooks/useAppShellStatusBar", () => ({
+  useAppShellStatusBar: () => undefined,
+}));
+vi.mock("./hooks/useLaunchpadTab", () => ({
+  useLaunchpadTab: () => undefined,
+}));
+vi.mock("./hooks/useTerminalTabTeardown", () => ({
+  useTerminalTabTeardown: () => undefined,
+}));
+vi.mock("./hooks/useWorkstationRouteEntry", () => ({
+  useWorkstationRouteEntry: () => undefined,
+}));
+
+describe("AppShell caption ownership", () => {
+  beforeEach(() => {
+    station.agent = true;
+    captionHook.mockReset();
+    frameSpy.mockClear();
+  });
+  function render(enabled: boolean, hasSession = true) {
+    const store = createStore();
+    store.set(simulatorCaptionBarEnabledAtom, enabled);
+    store.set(
+      workstationActiveSessionIdAtom,
+      hasSession ? "caption-session" : null
+    );
+    store.set(simulatorEffectiveDockAppAtom, AppType.CHANNELS);
+    return renderToStaticMarkup(
+      createElement(
+        Provider,
+        { store },
+        createElement(MemoryRouter, null, createElement(AppShell))
+      )
+    );
+  }
+  it.each([
+    ["assistant", "message", "simulator.agentSentMessageCaption"],
+    ["user", "message", "simulator.userSentMessageCaption"],
+    ["assistant", "thought", "simulator.thoughtSentMessageCaption"],
+  ])(
+    "selects once and preserves %s/%s channel notices",
+    (source, eventKind, expected) => {
+      captionHook.mockReturnValue({
+        text: "body",
+        source,
+        eventKind,
+        eventId: "e",
+        isCurrentEvent: true,
+      });
+      const markup = render(true);
+      expect(captionHook).toHaveBeenCalledTimes(1);
+      expect(markup).toContain(expected);
+      expect(frameSpy.mock.calls[0][0].captionVisible).toBe(true);
+    }
+  );
+  it.each([
+    [false, true],
+    [true, false],
+  ])(
+    "keeps frame and caption visibility aligned (%s/%s)",
+    (enabled, hasSession) => {
+      captionHook.mockReturnValue({
+        text: "body",
+        source: "assistant",
+        eventKind: "message",
+        eventId: "e",
+        isCurrentEvent: false,
+      });
+      expect(render(enabled, hasSession)).not.toContain("data-caption");
+      expect(frameSpy.mock.calls[0][0].captionVisible).toBe(false);
+    }
+  );
+  it("handles no message and My Station without caption spacing", () => {
+    captionHook.mockReturnValue(null);
+    expect(render(true)).not.toContain("data-caption");
+    expect(frameSpy.mock.calls[0][0].captionVisible).toBe(false);
+    frameSpy.mockClear();
+    station.agent = false;
+    expect(render(true)).not.toContain("data-caption");
+    expect(frameSpy.mock.calls[0][0].captionVisible).toBe(false);
+  });
+});

--- a/src/modules/WorkStation/AppShell/index.tsx
+++ b/src/modules/WorkStation/AppShell/index.tsx
@@ -134,7 +134,12 @@ const AppShell = React.memo(
         className="relative flex h-full w-full min-w-0 flex-col overflow-hidden bg-workstation-bg"
         style={isAgentStation ? undefined : primaryPaneSurfaceStyle}
       >
-        {isAgentStation && <AgentStationTopHeader />}
+        {isAgentStation && (
+          <AgentStationTopHeader
+            captionMessage={captionMessage}
+            captionVisible={agentStationCaptionVisible}
+          />
+        )}
         <AgentStationChromeFrame
           enabled={followAgentHighlightEnabled && isAgentStation}
           illuminated={illuminateAgentStationChrome}


### PR DESCRIPTION
## Problem

AppShell and AgentStationTopHeader each select the current caption and independently decide whether its row is visible.

## Solution

AppShell selects the caption once and passes the message and its existing visibility decision to AgentStationTopHeader. The frame and header now use the same visibility result. Keep user, assistant and thought channel notices and caption-toggle behavior.

## Potential risks

#1567 has merged into `develop`; this PR now targets `develop`.

A mismatch in parent/header props could affect caption spacing or notices. A rendered AppShell test with the real header verifies one selector call and aligned visibility, plus all three channel notices. No replay cursor, event payload, persistence or native webview behavior changes. Native pixels and runtime timing were not profiled. No dependency, schema, storage-key or wire-format changes; rollback is a normal revert.

## Verification

- `pnpm run typecheck:fast` — passed.
- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/AppShell/AppShell.caption.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx src/modules/WorkStation/AppShell/index.tsx` — passed, zero warnings.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell/AppShell.caption.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts` — 2 files, 9 tests passed.
- `git diff --check` — passed.

No native screenshots, actual webview interaction, CPU/RSS profiling or Rust checks were run. This is a behavior-preserving TypeScript refactor; native visual verification remains unclaimed. Architecture/lifecycle review and applicable UI audit are included under `docs/`.

### CI follow-up

Merged the updated #1567 base without rewriting history to include its shared pane-action rejection handler and rendered regression test.

- `pnpm test src/modules/WorkStation/AppShell/AppShell.caption.test.ts src/modules/WorkStation/AppShell/AgentStationTopHeader.test.ts src/modules/WorkStation/shared/StationPaneControls.test.ts` — 13 tests passed.
- `pnpm test:typed-lint` — 6 tests passed.
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm check:typed-lint` — passed, zero new or increased findings; baseline unchanged.
- `GOMAXPROCS=2 pnpm run typecheck:fast` — passed.
- `git diff --check` — passed.
