### PR TITLE
fix(codemirror): load missing baselines and reject stale markers

### DIFF
--- a/docs/org2-performance-guard-2026-09-11/RegularFileDiff.md
+++ b/docs/org2-performance-guard-2026-09-11/RegularFileDiff.md
@@ -1,0 +1,16 @@
+# Missing regular-file diff markers
+
+Git HEAD and the current editor buffer are the authoritative comparison inputs. Git status deliberately omits file bodies. Previously, regular tabs treated an unavailable HEAD body as permission to fall back to the saved disk content. Saved modified files could therefore compare equal while their tabs correctly showed `M`.
+
+The active regular-file renderer now loads the missing HEAD baseline through the existing shared working-tree diff resource. A Git-status file does not fall back to disk content while HEAD is unavailable. Missing or failed loads remain unavailable rather than becoming an invented empty file. Added files still compare against an empty baseline. No persisted data was malformed and no historical cleanup is needed.
+
+The async dirty-marker producer now rejects results computed for an obsolete document/baseline snapshot. Backend failures retain existing markers instead of publishing an empty map. The next queued computation uses the current snapshot.
+
+| Area               | Verdict | Evidence                                                                     | Change or reason kept                                                   | Verification                               |
+| ------------------ | ------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------ |
+| Background work    | fix     | Active-file effects and existing single-flight debounce                      | No polling; obsolete responses ignored; queued timer cleared on destroy | Inactive-tab, stale-result and close tests |
+| Memory             | keep    | Existing shared resource has four-entry/8 MiB bounds                         | No new global cache; release settled resource on effect cleanup         | Resource-bound and release tests           |
+| Scope/isolation    | fix     | Repository/worktree, path, original path, status and stage identify requests | Loaded baseline is exposed only for its matching key                    | File-switch response test                  |
+| Rendering/hot path | fix     | Marker results require the original snapshot                                 | Do not dispatch stale results or clear markers on failure               | Lifecycle regression tests                 |
+
+Tests exercise actual hooks and CodeMirror DOM with mocked transport, plus existing shared-resource tests. No UI style changes are included. Live Git transport recovery, Tauri rendering, visible/hidden idle CPU and RSS remain unmeasured. Performance verdict: blocked for those desktop measurements; no performance improvement is claimed.

--- a/src/features/CodeMirror/config/dirtyDiff.lifecycle.test.ts
+++ b/src/features/CodeMirror/config/dirtyDiff.lifecycle.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { EditorView, lineNumbers } from "@codemirror/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dirtyDiffGutter } from "./dirtyDiff";
+
+const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+const mounted: EditorView[] = [];
+function editor() {
+  const view = new EditorView({
+    parent: document.body,
+    doc: "new\nchanged\nsame",
+    extensions: [lineNumbers(), dirtyDiffGutter({ current: "old\nsame" })],
+  });
+  mounted.push(view);
+  return view;
+}
+const result = (line: number, type = "added") => ({
+  markers: [{ line, type }],
+});
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.invoke.mockReset();
+});
+afterEach(() => {
+  mounted.splice(0).forEach((view) => view.destroy());
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
+
+describe("dirty diff rendering", () => {
+  it("rejects a result for an obsolete document before applying fresh markers", async () => {
+    let resolve!: (value: ReturnType<typeof result>) => void;
+    mocks.invoke
+      .mockReturnValueOnce(
+        new Promise((done) => {
+          resolve = done;
+        })
+      )
+      .mockResolvedValueOnce(result(2, "modified"));
+    const view = editor();
+    await vi.advanceTimersByTimeAsync(50);
+    view.dispatch({ changes: { from: 0, to: 3, insert: "latest" } });
+    resolve(result(1));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(view.dom.querySelector(".cm-dirty-diff-added")).toBeNull();
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.dom.querySelector(".cm-dirty-diff-modified")).not.toBeNull();
+    expect(mocks.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves existing markers on backend failure and stops work on close", async () => {
+    mocks.invoke
+      .mockResolvedValueOnce(result(1))
+      .mockRejectedValueOnce(new Error("offline"));
+    const view = editor();
+    await vi.advanceTimersByTimeAsync(50);
+    view.dispatch({ changes: { from: view.state.doc.length, insert: "!" } });
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.dom.querySelector(".cm-dirty-diff-added")).not.toBeNull();
+    view.dispatch({ changes: { from: view.state.doc.length, insert: "!" } });
+    view.destroy();
+    mounted.pop();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(mocks.invoke).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/CodeMirror/config/dirtyDiff.ts
+++ b/src/features/CodeMirror/config/dirtyDiff.ts
@@ -59,21 +59,16 @@ async function computeDirtyDiffRust(
   original: string,
   current: string
 ): Promise<Map<number, DiffLineType>> {
-  try {
-    const result = await invoke<DirtyDiffResult>("compute_dirty_diff_markers", {
-      original,
-      current,
-    });
+  const result = await invoke<DirtyDiffResult>("compute_dirty_diff_markers", {
+    original,
+    current,
+  });
 
-    const changes = new Map<number, DiffLineType>();
-    for (const marker of result.markers) {
-      changes.set(marker.line, marker.type);
-    }
-    return changes;
-  } catch (error) {
-    log.warn("[DirtyDiff] Rust computation failed, returning empty:", error);
-    return new Map();
+  const changes = new Map<number, DiffLineType>();
+  for (const marker of result.markers) {
+    changes.set(marker.line, marker.type);
   }
+  return changes;
 }
 
 // ============================================
@@ -266,7 +261,8 @@ export function dirtyDiffGutter(
           }
 
           const original = originalRef.current;
-          const current = this.view.state.doc.toString();
+          const document = this.view.state.doc;
+          const current = document.toString();
 
           let markers: RangeSet<GutterMarker>;
 
@@ -296,7 +292,17 @@ export function dirtyDiffGutter(
               return;
             }
 
-            markers = buildMarkerRangeSet(changes, this.view.state.doc);
+            // A result belongs to the exact document/baseline that produced
+            // it. Never apply old line numbers to a newer editor snapshot.
+            if (
+              this.view.state.doc !== document ||
+              originalRef.current !== original
+            ) {
+              this.pendingUpdate = true;
+              return;
+            }
+
+            markers = buildMarkerRangeSet(changes, document);
           }
 
           // Apply markers (check view still valid after async)

--- a/src/modules/WorkStation/TabContent/renderers/file.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/file.tsx
@@ -19,6 +19,7 @@ import { useEditorHostContext } from "@src/modules/WorkStation/CodeEditor/Panels
 import { requiresFilePreviewRoute as shouldUseDedicatedPreviewRoute } from "@src/util/file/previewTypes";
 
 import type { UnifiedTabContentProps } from "../types";
+import { useFileGitBaseline } from "./useFileGitBaseline";
 
 const CodeViewerContent = React.lazy(
   () =>
@@ -34,7 +35,8 @@ function isCsvTableFile(filePath: string): boolean {
   return lowerPath.endsWith(".csv") || lowerPath.endsWith(".tsv");
 }
 
-const FileTabRenderer: React.FC<UnifiedTabContentProps> = memo(({ tab }) => {
+const FileTabRenderer: React.FC<UnifiedTabContentProps> = memo((props) => {
+  const { tab, isActive } = props;
   const {
     fileContentState,
     gitFilesByPath,
@@ -50,6 +52,12 @@ const FileTabRenderer: React.FC<UnifiedTabContentProps> = memo(({ tab }) => {
   const gitFileInfo = filePath
     ? getGitFileForPath(filePath, repoPath, gitFilesByPath)
     : undefined;
+  const loadedBaseline = useFileGitBaseline(
+    gitFileInfo,
+    repoPath,
+    isActive,
+    fileContentState.originalContent
+  );
 
   // Check if file was deleted (exists in git but removed from disk)
   // Also treat as deleted if we have git info with oldContent and file read failed
@@ -68,18 +76,17 @@ const FileTabRenderer: React.FC<UnifiedTabContentProps> = memo(({ tab }) => {
       ? "" // Untracked file - compare against empty to show all green
       : gitFileInfo.status === "deleted"
         ? "" // Deleted file - compare against empty (we'll mark all as deleted)
-        : gitFileInfo.oldContent
+        : loadedBaseline
     : undefined;
 
   // For deleted files, show the old content instead of trying to read from disk
   const displayContent = isDeletedFile
-    ? (gitFileInfo?.oldContent ?? "")
+    ? (loadedBaseline ?? "")
     : fileContentState.content;
 
   // Saved-on-disk content for unsaved changes diff (when file not in git status)
-  const savedContent = isDeletedFile
-    ? undefined
-    : fileContentState.originalContent;
+  const savedContent =
+    isDeletedFile || gitFileInfo ? undefined : fileContentState.originalContent;
 
   return (
     <Suspense fallback={<LazyFallback />}>

--- a/src/modules/WorkStation/TabContent/renderers/useFileGitBaseline.test.ts
+++ b/src/modules/WorkStation/TabContent/renderers/useFileGitBaseline.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GitFile } from "@src/types/git/types";
+
+import { useFileGitBaseline } from "./useFileGitBaseline";
+
+const mocks = vi.hoisted(() => ({ load: vi.fn(), release: vi.fn() }));
+vi.mock("@src/services/git/workingTreeDiffResource", () => ({
+  loadWorkingTreeDiff: mocks.load,
+  releaseWorkingTreeDiff: mocks.release,
+}));
+const file = (path: string): GitFile => ({
+  id: path,
+  path,
+  status: "modified",
+  staged: false,
+  additions: 0,
+  deletions: 0,
+});
+let root: Root;
+let latest: string | undefined;
+function Harness({
+  entry,
+  active = true,
+}: {
+  entry: GitFile;
+  active?: boolean;
+}) {
+  const baseline = useFileGitBaseline(entry, "/repo", active, "disk contents");
+  useEffect(() => {
+    latest = baseline;
+  }, [baseline]);
+  return null;
+}
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  mocks.load.mockReset();
+  mocks.release.mockReset();
+  root = createRoot(document.body.appendChild(document.createElement("div")));
+});
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+});
+
+describe("useFileGitBaseline", () => {
+  it("fetches HEAD when M status has metadata but no body", async () => {
+    mocks.load.mockResolvedValue({
+      oldContent: "HEAD contents",
+      binary: false,
+    });
+    await act(async () =>
+      root.render(createElement(Harness, { entry: file("a.ts") }))
+    );
+    expect(latest).toBe("HEAD contents");
+    expect(mocks.load).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoPath: "/repo",
+        file: expect.objectContaining({ path: "a.ts", status: "modified" }),
+      })
+    );
+  });
+
+  it("does not fetch for inactive tabs or new files", async () => {
+    await act(async () =>
+      root.render(
+        createElement(Harness, { entry: file("a.ts"), active: false })
+      )
+    );
+    expect(mocks.load).not.toHaveBeenCalled();
+    await act(async () =>
+      root.render(
+        createElement(Harness, {
+          entry: { ...file("new.ts"), status: "added" },
+        })
+      )
+    );
+    expect(latest).toBe("");
+    expect(mocks.load).not.toHaveBeenCalled();
+  });
+
+  it("ignores stale responses after switching file and releases the old resource", async () => {
+    let resolve!: (value: { oldContent: string; binary: boolean }) => void;
+    mocks.load
+      .mockReturnValueOnce(
+        new Promise((done) => {
+          resolve = done;
+        })
+      )
+      .mockResolvedValueOnce({ oldContent: "B", binary: false });
+    await act(async () =>
+      root.render(createElement(Harness, { entry: file("a.ts") }))
+    );
+    await act(async () =>
+      root.render(createElement(Harness, { entry: file("b.ts") }))
+    );
+    await act(async () => resolve({ oldContent: "A", binary: false }));
+    expect(latest).toBe("B");
+    expect(mocks.release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file: expect.objectContaining({ path: "a.ts" }),
+      })
+    );
+  });
+
+  it("does not invent an empty HEAD baseline on missing or failed loads", async () => {
+    mocks.load
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("offline"));
+    await act(async () =>
+      root.render(createElement(Harness, { entry: file("a.ts") }))
+    );
+    expect(latest).toBeUndefined();
+    await act(async () =>
+      root.render(createElement(Harness, { entry: file("b.ts") }))
+    );
+    expect(latest).toBeUndefined();
+  });
+});

--- a/src/modules/WorkStation/TabContent/renderers/useFileGitBaseline.ts
+++ b/src/modules/WorkStation/TabContent/renderers/useFileGitBaseline.ts
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { createLogger } from "@src/hooks/logger";
+import {
+  loadWorkingTreeDiff,
+  releaseWorkingTreeDiff,
+} from "@src/services/git/workingTreeDiffResource";
+import type { GitFile } from "@src/types/git/types";
+
+const log = createLogger("FileGitBaseline");
+
+/** Status is metadata only. Load HEAD on demand for the active file editor. */
+export function useFileGitBaseline(
+  file: GitFile | undefined,
+  repoPath: string,
+  isActive: boolean,
+  savedContent: string
+) {
+  const key =
+    file && repoPath
+      ? JSON.stringify([
+          repoPath,
+          file.path,
+          file.original_path,
+          file.status,
+          file.staged,
+          file.repoRoot,
+        ])
+      : null;
+  const request = useMemo(() => {
+    if (!key) return null;
+    const [root, path, original_path, status, staged, repoRoot] =
+      JSON.parse(key);
+    return {
+      repoPath: root,
+      file: { path, original_path, status, staged, repoRoot },
+    };
+  }, [key]);
+  const [loaded, setLoaded] = useState<{ key: string; content: string } | null>(
+    null
+  );
+  const supplied = file?.oldContent;
+  const added = file?.status === "added";
+
+  useEffect(() => {
+    if (!isActive || !request || !key || supplied !== undefined || added)
+      return;
+    let cancelled = false;
+    loadWorkingTreeDiff(request)
+      .then((diff) => {
+        if (!cancelled && diff && !diff.binary) {
+          setLoaded({ key, content: diff.oldContent });
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) log.warn("Unable to load HEAD baseline", error);
+      });
+    return () => {
+      cancelled = true;
+      releaseWorkingTreeDiff(request);
+    };
+  }, [isActive, request, key, supplied, added, savedContent]);
+
+  if (added) return "";
+  return supplied ?? (loaded?.key === key ? loaded?.content : undefined);
+}


### PR DESCRIPTION
## Problem

A regular file tab could correctly show Git's `M` badge but no line markers. Git status intentionally carries metadata without file bodies; the renderer treated a missing HEAD baseline as permission to compare with saved disk content, which is identical for a saved modified file. Async marker calculations could also apply obsolete line numbers, while backend failures cleared valid markers.

## Solution

Load the active file's missing HEAD baseline through the existing shared, bounded working-tree diff resource. Files with Git status no longer fall back to disk content while HEAD is unavailable, and failed/missing loads do not invent an empty baseline. Ignore responses for a previously selected file. Reject marker results whose document or baseline changed in flight, and retain existing markers on computation failure.

This PR fixes marker availability/correctness; visual styling is handled separately. There is no historical data cleanup because the persisted Git data is valid.

## Potential risks

Missing baselines add an on-demand request for the active editor. Requests reuse existing deduplication and cache bounds; cleanup releases settled content and rejects stale callbacks. Real Git transport recovery and live Tauri CPU/RSS were not measured. If HEAD loading fails, the baseline remains unavailable instead of falsely treating the file as clean. No dependency, persistence, schema or wire changes are included; reverting the commit restores the previous loading path.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/features/CodeMirror/config/dirtyDiff.lifecycle.test.ts src/modules/WorkStation/TabContent/renderers/useFileGitBaseline.test.ts src/services/git/workingTreeDiffResource.test.ts` — 10 tests passed
- `pnpm exec eslint src/features/CodeMirror/config/dirtyDiff.ts src/features/CodeMirror/config/dirtyDiff.lifecycle.test.ts src/modules/WorkStation/TabContent/renderers/file.tsx src/modules/WorkStation/TabContent/renderers/useFileGitBaseline.ts src/modules/WorkStation/TabContent/renderers/useFileGitBaseline.test.ts` — passed
- `pnpm exec tsgo --noEmit --pretty false` — passed
- `git diff --check` — passed
- Regression coverage includes metadata-only modified files, inactive/new files, file-switch cancellation, missing/failed HEAD loads, obsolete calculations, preserving markers on backend failure and timer cleanup on close.
- Tests use mocked transport and CodeMirror DOM. No screenshot is included because this PR changes baseline loading and async correctness without changing the visual design; live transport verification remains unrun.
