### PR TITLE
fix(agent-org): preserve direct member routing and return

### DIFF
--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/store_drain.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox/store_drain.rs
@@ -565,27 +565,33 @@ impl AgentInboxStore {
                     let is_resume_continuation =
                         turn_is_resume_continuation(&tx, session_id, turn_intent_id)?;
                     for id in ids {
-                        let assignment_status: Option<String> = tx
+                        let unsettled_assignment_status: Option<String> = tx
                             .query_row(
                                 "SELECT task.status
                                  FROM agent_org_runtime_inbox inbox
                                  JOIN agent_org_runtime_tasks task
                                    ON task.org_run_id=inbox.org_run_id
                                   AND task.id=json_extract(inbox.payload_json,'$.task_id')
-                                 WHERE inbox.id=?1 AND inbox.payload_kind='task_assigned'",
+                                 WHERE inbox.id=?1 AND inbox.payload_kind='task_assigned'
+                                   AND NOT EXISTS (
+                                       SELECT 1
+                                       FROM agent_org_runtime_inbox_delivery_resolutions resolution
+                                       WHERE resolution.inbox_id=inbox.id
+                                   )",
                                 [id],
                                 |row| row.get(0),
                             )
                             .optional()
                             .map_err(|err| err.to_string())?;
-                        if is_resume_continuation && assignment_status.is_some() {
+                        if is_resume_continuation && unsettled_assignment_status.is_some() {
                             let owns_assignment = resume_continuation_owns_assignment(
                                 &tx,
                                 session_id,
                                 turn_intent_id,
                                 *id,
                             )?;
-                            if assignment_status.as_deref() != Some("completed") || !owns_assignment
+                            if unsettled_assignment_status.as_deref() != Some("completed")
+                                || !owns_assignment
                             {
                                 return Err(format!(
                                     "Agent Org Inbox row {id} remains unread because its exact Resume continuation did not complete the Task successfully"
@@ -758,17 +764,19 @@ fn task_status_is_pending(
     .map_err(|error| error.to_string())
 }
 
-/// Exact authority for the one exceptional TaskAssigned transition: the Task
-/// was already moved to in_progress by the pre-Pause Turn, so only the
-/// durable continuation created from that same handoff may consume it.
+/// Exact authority for the exceptional TaskAssigned continuation: the Task
+/// was already moved to in_progress by the suspended Turn, so only the
+/// durable continuation created from that exact Pause handoff or Member
+/// intervention receipt may consume it.
 fn resume_continuation_owns_assignment(
     conn: &rusqlite::Connection,
     session_id: &str,
     turn_intent_id: &str,
     inbox_id: i64,
 ) -> Result<bool, String> {
-    conn.query_row(
-        "SELECT EXISTS(
+    let owns_pause_assignment = conn
+        .query_row(
+            "SELECT EXISTS(
              SELECT 1
              FROM agent_org_runtime_pause_handoffs handoff
              JOIN agent_org_runtime_pause_episodes episode
@@ -822,6 +830,68 @@ fn resume_continuation_owns_assignment(
                    WHERE resolution.inbox_id=inbox.id
                )
          )",
+            params![session_id, turn_intent_id, inbox_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| error.to_string())?;
+    if owns_pause_assignment {
+        return Ok(true);
+    }
+
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1
+             FROM agent_org_runtime_member_interventions intervention
+             JOIN agent_org_runtime_runs run ON run.id=intervention.org_run_id
+             JOIN agent_org_runtime_turn_contexts continuation
+               ON continuation.session_id=intervention.session_id
+              AND continuation.turn_intent_id=intervention.continuation_turn_intent_id
+             JOIN agent_org_runtime_turn_contexts original
+               ON original.session_id=intervention.session_id
+              AND original.turn_intent_id=intervention.original_turn_intent_id
+             JOIN session_turn_intents intent
+               ON intent.session_id=intervention.session_id
+              AND intent.turn_intent_id=intervention.continuation_turn_intent_id
+             JOIN agent_org_runtime_tasks task
+               ON task.org_run_id=intervention.org_run_id
+              AND task.id=intervention.original_task_id
+             JOIN agent_org_runtime_inbox inbox
+               ON inbox.id=?3
+              AND inbox.org_run_id=intervention.org_run_id
+              AND inbox.recipient_member_id=intervention.member_id
+             JOIN agent_org_runtime_inbox_materializations materialization
+               ON materialization.inbox_id=inbox.id
+              AND materialization.session_id=intervention.session_id
+             WHERE intervention.session_id=?1
+               AND intervention.continuation_turn_intent_id=?2
+               AND intervention.status='cleared'
+               AND intervention.return_outcome='restored_task'
+               AND run.status='running'
+               AND intent.status IN ('queued','running')
+               AND continuation.turn_kind='task_execution'
+               AND continuation.source_kind='task'
+               AND continuation.task_id=intervention.original_task_id
+               AND continuation.owner_member_id=intervention.member_id
+               AND continuation.activation_generation=run.activation_generation
+               AND original.turn_kind='task_execution'
+               AND original.source_kind='task'
+               AND original.task_id=intervention.original_task_id
+               AND original.owner_member_id=intervention.member_id
+               AND original.activation_generation=run.activation_generation
+               AND task.status IN ('in_progress','completed')
+               AND task.owner=intervention.member_id
+               AND inbox.delivery_class='formal_work'
+               AND inbox.read_at IS NULL
+               AND inbox.payload_kind='task_assigned'
+               AND json_valid(inbox.payload_json)
+               AND json_type(inbox.payload_json,'$.task_id')='text'
+               AND json_extract(inbox.payload_json,'$.task_id')=intervention.original_task_id
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM agent_org_runtime_inbox_delivery_resolutions resolution
+                   WHERE resolution.inbox_id=inbox.id
+               )
+         )",
         params![session_id, turn_intent_id, inbox_id],
         |row| row.get(0),
     )
@@ -839,6 +909,12 @@ fn turn_is_resume_continuation(
              WHERE session_id=?1
                AND continuation_turn_intent_id=?2
                AND continuation_status='dispatched'
+             UNION ALL
+             SELECT 1 FROM agent_org_runtime_member_interventions
+             WHERE session_id=?1
+               AND continuation_turn_intent_id=?2
+               AND status='cleared'
+               AND return_outcome='restored_task'
          )",
         params![session_id, turn_intent_id],
         |row| row.get(0),

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_member_interventions_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_member_interventions_tests.rs
@@ -1,9 +1,11 @@
 use super::*;
+use crate::coordination::agent_inbox::{AgentInboxStore, AgentMessage, InsertInboxParams};
 use crate::coordination::agent_org_runs::{
     AgentOrgRunEntryMode, AgentOrgRunStore, CreateAgentOrgRunParams,
 };
 use crate::coordination::agent_org_tasks::{
-    AgentOrgTaskStore, CreateTaskParams, TaskStatus, TASK_METADATA_ELIGIBLE_MEMBER_IDS,
+    AgentOrgTaskStore, CreateTaskParams, TaskOutputInput, TaskOwnerExecution, TaskStatus,
+    TASK_METADATA_ELIGIBLE_MEMBER_IDS,
 };
 use crate::definitions::orgs::{FlatOrgMember, OrgDefinition, PlanApprovalPolicy};
 use crate::foundation::session_bridge::{TurnIntentBridgeSource, TurnIntentBridgeStatus};
@@ -1071,6 +1073,22 @@ fn return_restores_one_exact_continuation_and_never_duplicates_it() {
         })),
     })
     .expect("create restorable Task");
+    let assignment = AgentInboxStore::insert(InsertInboxParams {
+        recipient_agent_id: MEMBER_AGENT_ID.to_string(),
+        recipient_member_id: Some(MEMBER_ID.to_string()),
+        sender_agent_id: "agent-root-restore".to_string(),
+        sender_member_id: Some(COORDINATOR_MEMBER_ID.to_string()),
+        org_run_id: Some(fixture.run_id.clone()),
+        message: AgentMessage::TaskAssigned {
+            task_id: "task-restore".to_string(),
+            subject: "restore me".to_string(),
+            description: String::new(),
+            assigned_by: "Coordinator".to_string(),
+            execution_mode: crate::coordination::agent_org_tasks::TaskExecutionMode::Build,
+            dependency_outputs: Vec::new(),
+        },
+    })
+    .expect("seed original Task assignment");
     agent_org_turn_contexts::accept(&AgentOrgTurnAdmission::task_execution(
         &fixture.run_id,
         &fixture.member_session_id,
@@ -1094,6 +1112,17 @@ fn return_restores_one_exact_continuation_and_never_duplicates_it() {
         [&fixture.member_session_id],
     )
     .expect("start original formal Turn");
+    conn.execute(
+        "INSERT INTO agent_org_runtime_inbox_materializations (
+             inbox_id,session_id,transcript_message_id,transcript_intent_id,materialized_at
+         ) VALUES (?1,?2,'task-restore-source','turn-original',?3)",
+        params![
+            assignment.id,
+            &fixture.member_session_id,
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )
+    .expect("materialize original Task assignment");
     drop(conn);
 
     seed_direct_source(&fixture, "event-restore", "turn-direct", "quick fix");
@@ -1168,6 +1197,30 @@ fn return_restores_one_exact_continuation_and_never_duplicates_it() {
         )
         .expect("count continuations");
     assert_eq!(continuation_count, 1);
+    let resumed_input = AgentInboxStore::list_unread_task_input_for_turn(
+        MEMBER_ID,
+        &fixture.run_id,
+        "task-restore",
+        &fixture.member_session_id,
+        &continuation_id,
+    )
+    .expect("Return continuation reclaims the original Task input");
+    assert_eq!(
+        resumed_input
+            .rows
+            .iter()
+            .map(|row| row.id)
+            .collect::<Vec<_>>(),
+        vec![assignment.id]
+    );
+    let early_ack = AgentInboxStore::mark_many_read_for_turn(
+        &[assignment.id],
+        &fixture.member_session_id,
+        &continuation_id,
+        None,
+    )
+    .expect_err("Return continuation must finish the Task before acknowledging its input");
+    assert!(early_ack.contains("exact Resume continuation did not complete the Task"));
     assert!(AgentMemberInterventionStore::continuation_is_dispatchable(
         &fixture.member_session_id,
         &continuation_id,
@@ -1200,6 +1253,176 @@ fn return_restores_one_exact_continuation_and_never_duplicates_it() {
         &continuation_id,
     )
     .expect("requeued continuation dispatchability"));
+    AgentOrgTaskStore::owner_complete_with_transactional_effects(
+        TaskOwnerExecution::new(&fixture.member_session_id, &continuation_id)
+            .expect("Return continuation owner authority"),
+        &fixture.run_id,
+        "task-restore",
+        TaskOutputInput {
+            summary: "restored Task completed".to_string(),
+            content: None,
+            artifact_ids: Vec::new(),
+        },
+        |_tx, _outcome, _tasks| Ok(()),
+    )
+    .expect("complete restored Task through the production settlement path");
+    let conn = get_connection().expect("test sqlite connection");
+    conn.execute(
+        "UPDATE session_turn_intents SET status='completed'
+         WHERE session_id=?1 AND turn_intent_id=?2",
+        params![&fixture.member_session_id, &continuation_id],
+    )
+    .expect("terminalize successful Return continuation before its drain guard runs");
+    drop(conn);
+    assert_eq!(
+        AgentInboxStore::mark_many_read_for_turn(
+            &[assignment.id],
+            &fixture.member_session_id,
+            &continuation_id,
+            None,
+        )
+        .expect("successful terminal Return continuation settles its Task input"),
+        0
+    );
+    let conn = get_connection().expect("test sqlite connection");
+    let settled_assignment: (Option<String>, i64, i64) = conn
+        .query_row(
+            "SELECT inbox.read_at,
+                    (SELECT COUNT(*)
+                     FROM agent_org_runtime_inbox_delivery_resolutions resolution
+                     WHERE resolution.inbox_id=inbox.id
+                       AND resolution.reason='task_completed'),
+                    (SELECT COUNT(*)
+                     FROM agent_org_runtime_inbox_materializations materialization
+                     WHERE materialization.inbox_id=inbox.id)
+             FROM agent_org_runtime_inbox inbox WHERE inbox.id=?1",
+            [assignment.id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read restored assignment settlement");
+    assert_eq!(
+        settled_assignment,
+        (None, 1, 0),
+        "terminal Task settlement keeps the source unread as immutable history while making it non-replayable"
+    );
+}
+
+#[test]
+fn return_rejects_a_receipt_owned_by_another_session_without_clearing_it() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let fixture = create_fixture("return-session-mismatch", AgentOrgRunStatus::Idle);
+    seed_direct_source(
+        &fixture,
+        "event-return-session-mismatch",
+        "turn-return-session-mismatch",
+        "keep the receipt active",
+    );
+    let accepted = enqueue(
+        &fixture,
+        "event-return-session-mismatch",
+        "turn-return-session-mismatch",
+        "keep the receipt active",
+        32,
+    )
+    .expect("accept direct Turn");
+    mark_direct_terminal(&fixture, "turn-return-session-mismatch");
+
+    let error = AgentMemberInterventionStore::return_to_work(
+        "different-member-session",
+        &accepted.intervention.intervention_receipt_id,
+        "return-wrong-session",
+    )
+    .expect_err("another Session must not clear this Member receipt");
+    assert!(error.contains("receipt belongs to another Session"));
+
+    let receipt = AgentMemberInterventionStore::get_by_receipt(
+        &accepted.intervention.intervention_receipt_id,
+    )
+    .expect("read receipt after rejected Return")
+    .expect("receipt remains present");
+    assert_eq!(receipt.status, MemberInterventionStatus::Active);
+    assert!(receipt.return_request_id.is_none());
+    assert!(receipt.cleared_revision.is_none());
+    assert!(receipt.continuation_turn_intent_id.is_none());
+}
+
+#[test]
+fn return_binds_one_continuation_to_the_current_activation_generation() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let (fixture, accepted, task_id, formal_turn_id) =
+        create_recoverable_formal_intervention("return-current-generation");
+    let conn = get_connection().expect("test sqlite connection");
+    conn.execute(
+        "UPDATE agent_org_runtime_runs
+         SET activation_generation=2,updated_at=?2 WHERE id=?1",
+        params![&fixture.run_id, chrono::Utc::now().to_rfc3339()],
+    )
+    .expect("advance Team activation generation");
+    conn.execute(
+        "UPDATE agent_org_runtime_tasks
+         SET activation_generation=2,updated_at=?3
+         WHERE org_run_id=?1 AND id=?2 AND owner=?4",
+        params![
+            &fixture.run_id,
+            &task_id,
+            chrono::Utc::now().to_rfc3339(),
+            MEMBER_ID
+        ],
+    )
+    .expect("keep the original Task owned in the current generation");
+    drop(conn);
+
+    let returned = AgentMemberInterventionStore::return_to_work(
+        &fixture.member_session_id,
+        &accepted.intervention.intervention_receipt_id,
+        "return-current-generation",
+    )
+    .expect("restore formal Task on the current generation");
+    assert_eq!(returned.outcome, ReturnToWorkOutcome::RestoredTask);
+    let continuation_id = returned
+        .continuation_turn_intent_id
+        .expect("current-generation continuation identity");
+
+    let conn = get_connection().expect("test sqlite connection");
+    let continuations: Vec<(String, i64)> = conn
+        .prepare(
+            "SELECT turn_intent_id,activation_generation
+             FROM agent_org_runtime_turn_contexts
+             WHERE session_id=?1 AND task_id=?2 AND turn_intent_id<>?3
+             ORDER BY context_id ASC",
+        )
+        .expect("prepare continuation query")
+        .query_map(
+            params![&fixture.member_session_id, &task_id, &formal_turn_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("query continuations")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect continuations");
+    assert_eq!(continuations, vec![(continuation_id.clone(), 2)]);
+    drop(conn);
+
+    let replay = AgentMemberInterventionStore::return_to_work(
+        &fixture.member_session_id,
+        &accepted.intervention.intervention_receipt_id,
+        "return-current-generation",
+    )
+    .expect("replay current-generation Return");
+    assert_eq!(replay.outcome, ReturnToWorkOutcome::AlreadyApplied);
+    assert_eq!(
+        replay.continuation_turn_intent_id.as_deref(),
+        Some(continuation_id.as_str())
+    );
+    let conn = get_connection().expect("test sqlite connection");
+    let continuation_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM agent_org_runtime_turn_contexts
+             WHERE session_id=?1 AND task_id=?2 AND turn_intent_id<>?3",
+            params![&fixture.member_session_id, &task_id, &formal_turn_id],
+            |row| row.get(0),
+        )
+        .expect("count current-generation continuations");
+    assert_eq!(continuation_count, 1);
 }
 
 #[test]

--- a/src-tauri/crates/agent-core/src/core/session/turn/event_handler/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/event_handler/mod.rs
@@ -148,6 +148,7 @@ pub struct EventHandlerConfig {
 pub struct AgentOrgTaskLifecycleContext {
     pub run_id: String,
     pub member_id: String,
+    pub turn_kind: crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind,
 }
 
 /// Unified event handler for agent turns.
@@ -1311,25 +1312,31 @@ impl TurnEventHandler for UnifiedEventHandler {
             .load(Ordering::SeqCst)
         {
             if let Some(context) = self.config.agent_org_task_lifecycle.clone() {
-                let feedback = tokio::task::spawn_blocking(move || {
-                    super::processor::member_idle::task_lifecycle_stop_feedback(
-                        &context.run_id,
-                        &context.member_id,
-                    )
-                })
-                .await
-                .ok()
-                .and_then(|result| match result {
-                    Ok(feedback) => feedback,
-                    Err(error) => {
-                        tracing::warn!(
-                            session_id = %session_id,
-                            error = %error,
-                            "failed to inspect Agent Org task lifecycle at turn stop"
-                        );
-                        None
-                    }
-                });
+                let feedback = if context.turn_kind
+                    == crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::TaskExecution
+                {
+                    tokio::task::spawn_blocking(move || {
+                        super::processor::member_idle::task_lifecycle_stop_feedback(
+                            &context.run_id,
+                            &context.member_id,
+                        )
+                    })
+                    .await
+                    .ok()
+                    .and_then(|result| match result {
+                        Ok(feedback) => feedback,
+                        Err(error) => {
+                            tracing::warn!(
+                                session_id = %session_id,
+                                error = %error,
+                                "failed to inspect Agent Org task lifecycle at turn stop"
+                            );
+                            None
+                        }
+                    })
+                } else {
+                    None
+                };
                 if feedback.is_some()
                     && self
                         .agent_org_lifecycle_correction_emitted
@@ -1528,7 +1535,7 @@ mod tests {
     use test_helpers::test_env;
 
     #[tokio::test]
-    async fn agent_org_lifecycle_stop_gate_corrects_at_most_once_per_turn() {
+    async fn agent_org_lifecycle_stop_gate_only_corrects_task_execution_once() {
         let _sandbox = test_env::sandbox();
         let conn = database::db::get_connection().expect("db");
         crate::coordination::agent_org_runs::init_schema(&conn).expect("run schema");
@@ -1580,8 +1587,10 @@ mod tests {
         .expect("seed task");
         let handler = UnifiedEventHandler::new(EventHandlerConfig {
             agent_org_task_lifecycle: Some(AgentOrgTaskLifecycleContext {
-                run_id: run.id,
+                run_id: run.id.clone(),
                 member_id: "member-worker".to_string(),
+                turn_kind:
+                    crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::TaskExecution,
             }),
             ..Default::default()
         });
@@ -1591,6 +1600,22 @@ mod tests {
             .as_deref()
             .is_some_and(|feedback| feedback.contains("unfinished-build")));
         assert_eq!(handler.on_turn_stop_check("member-session").await, None);
+
+        let direct_handler = UnifiedEventHandler::new(EventHandlerConfig {
+            agent_org_task_lifecycle: Some(AgentOrgTaskLifecycleContext {
+                run_id: run.id,
+                member_id: "member-worker".to_string(),
+                turn_kind:
+                    crate::coordination::agent_org_turn_contexts::AgentOrgTurnKind::UserDirectedWork,
+            }),
+            ..Default::default()
+        });
+        assert_eq!(
+            direct_handler
+                .on_turn_stop_check("member-direct-session")
+                .await,
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/execute.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/execute.rs
@@ -51,6 +51,22 @@ impl UnifiedMessageProcessor {
         } else {
             false
         };
+        let agent_org_turn_kind = self
+            .runtime
+            .agent_org_context
+            .as_ref()
+            .zip(self.runtime.agent_org_current_member_id.as_ref())
+            .filter(|(_, member_id)| {
+                member_id.as_str() != crate::coordination::agent_org_runs::COORDINATOR_MEMBER_ID
+            })
+            .map(|_| {
+                crate::coordination::agent_org_turn_contexts::require_existing_context_for_session(
+                    session_id,
+                    turn_intent_id,
+                )
+                .map(|context| context.turn_kind)
+            })
+            .transpose()?;
 
         self.runtime
             .provider
@@ -151,13 +167,13 @@ impl UnifiedMessageProcessor {
             .agent_org_context
             .as_ref()
             .zip(self.runtime.agent_org_current_member_id.as_ref())
-            .and_then(|(context, member_id)| {
-                (member_id != crate::coordination::agent_org_runs::COORDINATOR_MEMBER_ID).then(
-                    || super::super::event_handler::AgentOrgTaskLifecycleContext {
-                        run_id: context.run_id.clone(),
-                        member_id: member_id.clone(),
-                    },
-                )
+            .zip(agent_org_turn_kind)
+            .map(|((context, member_id), turn_kind)| {
+                super::super::event_handler::AgentOrgTaskLifecycleContext {
+                    run_id: context.run_id.clone(),
+                    member_id: member_id.clone(),
+                    turn_kind,
+                }
             });
         let handler = UnifiedEventHandler::new(event_handler_config);
 

--- a/src/engines/ChatPanel/ChatHistory/ChatHistory.types.ts
+++ b/src/engines/ChatPanel/ChatHistory/ChatHistory.types.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { AgentOrgRunMemberView } from "@src/api/tauri/agent";
-import type { QueuedConversationDispatch } from "@src/engines/SessionCore/conversations/queuedConversationContract";
+import type { QueuedConversationDispatchResolution } from "@src/engines/SessionCore/conversations/queuedConversationContract";
 import type { ChatHistoryDisplayMode } from "@src/store/ui/chatPanel/displayPrefsAtoms";
 
 export interface FollowAgentNavState {
@@ -103,7 +103,7 @@ export interface ChatHistoryProps {
    * The canonical dispatch a retry of a held Agent row should carry: the
    * current root and the runtime the picker shows now.
    */
-  resolveFailedUserIntentDispatch?: () => QueuedConversationDispatch | null;
+  resolveFailedUserIntentDispatch?: () => QueuedConversationDispatchResolution;
   /**
    * Session-scoped source for the planning footer. Session-scoped surfaces
    * should set `isLive` to false while showing a replay slice.

--- a/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useEditUserMessage.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useEditUserMessage.test.ts
@@ -12,7 +12,10 @@ import {
   vi,
 } from "vitest";
 
-import type { QueuedConversationDispatch } from "@src/engines/SessionCore/conversations/queuedConversationContract";
+import type {
+  QueuedConversationDispatch,
+  QueuedConversationDispatchResolution,
+} from "@src/engines/SessionCore/conversations/queuedConversationContract";
 
 import type { OptimizedChatItem } from "../../chatItemPipeline/types";
 import { useEditUserMessage } from "../useEditUserMessage";
@@ -173,17 +176,30 @@ type EditUserMessageFn = (
   newText: string,
   imageDataUrls?: string[]
 ) => Promise<void>;
+type FailedUserIntentRetry = NonNullable<
+  Parameters<typeof useEditUserMessage>[0]
+>;
 
 let resolveDispatchForTest:
-  | (() => QueuedConversationDispatch | null)
+  | (() => QueuedConversationDispatchResolution)
   | undefined;
+let failedUserIntentRetryForTest: FailedUserIntentRetry | undefined;
 
-function resolveDispatchViaTest(): QueuedConversationDispatch | null {
-  return resolveDispatchForTest?.() ?? null;
+function resolveDispatchViaTest(): QueuedConversationDispatchResolution {
+  return resolveDispatchForTest?.() ?? { action: "preserve" };
+}
+
+async function retryFailedUserIntentViaTest(
+  input: Parameters<FailedUserIntentRetry>[0]
+): Promise<boolean> {
+  return (await failedUserIntentRetryForTest?.(input)) ?? false;
 }
 
 function Harness({ onReady }: { onReady: (fn: EditUserMessageFn) => void }) {
-  const editUserMessage = useEditUserMessage(undefined, resolveDispatchViaTest);
+  const editUserMessage = useEditUserMessage(
+    retryFailedUserIntentViaTest,
+    resolveDispatchViaTest
+  );
   useEffect(() => {
     onReady(editUserMessage);
   }, [editUserMessage, onReady]);
@@ -221,6 +237,8 @@ describe("useEditUserMessage resend projection", () => {
     truncateBeforeIdSpy.mockClear();
     storeSessionId.current = "osagent-session-1";
     surfaceSessionId.current = undefined;
+    failedUserIntentRetryForTest = undefined;
+    resolveDispatchForTest = undefined;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -327,6 +345,54 @@ describe("useEditUserMessage resend projection", () => {
     );
     expect(checkSnapshotChangesSpy).not.toHaveBeenCalled();
     expect(truncateBeforeIdSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the mounted Member dispatcher when canonical retry declines", async () => {
+    surfaceSessionId.current = "member-session";
+    storeSessionId.current = "root-session";
+    const canonicalRetry = vi.fn().mockResolvedValue(false);
+    failedUserIntentRetryForTest = canonicalRetry;
+    act(() =>
+      root.render(
+        createElement(Harness, {
+          onReady: (fn: EditUserMessageFn) => {
+            editUserMessage = fn;
+          },
+        })
+      )
+    );
+    const failed = {
+      event: {
+        id: "member-user-input-failed",
+        source: "user",
+        displayText: "retry with the same Member",
+        displayStatus: "failed",
+        result: {
+          syntheticUserInput: true,
+          deliveryStatus: "failed",
+          turnIntentId: "member-turn-intent-failed",
+        },
+      },
+      chunk_id: "member-user-input-failed",
+    } as unknown as OptimizedChatItem;
+
+    await act(async () => {
+      await editUserMessage?.(failed, "retry with the same Member");
+    });
+
+    expect(canonicalRetry).toHaveBeenCalledOnce();
+    expect(submitUserIntentSpy).toHaveBeenCalledOnce();
+    expect(submitUserIntentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "member-session",
+        displayContent: "retry with the same Member",
+        turnIntentId: "member-turn-intent-failed",
+      })
+    );
+    expect(removeByIdPrefixSpy).toHaveBeenCalledWith(
+      "member-user-input-failed",
+      "member-session"
+    );
   });
 
   it("retries a reconciled orphan through the current submit path", async () => {
@@ -459,7 +525,10 @@ describe("useEditUserMessage resend projection", () => {
         model: "gpt-5.6-sol",
       },
     };
-    resolveDispatchForTest = () => currentDispatch;
+    resolveDispatchForTest = () => ({
+      action: "replace",
+      dispatch: currentDispatch,
+    });
     queuedDeliveries.current = [
       {
         id: "queue-rejected",
@@ -509,6 +578,96 @@ describe("useEditUserMessage resend projection", () => {
       expect.objectContaining({ debugLabel: "forceSendMessageAtom" }),
       "queue-rejected"
     );
+  });
+
+  it("clears stale canonical ownership when a Member retries its durable failed row", async () => {
+    surfaceSessionId.current = "member-session";
+    storeSessionId.current = "root-session";
+    const admittedDispatch: QueuedConversationDispatch = {
+      kind: "canonical_conversation",
+      root: {
+        authority: "local-session",
+        authorityScope: [],
+        conversationId: "root-session",
+      },
+      target: {
+        cliAgentType: "codex",
+        accountId: "root-account",
+        model: "gpt-root",
+      },
+    };
+    resolveDispatchForTest = () => ({ action: "clear" });
+    queuedDeliveries.current = [
+      {
+        id: "member-queue-rejected",
+        turnIntentId: "member-turn-intent-rejected",
+        sessionId: "member-session",
+        content: "retry on the member",
+        displayContent: "retry on the member",
+        imageDataUrls: ["data:image/png;base64,member"],
+        priority: "next",
+        status: "queued",
+        requiresExplicitDispatch: true,
+        deliveryError: "old root runtime failed",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        conversationDispatch: admittedDispatch,
+      },
+    ];
+    act(() =>
+      root.render(
+        createElement(Harness, {
+          onReady: (fn: EditUserMessageFn) => {
+            editUserMessage = fn;
+          },
+        })
+      )
+    );
+    const failed = {
+      event: {
+        id: "queued-user:member-queue-rejected:",
+        displayText: "retry on the member",
+        displayStatus: "failed",
+        result: {
+          syntheticUserInput: true,
+          deliveryStatus: "failed",
+          queueMessageId: "member-queue-rejected",
+          turnIntentId: "member-turn-intent-rejected",
+        },
+      },
+      chunk_id: "queued-user:member-queue-rejected:",
+    } as unknown as OptimizedChatItem;
+
+    try {
+      await act(async () => {
+        await editUserMessage?.(failed, "retry on the member");
+      });
+    } finally {
+      resolveDispatchForTest = undefined;
+    }
+
+    expect(storeSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ debugLabel: "editMessageAtom" }),
+      expect.objectContaining({
+        messageId: "member-queue-rejected",
+        conversationDispatch: null,
+        imageDataUrls: undefined,
+      })
+    );
+    expect(updateByIdSpy).toHaveBeenCalledWith(
+      "queued-user:member-queue-rejected:",
+      expect.objectContaining({
+        result: expect.objectContaining({
+          images: ["data:image/png;base64,member"],
+          queueMessageId: "member-queue-rejected",
+        }),
+      }),
+      "member-session"
+    );
+    expect(storeSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ debugLabel: "forceSendMessageAtom" }),
+      "member-queue-rejected"
+    );
+    expect(submitUserIntentSpy).not.toHaveBeenCalled();
   });
 
   it("hydrates a cold failed owner and patches its runner row from the root surface", async () => {

--- a/src/engines/ChatPanel/ChatHistory/hooks/useEditUserMessage.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useEditUserMessage.ts
@@ -201,17 +201,25 @@ export function useEditUserMessage(
             // A held canonical row keeps the runtime it was admitted with.
             // The user changes the picker precisely because that runtime
             // failed, so the retry must carry the runtime shown now.
-            const retryDispatch =
+            const retryDispatchResolution =
               durableFailedQueueRow.conversationDispatch?.kind ===
               "canonical_conversation"
-                ? (resolveFailedUserIntentDispatch?.() ?? undefined)
+                ? (resolveFailedUserIntentDispatch?.() ?? {
+                    action: "preserve" as const,
+                  })
                 : undefined;
             const updated = store.set(editMessageAtom, {
               messageId: durableFailedQueueRow.id,
               content: projection.displayContent,
               imageDataUrls: resendImages,
               turnIntentId: retryTurnIntentId,
-              ...(retryDispatch ? { conversationDispatch: retryDispatch } : {}),
+              ...(retryDispatchResolution?.action === "replace"
+                ? {
+                    conversationDispatch: retryDispatchResolution.dispatch,
+                  }
+                : retryDispatchResolution?.action === "clear"
+                  ? { conversationDispatch: null }
+                  : {}),
             });
             if (!updated) {
               throw new Error("failed delivery is no longer retryable");

--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -34,6 +34,7 @@ import React, {
 } from "react";
 
 import { useShowInteractArea } from "@src/contexts/workspace/ChatContext";
+import { resolveAgentOrgComposerExecutionOwnership } from "@src/engines/ChatPanel/agentOrgComposerOwnership";
 import { derivePlanApprovalViewState } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
 import { useTodoSync } from "@src/engines/SessionCore/hooks/session/useTodoSync";
@@ -323,12 +324,32 @@ const ResolvedChatView: React.FC<ResolvedChatViewProps> = memo(
       showCurrentPlanSurface,
       conversationRoot: conversationTargetBinding?.root ?? null,
     });
+    // The visible ChatView's session is the authoritative composer target.
+    // Agent-org member views may override it with queueSessionId, but ordinary
+    // imported teammate sessions have no agent-org queue target. Passing null
+    // there made useMessageDispatch fail before onSubmitOverride could admit
+    // the turn to the canonical queue ("no active sessionId"), so no writable
+    // native execution episode could be prepared.
+    const inputAreaSessionId = queueSessionId ?? sessionId;
+    const inputAreaSession = useAtomValue(sessionByIdAtom(inputAreaSessionId));
+    const composerOwnership = groupChatViewActive
+      ? {
+          isDirectAgentOrgMember: false,
+          executionBinding: conversationTargetBinding,
+        }
+      : resolveAgentOrgComposerExecutionOwnership(
+          inputAreaSession,
+          conversationTargetBinding
+        );
+    const { isDirectAgentOrgMember } = composerOwnership;
+    const composerExecutionBinding = composerOwnership.executionBinding;
     const {
       submit: handleConversationSubmit,
       retry: handleCanonicalConversationRetry,
       resolveDispatch: resolveCanonicalRetryDispatch,
     } = useConversationSubmitRouter({
       sessionId,
+      isDirectAgentOrgMember,
       currentSession,
       root: conversationTargetBinding?.root ?? null,
       selectedTarget: conversationTargetBinding?.target ?? null,
@@ -395,13 +416,6 @@ const ResolvedChatView: React.FC<ResolvedChatViewProps> = memo(
     const chatHistorySessionId = groupChatViewActive
       ? sessionId
       : agentOrgInteractionSessionId;
-    // The visible ChatView's session is the authoritative composer target.
-    // Agent-org member views may override it with queueSessionId, but ordinary
-    // imported teammate sessions have no agent-org queue target. Passing null
-    // there made useMessageDispatch fail before onSubmitOverride could admit
-    // the turn to the canonical queue ("no active sessionId"), so no writable
-    // native execution episode could be prepared.
-    const inputAreaSessionId = queueSessionId ?? sessionId;
     const {
       suggestions: followUpSuggestions,
       clearSuggestions: clearFollowUpSuggestions,
@@ -622,7 +636,7 @@ const ResolvedChatView: React.FC<ResolvedChatViewProps> = memo(
                   />
                 ) : (
                   <ConversationExecutionBindingContext.Provider
-                    value={conversationTargetBinding}
+                    value={composerExecutionBinding}
                   >
                     <ChatViewComposerSection
                       {...composerSectionProps}

--- a/src/engines/ChatPanel/InputArea/components/ModelPill.memberOwnership.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/ModelPill.memberOwnership.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { modelSelectorAtom } from "@src/store/ui/modelSelectorAtom";
+
+import ModelPill from "./ModelPill";
+
+const fixture = vi.hoisted(() => ({
+  rootApplyModelPick: vi.fn(),
+  setMemberModel: vi.fn(),
+  memberSession: {
+    session_id: "member-session",
+    parentSessionId: "root-session",
+    orgMemberId: "implementer",
+    keySource: "own_key",
+    cliAgentType: "codex",
+    category: "cli_agent",
+    model: "gpt-member-b",
+    accountId: "member-account",
+    status: "completed",
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/engines/ChatPanel/ConversationExecutionBindingContext", () => ({
+  // The composer ownership resolver removes the outer Root binding before
+  // ModelPill renders for a direct Member.
+  useConversationExecutionBinding: () => null,
+}));
+vi.mock("@src/engines/SessionCore/hooks/session", () => ({
+  useSessionId: () => ({ sessionId: "member-session" }),
+}));
+vi.mock("@src/hooks/models/useValidatedLastPair", () => ({
+  useValidatedLastPair: () => null,
+}));
+vi.mock("@src/hooks/session/useSessionPatch", () => ({
+  useSessionModelField: () => ({ setModel: fixture.setMemberModel }),
+}));
+vi.mock("@src/store/session", async () => {
+  const { atom } = await import("jotai");
+  const memberSessionAtom = atom(fixture.memberSession);
+  return { sessionByIdAtom: () => memberSessionAtom };
+});
+vi.mock("@src/store/session/cliSessionStatusAtom", async () => {
+  const { atom } = await import("jotai");
+  return { sessionRuntimeStatusAtom: atom("idle") };
+});
+vi.mock("@src/store/session/creatorDefaultModelAtom", async () => {
+  const { atom } = await import("jotai");
+  return {
+    creatorDefaultModelSelectionAtom: atom(null),
+    extractModelPair: (config: Record<string, unknown>) => config,
+  };
+});
+vi.mock("@src/store/ui/chatPanel/displayPrefsAtoms", async () => {
+  const { atom } = await import("jotai");
+  return { modelPickerStyleAtom: atom("spotlight") };
+});
+vi.mock("@src/components/AnyIcon", () => ({ default: () => null }));
+vi.mock("@src/components/ModelIcon", () => ({ default: () => null }));
+vi.mock("@src/components/Message", () => ({
+  Message: { info: vi.fn(), warning: vi.fn() },
+}));
+vi.mock("@src/components/SelectorPill", () => ({ default: () => null }));
+vi.mock("@src/components/ModelSelectorPill", async () => {
+  const { createElement, forwardRef } = await import("react");
+  return {
+    default: forwardRef<
+      HTMLButtonElement,
+      { onClick: () => void; dataTestId: string }
+    >(({ onClick, dataTestId }, ref) =>
+      createElement("button", {
+        ref,
+        "data-testid": dataTestId,
+        onClick,
+      })
+    ),
+  };
+});
+vi.mock(
+  "@src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/DispatchCategoryPicker",
+  () => ({ DispatchCategoryPicker: () => null })
+);
+vi.mock(
+  "@src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette",
+  async () => {
+    const ReactModule = await import("react");
+    return {
+      UnifiedModelPalette: ({
+        isOpen,
+        onConfigChange,
+      }: {
+        isOpen: boolean;
+        onConfigChange: (config: Record<string, unknown>) => void;
+      }) =>
+        isOpen
+          ? ReactModule.createElement("button", {
+              "data-testid": "member-model-c",
+              onClick: () =>
+                onConfigChange({
+                  keySource: "own_key",
+                  cliAgentType: "codex",
+                  model: "gpt-member-c",
+                  selectedAccountId: "member-account-c",
+                }),
+            })
+          : null,
+    };
+  }
+);
+vi.mock(
+  "@src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/UnifiedModelDropdown",
+  () => ({ UnifiedModelDropdown: () => null })
+);
+
+describe("ModelPill direct Member ownership", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    fixture.rootApplyModelPick.mockReset();
+    fixture.setMemberModel.mockReset().mockResolvedValue(undefined);
+    store = createStore();
+    store.set(modelSelectorAtom, { isOpen: false });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() =>
+      root.render(
+        React.createElement(Provider, { store }, React.createElement(ModelPill))
+      )
+    );
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("shows and updates the Member model without calling the Root binding", () => {
+    expect(
+      container
+        .querySelector('[data-testid="chat-model-target"]')
+        ?.getAttribute("data-model-id")
+    ).toBe("gpt-member-b");
+    expect(
+      container.querySelector('[data-testid="chat-runtime-pill"]')
+    ).toBeNull();
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="chat-model-pill-model"]'
+        )
+        ?.click();
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="member-model-c"]')
+        ?.click();
+    });
+
+    expect(fixture.setMemberModel).toHaveBeenCalledWith(
+      "gpt-member-c",
+      "member-account-c"
+    );
+    expect(fixture.rootApplyModelPick).not.toHaveBeenCalled();
+  });
+});

--- a/src/engines/ChatPanel/SideChat/SideChatSessionBody.test.ts
+++ b/src/engines/ChatPanel/SideChat/SideChatSessionBody.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SideChatSessionBody } from ".";
+
+const fixture = vi.hoisted(() => ({
+  binding: {
+    root: {
+      authority: "local-session",
+      authorityScope: [],
+      conversationId: "root-session",
+    },
+    target: {
+      cliAgentType: "codex",
+      accountId: "root-account",
+      model: "gpt-root",
+    },
+  },
+  bindingProviderValue: undefined as unknown,
+  chatHistoryProps: undefined as Record<string, unknown> | undefined,
+  directSubmit: vi.fn(),
+  inputAreaProps: undefined as Record<string, unknown> | undefined,
+  routerOptions: undefined as Record<string, unknown> | undefined,
+  routerSubmit: vi.fn(),
+  routerRetry: vi.fn(),
+  routerResolve: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/contexts/workspace/ChatContext", () => ({
+  ChatProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("../ConversationExecutionBindingContext", () => ({
+  ConversationExecutionBindingContext: {
+    Provider: ({
+      value,
+      children,
+    }: {
+      value: unknown;
+      children: React.ReactNode;
+    }) => {
+      fixture.bindingProviderValue = value;
+      return children;
+    },
+  },
+}));
+vi.mock("../ChatHistory", () => ({
+  default: (props: Record<string, unknown>) => {
+    fixture.chatHistoryProps = props;
+    return null;
+  },
+}));
+vi.mock("../InputArea", () => ({
+  default: (props: Record<string, unknown>) => {
+    fixture.inputAreaProps = props;
+    return null;
+  },
+}));
+vi.mock("../hooks/useConversationTargetBinding", () => ({
+  useConversationTargetBinding: () => fixture.binding,
+}));
+vi.mock("../hooks/useWorkspaceChat/useUserIntentSubmit", () => ({
+  useUserIntentSubmit: () => fixture.directSubmit,
+}));
+vi.mock("../hooks/conversationSubmit/useConversationSubmitRouter", () => ({
+  useConversationSubmitRouter: (options: Record<string, unknown>) => {
+    fixture.routerOptions = options;
+    return {
+      submit: fixture.routerSubmit,
+      retry: fixture.routerRetry,
+      resolveDispatch: fixture.routerResolve,
+    };
+  },
+}));
+
+describe("SideChatSessionBody direct Member ownership", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    fixture.bindingProviderValue = undefined;
+    fixture.chatHistoryProps = undefined;
+    fixture.inputAreaProps = undefined;
+    fixture.routerOptions = undefined;
+    fixture.directSubmit.mockReset().mockResolvedValue(undefined);
+    fixture.routerSubmit.mockReset();
+    fixture.routerRetry.mockReset();
+    fixture.routerResolve.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        React.createElement(
+          Provider,
+          { store: createStore() },
+          React.createElement(SideChatSessionBody, {
+            sessionId: "member-session",
+            isLive: false,
+            session: {
+              session_id: "member-session",
+              parentSessionId: "root-session",
+              orgMemberId: "implementer",
+            } as never,
+          })
+        )
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("ignores a discoverable Root binding and keeps all sends on the Member", async () => {
+    expect(fixture.routerOptions).toMatchObject({
+      sessionId: "member-session",
+      isDirectAgentOrgMember: true,
+      root: fixture.binding.root,
+      selectedTarget: fixture.binding.target,
+    });
+    expect(fixture.bindingProviderValue).toBeNull();
+    expect(fixture.inputAreaProps).toMatchObject({
+      sessionId: "member-session",
+      showAgentControls: true,
+      onSubmitOverride: fixture.routerSubmit,
+    });
+    expect(fixture.chatHistoryProps).toMatchObject({
+      onFailedUserIntentRetry: fixture.routerRetry,
+      resolveFailedUserIntentDispatch: fixture.routerResolve,
+    });
+
+    const onSurfaceSubmit = fixture.routerOptions?.onSurfaceSubmit as (
+      input: Record<string, unknown>
+    ) => Promise<boolean>;
+    await expect(
+      onSurfaceSubmit({
+        displayText: "side quest",
+        agentContent: "side quest",
+        imageDataUrls: ["data:image/png;base64,side"],
+      })
+    ).resolves.toBe(true);
+    expect(fixture.directSubmit).toHaveBeenCalledWith({
+      sessionId: "member-session",
+      displayContent: "side quest",
+      agentContent: "side quest",
+      imageDataUrls: ["data:image/png;base64,side"],
+      source: "dispatch",
+    });
+  });
+});

--- a/src/engines/ChatPanel/SideChat/index.tsx
+++ b/src/engines/ChatPanel/SideChat/index.tsx
@@ -42,6 +42,7 @@ import {
   HEADER_ICON_SIZE,
 } from "@src/config/workstation/tokens";
 import { ChatProvider } from "@src/contexts/workspace/ChatContext";
+import { resolveAgentOrgComposerExecutionOwnership } from "@src/engines/ChatPanel/agentOrgComposerOwnership";
 import { isUserIntentSendError } from "@src/engines/SessionCore/services/userIntentDispatch";
 import { createLogger } from "@src/hooks/logger";
 import {
@@ -290,13 +291,18 @@ interface SideChatSessionBodyProps {
   isLive: boolean;
 }
 
-const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
+export const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
   sessionId,
   session,
   isLive,
 }) => {
   const turnPaginationEnabled = useAtomValue(chatTurnPaginationEnabledAtom);
   const conversationTargetBinding = useConversationTargetBinding(sessionId);
+  const { isDirectAgentOrgMember, executionBinding: composerExecutionBinding } =
+    resolveAgentOrgComposerExecutionOwnership(
+      session,
+      conversationTargetBinding
+    );
   const getSessionId = useCallback(() => sessionId, [sessionId]);
   const submitUserIntent = useUserIntentSubmit({ getSessionId });
 
@@ -306,7 +312,7 @@ const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
       agentContent,
       imageDataUrls,
     }: SubmitOverrideInput): Promise<boolean> => {
-      if (conversationTargetBinding?.root) return false;
+      if (composerExecutionBinding?.root) return false;
       const content = agentContent ?? displayText;
       if (!content.trim()) return false;
       try {
@@ -327,7 +333,7 @@ const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
         return false;
       }
     },
-    [conversationTargetBinding?.root, sessionId, submitUserIntent]
+    [composerExecutionBinding?.root, sessionId, submitUserIntent]
   );
   const {
     submit: handleSubmit,
@@ -335,6 +341,7 @@ const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
     resolveDispatch: resolveCanonicalRetryDispatch,
   } = useConversationSubmitRouter({
     sessionId,
+    isDirectAgentOrgMember,
     currentSession: session,
     root: conversationTargetBinding?.root ?? null,
     selectedTarget: conversationTargetBinding?.target ?? null,
@@ -351,12 +358,12 @@ const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
               turnPaginationEnabled={turnPaginationEnabled}
               planningIndicatorScope={{ sessionId, isLive }}
               onFailedUserIntentRetry={
-                conversationTargetBinding
+                conversationTargetBinding || isDirectAgentOrgMember
                   ? handleCanonicalConversationRetry
                   : undefined
               }
               resolveFailedUserIntentDispatch={
-                conversationTargetBinding
+                conversationTargetBinding || isDirectAgentOrgMember
                   ? resolveCanonicalRetryDispatch
                   : undefined
               }
@@ -364,7 +371,7 @@ const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
           </div>
           <div className="shrink-0 px-1.5 pt-0.5 pb-1.5">
             <ConversationExecutionBindingContext.Provider
-              value={conversationTargetBinding}
+              value={composerExecutionBinding}
             >
               <InputArea
                 key={sessionId}
@@ -374,7 +381,9 @@ const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
                 sessionScope="none"
                 onSubmitOverride={handleSubmit}
                 disableStopWhenEmpty
-                showAgentControls={Boolean(conversationTargetBinding)}
+                showAgentControls={
+                  Boolean(composerExecutionBinding) || isDirectAgentOrgMember
+                }
                 allowFileAttachments={false}
                 enableAgentInterceptors={false}
               />

--- a/src/engines/ChatPanel/agentOrgComposerOwnership.ts
+++ b/src/engines/ChatPanel/agentOrgComposerOwnership.ts
@@ -1,0 +1,33 @@
+interface AgentOrgComposerSessionIdentity {
+  parentSessionId?: string | null;
+  orgMemberId?: string | null;
+}
+
+/**
+ * A materialized non-Coordinator Member owns its composer execution directly.
+ * The parent/root Session may still own the surrounding Agent Org surface,
+ * but it must not supply that Member's model binding or canonical dispatch.
+ */
+export function isAgentOrgMemberDirectTarget(
+  session: AgentOrgComposerSessionIdentity | null | undefined
+): boolean {
+  return Boolean(
+    session?.parentSessionId &&
+    session.orgMemberId &&
+    session.orgMemberId !== "coordinator"
+  );
+}
+
+export function resolveAgentOrgComposerExecutionOwnership<T>(
+  session: AgentOrgComposerSessionIdentity | null | undefined,
+  outerBinding: T | null
+): {
+  isDirectAgentOrgMember: boolean;
+  executionBinding: T | null;
+} {
+  const isDirectAgentOrgMember = isAgentOrgMemberDirectTarget(session);
+  return {
+    isDirectAgentOrgMember,
+    executionBinding: isDirectAgentOrgMember ? null : outerBinding,
+  };
+}

--- a/src/engines/ChatPanel/hooks/conversationSubmit/useConversationSubmitRouter.test.ts
+++ b/src/engines/ChatPanel/hooks/conversationSubmit/useConversationSubmitRouter.test.ts
@@ -1,4 +1,17 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import type { ConversationRootLocator } from "@src/engines/SessionCore/conversations/conversationTypes";
 
@@ -6,13 +19,224 @@ import { SubmitValidationError } from "../useInputArea/types";
 import {
   buildCanonicalConversationDispatch,
   canonicalConversationTargetOrThrow,
+  useConversationSubmitRouter,
 } from "./useConversationSubmitRouter";
+
+const mocks = vi.hoisted(() => ({
+  downloadProgress: null as unknown,
+  submitUserIntent: vi.fn(),
+}));
+
+vi.mock(
+  "@src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit",
+  () => ({ useUserIntentSubmit: () => mocks.submitUserIntent })
+);
+
+vi.mock("@src/features/Org2Cloud/useCloudSessionDownloadSurface", () => ({
+  useCloudSessionDownloadProgressEntry: () => mocks.downloadProgress,
+}));
 
 const root: ConversationRootLocator = {
   authority: "imported-history",
   authorityScope: ["codex_app"],
   conversationId: "codexapp-session-1",
 };
+
+const selectedTarget = {
+  cliAgentType: "codex" as const,
+  accountId: "openai-1",
+  model: "gpt-5.6-sol",
+};
+
+type ConversationSubmitRouter = ReturnType<typeof useConversationSubmitRouter>;
+
+interface RouterHarnessProps {
+  sessionId: string;
+  isDirectAgentOrgMember: boolean;
+  onSurfaceSubmit: () => Promise<boolean>;
+  selectedTarget: typeof selectedTarget | null;
+  onReady: (router: ConversationSubmitRouter) => void;
+}
+
+function RouterHarness({
+  sessionId,
+  isDirectAgentOrgMember,
+  onSurfaceSubmit,
+  selectedTarget: runtimeTarget,
+  onReady,
+}: RouterHarnessProps): null {
+  const router = useConversationSubmitRouter({
+    sessionId,
+    isDirectAgentOrgMember,
+    currentSession: undefined,
+    root,
+    selectedTarget: runtimeTarget,
+    onSurfaceSubmit,
+  });
+  useEffect(() => onReady(router), [onReady, router]);
+  return null;
+}
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+function renderRouter(params: {
+  sessionId?: string;
+  isDirectAgentOrgMember?: boolean;
+  onSurfaceSubmit?: () => Promise<boolean>;
+  selectedTarget?: typeof selectedTarget | null;
+}) {
+  let router: ConversationSubmitRouter | undefined;
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const reactRoot = createRoot(container);
+  mountedRoots.push({ container, root: reactRoot });
+  act(() => {
+    reactRoot.render(
+      createElement(
+        Provider,
+        { store: createStore() },
+        createElement(RouterHarness, {
+          sessionId: params.sessionId ?? "root-session",
+          isDirectAgentOrgMember: params.isDirectAgentOrgMember ?? false,
+          selectedTarget:
+            params.selectedTarget === undefined
+              ? selectedTarget
+              : params.selectedTarget,
+          onSurfaceSubmit:
+            params.onSurfaceSubmit ?? vi.fn().mockResolvedValue(false),
+          onReady: (value) => {
+            router = value;
+          },
+        })
+      )
+    );
+  });
+
+  if (!router) throw new Error("conversation submit router was not captured");
+  return router;
+}
+
+describe("useConversationSubmitRouter", () => {
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    mocks.downloadProgress = null;
+    mocks.submitUserIntent.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    for (const mounted of mountedRoots.splice(0)) {
+      act(() => mounted.root.unmount());
+      mounted.container.remove();
+    }
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("leaves a Member composer submission to its direct dispatcher", async () => {
+    const router = renderRouter({ isDirectAgentOrgMember: true });
+
+    await expect(
+      router.submit({ displayText: "direct work", agentContent: "direct work" })
+    ).resolves.toBe(false);
+    expect(mocks.submitUserIntent).not.toHaveBeenCalled();
+  });
+
+  it("leaves a Member failed retry to its direct dispatcher", async () => {
+    const router = renderRouter({ isDirectAgentOrgMember: true });
+
+    await expect(
+      router.retry({
+        displayText: "retry direct work",
+        agentContent: "retry direct work",
+        turnIntentId: "member-retry-intent",
+      })
+    ).resolves.toBe(false);
+    expect(mocks.submitUserIntent).not.toHaveBeenCalled();
+  });
+
+  it("keeps direct ownership when a Member is the outer Session", async () => {
+    const router = renderRouter({
+      sessionId: "member-session",
+      isDirectAgentOrgMember: true,
+    });
+
+    await expect(
+      router.submit({ displayText: "member tab", agentContent: "member tab" })
+    ).resolves.toBe(false);
+    await expect(
+      router.retry({
+        displayText: "member retry",
+        agentContent: "member retry",
+      })
+    ).resolves.toBe(false);
+    expect(mocks.submitUserIntent).not.toHaveBeenCalled();
+    expect(router.resolveDispatch()).toEqual({ action: "clear" });
+  });
+
+  it("keeps an ordinary Root continuation canonical", async () => {
+    const router = renderRouter({});
+
+    await expect(
+      router.submit({ displayText: "continue", agentContent: "continue" })
+    ).resolves.toBe(true);
+    expect(mocks.submitUserIntent).toHaveBeenCalledOnce();
+    expect(mocks.submitUserIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "root-session",
+        conversationDispatch: expect.objectContaining({
+          kind: "canonical_conversation",
+          root,
+          target: selectedTarget,
+        }),
+      })
+    );
+    expect(router.resolveDispatch()).toEqual({
+      action: "replace",
+      dispatch: expect.objectContaining({
+        kind: "canonical_conversation",
+        root,
+        target: selectedTarget,
+      }),
+    });
+  });
+
+  it("keeps surface routing first and never submits a second time", async () => {
+    const onSurfaceSubmit = vi.fn().mockResolvedValue(true);
+    const router = renderRouter({
+      isDirectAgentOrgMember: true,
+      onSurfaceSubmit,
+    });
+    const input = { displayText: "group delivery", agentContent: "delivery" };
+
+    await expect(router.submit(input)).resolves.toBe(true);
+    expect(onSurfaceSubmit).toHaveBeenCalledWith(input);
+    expect(mocks.submitUserIntent).not.toHaveBeenCalled();
+  });
+
+  it("preserves the canonical missing-runtime validation", async () => {
+    const router = renderRouter({ selectedTarget: null });
+
+    await expect(
+      router.submit({ displayText: "continue", agentContent: "continue" })
+    ).rejects.toThrow(SubmitValidationError);
+    expect(mocks.submitUserIntent).not.toHaveBeenCalled();
+  });
+
+  it("preserves an existing failed-row dispatch while runtime selection is unavailable", () => {
+    const router = renderRouter({ selectedTarget: null });
+
+    expect(router.resolveDispatch()).toEqual({ action: "preserve" });
+  });
+});
 
 describe("canonicalConversationTargetOrThrow", () => {
   it("allows an ordinary session to use its existing direct dispatcher", () => {
@@ -37,11 +261,7 @@ describe("canonicalConversationTargetOrThrow", () => {
 });
 
 describe("buildCanonicalConversationDispatch", () => {
-  const target = {
-    cliAgentType: "codex" as const,
-    accountId: "openai-1",
-    model: "gpt-5.6-sol",
-  };
+  const target = selectedTarget;
 
   it("carries the current root and runtime for a local canonical retry", () => {
     expect(

--- a/src/engines/ChatPanel/hooks/conversationSubmit/useConversationSubmitRouter.ts
+++ b/src/engines/ChatPanel/hooks/conversationSubmit/useConversationSubmitRouter.ts
@@ -6,7 +6,10 @@ import type {
   ConversationRootLocator,
   LocalConversationTarget,
 } from "@src/engines/SessionCore/conversations/conversationTypes";
-import type { QueuedConversationDispatch } from "@src/engines/SessionCore/conversations/queuedConversationContract";
+import type {
+  QueuedConversationDispatch,
+  QueuedConversationDispatchResolution,
+} from "@src/engines/SessionCore/conversations/queuedConversationContract";
 import {
   type Org2CloudAuthState,
   org2CloudAuthAtom,
@@ -22,7 +25,10 @@ import {
 } from "../useInputArea/types";
 
 interface UseConversationSubmitRouterOptions {
+  /** Session that owns the outer conversation surface. */
   sessionId: string;
+  /** The composer belongs to a materialized non-Coordinator Agent Org Member. */
+  isDirectAgentOrgMember: boolean;
   currentSession: Session | undefined;
   root: ConversationRootLocator | null;
   selectedTarget: LocalConversationTarget | null;
@@ -43,7 +49,7 @@ interface ConversationSubmitRouter {
    * current root and the runtime the picker shows, not the pair the row was
    * admitted with. Null while no canonical runtime is selected.
    */
-  resolveDispatch: () => QueuedConversationDispatch | null;
+  resolveDispatch: () => QueuedConversationDispatchResolution;
 }
 
 export function buildCanonicalConversationDispatch(params: {
@@ -108,6 +114,7 @@ export function canonicalConversationTargetOrThrow(
  */
 export function useConversationSubmitRouter({
   sessionId,
+  isDirectAgentOrgMember,
   currentSession,
   root,
   selectedTarget,
@@ -183,19 +190,31 @@ export function useConversationSubmitRouter({
   const submit = useCallback(
     async (input: SubmitOverrideInput) => {
       if (await onSurfaceSubmit(input)) return true;
+      if (isDirectAgentOrgMember) return false;
       return enqueueCanonical(input);
     },
-    [enqueueCanonical, onSurfaceSubmit]
+    [enqueueCanonical, isDirectAgentOrgMember, onSurfaceSubmit]
   );
-  const resolveDispatch = useCallback(
-    () =>
-      buildCanonicalConversationDispatch({
+
+  const retry = useCallback(
+    async (input: CanonicalConversationRetryInput) => {
+      if (isDirectAgentOrgMember) return false;
+      return enqueueCanonical(input);
+    },
+    [enqueueCanonical, isDirectAgentOrgMember]
+  );
+  const resolveDispatch =
+    useCallback((): QueuedConversationDispatchResolution => {
+      if (isDirectAgentOrgMember) return { action: "clear" };
+      const dispatch = buildCanonicalConversationDispatch({
         root,
         selectedTarget,
         auth: store.get(org2CloudAuthAtom),
-      }),
-    [root, selectedTarget, store]
-  );
+      });
+      return dispatch
+        ? { action: "replace", dispatch }
+        : { action: "preserve" };
+    }, [isDirectAgentOrgMember, root, selectedTarget, store]);
 
-  return { submit, retry: enqueueCanonical, resolveDispatch };
+  return { submit, retry, resolveDispatch };
 }

--- a/src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.intervention.test.ts
+++ b/src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.intervention.test.ts
@@ -7,6 +7,7 @@ import { postStopDispatchSessionsAtom } from "@src/store/session/cliSessionStatu
 import { sessionsAtom } from "@src/store/session/sessionAtom";
 import { messageQueueAtom } from "@src/store/ui/messageQueueAtom";
 
+import { resolveAgentOrgComposerExecutionOwnership } from "../../agentOrgComposerOwnership";
 import {
   type SubmitUserIntentOptions,
   isAgentOrgMemberDirectTarget,
@@ -113,6 +114,34 @@ describe("useUserIntentSubmit Agent Org intervention", () => {
       false
     );
     expect(isAgentOrgMemberDirectTarget(undefined)).toBe(false);
+  });
+
+  it("removes only a direct Member's outer Root execution binding", () => {
+    const rootBinding = { id: "root-binding" };
+    expect(
+      resolveAgentOrgComposerExecutionOwnership(
+        {
+          parentSessionId: "root-session",
+          orgMemberId: "member-direct",
+        },
+        rootBinding
+      )
+    ).toEqual({
+      isDirectAgentOrgMember: true,
+      executionBinding: null,
+    });
+    expect(
+      resolveAgentOrgComposerExecutionOwnership(
+        {
+          parentSessionId: "root-session",
+          orgMemberId: "coordinator",
+        },
+        rootBinding
+      )
+    ).toEqual({
+      isDirectAgentOrgMember: false,
+      executionBinding: rootBinding,
+    });
   });
 
   it("routes the direct turn through the shared user-intent dispatcher", async () => {

--- a/src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.ts
+++ b/src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.ts
@@ -12,6 +12,7 @@ import { useCallback, useEffect } from "react";
 import type { AgentExecMode } from "@src/config/sessionCreatorConfig";
 import { resolveSessionAgentExecMode } from "@src/config/sessionCreatorConfig";
 import { refreshAgentOrgRunView } from "@src/engines/ChatPanel/InputArea/components/agentOrgRunViewStore";
+import { isAgentOrgMemberDirectTarget } from "@src/engines/ChatPanel/agentOrgComposerOwnership";
 import { getTurnPhase } from "@src/engines/SessionCore/control/turnLifecycle";
 import type { QueuedConversationDispatch } from "@src/engines/SessionCore/conversations/queuedConversationContract";
 import { flushMessageQueuePersistence } from "@src/engines/SessionCore/hooks/session/messageQueuePersistence";
@@ -87,25 +88,7 @@ interface UseUserIntentSubmitOptions {
   getSessionId: () => string | null;
 }
 
-interface AgentOrgMemberDirectTarget {
-  parentSessionId?: string;
-  orgMemberId?: string;
-}
-
-export function isAgentOrgMemberDirectTarget(
-  session: AgentOrgMemberDirectTarget | null | undefined
-): boolean {
-  // `agentOrgId` intentionally exists only on the root/coordinator Session.
-  // A materialized Member is identified by its canonical parent + roster
-  // identity; Rust still revalidates both against the run before accepting
-  // the source event. Requiring the root-only field here silently downgraded
-  // real Member submits to ordinary SDE sends.
-  return Boolean(
-    session?.parentSessionId &&
-    session.orgMemberId &&
-    session.orgMemberId !== "coordinator"
-  );
-}
+export { isAgentOrgMemberDirectTarget } from "@src/engines/ChatPanel/agentOrgComposerOwnership";
 
 export function useUserIntentSubmit({
   getSessionId,

--- a/src/engines/SessionCore/conversations/queuedConversationContract.ts
+++ b/src/engines/SessionCore/conversations/queuedConversationContract.ts
@@ -19,6 +19,12 @@ export interface QueuedConversationDispatch {
   dispatchIdentityKey?: string;
 }
 
+/** Explicit retry-time update for a queue row's canonical ownership. */
+export type QueuedConversationDispatchResolution =
+  | { action: "preserve" }
+  | { action: "replace"; dispatch: QueuedConversationDispatch }
+  | { action: "clear" };
+
 /** Neutral subset consumed by a canonical authority executor. */
 export interface QueuedConversationMessage {
   id: string;

--- a/src/store/ui/__tests__/messageQueueAtom.test.ts
+++ b/src/store/ui/__tests__/messageQueueAtom.test.ts
@@ -1,5 +1,6 @@
 import { createStore } from "jotai/vanilla";
 
+import type { QueuedConversationDispatch } from "@src/engines/SessionCore/conversations/queuedConversationContract";
 import type { LastModelSelection } from "@src/store/session/creatorDefaultModelAtom";
 
 import {
@@ -36,6 +37,22 @@ function makeMessage(
     status: "queued",
     createdAt: "2026-01-01T00:00:00Z",
     ...overrides,
+  };
+}
+
+function makeConversationDispatch(model: string): QueuedConversationDispatch {
+  return {
+    kind: "canonical_conversation",
+    root: {
+      authority: "local-session",
+      authorityScope: [],
+      conversationId: "root-session",
+    },
+    target: {
+      cliAgentType: "codex",
+      accountId: "openai-account",
+      model,
+    },
   };
 }
 
@@ -525,6 +542,62 @@ describe("messageQueueAtom", () => {
       );
       store.set(editMessageAtom, { messageId: "m1", content: "new" });
       expect(store.get(messageQueueAtom)[0].modelSelection).toEqual(selection);
+    });
+
+    it("preserves canonical dispatch when the retry resolution is omitted", () => {
+      const admittedDispatch = makeConversationDispatch("gpt-old");
+      store.set(
+        enqueueMessageAtom,
+        makeMessage({ id: "m1", conversationDispatch: admittedDispatch })
+      );
+
+      store.set(editMessageAtom, { messageId: "m1", content: "retry" });
+
+      expect(store.get(messageQueueAtom)[0].conversationDispatch).toEqual(
+        admittedDispatch
+      );
+    });
+
+    it("replaces canonical dispatch with the retry-time runtime", () => {
+      const currentDispatch = makeConversationDispatch("gpt-current");
+      store.set(
+        enqueueMessageAtom,
+        makeMessage({
+          id: "m1",
+          conversationDispatch: makeConversationDispatch("gpt-old"),
+        })
+      );
+
+      store.set(editMessageAtom, {
+        messageId: "m1",
+        content: "retry",
+        conversationDispatch: currentDispatch,
+      });
+
+      expect(store.get(messageQueueAtom)[0].conversationDispatch).toEqual(
+        currentDispatch
+      );
+    });
+
+    it("clears stale canonical dispatch for a direct Member retry", () => {
+      store.set(
+        enqueueMessageAtom,
+        makeMessage({
+          id: "m1",
+          sessionId: "member-session",
+          conversationDispatch: makeConversationDispatch("gpt-root"),
+        })
+      );
+
+      store.set(editMessageAtom, {
+        messageId: "m1",
+        content: "retry directly",
+        conversationDispatch: null,
+      });
+
+      const message = store.get(messageQueueAtom)[0];
+      expect(message.sessionId).toBe("member-session");
+      expect(message).not.toHaveProperty("conversationDispatch");
     });
 
     it("is a no-op for non-matching messageId", () => {

--- a/src/store/ui/messageQueueAtom.ts
+++ b/src/store/ui/messageQueueAtom.ts
@@ -420,8 +420,8 @@ export const editMessageAtom = atom(
       agentExecMode?: AgentExecMode;
       /** Caller-owned retry intent when its EventStore projection must match. */
       turnIntentId?: string;
-      /** Re-resolved canonical runtime for a retry of a held canonical row. */
-      conversationDispatch?: QueuedConversationDispatch;
+      /** Re-resolved canonical runtime; null explicitly clears stale ownership. */
+      conversationDispatch?: QueuedConversationDispatch | null;
     }
   ) => {
     if (get(messageQueueHandoffIdsAtom).has(update.messageId)) return false;
@@ -452,8 +452,12 @@ export const editMessageAtom = atom(
             !(nextImageDataUrls && nextImageDataUrls.length > 0) &&
             !isCliSession(msg.sessionId),
         });
+        const dispatchBase = { ...msg };
+        if (update.conversationDispatch === null) {
+          delete dispatchBase.conversationDispatch;
+        }
         const next: QueuedMessage = {
-          ...msg,
+          ...dispatchBase,
           // Saving an edit is a new logical user intent. The previous id may
           // already be a durable stale/rejected pre-run terminal after a
           // crash; terminal intent ids are immutable and cannot be safely
@@ -470,9 +474,10 @@ export const editMessageAtom = atom(
           ...(update.agentExecMode !== undefined && {
             agentExecMode: update.agentExecMode,
           }),
-          ...(update.conversationDispatch !== undefined && {
-            conversationDispatch: update.conversationDispatch,
-          }),
+          ...(update.conversationDispatch !== undefined &&
+            update.conversationDispatch !== null && {
+              conversationDispatch: update.conversationDispatch,
+            }),
           deliveryError: undefined,
         };
         const siblings = prev.filter((item) => item.id !== msg.id);

--- a/tests/e2e/specs/core/agent-org-direct-user-directed-work-live.spec.mjs
+++ b/tests/e2e/specs/core/agent-org-direct-user-directed-work-live.spec.mjs
@@ -1,8 +1,9 @@
-/* global before, browser, describe, it, process */
-import { readFile } from "node:fs/promises";
+/* global after, before, browser, describe, it, process */
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
+  AGENT_ORG_TASK_STATUS,
   E2E_REPO_PATH,
   RENDER_TIMEOUT_MS,
   REPLY_TIMEOUT_MS,
@@ -16,8 +17,13 @@ import {
   unwrap,
   waitForApp,
 } from "../../support/core/agentOrgUiDriver.mjs";
+import { switchAccountThroughRenderedPicker } from "../../support/core/session/accountSwitchDriver.mjs";
 
 const E2E_BASE_URL = `http://127.0.0.1:${process.env.E2E_IDE_SERVER_PORT ?? "13847"}`;
+const LIVE_PROVIDER_TIMEOUT_MS = Number.parseInt(
+  process.env.E2E_AGENT_ORG_LIVE_PROVIDER_TIMEOUT_MS ?? "300000",
+  10
+);
 
 async function postFixture(pathname, body, timeoutMs = 30_000) {
   const controller = new AbortController();
@@ -134,6 +140,26 @@ async function runView(sessionId, label) {
   ).view;
 }
 
+async function readExactFile(filePath, expectedContent) {
+  try {
+    return (await readFile(filePath, "utf8")).trim() === expectedContent;
+  } catch {
+    return false;
+  }
+}
+
+async function sessionRow(sessionId, label) {
+  return unwrap(
+    await invokeE2E("getSessionAggregateRow", sessionId),
+    `getSessionAggregateRow(${label})`
+  ).session;
+}
+
+async function runtimeModelSnapshot(sessionId) {
+  const result = await invokeE2E("debugSessionModelSnapshot", sessionId);
+  return result?.ok === true ? result.snapshot : null;
+}
+
 describe("Agent Org direct UserDirectedWork with a live provider", () => {
   before(async () => {
     if (
@@ -147,12 +173,25 @@ describe("Agent Org direct UserDirectedWork with a live provider", () => {
     }
     assertE2ERepoFixture();
     await waitForApp();
+    await postFixture("/agent/test/agent-org/run/cleanup", {});
   });
 
-  it("uses the rendered Member composer, performs real file/shell work, and Returns by receipt", async () => {
+  after(async () => {
+    await postFixture("/agent/test/agent-org/run/cleanup", {});
+  });
+
+  it("keeps model, direct work, retry ownership, and formal continuation on the rendered Member", async () => {
     const account = await getApiAccount();
-    const model = selectPreferredModel(account);
-    const orgId = `e2e-direct-live-${RUN_ID}`;
+    const memberModel = selectPreferredModel(account);
+    const rootModel = (account.enabled_models ?? []).find(
+      (candidate) => candidate !== memberModel
+    );
+    if (!rootModel) {
+      throw new Error(
+        `This live ownership scenario requires two enabled models on ${account.name ?? account.id}; selected Member model=${memberModel}, enabled=${JSON.stringify(account.enabled_models ?? [])}`
+      );
+    }
+    const orgId = "e2e-agent-org-fixture:direct-member-live";
     const orgName = `E2E Direct Live ${RUN_ID}`;
     const memberId = `direct-member-${RUN_ID}`;
     const markerName = `member-direct-${RUN_ID}.txt`;
@@ -160,7 +199,35 @@ describe("Agent Org direct UserDirectedWork with a live provider", () => {
     const markerPath = path.join(E2E_REPO_PATH, markerName);
     const shellMarkerPath = path.join(E2E_REPO_PATH, shellMarkerName);
     const exactContent = `MEMBER_DIRECT_PROVIDER_${RUN_ID}`;
-    const writerTaskSubject = `Direct Writer Proof ${RUN_ID}`;
+    let formalTaskId = null;
+    const formalTaskRequestId = `formal-task-${RUN_ID}`;
+    const formalTaskSubject = `Formal Member Work ${RUN_ID}`;
+    const formalStartName = `formal-start-${RUN_ID}.txt`;
+    const formalReleaseName = `formal-release-${RUN_ID}.txt`;
+    const formalCompleteName = `formal-complete-${RUN_ID}.txt`;
+    const formalStartPath = path.join(E2E_REPO_PATH, formalStartName);
+    const formalReleasePath = path.join(E2E_REPO_PATH, formalReleaseName);
+    const formalCompletePath = path.join(E2E_REPO_PATH, formalCompleteName);
+    const formalStarted = `FORMAL_STARTED_${RUN_ID}`;
+    const formalReleased = `FORMAL_RELEASE_${RUN_ID}`;
+    const formalCompleted = `FORMAL_COMPLETED_${RUN_ID}`;
+    const independentMarkerName = `member-independent-${RUN_ID}.txt`;
+    const independentMarkerPath = path.join(
+      E2E_REPO_PATH,
+      independentMarkerName
+    );
+    const independentContent = `MEMBER_INDEPENDENT_${RUN_ID}`;
+    const formalDescription = [
+      `This is the original formal Task ${formalTaskRequestId}. If UserDirectedWork interrupts it, obey the direct user message while that intervention is active; only resume this exact formal assignment after the user chooses Return.`,
+      `First use a shell command in the workspace to write exactly ${formalStarted} to ${formalStartName}.`,
+      `Then keep this Task interruptible by running one foreground shell loop for up to 90 seconds that waits for ${formalReleaseName} to exist. Do not create the release file yourself.`,
+      `After the release file exists, read this original assignment again, write exactly ${formalCompleted} to ${formalCompleteName}, and verify both files.`,
+      `Finally complete this exact Task through task_update and reply with exactly FORMAL_DONE_${RUN_ID}.`,
+    ].join(" ");
+    const coordinatorPrompt = [
+      `Create exactly one build Task by calling task_create with id ${formalTaskRequestId}, subject ${JSON.stringify(formalTaskSubject)}, description ${JSON.stringify(formalDescription)}, owner_member_id ${memberId}, dispatch_policy immediate, execution_mode build, and allow_parallel_with_unlisted_open_tasks true.`,
+      `Do not perform the Task yourself and do not create any other Task. Reply with exactly COORDINATOR_DISPATCHED_${RUN_ID} only after task_create succeeds.`,
+    ].join(" ");
 
     await postFixture("/agent/test/agent-org/seed", {
       id: orgId,
@@ -182,7 +249,7 @@ describe("Agent Org direct UserDirectedWork with a live provider", () => {
         agent_org_id: orgId,
         workspace_path: E2E_REPO_PATH,
         content: "",
-        model,
+        model: rootModel,
         account_id: account.id,
         sync_turn: false,
         name: orgName,
@@ -252,12 +319,123 @@ describe("Agent Org direct UserDirectedWork with a live provider", () => {
       throw new Error("direct-work notice belongs to the wrong Member");
     }
 
+    const initialRootRow = await sessionRow(rootSessionId, "Root initial");
+    const initialMemberRow = await sessionRow(
+      memberSessionId,
+      "Member initial"
+    );
+    if (
+      initialRootRow?.model !== rootModel ||
+      initialMemberRow?.model !== rootModel
+    ) {
+      throw new Error(
+        `Root and Member did not start on the launch model: ${JSON.stringify({ root: initialRootRow, member: initialMemberRow, rootModel })}`
+      );
+    }
+    const allowedMemberModels = await switchAccountThroughRenderedPicker(
+      account,
+      memberModel,
+      "Agent Org direct Member model ownership"
+    );
+    const switchedRootRow = await sessionRow(
+      rootSessionId,
+      "Root after switch"
+    );
+    const switchedUiState = unwrap(
+      await invokeE2E("inspectChatState"),
+      "inspectChatState(Member model switch)"
+    );
+    if (
+      switchedRootRow?.model !== rootModel ||
+      switchedRootRow?.accountId !== account.id ||
+      switchedUiState.activeSession?.id !== memberSessionId ||
+      switchedUiState.activeSession?.accountId !== account.id ||
+      !allowedMemberModels.includes(switchedUiState.activeSession?.model)
+    ) {
+      throw new Error(
+        `rendered model switch did not stay Member-owned: ${JSON.stringify({ root: switchedRootRow, activeSession: switchedUiState.activeSession, rootModel, allowedMemberModels })}`
+      );
+    }
+    let persistedSwitchedMember = null;
+    await browser.waitUntil(
+      async () => {
+        persistedSwitchedMember = await sessionRow(
+          memberSessionId,
+          "Member model persisted before formal work"
+        );
+        return (
+          persistedSwitchedMember?.accountId === account.id &&
+          allowedMemberModels.includes(persistedSwitchedMember?.model)
+        );
+      },
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        interval: 250,
+        timeoutMsg: `idle Member model switch did not persist: ${JSON.stringify({ member: persistedSwitchedMember, allowedMemberModels })}`,
+      }
+    );
+
+    unwrap(
+      await invokeE2E("openSession", rootSessionId),
+      "open Root before formal Task dispatch"
+    );
+    await browser.waitUntil(
+      async () =>
+        unwrap(
+          await invokeE2E("getActiveSessionId"),
+          "getActiveSessionId(Root formal dispatch)"
+        ).sessionId === rootSessionId,
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        interval: 200,
+        timeoutMsg: "Root Session did not become active for formal dispatch",
+      }
+    );
+    await sendVisiblePrompt(coordinatorPrompt);
+    await browser.waitUntil(
+      async () => await readExactFile(formalStartPath, formalStarted),
+      {
+        timeout: LIVE_PROVIDER_TIMEOUT_MS,
+        interval: 1_000,
+        timeoutMsg:
+          "live Provider did not start the original formal Member Task",
+      }
+    );
+    const runningFormalView = await runView(
+      memberSessionId,
+      "formal Task started"
+    );
+    const runningFormalTask = runningFormalView?.tasks?.find(
+      (task) => task.subject === formalTaskSubject
+    );
+    if (
+      runningFormalTask?.status !== AGENT_ORG_TASK_STATUS.IN_PROGRESS ||
+      runningFormalTask?.owner !== memberId
+    ) {
+      throw new Error(
+        `formal Task was not active on the Member before intervention: ${JSON.stringify(runningFormalTask)}`
+      );
+    }
+    formalTaskId = runningFormalTask.id;
+    await openRenderedMember(memberId, "Direct Live Member");
+    await browser.waitUntil(
+      async () =>
+        unwrap(
+          await invokeE2E("getActiveSessionId"),
+          "getActiveSessionId(Member formal work)"
+        ).sessionId === memberSessionId,
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        interval: 200,
+        timeoutMsg:
+          "Member switch did not reopen the running formal Member Session",
+      }
+    );
+
     const prompt = [
-      `Before editing files, call task_create exactly once with subject ${writerTaskSubject}, dispatch_policy immediate, execution_mode build, owner omitted, eligible_member_ids [${memberId}], and allow_parallel_with_unlisted_open_tasks true.`,
-      `Continue only after task_create confirms that the durable Task exists. Leave that Task pending and ownerless, and do not call task_update.`,
-      `This is direct user work. Create ${markerName} in the workspace with exactly ${exactContent}.`,
-      `Then run a shell command that reads ${markerName}, verifies the exact content, and writes SHELL_OK_${RUN_ID} to ${shellMarkerName}.`,
-      `Read both files back and reply with exactly DIRECT_DONE_${RUN_ID} only after both checks pass.`,
+      `This is direct UserDirectedWork and the formal Task is intentionally paused. Do not inspect or wait for ${formalReleaseName}, do not work on the formal Task, and do not message the Coordinator during this turn.`,
+      `Use one shell command without command substitution to write exactly ${exactContent} to ${markerName}, verify it with cmp, write exactly SHELL_OK_${RUN_ID} to ${shellMarkerName}, and read both files back.`,
+      `Then reply with exactly DIRECT_DONE_${RUN_ID} and do nothing else.`,
     ].join(" ");
     await sendVisiblePrompt(prompt);
 
@@ -298,7 +476,7 @@ describe("Agent Org direct UserDirectedWork with a live provider", () => {
         return renderedReply.includes(`DIRECT_DONE_${RUN_ID}`);
       },
       {
-        timeout: REPLY_TIMEOUT_MS,
+        timeout: LIVE_PROVIDER_TIMEOUT_MS,
         interval: 1_000,
         timeoutMsg: `live Provider reply did not render: ${renderedReply}`,
       }
@@ -315,6 +493,38 @@ describe("Agent Org direct UserDirectedWork with a live provider", () => {
         "live Provider shell verification did not create its marker"
       );
     }
+
+    // A rendered final text delta can appear just before the native Turn
+    // terminal commits. Wait for the user-facing Return boundary instead of
+    // racing EventStore reconciliation: enabled means the direct Turn is
+    // terminal, while the still-present receipt proves completion did not
+    // auto-return the Member to formal work.
+    const returnButton = await waitForDisplayed(
+      '[data-testid="agent-org-return-to-work-button"]',
+      "Return to formal work button"
+    );
+    await browser.waitUntil(async () => returnButton.isEnabled(), {
+      timeout: RENDER_TIMEOUT_MS,
+      interval: 200,
+      timeoutMsg:
+        "Return to formal work remained disabled after direct work became terminal",
+    });
+    const awaitingConfirmation = await runView(
+      memberSessionId,
+      "direct terminal awaiting confirmation"
+    );
+    const awaitingMember = awaitingConfirmation?.members?.find(
+      (candidate) => candidate.memberId === memberId
+    );
+    if (
+      awaitingMember?.intervention?.interventionReceiptId !== acceptedReceipt ||
+      awaitingMember?.activity?.source !== "direct_member"
+    ) {
+      throw new Error(
+        `direct completion auto-cleared before user confirmation: ${JSON.stringify(awaitingMember)}`
+      );
+    }
+
     const chatEvidence = unwrap(
       await invokeE2E("inspectChatState"),
       "inspectChatState(direct source/reply evidence)"
@@ -363,64 +573,174 @@ describe("Agent Org direct UserDirectedWork with a live provider", () => {
         `direct Turn did not retain one committed runtime admission: ${JSON.stringify(matchingAdmissions)}`
       );
     }
-    const writerView = await runView(memberSessionId, "Writer Task created");
-    const writerTask = writerView?.tasks?.find(
-      (task) => task.subject === writerTaskSubject
-    );
-    if (!writerTask) {
-      throw new Error(
-        `frozen-snapshot Writer did not create the durable Task: ${JSON.stringify(writerView?.tasks ?? [])}`
-      );
-    }
-    if (
-      writerView?.workState?.openTasks < 1 ||
-      !(writerView?.blockers ?? []).some(
-        (blocker) =>
-          blocker.kind === "openTasks" &&
-          blocker.objects?.some((object) => object.id === writerTask.id)
-      )
-    ) {
-      throw new Error(
-        `Run View did not expose the Writer Task through canonical typed blockers: ${JSON.stringify({ workState: writerView?.workState, blockers: writerView?.blockers })}`
-      );
-    }
-
-    const returnButton = await waitForDisplayed(
-      '[data-testid="agent-org-end-direct-work-button"]',
-      "End direct work button"
-    );
-    await browser.waitUntil(async () => returnButton.isEnabled(), {
-      timeout: RENDER_TIMEOUT_MS,
-      interval: 200,
-      timeoutMsg:
-        "End direct work remained disabled after direct work became terminal",
-    });
-    await returnButton.click();
-
+    let directRuntimeSnapshot = null;
+    let persistedDirectMember = null;
     await browser.waitUntil(
       async () => {
-        const view = await runView(memberSessionId, "Return cleared");
-        const member = view?.members?.find(
+        directRuntimeSnapshot = await runtimeModelSnapshot(memberSessionId);
+        persistedDirectMember = await sessionRow(
+          memberSessionId,
+          "Member direct runtime"
+        );
+        return (
+          directRuntimeSnapshot?.activeAccountId === account.id &&
+          allowedMemberModels.includes(directRuntimeSnapshot?.activeModel) &&
+          persistedDirectMember?.accountId === account.id &&
+          allowedMemberModels.includes(persistedDirectMember?.model)
+        );
+      },
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        interval: 500,
+        timeoutMsg: `Member runtime did not execute direct work with the selected model: ${JSON.stringify({ snapshot: directRuntimeSnapshot, persisted: persistedDirectMember, allowedMemberModels })}`,
+      }
+    );
+    const interruptedView = await runView(
+      memberSessionId,
+      "formal Task held during direct work"
+    );
+    const interruptedFormalTask = interruptedView?.tasks?.find(
+      (task) => task.id === formalTaskId
+    );
+    if (
+      interruptedFormalTask?.status !== AGENT_ORG_TASK_STATUS.IN_PROGRESS ||
+      interruptedFormalTask?.owner !== memberId
+    ) {
+      throw new Error(
+        `UserDirectedWork incorrectly changed the formal Task lifecycle: ${JSON.stringify(interruptedFormalTask)}`
+      );
+    }
+
+    await returnButton.click();
+    let returnedView = null;
+    let returnedMember = null;
+    await browser.waitUntil(
+      async () => {
+        returnedView = await runView(memberSessionId, "Return acknowledged");
+        returnedMember = returnedView?.members?.find(
           (candidate) => candidate.memberId === memberId
         );
-        return member?.intervention == null && member?.activity == null;
+        return returnedMember != null && returnedMember.intervention == null;
       },
       {
         timeout: RENDER_TIMEOUT_MS,
         interval: 200,
-        timeoutMsg: `End direct work did not clear receipt ${acceptedReceipt} from current activity`,
+        timeoutMsg: `Return did not clear receipt ${acceptedReceipt}: ${JSON.stringify(returnedMember)}`,
       }
     );
-    const refreshed = await runView(memberSessionId, "cleared receipt refresh");
-    const refreshedMember = refreshed?.members?.find(
-      (candidate) => candidate.memberId === memberId
+    await writeFile(formalReleasePath, `${formalReleased}\n`, "utf8");
+
+    let durableTasks = null;
+    await browser.waitUntil(
+      async () => {
+        durableTasks = (
+          await postFixture("/agent/test/agent-org/tasks/list", {
+            org_run_id: launched.agent_org_run_id,
+          })
+        ).tasks;
+        const task = durableTasks?.find(
+          (candidate) => candidate.id === formalTaskId
+        );
+        return (
+          task?.status === AGENT_ORG_TASK_STATUS.COMPLETED &&
+          task?.owner === memberId &&
+          (await readExactFile(formalCompletePath, formalCompleted))
+        );
+      },
+      {
+        timeout: LIVE_PROVIDER_TIMEOUT_MS,
+        interval: 1_000,
+        timeoutMsg: `the unique continuation did not complete the original formal Task: ${JSON.stringify(durableTasks)}`,
+      }
     );
+    const matchingFormalTasks = (durableTasks ?? []).filter(
+      (task) => task.id === formalTaskId
+    );
+    if (matchingFormalTasks.length !== 1) {
+      throw new Error(
+        `Return created duplicate formal Task state: ${JSON.stringify(matchingFormalTasks)}`
+      );
+    }
+
+    unwrap(
+      await invokeE2E("openSession", memberSessionId),
+      "open Member as outer Session"
+    );
+    await browser.waitUntil(
+      async () =>
+        unwrap(
+          await invokeE2E("getActiveSessionId"),
+          "getActiveSessionId(independent Member)"
+        ).sessionId === memberSessionId,
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        interval: 200,
+        timeoutMsg: "Member did not open as the independent outer Session",
+      }
+    );
+    const independentPrompt = [
+      `This is a second direct user task on the independently opened Member Session.`,
+      `Use one shell command without command substitution to write exactly ${independentContent} to ${independentMarkerName} and read it back. Then reply with exactly INDEPENDENT_DONE_${RUN_ID} and do nothing else.`,
+    ].join(" ");
+    await sendVisiblePrompt(independentPrompt);
+
+    let independentReceipt = null;
+    await browser.waitUntil(
+      async () => {
+        const view = await runView(
+          memberSessionId,
+          "independent direct accepted"
+        );
+        const member = view?.members?.find(
+          (candidate) => candidate.memberId === memberId
+        );
+        independentReceipt =
+          member?.intervention?.interventionReceiptId ?? null;
+        return (
+          Boolean(independentReceipt) &&
+          independentReceipt !== acceptedReceipt &&
+          member?.activity?.source === "direct_member"
+        );
+      },
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        interval: 200,
+        timeoutMsg:
+          "independently opened Member did not create a new direct intervention",
+      }
+    );
+    await browser.waitUntil(
+      async () => {
+        const assistantRows = await browser.$$(
+          '[data-testid="chat-message-assistant"], [data-testid="agent-org-group-projection-item"][data-item-kind="assistant_reply"]'
+        );
+        for (const row of assistantRows) {
+          if ((await row.getText()).includes(`INDEPENDENT_DONE_${RUN_ID}`)) {
+            return true;
+          }
+        }
+        return false;
+      },
+      {
+        timeout: LIVE_PROVIDER_TIMEOUT_MS,
+        interval: 1_000,
+        timeoutMsg: "independent Member live Provider reply did not render",
+      }
+    );
+    if (!(await readExactFile(independentMarkerPath, independentContent))) {
+      throw new Error(
+        "independently opened Member did not complete the real file/shell task"
+      );
+    }
+
+    const finalRootRow = await sessionRow(rootSessionId, "Root final");
+    const finalMemberRow = await sessionRow(memberSessionId, "Member final");
     if (
-      refreshedMember?.activity != null ||
-      refreshedMember?.intervention != null
+      finalRootRow?.model !== rootModel ||
+      !allowedMemberModels.includes(finalMemberRow?.model)
     ) {
       throw new Error(
-        `cleared receipt reappeared as current activity: ${JSON.stringify(refreshedMember)}`
+        `Member model ownership leaked into Root after both direct tasks: ${JSON.stringify({ root: finalRootRow, member: finalMemberRow, rootModel, allowedMemberModels })}`
       );
     }
   });

--- a/tests/e2e/support/core/session/accountSwitchDriver.mjs
+++ b/tests/e2e/support/core/session/accountSwitchDriver.mjs
@@ -184,6 +184,16 @@ const js = {
         modelId: node.getAttribute('data-spotlight-model-id'),
         groupModelIds: node.getAttribute('data-spotlight-group-model-ids'),
       })),
+      keyFirstAccountOptions: Array.from(document.querySelectorAll('[data-testid="unified-model-key-option"]')).map((node) => ({
+        text: node.textContent || "",
+        itemId: node.getAttribute('data-spotlight-item-id'),
+      })),
+      keyFirstModelOptions: Array.from(document.querySelectorAll('[data-testid="unified-model-key-model-option"]')).map((node) => ({
+        text: node.textContent || "",
+        modelId: node.getAttribute('data-spotlight-model-id'),
+        groupModelIds: node.getAttribute('data-spotlight-group-model-ids'),
+      })),
+      keyFirstPreference: localStorage.getItem('orgii-spotlight-model-key-first'),
       spotlightContainers: Array.from(document.querySelectorAll('[data-spotlight-container]')).map((node) => ({
         text: node.textContent || "",
         rect: (() => {
@@ -957,6 +967,11 @@ export async function switchAccountThroughRenderedPicker(
 
   const sourceSelector = `[data-testid="unified-model-source-option"][data-source-account-id="${followupAccount.id}"]`;
   const modelSelector = `[data-spotlight-model-section="all"][data-spotlight-model-id="${model}"], [data-spotlight-model-section="all"][data-spotlight-model-id^="${model}-"], [data-spotlight-model-section="all"][data-spotlight-group-model-ids~="${model}"]`;
+  const keyFirstAccountSelector = `[data-testid="unified-model-key-option"][data-spotlight-item-id="key:${followupAccount.id}"]`;
+  const keyFirstModelSelector = `[data-testid="unified-model-key-model-option"][data-spotlight-model-id="${model}"], [data-testid="unified-model-key-model-option"][data-spotlight-model-id^="${model}-"], [data-testid="unified-model-key-model-option"][data-spotlight-group-model-ids~="${model}"]`;
+  const compactSwitchModelSelector =
+    '[data-testid="model-settings-switch-model"]';
+  const advancedSwitchModelSelector = '[data-testid="model-settings-model"]';
 
   const clicked = await clickLastVisibleNative(
     '[data-testid="chat-model-pill-model"]'
@@ -970,11 +985,107 @@ export async function switchAccountThroughRenderedPicker(
     `[account-switch-evidence] label=${label} clickedModelPill=${JSON.stringify(clicked)}`
   );
 
-  await browser.waitUntil(async () => execJS(js.exists(modelSelector)), {
-    timeout: MOUNT_TIMEOUT_MS,
-    interval: 250,
-    timeoutMsg: `${label} model option never appeared for model=${model}; dump=${JSON.stringify(await execJS(js.pageDump))}`,
-  });
+  let settingsSwitchSelector = null;
+  await browser.waitUntil(
+    async () => {
+      if (
+        (await execJS(js.exists(modelSelector))) ||
+        (await execJS(js.exists(keyFirstAccountSelector)))
+      ) {
+        return true;
+      }
+      if (await execJS(js.exists(compactSwitchModelSelector))) {
+        settingsSwitchSelector = compactSwitchModelSelector;
+        return true;
+      }
+      if (await execJS(js.exists(advancedSwitchModelSelector))) {
+        settingsSwitchSelector = advancedSwitchModelSelector;
+        return true;
+      }
+      return false;
+    },
+    {
+      timeout: MOUNT_TIMEOUT_MS,
+      interval: 100,
+      timeoutMsg: `${label} model picker did not open; dump=${JSON.stringify(await execJS(js.pageDump))}`,
+    }
+  );
+  if (settingsSwitchSelector) {
+    const switchModelClicked = await clickLastVisibleNative(
+      settingsSwitchSelector
+    );
+    if (switchModelClicked?.status !== "clicked") {
+      throw new Error(
+        `${label} Switch model action was not clickable: ${JSON.stringify(switchModelClicked)} dump=${JSON.stringify(await execJS(js.pageDump))}`
+      );
+    }
+    console.log(
+      `[account-switch-evidence] label=${label} clickedSwitchModel=${JSON.stringify(switchModelClicked)}`
+    );
+  }
+
+  let pickerFlow = null;
+  await browser.waitUntil(
+    async () => {
+      if (await execJS(js.exists(modelSelector))) {
+        pickerFlow = "model-first";
+        return true;
+      }
+      if (await execJS(js.exists(keyFirstAccountSelector))) {
+        pickerFlow = "key-first";
+        return true;
+      }
+      return false;
+    },
+    {
+      timeout: MOUNT_TIMEOUT_MS,
+      interval: 250,
+      timeoutMsg: `${label} neither model-first nor key-first option appeared for model=${model} account=${followupAccount.id}; dump=${JSON.stringify(await execJS(js.pageDump))}`,
+    }
+  );
+
+  if (pickerFlow === "key-first") {
+    const keyClicked = await clickLastVisibleNative(keyFirstAccountSelector);
+    if (keyClicked?.status !== "clicked") {
+      throw new Error(
+        `${label} key-first account click failed for account=${followupAccount.id}: ${JSON.stringify(keyClicked)} dump=${JSON.stringify(await execJS(js.pageDump))}`
+      );
+    }
+    await browser.waitUntil(
+      async () => execJS(js.exists(keyFirstModelSelector)),
+      {
+        timeout: MOUNT_TIMEOUT_MS,
+        interval: 250,
+        timeoutMsg: `${label} key-first model option never appeared for model=${model}; dump=${JSON.stringify(await execJS(js.pageDump))}`,
+      }
+    );
+    const modelClicked = await clickLastVisibleNative(keyFirstModelSelector);
+    if (modelClicked?.status !== "clicked") {
+      throw new Error(
+        `${label} key-first model click failed for model=${model}: ${JSON.stringify(modelClicked)} dump=${JSON.stringify(await execJS(js.pageDump))}`
+      );
+    }
+    const modelGroupIds = parseModelIdList(modelClicked.groupModelIds);
+    const allowedSwitchModels = [
+      ...new Set([
+        ...getAllowedSwitchModels(followupAccount, model, modelGroupIds),
+        ...(modelClicked.modelId ? [String(modelClicked.modelId)] : []),
+      ]),
+    ];
+    await browser.waitUntil(
+      async () =>
+        isSessionPatchedTo(followupAccount.id, allowedSwitchModels, label),
+      {
+        timeout: 20_000,
+        interval: 250,
+        timeoutMsg: `${label} key-first selection did not patch the session; account=${followupAccount.id} allowedModels=${JSON.stringify(allowedSwitchModels)} state=${JSON.stringify(await invokeE2E("inspectChatState"))}`,
+      }
+    );
+    console.log(
+      `[account-switch-evidence] label=${label} keyFirst=true clickedKey=${JSON.stringify(keyClicked)} clickedModel=${JSON.stringify(modelClicked)} allowedModels=${JSON.stringify(allowedSwitchModels)}`
+    );
+    return allowedSwitchModels;
+  }
 
   const modelHovered = await hoverLastVisibleNative(modelSelector);
   if (modelHovered?.status !== "hovered") {


### PR DESCRIPTION
## Problem

Follow-up to #1440.

Agent Org keeps the WorkStation anchored to the Team Root while a selected Member Session owns the visible composer. The outer Root canonical binding could therefore intercept a Member's model selection, first submit, and failed-message retry. In particular, a persisted failed Member queue row carrying an old canonical dispatch could be retried through the Coordinator instead of the original Member.

The intervention return path also had two lifecycle gaps: an exact returned continuation could not reclaim and settle its original `TaskAssigned` input, and a completed `UserDirectedWork` turn could incorrectly enter the formal Task unfinished-lifecycle correction.

## Solution

- Define direct Member ownership once: only a materialized non-Coordinator Session with both `parentSessionId` and `orgMemberId` qualifies. Unknown Sessions, ordinary child Sessions, and the Coordinator fail closed.
- Compute execution ownership from the actual composer Session in the main ChatView and Side Chat. A direct Member receives no Root canonical binding, so its model pill reads and patches the Member account/model and hides the canonical-only runtime switch. Root, ordinary canonical conversations, Group Chat, and mentions retain their existing binding.
- Route submit and retry from explicit direct Member ownership instead of comparing two Session IDs. Surface/Group Chat/@mention remains first-refusal and single-send; direct Member paths fall back to the Member dispatcher; Root follow-ups continue canonical enqueue.
- Make failed retry dispatch resolution explicit with `preserve`, `replace`, and `clear`. A direct Member retry clears historical canonical dispatch metadata atomically while preserving the original Member Session, content, and attachments before Force Send. Root retry can still replace the dispatch with the currently selected canonical runtime.
- Extend exact resume-continuation authority to a cleared Member intervention so Return can reclaim the original formal assignment, settle it once, and remain generation-bound and idempotent. Unfinished Task correction now runs only for `TaskExecution`, never for `UserDirectedWork`.

The resulting invariant is: when the composer belongs to a materialized non-Coordinator Member, model selection, submit, ordinary retry, and persisted failed retry are all Member-owned; the Root canonical binding cannot intervene.

No dependency, IPC, public API, database schema, persistence format, or migration changed. Permission cards, process lists, stream-retry copy, and terminal-refresh production code are intentionally outside this PR.

## Potential risks

- Future surfaces that render a different composer Session must pass the same explicit ownership decision. The helper fails closed unless the full materialized Member identity is present, and Root/Group routes have regression coverage.
- Historical failed Member rows are corrected when the user retries them; this PR does not migrate or delete existing conversation data. The clear operation is scoped to a direct Member retry only.
- Return continuation uses exact persisted joins across the intervention, Task, inbox materialization, turn context, owner, and activation generation. Any mismatch is rejected rather than guessed; completed, cancelled, or reassigned work is not restored.
- The rendered live test uses an external OAuth provider, so provider availability can affect runtime. Durable receipts, EventStore identity, real filesystem results, and final Task state are asserted rather than treating request acceptance as success.
- Rollback the original feature commit; retain the develop integration merge. There is no schema or data migration to undo.

- Current integration verification has the TypeScript tsc baseline error and unexecuted desktop/performance checks listed below. No new runtime performance claim is made.

## Verification

Current stack integration review (2026-09-13), superseding previous-head command results. Tests used develop `f191e81fd`; develop subsequently advanced to `1125ae15e`, and `git merge-tree --write-tree origin/develop dev/review-stack-1580` confirmed clean integration without further conflict. Tests were not rerun on that newer merge-tree result:

- `pnpm exec vitest run --config config/vitest.config.ts src/engines/ChatPanel/ChatHistory/hooks/__tests__/useEditUserMessage.test.ts src/engines/ChatPanel/InputArea/components/ModelPill.memberOwnership.test.ts src/engines/ChatPanel/SideChat/SideChatSessionBody.test.ts src/engines/ChatPanel/hooks/conversationSubmit/useConversationSubmitRouter.test.ts src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.intervention.test.ts src/store/ui/__tests__/messageQueueAtom.test.ts` — 6 files, 90 tests passed after merging develop.
- From `src-tauri`: `cargo test -p agent_core --lib agent_member_interventions::tests` — 22 passed; `cargo test -p agent_core --lib agent_org_lifecycle_stop_gate` — 1 passed; `cargo clippy -p agent_core --lib --message-format=short` — passed.
- `node --check tests/e2e/specs/core/agent-org-direct-user-directed-work-live.spec.mjs` and `node --check tests/e2e/support/core/session/accountSwitchDriver.mjs` — passed.
- `git diff --check origin/develop...HEAD` — passed; 21 files remain scoped to Member ownership and return. No historical data was modified or deleted.
- Full desktop E2E, UI capture, packaged builds, and CPU/RSS/frame-time measurements were not rerun: computer control was not authorized. Earlier PR evidence does not certify these updated heads.
- `pnpm run typecheck` (TypeScript tsc) on the integrated foundation reports TS2769 in unchanged `src/components/SearchInput/SearchInput.test.ts:79`; that file is identical to develop. The native `pnpm exec tsgo --noEmit --pretty false` check passes after the search fixture integration repair.
- Merge hooks ran normally. Changed-file oxlint, ESLint/Prettier and the hook's native TypeScript check passed. The broad merge hook reported Clippy issues outside its staged error gate, so that hook is not evidence of a clean whole-workspace Rust check; independent scoped `agent_core` Clippy passed.

## Review

Architecture review covered compilation (1), dispatch duplication (2), names and ownership meaning (3–4), fail-closed direct-Member defaults (5), composer versus canonical boundaries (6), clarity (7), main/side composer parity (9), and model/retry ownership resolution (10). No new wire/persistence shape was introduced (8); no live external payload capture was performed.

Authoritative retry state is the queued message's dispatch metadata; the original producing edit path now clears stale canonical metadata atomically for a direct Member. Return authority is checked against persisted intervention/task/inbox/turn-context identities and activation generation. No historical cleanup or data deletion was performed during this review.
