### PR TITLE
fix(org2-cloud): judge superseded siblings the roster still lists

### DIFF
--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -145,6 +145,7 @@ import {
   type ContinuationStatusResolver,
   type LocalSessionIdResolver,
   type SupersededPushedSession,
+  continuationLiveSessionIds,
   findSupersededPushedSessions,
   findSupersededSelfOwnedRemoteSessions,
   findVanishedPushedSessionIds,
@@ -1087,10 +1088,13 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     // tradeoff: the demoted row is the only cloud replay of the pre-compact
     // detail; the winner carries the compacted continuation. The source
     // transcript stays on the owner's disk and can always be re-shared.
+    // A demoted sibling can still sit in the roster (union merge, persisted
+    // rehydrate); judge it by lineage rather than by mere presence.
+    const continuationLiveIds = continuationLiveSessionIds(liveSessions);
     const superseded = await findSupersededPushedSessions({
       orgId,
       markedSessionIds,
-      liveSessionIds,
+      liveSessionIds: continuationLiveIds,
       resolveStatuses: this.resolveContinuationStatuses,
     });
     if (this.generation !== generation) return;
@@ -1124,7 +1128,7 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
         remoteSelfSessionIds: [...remoteSelfIds].filter(
           (sessionId) => !markedSessionIds.has(sessionId)
         ),
-        liveSessionIds,
+        liveSessionIds: continuationLiveIds,
         resolveStatuses: this.resolveContinuationStatuses,
       });
       if (this.generation !== generation) return;

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSessions.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSessions.ts
@@ -31,6 +31,7 @@ import {
 } from "@src/api/tauri/externalHistory/imported/cloudReplay";
 import { sessionAggregateList } from "@src/api/tauri/session";
 import { createLogger } from "@src/hooks/logger";
+import type { Session } from "@src/store/session";
 
 const log = createLogger("Org2CloudVanishedSessions");
 
@@ -188,4 +189,42 @@ async function findSupersededSessions(
       sessionId: status.sessionId,
       lineageId: status.lineageId as string,
     }));
+}
+
+/**
+ * The roster the superseded reconcile may treat as live. `sessionsAtom` is
+ * a union that is never pruned and is rehydrated from persistence, so a
+ * continuation sibling the backend election already demoted can stay listed
+ * next to its winner indefinitely. Absence from the roster is what makes a
+ * push-marked id a suspect, so such a row would never be judged and its
+ * cloud copy would never be retracted. Keep only the newest row per lineage
+ * as live; the backend status lookup remains the authority on supersession.
+ */
+export function continuationLiveSessionIds(
+  sessions: readonly Session[]
+): Set<string> {
+  const newestByLineage = new Map<string, Session>();
+  for (const session of sessions) {
+    const lineageId = session.continuationLineageId;
+    if (!lineageId) continue;
+    const current = newestByLineage.get(lineageId);
+    if (
+      !current ||
+      (session.updated_at || "").localeCompare(current.updated_at || "") > 0
+    ) {
+      newestByLineage.set(lineageId, session);
+    }
+  }
+  const live = new Set<string>();
+  for (const session of sessions) {
+    const lineageId = session.continuationLineageId;
+    if (
+      lineageId &&
+      newestByLineage.get(lineageId)?.session_id !== session.session_id
+    ) {
+      continue;
+    }
+    live.add(session.session_id);
+  }
+  return live;
 }

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSessions.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSessions.ts
@@ -197,32 +197,45 @@ async function findSupersededSessions(
  * continuation sibling the backend election already demoted can stay listed
  * next to its winner indefinitely. Absence from the roster is what makes a
  * push-marked id a suspect, so such a row would never be judged and its
- * cloud copy would never be retracted. Keep only the newest row per lineage
- * as live; the backend status lookup remains the authority on supersession.
+ * cloud copy would never be retracted. Within a lineage only a row that is
+ * strictly newest stays live; siblings tied on `updated_at` are all left
+ * to the backend status lookup, which breaks the tie the way the election
+ * did. Rows without a lineage are always live.
  */
 export function continuationLiveSessionIds(
   sessions: readonly Session[]
 ): Set<string> {
-  const newestByLineage = new Map<string, Session>();
+  const newestByLineage = new Map<
+    string,
+    { updatedAt: string; count: number; sessionId: string }
+  >();
   for (const session of sessions) {
     const lineageId = session.continuationLineageId;
     if (!lineageId) continue;
+    const updatedAt = session.updated_at || "";
     const current = newestByLineage.get(lineageId);
-    if (
-      !current ||
-      (session.updated_at || "").localeCompare(current.updated_at || "") > 0
-    ) {
-      newestByLineage.set(lineageId, session);
+    if (!current || updatedAt.localeCompare(current.updatedAt) > 0) {
+      newestByLineage.set(lineageId, {
+        updatedAt,
+        count: 1,
+        sessionId: session.session_id,
+      });
+    } else if (updatedAt === current.updatedAt) {
+      current.count += 1;
     }
   }
   const live = new Set<string>();
   for (const session of sessions) {
     const lineageId = session.continuationLineageId;
-    if (
-      lineageId &&
-      newestByLineage.get(lineageId)?.session_id !== session.session_id
-    ) {
-      continue;
+    if (lineageId) {
+      const newest = newestByLineage.get(lineageId);
+      if (
+        !newest ||
+        newest.count !== 1 ||
+        newest.sessionId !== session.session_id
+      ) {
+        continue;
+      }
     }
     live.add(session.session_id);
   }

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
@@ -255,6 +255,46 @@ describe("superseded-continuation reconcile", () => {
     );
   });
 
+  it("lets the backend break an updated_at tie instead of exempting the first row", async () => {
+    // Both generations carry the same last activity (a resend that copied
+    // the prior events). The backend election broke the tie by id and
+    // elected "winner"; the roster lists old-sib first. Neither row may be
+    // exempt from judgement, or the demoted one is never retracted.
+    store.set(sessionsAtom, [
+      {
+        ...SESSION,
+        session_id: "old-sib",
+        updated_at: "2026-09-11T00:18:38.000Z",
+        continuationLineageId: "lin-1",
+      },
+      {
+        ...SESSION,
+        session_id: "winner",
+        updated_at: "2026-09-11T00:18:38.000Z",
+        continuationLineageId: "lin-1",
+      },
+    ]);
+    resolveContinuationStatuses.mockImplementation(
+      async (ids: readonly string[]) =>
+        ids.map((sessionId) => ({
+          sessionId,
+          lineageId: "lin-1",
+          superseded: sessionId === "old-sib",
+        }))
+    );
+    startSweepEngine();
+
+    await engine.runSyncPass();
+    expect(client.deleteSession).not.toHaveBeenCalled();
+    await runSweepPass();
+    expect(client.deleteSession).toHaveBeenCalledTimes(1);
+    expect(client.deleteSession).toHaveBeenCalledWith(
+      "jwt-1",
+      "corg-1",
+      "old-sib"
+    );
+  });
+
   it("leaves the row alone while the family has no pushed winner", async () => {
     // No session carries the suspect's lineage at all.
     store.set(sessionsAtom, []);

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
@@ -224,6 +224,37 @@ describe("superseded-continuation reconcile", () => {
     expect(client.deleteSession).toHaveBeenCalledTimes(1);
   });
 
+  it("judges a demoted sibling the roster still lists next to its winner", async () => {
+    // The union-merged, persisted roster keeps the demoted sibling; only its
+    // lineage reveals that the newer winner replaced it. Live on 2026-09-11
+    // this kept a resent Codex generation's cloud row forever.
+    store.set(sessionsAtom, [
+      {
+        ...SESSION,
+        session_id: "winner",
+        updated_at: "2026-09-11T00:29:51.000Z",
+        continuationLineageId: "lin-1",
+      },
+      {
+        ...SESSION,
+        session_id: "old-sib",
+        updated_at: "2026-09-11T00:18:38.000Z",
+        continuationLineageId: "lin-1",
+      },
+    ]);
+    startSweepEngine();
+
+    await engine.runSyncPass();
+    expect(client.deleteSession).not.toHaveBeenCalled();
+    await runSweepPass();
+    expect(client.deleteSession).toHaveBeenCalledTimes(1);
+    expect(client.deleteSession).toHaveBeenCalledWith(
+      "jwt-1",
+      "corg-1",
+      "old-sib"
+    );
+  });
+
   it("leaves the row alone while the family has no pushed winner", async () => {
     // No session carries the suspect's lineage at all.
     store.set(sessionsAtom, []);


### PR DESCRIPTION
## Problem

After a Codex resend (or a Claude compact), the backend election demotes the older generation and the cloud engine is supposed to retract its cloud row once the winner is replay-pushed. `findSupersededPushedSessions` only considers push-marked ids that are **absent** from `sessionsAtom`. That roster is built by `mergeSessions`, a union that never drops rows, and is rehydrated from `orgii:sessionsAtom:v1` on boot, so a demoted sibling that was loaded before the election stays listed next to its winner indefinitely. It is therefore never a suspect, never judged by the backend continuation status, and its cloud row (plus every receiver's duplicate row) never goes away.

Observed live on 2026-09-11 while verifying #1576 with two instances: a resent Codex probe thread's old generation stayed in org `34e24e9e` for over 40 minutes and instance 2 kept listing both generations, while the identical path retracted the older generations of two other Codex threads in a background org at 00:44. The difference was only that those older rows had already been truncated out of the persisted roster (200 most recent rows), so they counted as absent. The primary's persisted atom still contained the resent thread's old generation.

## Solution

`continuationLiveSessionIds(sessions)` keeps only the newest row (by `updated_at`) per `continuationLineageId` as live; rows without a lineage are untouched. The superseded reconcile (both the push-marked arm and the self-owned-remote arm) uses that set instead of the raw roster. The vanished sweep keeps the raw roster, because a stale sibling is present locally, not vanished. The backend `importedHistoryContinuationStatuses` lookup remains the authority: a candidate is retracted only when it reports `superseded` with a lineage, and only after the existing two-strike confirmation and replay-pushed-winner check.

Invariant: a push-marked session that the backend election has superseded is judged on the next sweep even if the frontend roster still lists it.

Stacked on #1576 (base `codex/fix-resend-sidebar`) because the live evidence and the Codex lineage stamping come from that PR; the change itself is frontend-only and independent of its Rust code.

## Potential risks

- A lineage whose newest roster row is not the backend's winner (roster carrying a stale `updated_at`) would put the wrong row in the candidate set; the backend status check rejects it, so the worst case is one extra status lookup, never a wrong retract.
- Rows with equal `updated_at` are all left in the candidate set (none is treated as live) and the backend decides; see the tie follow-up below.
- No cloud, wire, or persistence change. The sidebar still shows the stale sibling until reload; that presentation gap is the same root cause but needs reveal-aware handling and is left for a separate change.
- Both strikes must happen in one engine lifetime and only while the app window is frontmost with a cloud org active; a restart or a long spell in another app between the two sweeps delays the retract until the next pass (observed on the final build, see below).

## Verification

- `vitest run src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts`: 9 passed, including new `judges a demoted sibling the roster still lists next to its winner`; with the engine change reverted (`git apply -R`) that test fails, the other 8 pass.
- `vitest run src/features/Org2Cloud/`: 143 test files passed.
- `tsc --noEmit`: clean. `eslint --max-warnings 0` on the three changed files: clean.
- Live evidence for the mechanism: primary `orgii:sessionsAtom:v1` contained both `rollout-2026-09-11T00-18-38-01a08f55…` (demoted) and `…00-29-51-01a08f55…_…` (winner); push markers for both existed in the org; no `superseded-continuation suspect` line was ever logged for that org, while the same pass logged and executed retracts for older demoted generations in another org.


## Live verification (2026-09-11, primary + instance 2)

Built into the live branch on top of #1576/#1582/#1583/#1587 (`4ad38bbe3`) and launched over the real `~/.orgii` home whose persisted roster still listed the demoted generation of the resent probe thread. First sync pass after boot (03:28:08) logged `superseded-continuation suspect codexapp-rollout-2026-09-11T00-18-38-01a08f55… (winner …00-29-51…)` for both orgs holding it, a line that never appeared for that org in 70 minutes on the previous build. The next sweep after the 10-minute gate (03:41:45) logged `cloud retract [superseded continuation]` for the same row in both orgs and the cloud ledger shows `deleted_at` set on the old generation while the winner row stays live. The interval between the two strikes is the existing sweep gate, unchanged here.


## Review follow-up: updated_at ties

Finding: the backend elects by `(updated_at_ms, source_session_id)`, while `continuationLiveSessionIds` kept the first roster row on an `updated_at` tie, so a generation demoted by id could stay live and never be judged. Confirmed. Follow-up commit: only a strictly newest row per lineage stays live; every row tied on `updated_at` is left in the candidate set and the backend status lookup decides. New test: two generations with identical `updated_at`, roster order `[old-sib, winner]`, backend reports `old-sib` superseded; `old-sib` is retracted after two sweeps. With the change reverted the test fails (no retract). Org2Cloud suite: 143 files pass; `tsc` and `eslint` clean.

## Live check on the final revision (2026-09-11, primary build `2813481dc` = all seven PR tips merged, no restart between steps)

Generation 4 of the probe thread entered the roster through a Codex-source rescan (#1597's swap) at 09:17 local. The same engine pass pushed it to both orgs (ledger rows `…08-59-16…` at 16:17:30Z and 16:17:42Z) and logged for the background org `superseded-continuation suspect codexapp-rollout-…04-28-26…_…23c98bec org bfa7b134… (winner …08-59-16…, 1/2)` at 09:17:38; the active org logged `kept: no replay-pushed winner … yet` at 09:17:26 because its push landed after that judgement. The next sweep at 09:28:05 retracted generation 3 in `bfa7b134` (`cloud retract [superseded continuation]`, ledger `deleted_at 16:28:05Z`) and logged strike 1 for `34e24e9e`. Passes then paused from 09:38 while the app window was not frontmost; the first pass after the window came back (10:06:08) logged `cloud retract [superseded continuation]` for `34e24e9e` and the ledger shows `deleted_at 17:06:08Z`. Both orgs now hold only generation 4 of the thread; generations 1, 2 and 3 are all retracted. The pause is the lifecycle limitation listed under risks, not a judgement failure.

The same pass also retracted `claudecodeapp-24d7a644…` in `34e24e9e` with winner `claudecodeapp-40d0c932…`: that is a Claude Code context-compaction continuation (lineage `cd66379a…`), i.e. the existing continuation semantics applied to a Claude lineage, not a Codex regression.
