### PR TITLE
fix(codex): skip vanished rollouts and dedupe profile symlinks

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/index.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/index.rs
@@ -294,9 +294,16 @@ fn best_codex_child_match(
 }
 
 fn sync_codex_app_cache(conn: &mut Connection) -> Result<(), String> {
+    sync_codex_app_cache_from_dirs(conn, &codex_sessions_dirs()?)
+}
+
+pub(super) fn sync_codex_app_cache_from_dirs(
+    conn: &mut Connection,
+    session_dirs: &[PathBuf],
+) -> Result<(), String> {
     let previous_snapshots = scan_snapshot::read_dir_snapshots_from_conn(conn, SOURCE_CODEX_APP);
     let mut walker = scan_snapshot::SnapshotDirWalker::new(&previous_snapshots, "jsonl", "Codex");
-    let discovery = discover_codex_app_records(&codex_sessions_dirs()?, &mut walker)?;
+    let discovery = discover_codex_app_records(session_dirs, &mut walker)?;
     let next_snapshots = walker.into_snapshots();
     scan_snapshot::persist_dir_snapshots_if_changed(
         conn,
@@ -486,6 +493,7 @@ fn discover_codex_app_records(
 ) -> Result<CodexAppDiscovery, String> {
     let mut records = Vec::new();
     let mut external_titles = HashMap::new();
+    let mut discovered_files = HashSet::new();
     for sessions_dir in sessions_dirs {
         if !sessions_dir.is_dir() {
             continue;
@@ -502,7 +510,31 @@ fn discover_codex_app_records(
                 continue;
             };
             let (source_mtime_ms, source_size_bytes) =
-                imported_paths::file_metadata_signature(&path, "Codex")?;
+                match imported_paths::file_metadata_signature(&path, "Codex") {
+                    Ok(signature) => signature,
+                    // Files can disappear between directory enumeration and
+                    // metadata lookup, and managed profiles keep rollout
+                    // symlinks whose target Codex has since archived. Neither
+                    // makes the other Codex rollouts unreadable.
+                    Err(_) if !path.exists() => continue,
+                    Err(error) => return Err(error),
+                };
+            // Managed profiles expose native rollouts through symlinks, so one
+            // rollout can be enumerated from CODEX_HOME and from a profile.
+            // Both share the file stem that keys the cache row; resolve the
+            // symlink and keep the first discovery so unchanged files do not
+            // alternate writers on every scan.
+            let canonical = match fs::canonicalize(&path) {
+                Ok(target) => target,
+                Err(_) if !path.exists() => continue,
+                Err(error) => return Err(format!("Failed to resolve Codex rollout: {error}")),
+            };
+            let is_symlink =
+                fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_symlink());
+            let path = if is_symlink { canonical.clone() } else { path };
+            if !discovered_files.insert((file_stem.clone(), canonical)) {
+                continue;
+            }
             if let Some(entry) = codex_title_entry_for_file_stem(&file_stem, &title_index) {
                 external_titles.insert(
                     file_stem.clone(),

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/index.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/index.rs
@@ -493,7 +493,7 @@ fn discover_codex_app_records(
 ) -> Result<CodexAppDiscovery, String> {
     let mut records = Vec::new();
     let mut external_titles = HashMap::new();
-    let mut discovered_files = HashSet::new();
+    let mut discovered_files: HashSet<String> = HashSet::new();
     for sessions_dir in sessions_dirs {
         if !sessions_dir.is_dir() {
             continue;
@@ -531,8 +531,13 @@ fn discover_codex_app_records(
             };
             let is_symlink =
                 fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.file_type().is_symlink());
-            let path = if is_symlink { canonical.clone() } else { path };
-            if !discovered_files.insert((file_stem.clone(), canonical)) {
+            let path = if is_symlink { canonical } else { path };
+            // The stem keys the cache row. A native rollout and a managed
+            // profile copy of the same session are two files with one stem;
+            // emitting both makes them alternate as the row's writer on
+            // every scan. Native roots enumerate first, so the first file
+            // per stem wins deterministically.
+            if !discovered_files.insert(file_stem.clone()) {
                 continue;
             }
             if let Some(entry) = codex_title_entry_for_file_stem(&file_stem, &title_index) {

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -3046,6 +3046,7 @@ fn codex_question_receipts_replay_with_ordered_answers() {
     std::fs::remove_file(path).unwrap();
 }
 
+#[cfg(unix)]
 #[test]
 fn discovery_survives_dangling_profile_symlinks_and_dedupes_live_ones() {
     let temp = std::env::temp_dir().join(format!(

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -3160,7 +3160,11 @@ fn discovery_keeps_the_first_file_when_two_roots_hold_the_same_stem() {
             |row| row.get(0),
         )
         .unwrap();
-    assert!(path.contains("/native/"), "the first enumerated root must win: {path}");
+    assert_eq!(
+        std::path::PathBuf::from(&path),
+        native.join(format!("{stem}.jsonl")),
+        "the first enumerated root must win"
+    );
     for _ in 0..3 {
         let before = conn.total_changes();
         index::sync_codex_app_cache_from_dirs(&mut conn, &dirs).unwrap();

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -3045,3 +3045,71 @@ fn codex_question_receipts_replay_with_ordered_answers() {
     }
     std::fs::remove_file(path).unwrap();
 }
+
+#[test]
+fn discovery_survives_dangling_profile_symlinks_and_dedupes_live_ones() {
+    let temp = std::env::temp_dir().join(format!(
+        "orgii-codex-discovery-symlinks-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let native = temp.join("native").join("sessions").join("2026").join("08").join("28");
+    let profile = temp.join("profile").join("sessions").join("2026").join("08").join("28");
+    std::fs::create_dir_all(&native).unwrap();
+    std::fs::create_dir_all(&profile).unwrap();
+    let stem = "rollout-2026-08-28T17-12-59-0236a8cf-8dbb-4c52-9555-f5f54438ceb1";
+    let real = native.join(format!("{stem}.jsonl"));
+    std::fs::write(
+        &real,
+        concat!(
+            r#"{"timestamp":"2026-08-28T17:12:59Z","type":"session_meta","payload":{"id":"0236a8cf-8dbb-4c52-9555-f5f54438ceb1","originator":"Codex Desktop","cwd":"/tmp/project"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-28T17:13:00Z","type":"event_msg","payload":{"type":"user_message","message":"hello"}}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+    std::os::unix::fs::symlink(&real, profile.join(format!("{stem}.jsonl"))).unwrap();
+    std::os::unix::fs::symlink(
+        temp.join("gone").join("rollout-2026-08-28T17-17-01-5787846d-f20d-4c89-b2cd-a755414c2500.jsonl"),
+        profile.join("rollout-2026-08-28T17-17-01-5787846d-f20d-4c89-b2cd-a755414c2500.jsonl"),
+    )
+    .unwrap();
+
+    let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+    crate::store::sqlite::SqliteRecordStore::init_tables(&conn).unwrap();
+    crate::store::sqlite::SqliteRecordStore::init_source_cache_tables(&conn).unwrap();
+    let dirs = [
+        temp.join("native").join("sessions"),
+        temp.join("profile").join("sessions"),
+    ];
+    for _ in 0..2 {
+        index::sync_codex_app_cache_from_dirs(&mut conn, &dirs).unwrap();
+        let rows: Vec<(String, String)> = conn
+            .prepare(
+                "SELECT source_session_id, source_path FROM imported_history_session_cache
+                 WHERE source = 'codex_app' ORDER BY source_session_id",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![(stem.to_string(), real.to_string_lossy().to_string())],
+            "one row for the real rollout; the dangling link is skipped"
+        );
+    }
+    let before = conn.total_changes();
+    index::sync_codex_app_cache_from_dirs(&mut conn, &dirs).unwrap();
+    assert_eq!(
+        conn.total_changes(),
+        before,
+        "a rescan over the same symlinked rollout must not rewrite the row"
+    );
+    std::fs::remove_dir_all(&temp).unwrap();
+}

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -3114,3 +3114,61 @@ fn discovery_survives_dangling_profile_symlinks_and_dedupes_live_ones() {
     );
     std::fs::remove_dir_all(&temp).unwrap();
 }
+
+#[test]
+fn discovery_keeps_the_first_file_when_two_roots_hold_the_same_stem() {
+    let temp = std::env::temp_dir().join(format!(
+        "orgii-codex-discovery-dup-stem-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let native = temp.join("native").join("sessions").join("2026").join("08").join("27");
+    let profile = temp.join("profile").join("sessions").join("2026").join("08").join("27");
+    std::fs::create_dir_all(&native).unwrap();
+    std::fs::create_dir_all(&profile).unwrap();
+    let stem = "rollout-2026-08-27T11-15-00-7a1d349c-0b12-49ce-844d-d03d204e15a0";
+    // The same session materialized into two roots as two diverged copies.
+    let header = r#"{"timestamp":"2026-08-27T11:15:00Z","type":"session_meta","payload":{"id":"7a1d349c-0b12-49ce-844d-d03d204e15a0","originator":"codex_cli_rs","cwd":"/tmp/project"}}"#;
+    let user = |text: &str| {
+        serde_json::json!({"timestamp":"2026-08-27T11:15:01Z","type":"event_msg","payload":{"type":"user_message","message":text}})
+    };
+    std::fs::write(
+        native.join(format!("{stem}.jsonl")),
+        format!("{header}\n{}\n", user("native copy")),
+    )
+    .unwrap();
+    std::fs::write(
+        profile.join(format!("{stem}.jsonl")),
+        format!("{header}\n{}\n", user("profile copy, longer")),
+    )
+    .unwrap();
+    let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+    crate::store::sqlite::SqliteRecordStore::init_tables(&conn).unwrap();
+    crate::store::sqlite::SqliteRecordStore::init_source_cache_tables(&conn).unwrap();
+    let dirs = [
+        temp.join("native").join("sessions"),
+        temp.join("profile").join("sessions"),
+    ];
+    index::sync_codex_app_cache_from_dirs(&mut conn, &dirs).unwrap();
+    let path: String = conn
+        .query_row(
+            "SELECT source_path FROM imported_history_session_cache WHERE source='codex_app' AND source_session_id = ?1",
+            [stem],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(path.contains("/native/"), "the first enumerated root must win: {path}");
+    for _ in 0..3 {
+        let before = conn.total_changes();
+        index::sync_codex_app_cache_from_dirs(&mut conn, &dirs).unwrap();
+        assert_eq!(
+            conn.total_changes(),
+            before,
+            "a rescan must not let the second copy take the row over"
+        );
+    }
+    std::fs::remove_dir_all(&temp).unwrap();
+}


### PR DESCRIPTION
## Problem

`discover_codex_app_records` propagates any `file_metadata_signature` error with `?`, so a single entry that cannot be stat'ed aborts discovery for the entire `codex_app` source. The session directory then logs `skipping external history source that failed to load source="codex_app" error=Failed to read Codex file metadata: No such file or directory` and caches nothing from that source.

ORGII-managed Codex CLI profiles (`~/.orgii/codex-cli-profiles/<id>/sessions/...`) hold symlinks to native rollouts under `~/.codex/sessions`. When Codex Desktop archives or deletes the target, the link dangles; `Path::metadata` follows it and fails. On the primary machine this has been happening on every sync since 2026-08-28: 11 dangling links (7 whose targets Codex archived, 4 pointing into a deleted E2E temp home) meant that not one of the 1,874 rollouts in `~/.codex/sessions` was ever cached, while the log carried one WARN per sync. Discovered while preparing the live verification of #1576.

The same profiles also hold 44 live symlinks to rollouts that are still in `~/.codex/sessions`. Once discovery loads, each of those rollouts is enumerated twice under the same file stem (which keys the cache row), so the two paths alternate as the row's writer on every scan.

## Solution

Mirror the Claude discovery contract in Codex discovery:

- A metadata read that fails because the path no longer exists (vanished between enumeration and stat, or a dangling symlink) skips that entry; any other error still fails the source.
- Every discovered path is canonicalized for deduplication, and the first discovery per `(file_stem, canonical path)` wins. A symlink entry records its resolved target as `source_path`; a regular file keeps its enumerated path, so existing rows for regular files see no path change and no reparse.

`sync_codex_app_cache_from_dirs` is extracted from `sync_codex_app_cache` (identical to the extraction in #1576) so the regression test can drive the production sync over fixture directories.

Invariant: one unreadable entry never hides the other Codex rollouts, and one rollout reachable through several paths yields exactly one stable cache row.

## Potential risks

- Rows previously cached through a profile symlink path (the 44 live links) will re-key to the native path on the first sync after upgrade, which reparses those 44 files once. Rows for regular files are untouched.
- Canonicalization adds one `realpath` per discovered file per scan (about 2,800 files here), the same cost Claude discovery already pays.
- The dangling links themselves are left in place; they are a symptom of E2E materialization writing into the real profile root and of Codex archiving targets, and cleaning them is out of scope. With this change they are harmless.
- On this machine the fix will make `~/.codex/sessions` ingest for the first time, including a 3.4 GiB active rollout that the existing large-file deferral handles; that path is unchanged by this PR but has not been exercised locally before.
- Overlaps textually with #1576 only in the extracted `sync_codex_app_cache_from_dirs`; the merge is clean in a local test branch.

## Verification

- `cargo test -p orgtrack_core` (src-tauri): 646 passed, 8 ignored, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `rustfmt --check` on `codex/app/index.rs`: clean. Pre-existing fmt drift elsewhere in `app_tests.rs` left untouched.
- New `discovery_survives_dangling_profile_symlinks_and_dedupes_live_ones`: a native rollout, a live profile symlink to it, and a dangling profile symlink; two syncs yield exactly one row whose `source_path` is the native file, and a third sync performs zero SQLite changes. Before the change the same fixture fails discovery with the production error string.
- Root cause confirmed on the primary machine by stat'ing every `.jsonl` under the Codex roots: 0 failures under `~/.codex/sessions`, 11 dangling symlinks under `~/.orgii/codex-cli-profiles/ae658db3/sessions/2026/08/{28,29}`, and zero `imported_history_scan_snapshots` rows for any `~/.codex` directory.
- Desktop run with this change is part of the #1576 live verification and is reported there; not yet run at the time of opening this PR.


## Live verification (2026-09-10, primary machine)

A `develop` + this fix build (`b5a90bf85`) over the real `~/.orgii` home ingested `~/.codex/sessions` for the first time since 2026-08-28: 1,873 of 1,874 rollouts cached in about a minute (the remaining one is a `~/.codex` symlink into a managed profile whose real file was already cached under its profile path), the 11 dangling profile symlinks skipped, the 44 live profile symlinks re-keyed to their native path, and no `skipping external history source` line since. Backend RSS peaked at 650 MiB while parsing the 3.4 GiB and 825 MiB rollouts (76% of one core over 120 s), then settled at 211 MiB. Side effect to be aware of: the newly visible repo-scoped sessions are auto-pushed to the team org by the existing cloud push design.


## Review follow-up

Finding: the symlink test used `std::os::unix::fs::symlink` without a platform gate, so Windows test builds would not compile. Confirmed; CI has no Windows matrix but the product does build there. Fix: `#[cfg(unix)]` on the test (follow-up commit). The vanished-file branch it exercises is platform-independent in production code; a Windows-runnable variant is not added because the failure mode being fixed (dangling profile symlinks) is Unix-only on this machine. Full crate tests and workspace clippy rerun clean.


## Follow-up: one record per stem

A five-minute idle sample of the primary (final live build) showed the cache row `rollout-2026-08-27T11-15-00-7a1d349c…` flipping between `~/.codex/sessions/2026/08/27/…` (41,216 bytes) and `~/.orgii/codex-cli-profiles/ae658db3/sessions/2026/08/27/…` (40,289 bytes) on consecutive scans: two distinct real files, same stem, both discovered once this PR made `~/.codex` load, so the upsert alternated between them and the row (and its watermark) was rewritten on every idle sync. Follow-up commit: discovery now keeps the first file per stem; native roots enumerate before managed profiles, so the native copy wins deterministically and a rescan writes nothing. New test `discovery_keeps_the_first_file_when_two_roots_hold_the_same_stem` (two diverged copies in two roots, native path wins, three rescans with zero SQLite changes); with the change reverted it fails on the zero-write assertion. This is the only such stem on the primary machine (1 of 953 profile files).



Third-round follow-up: the stem-dedup test now compares the cached path with the expected `PathBuf` instead of a `/native/` substring, so it holds on Windows separators too.
