### PR TITLE
fix(spotlight): correct embedded session creator presentation

### DIFF
--- a/src/components/Tooltip/index.scss
+++ b/src/components/Tooltip/index.scss
@@ -5,7 +5,8 @@
 
 .native-tooltip {
   position: fixed;
-  z-index: 1060;
+  // Tooltips portal to body and must clear Spotlight (9999) and its menus (10000).
+  z-index: 10001;
   box-sizing: border-box;
   max-width: min(320px, calc(100vw - 16px));
   padding: 8px 12px;

--- a/src/features/SessionCreator/components/SessionInfoLine.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine.tsx
@@ -75,6 +75,8 @@ import WorktreeSourceSelector from "./WorktreeSourceSelector";
 // ============================================
 
 export interface SessionInfoLineProps {
+  /** Use the original stronger hover/open surface unless explicitly disabled. */
+  strongSurface?: boolean;
   /** Current repository ID */
   repoId?: string;
   /** Current repository name */
@@ -260,6 +262,7 @@ function useSelectorShortcutBridge({
 // ============================================
 
 const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
+  strongSurface = true,
   repoId,
   repoName,
   repoPath,
@@ -614,7 +617,9 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
     return segment;
   });
 
-  const sessionInfoPills = <SessionInfoPillGroup segments={segments} />;
+  const sessionInfoPills = (
+    <SessionInfoPillGroup segments={segments} strongSurface={strongSurface} />
+  );
 
   return (
     <>

--- a/src/features/SessionCreator/components/SessionInfoLine/SessionInfoPillGroup.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine/SessionInfoPillGroup.tsx
@@ -3,14 +3,16 @@ import PillGroup, { type PillGroupSegment } from "@src/components/PillGroup";
 /** Keep the source/location/branch controls on one bounded, shrinkable row. */
 export function SessionInfoPillGroup({
   segments,
+  strongSurface = true,
 }: {
   segments: PillGroupSegment[];
+  strongSurface?: boolean;
 }) {
   return (
     <PillGroup
       segments={segments}
       className="max-w-full min-w-0"
-      strongSurface
+      strongSurface={strongSurface}
     />
   );
 }

--- a/src/features/SessionCreator/components/__tests__/SessionInfoPillGroup.test.ts
+++ b/src/features/SessionCreator/components/__tests__/SessionInfoPillGroup.test.ts
@@ -58,6 +58,30 @@ function renderRow(scenario: (typeof scenarios)[number]): string {
 }
 
 describe("SessionInfoPillGroup", () => {
+  it.each([false, true])(
+    "preserves the original surface by default and supports Spotlight (active=%s)",
+    (active) => {
+      const segments = [{ id: "branch", icon: null, label: "develop", active }];
+      const original = renderToStaticMarkup(
+        React.createElement(SessionInfoPillGroup, { segments })
+      );
+      const spotlight = renderToStaticMarkup(
+        React.createElement(SessionInfoPillGroup, {
+          segments,
+          strongSurface: false,
+        })
+      );
+
+      expect(original).toContain(
+        active ? "bg-fill-3!" : "enabled:hover:bg-fill-3!"
+      );
+      expect(spotlight).toContain(
+        active ? "bg-surface-hover!" : "enabled:hover:bg-surface-hover!"
+      );
+      expect(spotlight).not.toContain("bg-fill-3!");
+    }
+  );
+
   it("renders the production row with only the branch consuming remaining width", () => {
     const markup = renderRow(scenarios[0]);
     expect(markup).not.toContain("flex-wrap");

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -92,6 +92,7 @@ interface SessionCreatorChatPanelViewProps {
   fileInputRef: React.RefObject<HTMLInputElement | null>;
   footerSlot?: React.ReactNode;
   headerLayout: SessionCreatorChatPanelHeaderLayout;
+  spotlight?: boolean;
   heroFooterSlot?: React.ReactNode;
   heroContent: SessionCreatorAgentHeroContent;
   heroIcon: React.ReactNode;
@@ -155,6 +156,7 @@ const SessionCreatorChatPanelView: React.FC<
   fileInputRef,
   footerSlot,
   headerLayout,
+  spotlight = false,
   heroFooterSlot,
   heroContent,
   heroIcon,
@@ -201,6 +203,7 @@ const SessionCreatorChatPanelView: React.FC<
   const sessionInfoLine = (
     <SessionInfoLine
       {...sessionInfoProps}
+      strongSurface={!spotlight}
       leadingContent={cliLaunchModeSwitch}
       dropdownDirection={
         isLaunchpadLayout ? "up" : sessionInfoProps.dropdownDirection
@@ -241,12 +244,12 @@ const SessionCreatorChatPanelView: React.FC<
         label={heroContent.name}
         active={isCategorySelectorOpen}
         danger={heroContent.danger}
-        size="md"
+        size={spotlight ? "sm" : "md"}
+        appearance={spotlight ? "default" : "bare"}
         tooltip={t("creator.switchAgent")}
         tooltipPosition="top"
         onClick={onCategoryPickerOpen}
         ariaLabel={heroContent.name}
-        appearance="bare"
       />
       <div className="ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-0.5">
         {sessionInfoLine}
@@ -267,7 +270,15 @@ const SessionCreatorChatPanelView: React.FC<
       ) : null,
     [browserElementScrollNav]
   );
-  const sessionSetupActions = !hideSessionSetupControls ? (
+  const showSessionSetupActions =
+    !hideSessionSetupControls &&
+    (!spotlight ||
+      showPinnedActionPills ||
+      browserElementRowContent ||
+      leadingActionSlot ||
+      orgMembersPanelProps ||
+      pinnedActionsContent);
+  const sessionSetupActions = showSessionSetupActions ? (
     <div
       className={`mx-auto flex w-full items-center ${CHAT_PANEL_WIDTH_TOKENS.contentMaxWidth}`}
       onContextMenu={handlePinnedActionsContextMenu}
@@ -512,7 +523,7 @@ const SessionCreatorChatPanelView: React.FC<
 
   return (
     <div
-      className={`session-creator-chat-panel-wrapper ${
+      className={`session-creator-chat-panel-wrapper ${spotlight ? "spotlight-session-creator" : ""} ${
         isLaunchpadLayout ? "h-full" : ""
       } ${
         isCenteredComposer ? "session-creator-chat-panel-centered-composer" : ""

--- a/src/features/SessionCreator/variants/ChatPanel/index.scss
+++ b/src/features/SessionCreator/variants/ChatPanel/index.scss
@@ -217,3 +217,20 @@
     border-radius: 0 0 12px 12px;
   }
 }
+
+.spotlight-session-creator.session-creator-chat-panel-wrapper {
+  // SpotlightFormBody owns the inset, including in short windows.
+  .session-creator-chat-panel-content {
+    padding: 0 !important;
+  }
+
+  .session-creator-chat-panel-compact-header,
+  .session-creator-chat-panel-fullscreen-composer-group {
+    background: transparent;
+  }
+
+  // The floating card shadow would still outline the transparent header.
+  .session-creator-chat-panel-fullscreen-composer-group::before {
+    content: none;
+  }
+}

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -90,6 +90,7 @@ const SessionCreatorChatPanelContent: React.FC<
   footerSlot,
   leadingActionSlot,
   headerLayout = "hero",
+  spotlight = false,
   hideRepoLine = false,
   hideWorkItemAttachmentControl = false,
   includeHumanSession = true,
@@ -610,6 +611,7 @@ const SessionCreatorChatPanelContent: React.FC<
       fileInputRef={fileInputRef}
       footerSlot={footerSlot}
       headerLayout={headerLayout}
+      spotlight={spotlight}
       heroContent={heroContent}
       heroIcon={heroIcon}
       hidePresenceButton={hidePresenceButton}

--- a/src/features/SessionCreator/variants/ChatPanel/types.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/types.ts
@@ -36,6 +36,8 @@ export interface SessionCreatorChatPanelProps {
   footerSlot?: React.ReactNode;
   leadingActionSlot?: React.ReactNode;
   headerLayout?: SessionCreatorChatPanelHeaderLayout;
+  /** Opt into the embedded Spotlight spacing, surfaces, and 28px controls. */
+  spotlight?: boolean;
   hideRepoLine?: boolean;
   /** Hide the work-item attachment action when the composer already creates one. */
   hideWorkItemAttachmentControl?: boolean;

--- a/src/scaffold/GlobalSpotlight/palettes/SessionCreatorPalette/SessionCreatorPalette.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/SessionCreatorPalette/SessionCreatorPalette.test.ts
@@ -1,0 +1,56 @@
+import { type ReactNode, createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { SessionCreatorPalette } from ".";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: () => "新建会话" }),
+}));
+
+vi.mock("@src/features/SessionCreator/variants", () => ({
+  SessionCreatorChatPanel: ({ spotlight }: { spotlight?: boolean }) =>
+    createElement("div", {
+      "data-testid": "creator",
+      "data-spotlight": spotlight,
+    }),
+}));
+
+vi.mock("../../components", () => ({
+  SpotlightPillBar: ({ path }: { path: { label: string }[] }) =>
+    createElement("div", null, path[0].label),
+}));
+
+vi.mock("../../shell", () => ({
+  SpotlightShell: ({ children }: { children: ReactNode }) =>
+    createElement("section", { "data-testid": "spotlight-shell" }, children),
+}));
+
+describe("SessionCreatorPalette", () => {
+  it("renders embedded content without a second modal shell", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SessionCreatorPalette, {
+        isOpen: true,
+        onClose: vi.fn(),
+        asBody: true,
+      })
+    );
+
+    expect(markup).toContain('data-testid="creator"');
+    expect(markup).toContain("新建会话");
+    expect(markup).toContain('data-spotlight="true"');
+    expect(markup).not.toContain('data-testid="spotlight-shell"');
+  });
+
+  it("retains its modal shell when opened standalone", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SessionCreatorPalette, {
+        isOpen: true,
+        onClose: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('data-testid="spotlight-shell"');
+    expect(markup).toContain('data-testid="creator"');
+  });
+});

--- a/src/scaffold/GlobalSpotlight/palettes/SessionCreatorPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/SessionCreatorPalette/index.tsx
@@ -14,6 +14,7 @@ import { Add01Icon } from "@src/icons";
 import type { BasePaletteProps } from "@src/scaffold/GlobalSpotlight/shared";
 
 import { SpotlightPillBar } from "../../components";
+import { SpotlightFormBody } from "../../forms/shared/SpotlightFormShell";
 import { SpotlightShell } from "../../shell";
 import type { PathSegment } from "../../types";
 
@@ -25,7 +26,7 @@ export function SessionCreatorPalette({
   isOpen,
   onClose,
   onGoBackToParent,
-  asBody: _asBody,
+  asBody = false,
 }: SessionCreatorPaletteProps) {
   const { t } = useTranslation("navigation");
   const handleBack = onGoBackToParent ?? onClose;
@@ -53,13 +54,19 @@ export function SessionCreatorPalette({
   const body = (
     <div className="flex min-h-0 flex-col">
       <SpotlightPillBar path={path} onRemoveSegment={handleBack} />
-      <SessionCreatorChatPanel
-        hidePresenceButton
-        onSessionStart={handleSessionStart}
-        innerClassName="pb-4!"
-      />
+      <SpotlightFormBody>
+        <SessionCreatorChatPanel
+          spotlight
+          headerLayout="compact"
+          hidePresenceButton
+          onSessionStart={handleSessionStart}
+          innerClassName="p-0!"
+        />
+      </SpotlightFormBody>
     </div>
   );
+
+  if (asBody) return body;
 
   return (
     <SpotlightShell

--- a/src/scaffold/GlobalSpotlight/palettes/SessionCreatorPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/SessionCreatorPalette/index.tsx
@@ -6,6 +6,7 @@
  * the palette (no navigation to Agent Station).
  */
 import React, { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { SessionLaunchSuccessInfo } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
 import { SessionCreatorChatPanel } from "@src/features/SessionCreator/variants";
@@ -26,6 +27,7 @@ export function SessionCreatorPalette({
   onGoBackToParent,
   asBody: _asBody,
 }: SessionCreatorPaletteProps) {
+  const { t } = useTranslation("navigation");
   const handleBack = onGoBackToParent ?? onClose;
 
   const handleSessionStart = useCallback(
@@ -40,12 +42,12 @@ export function SessionCreatorPalette({
       {
         type: "action",
         id: "new-session",
-        label: "New Session",
+        label: t("labels.newSession"),
         icon: Add01Icon,
         color: "primary",
       },
     ],
-    []
+    [t]
   );
 
   const body = (


### PR DESCRIPTION
## Problem

The Spotlight session creator hardcodes its New Session breadcrumb and ignores the embedded `asBody` mode. Opening it from Global Spotlight creates a second modal, leaving the empty parent border visible as a top line. The embedded creator also inherits floating-card spacing and surfaces, inconsistent picker hover styles, and tooltips layered below Spotlight.

## Solution

- Localize the breadcrumb with the existing `navigation:labels.newSession` key, including language-change memo dependencies.
- Honor `asBody` so embedded use reuses the parent Spotlight shell while standalone use retains its own shell.
- Add an opt-in `spotlight` prop to the session creator. Only this palette enables the 28px agent pill, matching agent/project/location/branch hover and active surfaces, transparent header, removal of the surrounding card shadow, and omission of an empty setup-actions row. Other creators retain their original presentation by default.
- Reuse `SpotlightFormBody` for one `p-3` inset and remove the creator's additional internal padding.
- Raise shared tooltips to z-index 10001, above Spotlight (9999) and dropdown menus (10000).
- Cover embedded/standalone rendering, Spotlight opt-in, and default versus Spotlight row surfaces with regression tests.

## Potential risks

The tooltip layer change applies globally, so interactions with other overlays still warrant visual review. Creator styling is opt-in; Kanban and other callers keep their original defaults. Live language switching, small-window spacing, dark/light themes, hover states, and stacking have not been visually verified after these changes. No dependencies, persisted settings, schemas, IPC, or session-launch behavior change; reverting this UI commit restores the previous presentation.

## Verification

- `pnpm test src/scaffold/GlobalSpotlight/palettes/SessionCreatorPalette/SessionCreatorPalette.test.ts src/features/SessionCreator/components/__tests__/SessionInfoPillGroup.test.ts src/features/SessionCreator/variants/Kanban/SessionCreatorKanban.test.ts src/components/Tooltip/index.test.ts src/components/Tooltip/tooltipPlacement.test.ts src/components/SelectorPill/index.test.ts src/components/PillGroup/index.test.ts` — 45 passed, one optional browser-layout test skipped because `ORGII_HEADLESS_CHROME` is not configured
- `pnpm typecheck:fast` — passed in the isolated PR worktree
- `node scripts/quality/check-missing-i18n-keys.mjs --namespace navigation --prefix labels.newSession` — passed for the original localization commit, zero missing keys
- Commit hooks run lint-staged (oxlint, ESLint, Prettier), TypeScript checking, and commitlint
- Fetched latest `origin/develop`; `git merge-tree --write-tree HEAD origin/develop` verifies conflict-free integration without rewriting published history
- `git diff --check origin/develop...HEAD` and final diff inspection check scope, formatting, and sensitive data
- No updated screenshots or desktop UI verification: computer control was not requested. User-provided screenshots identify the defects but do not verify the final implementation
