### PR TITLE
refactor(station-layout): narrow sidebar sync and guard webview timing

### DIFF
--- a/docs/architecture-audit-2026-09-11/StationSidebarPosition.md
+++ b/docs/architecture-audit-2026-09-11/StationSidebarPosition.md
@@ -1,0 +1,41 @@
+# StationSidebarPosition implementation review
+
+## Acceptance and ownership
+
+The sidebar synchronization hook accepts the entire workstation panel controller although it needs only layoutMode. The proposed removal of its gated mirror would change native webview invalidation timing.
+
+Narrow the hook contract to layoutMode and retain its existing Agent Station gate and effect timing. Document why the mirror is intentional. Add tests using the real BrowserSessionWebview component and a mocked native boundary to protect geometry-update behavior.
+
+Acceptance: replace all matching in-scope callers, preserve user behavior and persistence, pass focused tests and frontend checks, and keep changes isolated from unrelated working-tree edits.
+
+| Line                                                                        | Element          | Verdict          | Reason                                                                                                                                                                                                                                                                  | Suggested change                                  |
+| --------------------------------------------------------------------------- | ---------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.ts:8` | Shared ownership | keep with reason | Narrow the hook contract to layoutMode and retain its existing Agent Station gate and effect timing. Document why the mirror is intentional. Add tests using the real BrowserSessionWebview component and a mocked native boundary to protect geometry-update behavior. | Implemented in this change; no unrelated cleanup. |
+
+## Architecture coverage
+
+Layers 1–7: frontend compilation/lint, caller sweep, naming, distinct station/host meanings, defaults, ownership boundaries, and readability reviewed. Layer 8: no serialized format, IPC or storage-key change; no real wire dump was needed for this internal refactor. Layer 9: existing station entry points retained and focused tests exercise changed ownership. Layer 10: preserve caller-specific visibility/selection policies rather than forcing false symmetry. Backend initialization and account/model resolvers are outside scope.
+
+## Lifecycle and performance
+
+| Area               | Verdict | Evidence                                       | Change or reason kept                                                                                                                                                                                                                                                   | Verification                        |
+| ------------------ | ------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Background work    | keep    | No new polling, listeners, workers or requests | Existing owner and mount/cleanup rules retained                                                                                                                                                                                                                         | Focused suites below                |
+| Memory             | keep    | No new app-lifetime collections or caches      | State stays with current atoms/components                                                                                                                                                                                                                               | Diff inspection; no RSS measurement |
+| Scope/isolation    | keep    | Existing station and store boundaries          | No shared cross-account/session cache introduced                                                                                                                                                                                                                        | Caller sweep                        |
+| Rendering/hot path | fix     | Common computation/config/action ownership     | Narrow the hook contract to layoutMode and retain its existing Agent Station gate and effect timing. Document why the mirror is intentional. Add tests using the real BrowserSessionWebview component and a mocked native boundary to protect geometry-update behavior. | Focused tests; no timing claim      |
+
+Applicable matrix: mount/unmount and station/visibility transitions at changed UI boundaries; existing online/offline, identity, transport and multi-instance ownership is unchanged. No provider ingestion or sync changes. Native Tauri pixels/CPU/RSS were not measured: Computer Use was not authorized. Performance verdict: blocked for live native measurement; no performance improvement is claimed. Automated correctness evidence is listed separately.
+
+## Risks
+
+The gated mirror is deliberately retained to meet the no-webview-impact requirement. Tests protect silence during My Station edits, four forced resize ticks at 0/50/100/170 ms for Agent Station changes, no duplicate ticks on unchanged renders, inactive-tab suppression and unmount cancellation. Actual WKWebView pixels were not exercised; no native/webview source was changed. Rollback is a normal commit revert; no data migration or recovery is required.
+
+## Verification
+
+- `pnpm run typecheck:fast` — passed.
+- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.test.ts src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.ts src/modules/WorkStation/AppShell/index.tsx` — passed with zero warnings.
+- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.test.ts src/engines/BrowserCore/BrowserSessionWebview.test.ts src/modules/WorkStation/AppShell/hostMountPolicy.test.ts` — 3 files, 17 tests passed.
+- `git diff --check` — passed.
+
+Focused suites may emit existing Vite/Sass/Jotai/React Router deprecation notices. Full Rust builds and native UI/CPU/RSS checks were not run; no backend code changed. Tests do not substitute for native visual verification.

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.test.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import BrowserSessionWebview from "@src/engines/BrowserCore/BrowserSessionWebview";
+import { simulatorPrimarySidebarPositionAtom } from "@src/store/ui/simulatorAtom";
+import type { LayoutMode } from "@src/store/ui/workStationLayout/splitLayoutAtoms";
+
+import { useAppShellSimulatorPanelSync } from "./useAppShellSimulatorPanelSync";
+
+const { updatePosition } = vi.hoisted(() => ({ updatePosition: vi.fn() }));
+vi.mock("@src/hooks/platform/useInlineWebview", () => ({
+  useInlineWebview: () => ({
+    updatePosition,
+    isWebviewAvailable: false,
+    isWebviewCreated: false,
+  }),
+}));
+
+const session = {
+  id: "geometry-test",
+  url: "https://example.com",
+  title: "Example",
+  history: ["https://example.com"],
+  historyIndex: 0,
+  isLoading: false,
+  error: null,
+};
+const containerRef = { current: null };
+const onSessionUpdate = vi.fn();
+function Harness({
+  isAgentStation,
+  layoutMode,
+  active = true,
+  tabActive = true,
+}: {
+  isAgentStation: boolean;
+  layoutMode: LayoutMode;
+  active?: boolean;
+  tabActive?: boolean;
+}) {
+  useAppShellSimulatorPanelSync({ isAgentStation, layoutMode });
+  return createElement(BrowserSessionWebview, {
+    session,
+    containerRef,
+    onSessionUpdate,
+    isActive: active,
+    isTabActive: tabActive,
+  });
+}
+
+describe("simulator sidebar sync at the native webview boundary", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let store: ReturnType<typeof createStore>;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    store = createStore();
+    container = document.createElement("div");
+    root = createRoot(container);
+    updatePosition.mockClear();
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.useRealTimers();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+  function render(
+    isAgentStation: boolean,
+    layoutMode: LayoutMode,
+    active = true,
+    tabActive = true
+  ) {
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(Harness, {
+            isAgentStation,
+            layoutMode,
+            active,
+            tabActive,
+          })
+        )
+      )
+    );
+  }
+  function flush() {
+    act(() => vi.advanceTimersByTime(200));
+  }
+
+  it("keeps My Station edits quiet and preserves Agent Station's four resize ticks", () => {
+    render(false, "left");
+    flush();
+    expect(updatePosition).toHaveBeenCalledTimes(4);
+    updatePosition.mockClear();
+    render(false, "right");
+    flush();
+    expect(store.get(simulatorPrimarySidebarPositionAtom)).toBe("left");
+    expect(updatePosition).not.toHaveBeenCalled();
+    render(true, "right");
+    expect(store.get(simulatorPrimarySidebarPositionAtom)).toBe("right");
+    act(() => vi.advanceTimersByTime(0));
+    expect(updatePosition).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(50));
+    expect(updatePosition).toHaveBeenCalledTimes(2);
+    act(() => vi.advanceTimersByTime(50));
+    expect(updatePosition).toHaveBeenCalledTimes(3);
+    act(() => vi.advanceTimersByTime(70));
+    expect(updatePosition).toHaveBeenCalledTimes(4);
+    expect(updatePosition).toHaveBeenLastCalledWith({ force: true });
+    updatePosition.mockClear();
+    render(true, "right");
+    flush();
+    expect(updatePosition).not.toHaveBeenCalled();
+    render(false, "left");
+    flush();
+    expect(store.get(simulatorPrimarySidebarPositionAtom)).toBe("right");
+    expect(updatePosition).not.toHaveBeenCalled();
+    render(true, "left");
+    flush();
+    expect(updatePosition).toHaveBeenCalledTimes(4);
+  });
+
+  it.each([
+    [false, true],
+    [true, false],
+  ])("does not resize inactive webviews (%s/%s)", (active, tabActive) => {
+    render(true, "right", active, tabActive);
+    flush();
+    render(true, "left", active, tabActive);
+    flush();
+    expect(updatePosition).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending animation ticks on unmount", () => {
+    render(true, "right");
+    act(() => vi.advanceTimersByTime(0));
+    expect(updatePosition).toHaveBeenCalledTimes(1);
+    act(() => root.render(null));
+    flush();
+    expect(updatePosition).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.ts
@@ -1,20 +1,23 @@
 import { useSetAtom } from "jotai";
 import { useEffect } from "react";
 
-import { useWorkStationPanels } from "@src/hooks/tabHost/useWorkStationPanels";
 import { simulatorPrimarySidebarPositionAtom } from "@src/store/ui/simulatorAtom";
+import type { LayoutMode } from "@src/store/ui/workStationLayout/splitLayoutAtoms";
 
 export function useAppShellSimulatorPanelSync({
   isAgentStation,
-  workStationPanels,
+  layoutMode,
 }: {
   isAgentStation: boolean;
-  workStationPanels: ReturnType<typeof useWorkStationPanels>;
+  layoutMode: LayoutMode;
 }): void {
   const setSimSidebarPosition = useSetAtom(simulatorPrimarySidebarPositionAtom);
 
+  // This is intentionally a gated mirror, not an always-live derivation:
+  // native browser webviews observe this atom to schedule position updates.
+  // My Station layout edits must not invalidate their simulator geometry.
   useEffect(() => {
     if (!isAgentStation) return;
-    setSimSidebarPosition(workStationPanels.layoutMode);
-  }, [isAgentStation, workStationPanels.layoutMode, setSimSidebarPosition]);
+    setSimSidebarPosition(layoutMode);
+  }, [isAgentStation, layoutMode, setSimSidebarPosition]);
 }

--- a/src/modules/WorkStation/AppShell/index.tsx
+++ b/src/modules/WorkStation/AppShell/index.tsx
@@ -83,7 +83,10 @@ const AppShell = React.memo(
     useTerminalTabTeardown();
 
     const workStationPanels = useWorkStationPanels();
-    useAppShellSimulatorPanelSync({ isAgentStation, workStationPanels });
+    useAppShellSimulatorPanelSync({
+      isAgentStation,
+      layoutMode: workStationPanels.layoutMode,
+    });
 
     const { handleSelectRepo, handleOpenSettings } = useAppShellActions();
 


### PR DESCRIPTION
## Problem

The sidebar synchronization hook accepts the entire workstation panel controller although it needs only layoutMode. The proposed removal of its gated mirror would change native webview invalidation timing.

## Solution

Narrow the hook contract to layoutMode and retain its existing Agent Station gate and effect timing. Document why the mirror is intentional. Add tests using the real BrowserSessionWebview component and a mocked native boundary to protect geometry-update behavior.

## Potential risks

The gated mirror is deliberately retained to meet the no-webview-impact requirement. Tests protect silence during My Station edits, four forced resize ticks at 0/50/100/170 ms for Agent Station changes, no duplicate ticks on unchanged renders, inactive-tab suppression and unmount cancellation. Actual WKWebView pixels were not exercised; no native/webview source was changed. No dependency, schema, storage-key or wire-format changes; rollback is a normal revert.

## Verification

- `pnpm run typecheck:fast` — passed.
- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.test.ts src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.ts src/modules/WorkStation/AppShell/index.tsx` — passed, zero warnings.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell/hooks/useAppShellSimulatorPanelSync.test.ts src/engines/BrowserCore/BrowserSessionWebview.test.ts src/modules/WorkStation/AppShell/hostMountPolicy.test.ts` — 3 files, 17 tests passed.
- `git diff --check` — passed.

No native screenshots, actual webview interaction, CPU/RSS profiling or Rust checks were run. This is a behavior-preserving TypeScript refactor; native visual verification remains unclaimed. Architecture/lifecycle review and applicable UI audit are included under `docs/`.
