### PR TITLE
fix(models): remove synthetic baseline effort choices

### DIFF
--- a/src/components/ModelPropertiesDropdown/ModelPropertiesDropdown.test.ts
+++ b/src/components/ModelPropertiesDropdown/ModelPropertiesDropdown.test.ts
@@ -129,6 +129,30 @@ describe("ModelPropertiesDropdown immediate changes", () => {
     expect(document.querySelector('[role="dialog"]')).toBeNull();
   }
 
+  it("shows only concrete efforts for a bare family selection", () => {
+    render("gpt-5.6-sol", ["gpt-5.6-sol", ...MODELS]);
+    open();
+    expect(range().max).toBe("5");
+    expect(range().getAttribute("aria-valuetext")).toBe("Medium");
+    expect(document.querySelector('[role="dialog"]')?.textContent).not.toMatch(
+      /Baseline|Default/
+    );
+    expect(save).not.toHaveBeenCalled();
+    changeRange("0");
+    expect(save).toHaveBeenLastCalledWith("gpt-5.6-sol-low");
+  });
+
+  it("shows Fast without a Default effort row for speed-only models", () => {
+    render("composer-2.5", ["composer-2.5", "composer-2.5-fast"]);
+    open();
+    expect(document.querySelector('input[type="range"]')).toBeNull();
+    expect(document.querySelector('[role="dialog"]')?.textContent).not.toMatch(
+      /Effort|Baseline|Default/
+    );
+    toggle("Fast");
+    expect(save).toHaveBeenLastCalledWith("composer-2.5-fast");
+  });
+
   it("saves valid effort and Fast changes without a footer, and stays open", () => {
     render("gpt-5.6-sol-high-fast");
     open();

--- a/src/hooks/models/useModelEffortSegment.ts
+++ b/src/hooks/models/useModelEffortSegment.ts
@@ -103,7 +103,14 @@ export function useModelEffortSegment({
     [groupModelIds, modelId]
   );
 
-  const variant = modelId ? parseModelVariant(modelId) : undefined;
+  const effectiveModelId = modelId
+    ? (variantOptions.resolveVariantId(
+        variantOptions.parseSelection(modelId)
+      ) ?? modelId)
+    : undefined;
+  const variant = effectiveModelId
+    ? parseModelVariant(effectiveModelId)
+    : undefined;
 
   const effortLabel = useMemo(() => {
     const parts: string[] = [];

--- a/src/modules/MainApp/Integrations/KeyVault/shared/ModelTable/ModelVariantInlineCard.test.ts
+++ b/src/modules/MainApp/Integrations/KeyVault/shared/ModelTable/ModelVariantInlineCard.test.ts
@@ -1,0 +1,48 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveModelVariantFields } from "@src/util/modelVariants";
+
+import ModelVariantInlineCard from "./ModelVariantInlineCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const dropdown = vi.hoisted(() => ({
+  value: "",
+  onChange: vi.fn<(modelId: string) => void>(),
+}));
+vi.mock("@src/components/ModelPropertiesDropdown", () => ({
+  default: (props: typeof dropdown) => {
+    Object.assign(dropdown, props);
+    return null;
+  },
+}));
+
+describe("ModelVariantInlineCard default persistence", () => {
+  it.each([
+    ["o4-mini", "o4"],
+    ["claude-opus-4-7", "claude-opus-4-7"],
+  ])(
+    "preserves the %s family key after filtering bare choices",
+    (base, key) => {
+      const onChange = vi.fn();
+      renderToStaticMarkup(
+        React.createElement(ModelVariantInlineCard, {
+          variants: [base, `${base}-low`, `${base}-medium`, `${base}-high`].map(
+            (model) => resolveModelVariantFields(model)
+          ),
+          embedded: true,
+          defaultVariantByBaseModel: new Map([[key, `${base}-high`]]),
+          onChangeDefaultVariant: onChange,
+        })
+      );
+
+      expect(dropdown.value).toBe(`${base}-high`);
+      dropdown.onChange(`${base}-low`);
+      expect(onChange).toHaveBeenCalledWith(key, `${base}-low`);
+    }
+  );
+});

--- a/src/modules/MainApp/Integrations/KeyVault/shared/ModelTable/ModelVariantInlineCard.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/shared/ModelTable/ModelVariantInlineCard.tsx
@@ -421,13 +421,18 @@ export default function ModelVariantInlineCard({
   // family (one group → one card), so the entire card collapses to a
   // single "Selected version" row. The dropdown enumerates every variant
   // in the family after excluding bare aliases of explicit efforts. We pick the
-  // shortest `base_model` string as the canonical key for persistence so
+  // shortest `base_model` string from the complete family as the persistence
+  // key. Filtering selectable efforts must not change that key (for example,
+  // the o4-mini bare record owns the existing o4 key). This also ensures
   // that "claude-opus-4-6" (unsuffixed fallback) and "claude-opus-4-6"
   // (parsed from "...-high") always resolve to the same entry.
   const canonicalBaseModel =
-    sortedVariants.length > 0
-      ? sortedVariants
-          .map((variant) => variant.base_model)
+    variants.length > 0
+      ? variants
+          .map(
+            (variant) =>
+              resolveModelVariantFields(variant.model, variant).base_model
+          )
           .reduce((shortest, candidate) =>
             candidate.length < shortest.length ? candidate : shortest
           )

--- a/src/modules/MainApp/Integrations/KeyVault/shared/ModelTable/ModelVariantInlineCard.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/shared/ModelTable/ModelVariantInlineCard.tsx
@@ -18,6 +18,7 @@ import {
   resolveModelVariantFields,
   toModelReasoningLevel,
 } from "@src/util/modelVariants";
+import { selectableModelVariants } from "@src/util/selectableModelVariants";
 import { buildVariantEditOptions } from "@src/util/variantEditOptions";
 
 import ModelTableTooltipContent from "./ModelTableTooltipContent";
@@ -83,7 +84,7 @@ function toTitleCaseSuffix(value: string): string {
 
 // ── GPT: group by reasoning level ─────────────────────────────────────────────
 
-const BASE_EFFORT_LABEL = "Baseline";
+const BASE_EFFORT_LABEL = formatReasoningLevel(MODEL_REASONING_LEVEL.BASELINE);
 
 function isUnsuffixedBaseVariant(variant: ModelTableVariantInfo): boolean {
   return variant.model.toLowerCase() === variant.base_model.toLowerCase();
@@ -266,7 +267,7 @@ export default function ModelVariantInlineCard({
 
   const sortedVariants = useMemo(
     () =>
-      [...variants]
+      (forceModelList ? [...variants] : selectableModelVariants(variants))
         .map((variant) => resolveModelVariantFields(variant.model, variant))
         .sort((variantA, variantB) => {
           const reasoningOrder =
@@ -274,7 +275,7 @@ export default function ModelVariantInlineCard({
           if (reasoningOrder !== 0) return reasoningOrder;
           return pillSortKey(variantA) - pillSortKey(variantB);
         }),
-    [variants]
+    [variants, forceModelList]
   );
 
   const gptGroup = isGptGroup(sortedVariants);
@@ -419,7 +420,7 @@ export default function ModelVariantInlineCard({
   // A ModelVariantInlineCard always renders variants for a single model
   // family (one group → one card), so the entire card collapses to a
   // single "Selected version" row. The dropdown enumerates every variant
-  // in the family, including the unsuffixed / Baseline one. We pick the
+  // in the family after excluding bare aliases of explicit efforts. We pick the
   // shortest `base_model` string as the canonical key for persistence so
   // that "claude-opus-4-6" (unsuffixed fallback) and "claude-opus-4-6"
   // (parsed from "...-high") always resolve to the same entry.

--- a/src/modules/MobileRemote/components/composer/useMobileModelEffortSegment.test.ts
+++ b/src/modules/MobileRemote/components/composer/useMobileModelEffortSegment.test.ts
@@ -1,10 +1,70 @@
-// @vitest-environment node
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import React, { act, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { KEY_SOURCE } from "@src/api/tauri/session";
 import type { MobileSessionModelConfig } from "@src/modules/MobileRemote/connection/types";
 
-import { toMobileLastModelSelection } from "./useMobileModelEffortSegment";
+import {
+  toMobileLastModelSelection,
+  useMobileModelEffortSegment,
+} from "./useMobileModelEffortSegment";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("useMobileModelEffortSegment session authority", () => {
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it.each([
+    ["gpt-5.6-sol", "common:selectors.modelProperties.default"],
+    ["gpt-5.6-sol-high", "High"],
+    ["gpt-5.6-sol-high-fast", "High · Fast"],
+  ])("labels the stored %s without applying a picker seed", (model, label) => {
+    const onApply = vi.fn();
+    let state: ReturnType<typeof useMobileModelEffortSegment> | undefined;
+    function Probe() {
+      const nextState = useMobileModelEffortSegment(
+        { sessionId: "s", model, accountId: "a", modelEditable: true },
+        [
+          "gpt-5.6-sol",
+          "gpt-5.6-sol-low",
+          "gpt-5.6-sol-medium",
+          "gpt-5.6-sol-high",
+          "gpt-5.6-sol-high-fast",
+        ].map((id) => ({ id, accountId: "a", accountLabel: "A" })),
+        onApply
+      );
+      useEffect(() => {
+        state = nextState;
+      }, [nextState]);
+      return null;
+    }
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    try {
+      act(() => root.render(React.createElement(Probe)));
+      expect(state?.modelId).toBe(model);
+      expect(state?.effortLabel).toBe(label);
+      expect(onApply).not.toHaveBeenCalled();
+      act(() => state?.handleApply("gpt-5.6-sol-medium"));
+      expect(onApply).toHaveBeenCalledTimes(1);
+      expect(onApply).toHaveBeenCalledWith("gpt-5.6-sol-medium");
+    } finally {
+      act(() => root.unmount());
+    }
+  });
+});
 
 describe("toMobileLastModelSelection", () => {
   it("maps own-key sessions to LastModelSelection", () => {

--- a/src/modules/MobileRemote/components/composer/useMobileModelEffortSegment.ts
+++ b/src/modules/MobileRemote/components/composer/useMobileModelEffortSegment.ts
@@ -75,7 +75,14 @@ export function useMobileModelEffortSegment(
     [groupModelIds, modelId]
   );
 
-  const variant = modelId ? parseModelVariant(modelId) : undefined;
+  const effectiveModelId = modelId
+    ? (variantOptions.resolveVariantId(
+        variantOptions.parseSelection(modelId)
+      ) ?? modelId)
+    : undefined;
+  const variant = effectiveModelId
+    ? parseModelVariant(effectiveModelId)
+    : undefined;
 
   const effortLabel = useMemo(() => {
     const parts: string[] = [];

--- a/src/modules/MobileRemote/components/composer/useMobileModelEffortSegment.ts
+++ b/src/modules/MobileRemote/components/composer/useMobileModelEffortSegment.ts
@@ -75,14 +75,9 @@ export function useMobileModelEffortSegment(
     [groupModelIds, modelId]
   );
 
-  const effectiveModelId = modelId
-    ? (variantOptions.resolveVariantId(
-        variantOptions.parseSelection(modelId)
-      ) ?? modelId)
-    : undefined;
-  const variant = effectiveModelId
-    ? parseModelVariant(effectiveModelId)
-    : undefined;
+  // The session/config model is authoritative until the user applies a
+  // selection through session/patch. A picker seed is not a runtime override.
+  const variant = modelId ? parseModelVariant(modelId) : undefined;
 
   const effortLabel = useMemo(() => {
     const parts: string[] = [];

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/VariantPill.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/VariantPill.tsx
@@ -43,12 +43,14 @@ export const VariantPill: React.FC<VariantPillProps> = ({
   groupModelIds,
   onApply,
 }) => {
-  const variant = parseModelVariant(modelId);
-
   const variantOptions = React.useMemo(
     () => buildVariantEditOptions(groupModelIds ?? [modelId]),
     [groupModelIds, modelId]
   );
+  const effectiveModelId =
+    variantOptions.resolveVariantId(variantOptions.parseSelection(modelId)) ??
+    modelId;
+  const variant = parseModelVariant(effectiveModelId);
 
   const pillClasses =
     "relative z-10 inline-flex h-[24px] shrink-0 items-center gap-0.5 rounded-full border border-transparent bg-transparent px-2 text-[11px] font-semibold text-text-2 transition-colors group-hover/model-row:border-border-3 group-hover/model-row:bg-bg-1 group-focus-within/model-row:border-border-3 group-focus-within/model-row:bg-bg-1";

--- a/src/util/__tests__/selectableModelVariants.test.ts
+++ b/src/util/__tests__/selectableModelVariants.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDefaultVariant } from "../defaultModelVariant";
+import {
+  MODEL_REASONING_LEVEL,
+  resolveModelVariantFields,
+} from "../modelVariants";
+import { selectableModelVariants } from "../selectableModelVariants";
+import { buildVariantEditOptions } from "../variantEditOptions";
+
+describe("selectable model efforts", () => {
+  it.each([
+    "gpt-6-astra",
+    "gpt-5.6-sol",
+    "gpt-5.3-codex",
+    "claude-opus-4-7",
+    "glm-5.2",
+    "grok-4.5",
+    "o3",
+    "o4-mini",
+    "cursor-gpt-5.5",
+    "cursor-claude-opus-4-7",
+  ])("does not create a baseline rung for %s", (base) => {
+    const ids = [base, `${base}-low`, `${base}-medium`, `${base}-high`];
+    const variants = ids.map((model) => resolveModelVariantFields(model));
+    expect(
+      selectableModelVariants(variants).map((variant) => variant.model)
+    ).toEqual(ids.slice(1));
+    const options = buildVariantEditOptions(ids);
+    expect(options.availableLevels).toEqual([
+      MODEL_REASONING_LEVEL.LOW,
+      MODEL_REASONING_LEVEL.MEDIUM,
+      MODEL_REASONING_LEVEL.HIGH,
+    ]);
+    const expected = `${base}-${base.startsWith("claude-") ? "high" : "medium"}`;
+    expect(options.resolveVariantId(options.parseSelection(base))).toBe(
+      expected
+    );
+    expect(resolveDefaultVariant(base, variants, base)).toBe(expected);
+    expect(resolveDefaultVariant(base, variants, `${base}-low`)).toBe(
+      `${base}-low`
+    );
+  });
+
+  it("preserves speed and thinking while resolving bare aliases", () => {
+    const base = "claude-opus-4-8";
+    const ids = [
+      base,
+      `${base}-high`,
+      `${base}-thinking-fast`,
+      `${base}-thinking-high-fast`,
+    ];
+    const options = buildVariantEditOptions(ids);
+    expect(options.availableLevels).toEqual([MODEL_REASONING_LEVEL.HIGH]);
+    expect(
+      options.resolveVariantId(options.parseSelection(`${base}-thinking-fast`))
+    ).toBe(`${base}-thinking-high-fast`);
+    const variants = ids.map((model) => resolveModelVariantFields(model));
+    expect(
+      resolveDefaultVariant(
+        base,
+        selectableModelVariants(variants),
+        `${base}-thinking-fast`
+      )
+    ).toBe(`${base}-thinking-high-fast`);
+  });
+
+  it("keeps standalone, speed-only and thinking-only model choices", () => {
+    const ids = [
+      "composer-2.5",
+      "composer-2.5-fast",
+      "claude-sonnet-4-6",
+      "claude-sonnet-4-6-thinking",
+      "custom-model",
+    ];
+    const variants = ids.map((model) => ({ model }));
+    expect(selectableModelVariants(variants)).toEqual(variants);
+    const options = buildVariantEditOptions(ids);
+    for (const id of ids) {
+      // Each real family is indexed separately by callers.
+      const family = buildVariantEditOptions([id]);
+      expect(family.availableLevels).toEqual([]);
+      expect(family.resolveVariantId(family.parseSelection(id))).toBe(id);
+    }
+    expect(options.thinkingToggleable).toBe(true);
+  });
+
+  it("keeps speed toggles usable without inventing an effort level", () => {
+    const options = buildVariantEditOptions([
+      "composer-2.5",
+      "composer-2.5-fast",
+    ]);
+    expect(options.availableLevels).toEqual([]);
+    const selection = options.parseSelection("composer-2.5");
+    expect(options.fastAvailable(selection)).toBe(true);
+    expect(options.resolveVariantId({ ...selection, fast: true })).toBe(
+      "composer-2.5-fast"
+    );
+  });
+});

--- a/src/util/defaultModelVariant.ts
+++ b/src/util/defaultModelVariant.ts
@@ -2,8 +2,11 @@ import type { ModelTableVariantInfo } from "@src/types/modelTable";
 import {
   MODEL_REASONING_LEVEL,
   type ModelReasoningLevel,
+  parseModelVariant,
   toModelReasoningLevel,
 } from "@src/util/modelVariants";
+
+import { selectableModelVariants } from "./selectableModelVariants";
 
 /**
  * Per-base-model default variant resolution.
@@ -118,11 +121,24 @@ export function resolveDefaultVariant(
   variants: ModelTableVariantInfo[],
   persistedModel: string | undefined
 ): string | undefined {
+  const selectable = selectableModelVariants(variants);
   if (
     persistedModel &&
-    variants.some((variant) => variant.model === persistedModel)
+    selectable.some((variant) => variant.model === persistedModel)
   ) {
     return persistedModel;
   }
-  return computeSeedDefaultVariant(baseModel, variants);
+  if (persistedModel && !parseModelVariant(persistedModel)?.reasoning) {
+    const previous = parseModelVariant(persistedModel);
+    const sameOptions = selectable.filter((variant) => {
+      const parsed = parseModelVariant(variant.model);
+      return (
+        (parsed?.thinking ?? false) === (previous?.thinking ?? false) &&
+        (parsed?.fast ?? false) === (previous?.fast ?? false)
+      );
+    });
+    if (sameOptions.length > 0)
+      return computeSeedDefaultVariant(baseModel, sameOptions);
+  }
+  return computeSeedDefaultVariant(baseModel, selectable);
 }

--- a/src/util/modelVariants.ts
+++ b/src/util/modelVariants.ts
@@ -7,6 +7,7 @@ import {
 
 export const MODEL_REASONING_LEVEL = {
   NONE: "none",
+  // No explicit effort override. Keep the internal key stable; display as Default.
   BASELINE: "baseline",
   LOW: "low",
   MEDIUM: "medium",
@@ -308,7 +309,7 @@ export function formatReasoningLevel(
     case MODEL_REASONING_LEVEL.NONE:
       return "None";
     case MODEL_REASONING_LEVEL.BASELINE:
-      return "Baseline";
+      return "Default";
     case MODEL_REASONING_LEVEL.LOW:
       return "Light";
     case MODEL_REASONING_LEVEL.MEDIUM:

--- a/src/util/selectableModelVariants.ts
+++ b/src/util/selectableModelVariants.ts
@@ -1,0 +1,37 @@
+import { parseModelVariant } from "./modelVariants";
+
+/** Size variants such as o4-mini own an effort ladder; mini is not effort. */
+export function getModelEffortBaseModel(model: string): string {
+  const parsed = parseModelVariant(model);
+  return parsed && (parsed.reasoning || parsed.thinking || parsed.fast)
+    ? parsed.baseModel
+    : model;
+}
+
+/**
+ * A family id is not an extra effort rung when concrete efforts cover the
+ * same thinking/speed combination. Keep bare ids for models without that
+ * ladder, including speed-only and thinking-only families.
+ */
+export function selectableModelVariants<T extends { model: string }>(
+  variants: readonly T[]
+): T[] {
+  const entries = variants.map((variant) => {
+    const parsed = parseModelVariant(variant.model);
+    return {
+      variant,
+      reasoning: parsed?.reasoning,
+      key: JSON.stringify([
+        getModelEffortBaseModel(variant.model),
+        parsed?.thinking ?? false,
+        parsed?.fast ?? false,
+      ]),
+    };
+  });
+  const explicitEfforts = new Set(
+    entries.filter((entry) => entry.reasoning).map((entry) => entry.key)
+  );
+  return entries
+    .filter((entry) => entry.reasoning || !explicitEfforts.has(entry.key))
+    .map((entry) => entry.variant);
+}

--- a/src/util/variantEditOptions.ts
+++ b/src/util/variantEditOptions.ts
@@ -14,18 +14,23 @@
  * the Effort/Reasoning row list without baking model-family specifics
  * into the component.
  */
+import { computeSeedDefaultVariant } from "./defaultModelVariant";
 import {
   MODEL_REASONING_LEVEL,
   type ModelReasoningLevel,
   parseModelVariant,
 } from "./modelVariants";
+import {
+  getModelEffortBaseModel,
+  selectableModelVariants,
+} from "./selectableModelVariants";
 
 /**
  * Order in which reasoning levels are displayed in the dropdown. Levels
- * the family does not expose are filtered out before rendering. `Baseline`
+ * the family does not expose are filtered out before rendering. `Default`
  * represents the unsuffixed / no-effort variant (e.g. `claude-sonnet-4-6`
- * or `claude-opus-4-6-thinking` with no level token) and is treated as a
- * regular selectable effort alongside Low/Medium/High/etc.
+ * or `claude-opus-4-6-thinking` with no level token). It is retained only
+ * when no explicit effort ladder covers that thinking/speed combination.
  */
 const LEVEL_DISPLAY_ORDER: ModelReasoningLevel[] = [
   MODEL_REASONING_LEVEL.BASELINE,
@@ -99,8 +104,8 @@ function indexVariants(modelIds: readonly string[]): IndexedVariant[] {
       // thinking). Effort level is independent — a variant can have
       // a reasoning level without being a thinking variant. Variants
       // with no parsed level (e.g. `claude-opus-4-6-thinking`,
-      // `composer-2.5-fast`) are surfaced as the `Baseline` effort row
-      // so they appear alongside Low/Medium/High in the dropdown.
+      // `composer-2.5-fast`) are surfaced as the `Default` effort row
+      // only when concrete effort variants do not cover that combination.
       out.push({
         modelId,
         thinking: parsed.thinking,
@@ -110,7 +115,7 @@ function indexVariants(modelIds: readonly string[]): IndexedVariant[] {
       continue;
     }
     // Unparsed ids (e.g. `claude-sonnet-4-6`) are treated as the
-    // unsuffixed Baseline variant.
+    // unsuffixed Default variant.
     out.push({
       modelId,
       thinking: false,
@@ -137,7 +142,9 @@ function selectionKey(selection: {
 export function buildVariantEditOptions(
   modelIds: readonly string[]
 ): VariantEditOptions {
-  const indexed = indexVariants(modelIds);
+  const indexed = selectableModelVariants(
+    modelIds.map((model) => ({ model }))
+  ).flatMap(({ model }) => indexVariants([model]));
 
   // Effort levels are collected across BOTH thinking and non-thinking
   // variants. After the parser split, a non-thinking Claude variant
@@ -146,8 +153,12 @@ export function buildVariantEditOptions(
   for (const variant of indexed) {
     if (variant.level) levelSet.add(variant.level);
   }
-  const availableLevels = LEVEL_DISPLAY_ORDER.filter((level) =>
-    levelSet.has(level)
+  // Speed/thinking-only families have no effort control. The internal
+  // no-effort key still resolves their toggles, but is not an effort rung.
+  const availableLevels = LEVEL_DISPLAY_ORDER.filter(
+    (level) =>
+      levelSet.has(level) &&
+      !(level === MODEL_REASONING_LEVEL.BASELINE && levelSet.size === 1)
   );
 
   // Thinking is "toggleable" only when the family exposes both states
@@ -183,6 +194,32 @@ export function buildVariantEditOptions(
   };
 
   const parseSelection = (modelId: string): VariantSelection => {
+    // Previously saved bare family ids resolve through the same seed rule
+    // as family selection, rather than adding an invented effort rung.
+    if (
+      !parseModelVariant(modelId)?.reasoning &&
+      !indexed.some((variant) => variant.modelId === modelId)
+    ) {
+      const original = parseModelVariant(modelId);
+      const base = getModelEffortBaseModel(modelId);
+      const candidates = indexed.filter((variant) => {
+        return (
+          getModelEffortBaseModel(variant.modelId) === base &&
+          variant.thinking === (original?.thinking ?? false) &&
+          variant.fast === (original?.fast ?? false)
+        );
+      });
+      const resolved = computeSeedDefaultVariant(
+        base,
+        candidates.map((variant) => ({
+          model: variant.modelId,
+          base_model: base,
+          reasoning: variant.level,
+          fast: variant.fast,
+        }))
+      );
+      if (resolved) return parseSelection(resolved);
+    }
     const parsed = parseModelVariant(modelId);
     if (!parsed) {
       return {


### PR DESCRIPTION
## Problem

Model families with explicit reasoning efforts also exposed a synthetic Baseline/Default option. The frontend treated bare family identifiers as extra effort rungs. Rust correctly retains bare identifiers without an effort override; those metadata records must remain available.

Filtering those choices also exposed two regressions: the Key Vault inline card derived its persistence key from the filtered family, losing saved o4-mini preferences, and Mobile Remote labeled unchanged bare sessions with a concrete picker seed that was never applied to the runtime.

## Solution

- Share selectable-variant projection across effort options and default resolution: exclude a bare alias when explicit efforts cover the same thinking/speed combination.
- Resolve bare family default choices through the existing family seed rule, preserving thinking and speed options and explicit selections.
- Align desktop and Spotlight labels with their resolved picker selection. Mobile Remote labels the authoritative session/config model until the user explicitly applies a choice through the existing session/patch path.
- Derive the Key Vault inline card's persistence key from the complete family before filtering choices. Existing o4 keys remain readable and writable, matching the preferred-version table control.
- Omit the effort row for speed/thinking-only families and preserve native size identifiers such as o4-mini when matching effort ladders.
- Add regression coverage for family projection, persisted default lookup and the card's write callback, and bare/explicit/Fast mobile labels and explicit apply behavior.

## Potential risks

Bare family default choices can resolve to a concrete seed effort when selected, which may differ from the provider's implicit default. Existing mobile sessions retain their stored model and show Default for a bare identifier; opening a picker does not change runtime effort. The existing persistence format and keys are preserved. No stored records are deleted or migrated, and no dependencies, Rust parser, IPC, or provider wire formats change. Reverting the PR restores the prior selection behavior without data recovery steps.

Native desktop/mobile appearance, themes, and viewport behavior have not been visually verified. Computer control is explicit opt-in in this workspace and was not requested; no screenshots are included. Automated tests cover the dropdown behavior, inline-card persistence callback, and mobile hook state.

## Verification

- `pnpm test src/util/__tests__/selectableModelVariants.test.ts src/util/__tests__/variantEditOptions.test.ts src/util/__tests__/modelVariants.test.ts src/components/ModelPropertiesDropdown/ModelPropertiesDropdown.test.ts src/components/ModelPropertiesDropdown/EffortSlider.test.ts src/modules/MobileRemote/components/composer/useMobileModelEffortSegment.test.ts src/modules/MainApp/Integrations/KeyVault/shared/ModelTable/ModelVariantInlineCard.test.ts` — 54 tests passed across seven files after both review fixes.
- `pnpm run check:test-placement` — passed across 548 directories.
- `git diff --cached --check` — passed; inspected the change for unrelated files, credentials, private paths, and generated artifacts.
- Normal commit hooks passed: `npx lint-staged` (oxlint, ESLint, Prettier), `npx tsgo --noEmit --pretty false` (full TypeScript check passed), and commitlint.
- The review's two reproductions passed on pre-PR base `76dc48ee9` and failed on original PR head `df29da6ef6`; permanent regression tests now cover both fixes.
- Native-app checks/screenshots and Rust tests were not run: computer control was not requested and no Rust implementation changed.
- Latest fetched develop was `60c7580cb2`; `git merge-tree --write-tree HEAD origin/develop` reported no conflicts. Newer develop commits were not incorporated into this branch; the tests ran on the PR branch based on `76dc48ee9`.
