### PR TITLE
refactor(browser): share selected element submission to chat

### DIFF
--- a/docs/architecture-audit-2026-09-11/BrowserSelectionChat.md
+++ b/docs/architecture-audit-2026-09-11/BrowserSelectionChat.md
@@ -1,0 +1,41 @@
+# BrowserSelectionChat implementation review
+
+## Acceptance and ownership
+
+The live browser status bar and Agent Station browser repeat DOM payload construction, add-to-agent submission and success feedback wiring.
+
+Route both owners through sendSelectedElementToChat. Keep the existing formatter and make selection clearing explicit: My Station retains selection and Agent Station clears it after submission, before the success toast.
+
+Acceptance: replace all matching in-scope callers, preserve user behavior and persistence, pass focused tests and frontend checks, and keep changes isolated from unrelated working-tree edits.
+
+| Line                                                                    | Element          | Verdict | Reason                                                                                                                                                                                                                      | Suggested change                                  |
+| ----------------------------------------------------------------------- | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.ts:7` | Shared ownership | fix     | Route both owners through sendSelectedElementToChat. Keep the existing formatter and make selection clearing explicit: My Station retains selection and Agent Station clears it after submission, before the success toast. | Implemented in this change; no unrelated cleanup. |
+
+## Architecture coverage
+
+Layers 1–7: frontend compilation/lint, caller sweep, naming, distinct station/host meanings, defaults, ownership boundaries, and readability reviewed. Layer 8: no serialized format, IPC or storage-key change; no real wire dump was needed for this internal refactor. Layer 9: existing station entry points retained and focused tests exercise changed ownership. Layer 10: preserve caller-specific visibility/selection policies rather than forcing false symmetry. Backend initialization and account/model resolvers are outside scope.
+
+## Lifecycle and performance
+
+| Area               | Verdict | Evidence                                       | Change or reason kept                                                                                                                                                                                                       | Verification                        |
+| ------------------ | ------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Background work    | keep    | No new polling, listeners, workers or requests | Existing owner and mount/cleanup rules retained                                                                                                                                                                             | Focused suites below                |
+| Memory             | keep    | No new app-lifetime collections or caches      | State stays with current atoms/components                                                                                                                                                                                   | Diff inspection; no RSS measurement |
+| Scope/isolation    | keep    | Existing station and store boundaries          | No shared cross-account/session cache introduced                                                                                                                                                                            | Caller sweep                        |
+| Rendering/hot path | fix     | Common computation/config/action ownership     | Route both owners through sendSelectedElementToChat. Keep the existing formatter and make selection clearing explicit: My Station retains selection and Agent Station clears it after submission, before the success toast. | Focused tests; no timing claim      |
+
+Applicable matrix: mount/unmount and station/visibility transitions at changed UI boundaries; existing online/offline, identity, transport and multi-instance ownership is unchanged. No provider ingestion or sync changes. Native Tauri pixels/CPU/RSS were not measured: Computer Use was not authorized. Performance verdict: blocked for live native measurement; no performance improvement is claimed. Automated correctness evidence is listed separately.
+
+## Risks
+
+Selection-clearing and feedback order must remain intact. Tests cover missing selection, both retention policies, one payload submission with URL/selector/dimensions, and failure before cleanup/feedback. No storage, native inspector, IPC or webview lifecycle changes. Native browser interaction was not exercised. Rollback is a normal commit revert; no data migration or recovery is required.
+
+## Verification
+
+- `pnpm run typecheck:fast` — passed.
+- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.test.ts src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.ts src/modules/WorkStation/Browser/BrowserLayout/useBrowserStatusBar.ts src/modules/WorkStation/Browser/SessionReplay/index.tsx` — passed with zero warnings.
+- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.test.ts src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts` — 2 files, 8 tests passed.
+- `git diff --check` — passed.
+
+Focused suites may emit existing Vite/Sass/Jotai/React Router deprecation notices. Full Rust builds and native UI/CPU/RSS checks were not run; no backend code changed. Tests do not substitute for native visual verification.

--- a/docs/frontend-ui-audit-2026-09-11/BrowserSelectionChat.md
+++ b/docs/frontend-ui-audit-2026-09-11/BrowserSelectionChat.md
@@ -1,0 +1,9 @@
+# BrowserSelectionChat UI audit
+
+| Line                                                                    | Element                  | Verdict          | Reason                                                                                                                                                         | Suggested change                                          |
+| ----------------------------------------------------------------------- | ------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.ts:7` | Existing visual boundary | keep with reason | This refactor preserves existing controls, sidebar content, caption presentation or browser status-bar ownership; no new design primitive or styling is needed | Retain existing DS components and owner-specific variants |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.
+
+The consolidation is implemented, with evidence in the architecture review of the same name. D1–D5 review of the changed diff found no new raw interactive HTML, arbitrary visual tokens/colors, accessibility semantics or repeated visual scaffolding needing another abstraction. No theme/viewport screenshots: behavior-preserving extraction, with native visual validation not performed because Computer Use was not authorized.

--- a/src/modules/WorkStation/Browser/BrowserLayout/useBrowserStatusBar.ts
+++ b/src/modules/WorkStation/Browser/BrowserLayout/useBrowserStatusBar.ts
@@ -16,8 +16,8 @@ import {
   browserStatusBarStateAtom,
 } from "@src/store/ui/workStationLayout/statusBarAtoms";
 
+import { sendSelectedElementToChat } from "../shared/sendSelectedElementToChat";
 import { buildSelectedElementLabel } from "./browserLayoutUtils";
-import { buildDomComponentJsonFromElementInfo } from "./buildDomComponentJson";
 
 interface BrowserStatusBarSyncOptions {
   isActive: boolean;
@@ -101,13 +101,12 @@ export function useBrowserStatusBar({
   useEffect(() => {
     if (!isActive) return;
     const handleSendSelectedElementToChat = () => {
-      if (!selectedElement) return;
-      const { jsonText, fileName } = buildDomComponentJsonFromElementInfo(
+      sendSelectedElementToChat({
         selectedElement,
-        currentUrl
-      );
-      setAddToAgent({ type: "dom-component", fileName, jsonText });
-      toastSuccess(chatSentToastMessage);
+        currentUrl,
+        setAddToAgent,
+        onSent: () => toastSuccess(chatSentToastMessage),
+      });
     };
 
     setStatusBarCallbacks((prev) => ({

--- a/src/modules/WorkStation/Browser/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/Browser/SessionReplay/index.tsx
@@ -16,7 +16,6 @@ import {
   Shield01Icon,
 } from "@src/icons";
 import { buildSelectedElementLabel } from "@src/modules/WorkStation/Browser/BrowserLayout/browserLayoutUtils";
-import { buildDomComponentJsonFromElementInfo } from "@src/modules/WorkStation/Browser/BrowserLayout/buildDomComponentJson";
 import { useBrowserSessions } from "@src/modules/WorkStation/Browser/hooks/useBrowserSessions";
 import {
   NoTabsPlaceholder,
@@ -49,6 +48,7 @@ import {
   SharedBrowserDevToolsPanel,
   SharedBrowserWorkspace,
 } from "../shared";
+import { sendSelectedElementToChat } from "../shared/sendSelectedElementToChat";
 import BrowserSidebar from "./BrowserSidebar";
 import {
   TAB_ID_BY_ENTRY_CATEGORY,
@@ -396,20 +396,14 @@ const SessionReplayBrowserComponent: React.FC<SessionReplayBrowserProps> = ({
   const clearSelection = myTabsBrowser.clearSelection;
 
   const handleSendSelectedElementToChat = useCallback(() => {
-    if (!selectedElement) return;
-
-    const { jsonText, fileName } = buildDomComponentJsonFromElementInfo(
+    sendSelectedElementToChat({
       selectedElement,
-      currentUrl
-    );
-
-    setAddToAgent({
-      type: "dom-component",
-      fileName,
-      jsonText,
+      currentUrl,
+      setAddToAgent,
+      clearSelection,
+      onSent: () =>
+        Message.success(tCommon("browser.selectedElement.sentToChat")),
     });
-    clearSelection();
-    Message.success(tCommon("browser.selectedElement.sentToChat"));
   }, [selectedElement, currentUrl, clearSelection, setAddToAgent, tCommon]);
 
   const myTabsStatusBar = useMemo(() => {

--- a/src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.test.ts
+++ b/src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AddToAgentRequest } from "@src/store/ui/addToAgentAtom";
+
+import type { ElementInfo } from "../hooks/useWebviewInspector";
+import { sendSelectedElementToChat } from "./sendSelectedElementToChat";
+
+const element: ElementInfo = {
+  tagName: "BUTTON",
+  selector: "#save",
+  id: "save",
+  className: "action",
+  attributes: {},
+  innerText: "Save",
+  innerHTML: "Save",
+  rect: { x: 10, y: 20, width: 80, height: 30 },
+  computedStyle: {
+    display: "block",
+    position: "static",
+    color: null,
+    backgroundColor: null,
+    fontSize: null,
+    fontFamily: null,
+  },
+  role: "button",
+  xpath: "/button",
+  sourceLocation: null,
+};
+
+describe("sendSelectedElementToChat", () => {
+  it("does nothing without a selection", () => {
+    const setAddToAgent = vi.fn();
+    const onSent = vi.fn();
+    const clearSelection = vi.fn();
+    sendSelectedElementToChat({
+      selectedElement: null,
+      currentUrl: "https://example.com",
+      setAddToAgent,
+      onSent,
+      clearSelection,
+    });
+    expect(setAddToAgent).not.toHaveBeenCalled();
+    expect(clearSelection).not.toHaveBeenCalled();
+    expect(onSent).not.toHaveBeenCalled();
+  });
+  it.each([false, true])(
+    "sends the payload once with explicit clear policy %s",
+    (clear) => {
+      const calls: string[] = [];
+      const setAddToAgent = vi.fn<(request: AddToAgentRequest) => void>(() => {
+        calls.push("send");
+      });
+      const clearSelection = vi.fn(() => {
+        calls.push("clear");
+      });
+      const onSent = () => {
+        calls.push("toast");
+      };
+      sendSelectedElementToChat({
+        selectedElement: element,
+        currentUrl: "https://example.com/page",
+        setAddToAgent,
+        onSent,
+        ...(clear ? { clearSelection } : {}),
+      });
+      expect(setAddToAgent).toHaveBeenCalledTimes(1);
+      expect(setAddToAgent).toHaveBeenCalledWith({
+        type: "dom-component",
+        fileName: "button.json",
+        jsonText: expect.any(String),
+      });
+      const payload = setAddToAgent.mock.calls[0];
+      if (payload[0].type !== "dom-component")
+        throw new Error("Expected DOM component payload");
+      expect(JSON.parse(payload[0].jsonText)).toMatchObject({
+        cssSelector: "#save",
+        dimensions: { width: 80, height: 30 },
+        meta: { url: "https://example.com/page" },
+      });
+      expect(calls).toEqual(
+        clear ? ["send", "clear", "toast"] : ["send", "toast"]
+      );
+    }
+  );
+  it("does not clear or announce success if submission fails", () => {
+    const clearSelection = vi.fn();
+    const onSent = vi.fn();
+    expect(() =>
+      sendSelectedElementToChat({
+        selectedElement: element,
+        currentUrl: "",
+        setAddToAgent: () => {
+          throw new Error("failed");
+        },
+        clearSelection,
+        onSent,
+      })
+    ).toThrow("failed");
+    expect(clearSelection).not.toHaveBeenCalled();
+    expect(onSent).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.ts
+++ b/src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.ts
@@ -1,0 +1,28 @@
+import type { AddToAgentRequest } from "@src/store/ui/addToAgentAtom";
+
+import { buildDomComponentJsonFromElementInfo } from "../BrowserLayout/buildDomComponentJson";
+import type { ElementInfo } from "../hooks/useWebviewInspector";
+
+/** Callers retain ownership of selection: My Station keeps it, replay clears it. */
+export function sendSelectedElementToChat({
+  selectedElement,
+  currentUrl,
+  setAddToAgent,
+  onSent,
+  clearSelection,
+}: {
+  selectedElement: ElementInfo | null;
+  currentUrl: string;
+  setAddToAgent: (request: AddToAgentRequest) => void;
+  onSent: () => void;
+  clearSelection?: () => void;
+}): void {
+  if (!selectedElement) return;
+  const { jsonText, fileName } = buildDomComponentJsonFromElementInfo(
+    selectedElement,
+    currentUrl
+  );
+  setAddToAgent({ type: "dom-component", fileName, jsonText });
+  clearSelection?.();
+  onSent();
+}


### PR DESCRIPTION
## Problem

The live browser status bar and Agent Station browser repeat DOM payload construction, add-to-agent submission and success feedback wiring.

## Solution

Route both owners through sendSelectedElementToChat. Keep the existing formatter and make selection clearing explicit: My Station retains selection and Agent Station clears it after submission, before the success toast.

## Potential risks

Selection-clearing and feedback order must remain intact. Tests cover missing selection, both retention policies, one payload submission with URL/selector/dimensions, and failure before cleanup/feedback. No storage, native inspector, IPC or webview lifecycle changes. Native browser interaction was not exercised. No dependency, schema, storage-key or wire-format changes; rollback is a normal revert.

## Verification

- `pnpm run typecheck:fast` — passed.
- `pnpm exec eslint --max-warnings 0 src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.test.ts src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.ts src/modules/WorkStation/Browser/BrowserLayout/useBrowserStatusBar.ts src/modules/WorkStation/Browser/SessionReplay/index.tsx` — passed, zero warnings.
- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/Browser/shared/sendSelectedElementToChat.test.ts src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts` — 2 files, 8 tests passed.
- `git diff --check` — passed.

No native screenshots, actual webview interaction, CPU/RSS profiling or Rust checks were run. This is a behavior-preserving TypeScript refactor; native visual verification remains unclaimed. Architecture/lifecycle review and applicable UI audit are included under `docs/`.
