### PR TITLE
fix(spotlight): distinguish sidebar move and hide icons

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -45,6 +45,7 @@ export { default as ArchiveIcon } from "@hugeicons/core-free-icons/ArchiveIcon";
 export { default as ArrangeByLettersZAIcon } from "@hugeicons/core-free-icons/ArrangeByLettersZAIcon";
 export { default as ArrangeByNumbersOneNineIcon } from "@hugeicons/core-free-icons/ArrangeByNumbersOneNineIcon";
 export { default as ArrowBigDownDashIcon } from "@hugeicons/core-free-icons/ArrowBigDownDashIcon";
+export { default as ArrowBigLeftDashIcon } from "@hugeicons/core-free-icons/ArrowBigLeftDashIcon";
 export { default as ArrowBigRightDashIcon } from "@hugeicons/core-free-icons/ArrowBigRightDashIcon";
 export { default as ArrowDown01Icon } from "@hugeicons/core-free-icons/ArrowDown01Icon";
 export { default as ArrowDown02Icon } from "@hugeicons/core-free-icons/ArrowDown02Icon";

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.settings.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.settings.ts
@@ -11,11 +11,12 @@
  */
 import { ACTION_ID } from "@src/ActionSystem";
 import {
+  ArrowBigLeftDashIcon,
+  ArrowBigRightDashIcon,
   ArrowLeftBigIcon,
   ArrowRightBigIcon,
   LayoutTopIcon,
   Menu01Icon,
-  PanelLeftIcon,
   SparklesIcon,
 } from "@src/icons";
 
@@ -102,7 +103,10 @@ export function buildChatPanelSettingsActions({
       workstationSidebarPosition === "left"
         ? "common:spotlightActions.moveWorkstationSidebarRight"
         : "common:spotlightActions.moveWorkstationSidebarLeft",
-    icon: PanelLeftIcon,
+    icon:
+      workstationSidebarPosition === "left"
+        ? ArrowBigRightDashIcon
+        : ArrowBigLeftDashIcon,
     keywords: [
       "workstation sidebar",
       "sidebar position",

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.view.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.view.ts
@@ -15,6 +15,7 @@ import {
   PanelLeftIcon,
   RotateLeft01Icon,
   SidebarBottomIcon,
+  SidebarLeftIcon,
   ZoomInAreaIcon,
   ZoomOutAreaIcon,
 } from "@src/icons";
@@ -41,7 +42,7 @@ export function buildViewActions(
       labelKey: isSidebarCollapsed
         ? "selectors.spotlight.actions.showAppSidebar.label"
         : "selectors.spotlight.actions.hideAppSidebar.label",
-      icon: PanelLeftIcon,
+      icon: isSidebarCollapsed ? PanelLeftIcon : SidebarLeftIcon,
       keywords: [
         "show app sidebar",
         "hide app sidebar",


### PR DESCRIPTION
## Problem

Spotlight uses the same panel glyph for moving the Workstation sidebar and hiding the app sidebar, making the actions harder to distinguish.

## Solution

Use ArrowBigLeftDashIcon and ArrowBigRightDashIcon according to the move destination, and SidebarLeftIcon for hiding the app sidebar. Preserve the show-sidebar icon and all action behavior.

## Potential risks

Risk is limited to glyph rendering and recognition. No dependency, persistence, API, or lifecycle changes. Actual rendering across themes and platforms has not been visually verified.

## Verification

- `pnpm exec eslint src/icons.ts src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.settings.ts src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.view.ts --max-warnings 0` — passed
- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightActionDefinitions.settings.test.ts` — 2 tests passed on the isolated branch
- Commit hooks: lint-staged (oxlint, ESLint, Prettier), TypeScript check (`npx tsgo --noEmit --pretty false`), and commitlint passed
- `git diff --check origin/develop...HEAD` — passed; inspected the three-file diff for unrelated changes and sensitive data
- No runtime screenshots captured: desktop UI control is not authorized under the workspace preferences
