### PR TITLE
fix(imported-history): re-promote superseded continuation winners

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
@@ -11,7 +11,8 @@ pub use continuation::{
     cached_session_continuation_status_from_conn, continuation_group_metadata_json,
     continuation_lineage_id_from_metadata_json, continuation_metadata_json,
     demote_superseded_continuations_from_conn, CONTINUATION_GROUP_KEY_FIELD,
-    CONTINUATION_LINEAGE_ID_FIELD, CONTINUATION_MARKERS_FIELD, MAX_CONTINUATION_MARKERS,
+    CONTINUATION_LINEAGE_ID_FIELD, CONTINUATION_MARKERS_FIELD, CONTINUATION_SUPERSEDED_FIELD,
+    MAX_CONTINUATION_MARKERS,
 };
 pub use lookup::{
     get_cached_source_path_by_suffix_from_conn, get_cached_source_path_from_conn,

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache/continuation.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache/continuation.rs
@@ -418,8 +418,14 @@ pub fn demote_superseded_continuations_from_conn(
         }
     }
 
+    // Stamp, demote and re-promote together: a promotion whose stamp removal
+    // landed but whose listable flip did not would leave the winner hidden
+    // with no marker for the next election to recover from.
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|err| format!("Failed to begin continuation election: {err}"))?;
     for (source_session_id, metadata_json) in metadata_updates {
-        conn.execute(
+        tx.execute(
             "UPDATE imported_history_session_cache
              SET source_metadata_json = ?3
              WHERE source = ?1 AND source_session_id = ?2",
@@ -428,7 +434,7 @@ pub fn demote_superseded_continuations_from_conn(
         .map_err(|err| format!("Failed to stamp continuation lineage: {err}"))?;
     }
     for source_session_id in &losers {
-        conn.execute(
+        tx.execute(
             "UPDATE imported_history_session_cache
              SET listable = 0
              WHERE source = ?1 AND source_session_id = ?2",
@@ -437,7 +443,7 @@ pub fn demote_superseded_continuations_from_conn(
         .map_err(|err| format!("Failed to demote superseded continuation: {err}"))?;
     }
     for source_session_id in &promoted {
-        conn.execute(
+        tx.execute(
             "UPDATE imported_history_session_cache
              SET listable = 1
              WHERE source = ?1 AND source_session_id = ?2",
@@ -445,5 +451,7 @@ pub fn demote_superseded_continuations_from_conn(
         )
         .map_err(|err| format!("Failed to re-promote continuation winner: {err}"))?;
     }
+    tx.commit()
+        .map_err(|err| format!("Failed to commit continuation election: {err}"))?;
     Ok(losers.len())
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache/continuation.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache/continuation.rs
@@ -96,6 +96,10 @@ pub const CONTINUATION_GROUP_KEY_FIELD: &str = "continuationGroupKey";
 pub const CONTINUATION_MARKERS_FIELD: &str = "continuationMarkers";
 /// Stable component id elected after every source sync.
 pub const CONTINUATION_LINEAGE_ID_FIELD: &str = "continuationLineageId";
+/// Set on a row the election hid because a newer sibling existed. Only rows
+/// carrying this flag are re-promoted when they win a later election, so a
+/// row hidden for another reason (managed mirror) never resurfaces here.
+pub const CONTINUATION_SUPERSEDED_FIELD: &str = "continuationSuperseded";
 /// Hard cap for source-controlled marker arrays read from cache metadata.
 pub const MAX_CONTINUATION_MARKERS: usize = 64;
 
@@ -105,6 +109,7 @@ struct ContinuationMetadata {
     group_key: Option<String>,
     markers: Vec<String>,
     lineage_id: Option<String>,
+    superseded: bool,
 }
 
 fn metadata_string(value: Option<&serde_json::Value>) -> Option<String> {
@@ -122,6 +127,10 @@ fn parse_continuation_metadata(metadata_json: &str) -> Option<ContinuationMetada
     }
     let group_key = metadata_string(value.get(CONTINUATION_GROUP_KEY_FIELD));
     let lineage_id = metadata_string(value.get(CONTINUATION_LINEAGE_ID_FIELD));
+    let superseded = value
+        .get(CONTINUATION_SUPERSEDED_FIELD)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
     let mut markers = Vec::with_capacity(MAX_CONTINUATION_MARKERS);
     let mut seen = HashSet::new();
     if let Some(group_key) = group_key.as_ref() {
@@ -152,6 +161,7 @@ fn parse_continuation_metadata(metadata_json: &str) -> Option<ContinuationMetada
         group_key,
         markers,
         lineage_id,
+        superseded,
     })
 }
 
@@ -213,10 +223,12 @@ pub fn continuation_metadata_json(
 /// `updated_at_ms`, then `source_session_id`) stays listable; every other
 /// currently-listable sibling flips to `listable = 0`.
 ///
-/// Demote-only by design: winners are never promoted here, so a winner that
-/// is unlistable for another reason (managed mirror, subagent) stays hidden.
-/// Runs after every sync; if a demoted file later changes on disk its
-/// re-parse resets `listable = 1` and the next election re-demotes it.
+/// A demoted sibling is stamped `continuationSuperseded`; when it later wins
+/// (the newer generation was pruned) that stamp is what allows re-promotion.
+/// A winner hidden for any other reason (managed mirror, subagent) carries no
+/// stamp and stays hidden. Runs after every sync; if a demoted file later
+/// changes on disk its re-parse resets `listable = 1` and the next election
+/// re-demotes it.
 pub fn demote_superseded_continuations_from_conn(
     conn: &Connection,
     source: &str,
@@ -334,6 +346,7 @@ pub fn demote_superseded_continuations_from_conn(
     }
 
     let mut losers = Vec::new();
+    let mut promoted = Vec::new();
     let mut metadata_updates = Vec::new();
     for member_indices in families.values() {
         let winner_index = *member_indices
@@ -365,19 +378,43 @@ pub fn demote_superseded_continuations_from_conn(
 
         for index in member_indices {
             let row = &election_rows[*index];
-            if row.listable && *index != winner_index {
+            let is_winner = *index == winner_index;
+            let demote = row.listable && !is_winner;
+            let promote = is_winner && !row.listable && row.metadata.superseded;
+            if demote {
                 losers.push(row.source_session_id.clone());
             }
-            if row.metadata.lineage_id.as_deref() != Some(lineage_id.as_str()) {
-                let mut metadata = row.metadata.value.clone();
-                if let Some(object) = metadata.as_object_mut() {
-                    object.insert(
-                        CONTINUATION_LINEAGE_ID_FIELD.to_string(),
-                        serde_json::Value::String(lineage_id.clone()),
-                    );
-                    metadata_updates.push((row.source_session_id.clone(), metadata.to_string()));
-                }
+            if promote {
+                promoted.push(row.source_session_id.clone());
             }
+            let superseded_after = if demote {
+                true
+            } else if is_winner {
+                false
+            } else {
+                row.metadata.superseded
+            };
+            let lineage_changed = row.metadata.lineage_id.as_deref() != Some(lineage_id.as_str());
+            if !lineage_changed && superseded_after == row.metadata.superseded {
+                continue;
+            }
+            let mut metadata = row.metadata.value.clone();
+            let Some(object) = metadata.as_object_mut() else {
+                continue;
+            };
+            object.insert(
+                CONTINUATION_LINEAGE_ID_FIELD.to_string(),
+                serde_json::Value::String(lineage_id.clone()),
+            );
+            if superseded_after {
+                object.insert(
+                    CONTINUATION_SUPERSEDED_FIELD.to_string(),
+                    serde_json::Value::Bool(true),
+                );
+            } else {
+                object.remove(CONTINUATION_SUPERSEDED_FIELD);
+            }
+            metadata_updates.push((row.source_session_id.clone(), metadata.to_string()));
         }
     }
 
@@ -398,6 +435,15 @@ pub fn demote_superseded_continuations_from_conn(
             rusqlite::params![source, source_session_id],
         )
         .map_err(|err| format!("Failed to demote superseded continuation: {err}"))?;
+    }
+    for source_session_id in &promoted {
+        conn.execute(
+            "UPDATE imported_history_session_cache
+             SET listable = 1
+             WHERE source = ?1 AND source_session_id = ?2",
+            rusqlite::params![source, source_session_id],
+        )
+        .map_err(|err| format!("Failed to re-promote continuation winner: {err}"))?;
     }
     Ok(losers.len())
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
@@ -707,6 +707,73 @@ fn continuation_election_never_promotes_and_skips_subagents() {
 }
 
 #[test]
+fn continuation_election_repromotes_a_superseded_winner_once_the_newer_generation_is_gone() {
+    let mut conn = fixture_conn();
+    let group = continuation_group_metadata_json(Some("family-b"));
+    let mut older = input(SOURCE_CODEX_APP, "gen1", 100);
+    older.source_metadata_json = group.clone();
+    let mut newer = input(SOURCE_CODEX_APP, "gen2", 200);
+    newer.source_metadata_json = group;
+    upsert_imported_session_cache_from_conn(&mut conn, &[older, newer]).expect("upsert");
+    demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP).expect("election");
+    assert!(!listable_of(&conn, SOURCE_CODEX_APP, "gen1"));
+    assert!(listable_of(&conn, SOURCE_CODEX_APP, "gen2"));
+    let stamped: String = conn
+        .query_row(
+            "SELECT source_metadata_json FROM imported_history_session_cache
+             WHERE source = ?1 AND source_session_id = 'gen1'",
+            [SOURCE_CODEX_APP],
+            |row| row.get(0),
+        )
+        .expect("gen1 metadata");
+    assert!(stamped.contains(CONTINUATION_SUPERSEDED_FIELD));
+
+    // The newer rollout's file is gone: the sync prunes its row while gen1's
+    // unchanged file is never re-parsed. The election must bring gen1 back.
+    prune_missing_records_from_conn(&conn, SOURCE_CODEX_APP, &["gen1".to_string()])
+        .expect("prune gen2");
+    demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP).expect("re-election");
+    assert!(listable_of(&conn, SOURCE_CODEX_APP, "gen1"));
+    let restored: String = conn
+        .query_row(
+            "SELECT source_metadata_json FROM imported_history_session_cache
+             WHERE source = ?1 AND source_session_id = 'gen1'",
+            [SOURCE_CODEX_APP],
+            |row| row.get(0),
+        )
+        .expect("gen1 metadata");
+    assert!(!restored.contains(CONTINUATION_SUPERSEDED_FIELD));
+
+    // A steady-state election must not rewrite anything.
+    let before = conn.total_changes();
+    demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP).expect("steady");
+    assert_eq!(conn.total_changes(), before);
+}
+
+#[test]
+fn continuation_election_keeps_a_winner_hidden_for_reasons_other_than_supersession() {
+    let mut conn = fixture_conn();
+    let group = continuation_group_metadata_json(Some("family-c"));
+    let mut older = input(SOURCE_CODEX_APP, "gen1", 100);
+    older.source_metadata_json = group.clone();
+    let mut newer = input(SOURCE_CODEX_APP, "gen2", 200);
+    newer.source_metadata_json = group.clone();
+    upsert_imported_session_cache_from_conn(&mut conn, &[older, newer]).expect("upsert");
+    demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP).expect("election");
+
+    // gen1 is re-parsed as a managed mirror: the upsert rewrites its metadata
+    // without the supersession stamp and hides it for ownership reasons.
+    let mut managed = input(SOURCE_CODEX_APP, "gen1", 100);
+    managed.source_metadata_json = group;
+    managed.listable = false;
+    upsert_imported_session_cache_from_conn(&mut conn, &[managed]).expect("managed upsert");
+    prune_missing_records_from_conn(&conn, SOURCE_CODEX_APP, &["gen1".to_string()])
+        .expect("prune gen2");
+    demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP).expect("re-election");
+    assert!(!listable_of(&conn, SOURCE_CODEX_APP, "gen1"));
+}
+
+#[test]
 fn canonical_lookup_skips_continuation_superseded_siblings() {
     let mut conn = fixture_conn();
     let group = continuation_group_metadata_json(Some("family-uuid"));

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
@@ -751,6 +751,50 @@ fn continuation_election_repromotes_a_superseded_winner_once_the_newer_generatio
 }
 
 #[test]
+fn continuation_election_keeps_the_supersession_stamp_when_promotion_fails() {
+    let mut conn = fixture_conn();
+    let group = continuation_group_metadata_json(Some("family-d"));
+    let mut older = input(SOURCE_CODEX_APP, "gen1", 100);
+    older.source_metadata_json = group.clone();
+    let mut newer = input(SOURCE_CODEX_APP, "gen2", 200);
+    newer.source_metadata_json = group;
+    upsert_imported_session_cache_from_conn(&mut conn, &[older, newer]).expect("upsert");
+    demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP).expect("election");
+    prune_missing_records_from_conn(&conn, SOURCE_CODEX_APP, &["gen1".to_string()])
+        .expect("prune gen2");
+
+    // Inject a failure into the promotion statement only: the stamp removal
+    // that precedes it must roll back with it, or the winner is hidden with
+    // no marker left for any later election to recover from.
+    conn.execute_batch(
+        "CREATE TRIGGER fail_promotion BEFORE UPDATE OF listable ON imported_history_session_cache
+         WHEN NEW.listable = 1 AND OLD.listable = 0
+         BEGIN SELECT RAISE(ABORT, 'injected promotion failure'); END",
+    )
+    .expect("install trigger");
+    let err = demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP)
+        .expect_err("promotion must fail under the injected fault");
+    assert!(err.contains("injected promotion failure"), "{err}");
+    assert!(!listable_of(&conn, SOURCE_CODEX_APP, "gen1"));
+    let metadata: String = conn
+        .query_row(
+            "SELECT source_metadata_json FROM imported_history_session_cache
+             WHERE source = ?1 AND source_session_id = 'gen1'",
+            [SOURCE_CODEX_APP],
+            |row| row.get(0),
+        )
+        .expect("gen1 metadata");
+    assert!(
+        metadata.contains(CONTINUATION_SUPERSEDED_FIELD),
+        "the recovery marker must survive a failed promotion: {metadata}"
+    );
+
+    conn.execute_batch("DROP TRIGGER fail_promotion").expect("remove trigger");
+    demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP).expect("retry election");
+    assert!(listable_of(&conn, SOURCE_CODEX_APP, "gen1"));
+}
+
+#[test]
 fn continuation_election_keeps_a_winner_hidden_for_reasons_other_than_supersession() {
     let mut conn = fixture_conn();
     let group = continuation_group_metadata_json(Some("family-c"));


### PR DESCRIPTION
## Problem

`demote_superseded_continuations_from_conn` is demote-only. Within a continuation family (Claude Code compact rewrites, and Codex resend rollouts once #1576 lands) it hides every sibling except the newest, but it never restores a hidden sibling. When the newest generation's file is removed, `prune_missing_records_from_conn` drops its cache row, while the older generation's file is unchanged on disk and therefore never re-parsed (re-parse is the only path that reset `listable = 1`). The older row stays `listable = 0` indefinitely, so the sidebar shows zero rows for a family whose history is still on disk. Meanwhile `has_newer_continuation_sibling` recomputes from content and already reports that row as current, so exact-id lookups and the sidebar disagree.

This predates #1576; it was surfaced by its review and is fixed separately so that PR stays scoped to Codex thread identity.

## Solution

The election stamps every row it demotes with `continuationSuperseded: true` in `source_metadata_json`. When a later election elects a row that is unlistable and carries that stamp, it sets `listable = 1` and removes the stamp. A winner hidden for any other reason (managed mirror, subagent, org2-origin mirror) carries no stamp and stays hidden, which preserves the existing `continuation_election_never_promotes_and_skips_subagents` contract. Metadata is rewritten only when the lineage id or the stamp actually changes, so a steady-state election still performs zero writes.

Invariant: after any sync, the newest member of a continuation family is listable unless it is hidden by an ownership rule, regardless of which files were added or removed since the previous sync.

## Potential risks

- Cached `source_metadata_json` gains one boolean field on demoted rows. Readers parse it as JSON and ignore unknown keys; no schema, wire, or frontend change. Rows demoted before this change carry no stamp and, if they are already hidden, will not be re-promoted until their file changes (same behavior as today). New demotions are stamped from the first sync after upgrade.
- A re-parse rewrites metadata without the stamp and resets `listable = 1`, matching the existing documented behavior; the next election re-demotes if a newer sibling still exists.
- Cloud: `org2CloudSyncEngine` retracts superseded continuations with a two-strike rule. A re-promoted local row is a normal visible session again and goes through the existing push path; no cloud change here and no live upload/download run in this PR.
- An end-to-end Codex sync-path test (remove the resend rollout file, resync, original generation returns) belongs in `app_resend_tests.rs`, which only exists on #1576; it is covered here at the cache boundary using the production `prune_missing_records_from_conn` followed by the election. The Claude Code sync entry point takes no directory argument, so it cannot be driven from a fixture.

## Verification

- `cargo test -p orgtrack_core` (src-tauri): 646 passed, 8 ignored, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed (worktree needed the `org2-pm` sidecar copied in for the Tauri build script).
- `rustfmt --check` on `cache.rs` and `cache/continuation.rs`: clean. Pre-existing fmt drift in `cache_tests.rs` and `cache/sidebar.rs` was deliberately left untouched.
- New `continuation_election_repromotes_a_superseded_winner_once_the_newer_generation_is_gone`: demote, prune the winner via `prune_missing_records_from_conn`, re-elect, assert the older row is listable and unstamped, then assert a further election performs zero writes. With the promotion statement neutralized (`SET listable = 0`) this test fails at the re-promotion assertion; it passes with the change.
- New `continuation_election_keeps_a_winner_hidden_for_reasons_other_than_supersession`: a demoted row re-parsed as a managed mirror stays hidden after the newer generation is pruned.
- All existing election tests (`demotes_all_but_newest_sibling`, `connects_compaction_epochs_transitively`, `survives_a_family_split_after_stamping`, `never_promotes_and_skips_subagents`, Claude `raw_new_uuid_continuation_preserves_ancestry_after_first_user_rewrite`) pass unchanged.
- Commit message validated with `commitlint --config config/commitlint.config.cjs`; the worktree lacks `node_modules`, so hooks were bypassed for the commit after clippy had passed.
- Not run: desktop build, frontend Vitest (no frontend change), cloud round-trip.


## Live verification (2026-09-10, primary machine)

Built into `test/live-1576-1582` with #1576, #1583 and #1587. Codex Desktop's Archive moves every generation of a thread plus its subagent rollouts to `archived_sessions` together, so the scenario was constructed by hand on a probe thread: copy its two generations and two children back into `~/.codex/sessions`, sync (first generation demoted and stamped, second visible), then remove only the second generation and its child and sync again. The first generation returned to `listable = 1` with the stamp removed and the lineage kept; its watermark (1381 bytes) and file signature were unchanged, so no reparse. Two cold boots afterwards left the cache byte-identical.


## Review follow-up

Finding: the lineage/stamp rewrite, the demotions and the re-promotion were separate statements, so a failure between removing the `continuationSuperseded` stamp and setting `listable = 1` would leave the winner hidden with no recovery marker. Confirmed. Fix (follow-up commit): the election now runs stamps, demotions and promotions inside one transaction on the caller's connection (`unchecked_transaction`) and commits once. New test `continuation_election_keeps_the_supersession_stamp_when_promotion_fails` installs a `BEFORE UPDATE OF listable` trigger that raises only on a promotion, asserts the election returns the injected error, that the row is still hidden and still stamped, then drops the trigger and asserts the retry promotes it. With the transaction stashed the test fails at the stamp assertion (the stamp is gone, the row hidden). Full crate tests (647) and workspace clippy rerun clean.
