### PR TITLE
test(file-header): align page settings label assertion

### DIFF
--- a/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts
+++ b/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts
@@ -135,7 +135,7 @@ describe("FileHeaderMoreMenu", () => {
       showReloadButton: false,
     });
     const menu = element("file-header-more-menu");
-    expect(menu.textContent).toContain("common:actions.uiSettings");
+    expect(menu.textContent).toContain("sessions:chat.pageSettings");
     expect(
       [...menu.children].filter(
         (child) => child.className === DROPDOWN_CLASSES.menuGroupSeparator


### PR DESCRIPTION
## Problem

The frontend test suite fails on develop because `FileHeaderMoreMenu` now renders `sessions:chat.pageSettings` after #1563, while its separator regression test still expects the former `common:actions.uiSettings` label. The same pre-existing failure blocks #1574's full frontend CI.

## Solution

Update the one stale label assertion to the current page-settings translation key. Keep the separator, item-count, and interaction assertions intact. No application code or translations change.

## Potential risks

This is a test-only correction to match the existing product behavior. It neither changes UI behavior nor weakens the separator regression assertions. Screenshots are unnecessary because there is no visual change. All applicable GitHub checks passed on `fbd462401`, including the complete frontend suite; Rust jobs were correctly skipped for this test-only change.

## Verification

- On an isolated checkout of develop `1efdb932c`, `node_modules/.bin/vitest run --config config/vitest.config.ts src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts` reproduced the failure: 1 failed, 5 passed.
- The same command after the one-line correction: all 6 tests passed.
- Normal commit hooks passed lint and TypeScript checks.
- `git diff --check` passed; the diff contains only the expected assertion change, with no runtime files, credentials, or generated artifacts.

- Combined with #1574 (`f0702aed7`) in an isolated detached checkout, `pnpm run test` passed all 1,781 files: **13,330 passed, 1 skipped** (216.73 seconds). This check used exactly the one-line correction from this PR.
