### PR TITLE
fix(sidebar): list one row per continuation lineage

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/continuationVisibility.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/continuationVisibility.test.ts
@@ -85,9 +85,10 @@ describe("continuationWinnerIds", () => {
   });
 
   it("breaks an updated_at tie by id, like the backend election", () => {
+    // The lower id comes first so insertion order alone would pick it.
     const rows = [
-      dated("codexapp-rollout-b", "lineage-a", "2026-09-11T00:18:38.000Z"),
       dated("codexapp-rollout-a", "lineage-a", "2026-09-11T00:18:38.000Z"),
+      dated("codexapp-rollout-b", "lineage-a", "2026-09-11T00:18:38.000Z"),
     ];
     expect(continuationWinnerIds(rows, new Set())).toEqual(
       new Set(["codexapp-rollout-b"])

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/continuationVisibility.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/continuationVisibility.test.ts
@@ -84,6 +84,16 @@ describe("continuationWinnerIds", () => {
     expect(isHiddenContinuationSibling(rows[2], winners)).toBe(false);
   });
 
+  it("breaks an updated_at tie by id, like the backend election", () => {
+    const rows = [
+      dated("codexapp-rollout-b", "lineage-a", "2026-09-11T00:18:38.000Z"),
+      dated("codexapp-rollout-a", "lineage-a", "2026-09-11T00:18:38.000Z"),
+    ];
+    expect(continuationWinnerIds(rows, new Set())).toEqual(
+      new Set(["codexapp-rollout-b"])
+    );
+  });
+
   it("lets a revealed older generation win its lineage", () => {
     const rows = [
       dated("gen1", "lineage-a", "2026-09-11T00:18:38.000Z"),

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/continuationVisibility.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/continuationVisibility.test.ts
@@ -4,6 +4,8 @@ import type { Session } from "@src/store/session";
 
 import {
   continuationLineagesForRevealedSessions,
+  continuationWinnerIds,
+  isHiddenContinuationSibling,
   isRosterSiblingOfRevealedContinuation,
 } from "../continuationVisibility";
 
@@ -57,5 +59,38 @@ describe("continuationLineagesForRevealedSessions", () => {
         revealedLineages
       )
     ).toBe(false);
+  });
+});
+
+describe("continuationWinnerIds", () => {
+  function dated(
+    sessionId: string,
+    lineage: string | undefined,
+    updatedAt: string
+  ): Session {
+    return { ...session(sessionId, lineage), updated_at: updatedAt };
+  }
+
+  it("shows only the newest row of a lineage when nothing is revealed", () => {
+    const rows = [
+      dated("gen1", "lineage-a", "2026-09-11T00:18:38.000Z"),
+      dated("gen2", "lineage-a", "2026-09-11T00:29:51.000Z"),
+      dated("plain", undefined, "2026-09-11T00:00:00.000Z"),
+    ];
+    const winners = continuationWinnerIds(rows, new Set());
+    expect(winners).toEqual(new Set(["gen2"]));
+    expect(isHiddenContinuationSibling(rows[0], winners)).toBe(true);
+    expect(isHiddenContinuationSibling(rows[1], winners)).toBe(false);
+    expect(isHiddenContinuationSibling(rows[2], winners)).toBe(false);
+  });
+
+  it("lets a revealed older generation win its lineage", () => {
+    const rows = [
+      dated("gen1", "lineage-a", "2026-09-11T00:18:38.000Z"),
+      dated("gen2", "lineage-a", "2026-09-11T00:29:51.000Z"),
+    ];
+    const winners = continuationWinnerIds(rows, new Set(["gen1"]));
+    expect(winners).toEqual(new Set(["gen1"]));
+    expect(isHiddenContinuationSibling(rows[1], winners)).toBe(true);
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/continuationVisibility.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/continuationVisibility.ts
@@ -27,3 +27,53 @@ export function isRosterSiblingOfRevealedContinuation(
     revealedContinuationLineages.has(session.continuationLineageId)
   );
 }
+
+/**
+ * One visible row per continuation lineage. Explicitly revealed rows (the
+ * open session and its reveal request) always win their lineage; otherwise
+ * the newest row does. Rows without a lineage are never affected. This
+ * covers the window between a backend demotion and the next roster merge
+ * that prunes the demoted sibling.
+ */
+export function continuationWinnerIds(
+  sessions: readonly Session[],
+  revealedSessionIds: ReadonlySet<string>
+): ReadonlySet<string> {
+  const revealedByLineage = new Map<string, string[]>();
+  const newestByLineage = new Map<string, Session>();
+  for (const session of sessions) {
+    const lineageId = session.continuationLineageId;
+    if (!lineageId) continue;
+    if (revealedSessionIds.has(session.session_id)) {
+      const ids = revealedByLineage.get(lineageId) ?? [];
+      ids.push(session.session_id);
+      revealedByLineage.set(lineageId, ids);
+    }
+    const current = newestByLineage.get(lineageId);
+    if (
+      !current ||
+      (session.updated_at || "").localeCompare(current.updated_at || "") > 0
+    ) {
+      newestByLineage.set(lineageId, session);
+    }
+  }
+  const winners = new Set<string>();
+  for (const [lineageId, newest] of newestByLineage) {
+    const revealed = revealedByLineage.get(lineageId);
+    if (revealed) {
+      for (const id of revealed) winners.add(id);
+    } else {
+      winners.add(newest.session_id);
+    }
+  }
+  return winners;
+}
+
+export function isHiddenContinuationSibling(
+  session: Session,
+  winnerIds: ReadonlySet<string>
+): boolean {
+  return Boolean(
+    session.continuationLineageId && !winnerIds.has(session.session_id)
+  );
+}

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/continuationVisibility.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/continuationVisibility.ts
@@ -28,8 +28,20 @@ export function isRosterSiblingOfRevealedContinuation(
   );
 }
 
+/** Same order as the backend election: `updated_at`, then the id. */
+function isNewerContinuationRow(candidate: Session, current: Session): boolean {
+  const byTime = (candidate.updated_at || "").localeCompare(
+    current.updated_at || ""
+  );
+  if (byTime !== 0) return byTime > 0;
+  return candidate.session_id.localeCompare(current.session_id) > 0;
+}
+
 /**
- * One visible row per continuation lineage. Explicitly revealed rows (the
+ * One visible row per continuation lineage. Callers pass only the rows
+ * that are otherwise eligible for display, so a cached row that already
+ * left the authoritative roster can never outrank the row the backend
+ * returned. Explicitly revealed rows (the
  * open session and its reveal request) always win their lineage; otherwise
  * the newest row does. Rows without a lineage are never affected. This
  * covers the window between a backend demotion and the next roster merge
@@ -50,10 +62,7 @@ export function continuationWinnerIds(
       revealedByLineage.set(lineageId, ids);
     }
     const current = newestByLineage.get(lineageId);
-    if (
-      !current ||
-      (session.updated_at || "").localeCompare(current.updated_at || "") > 0
-    ) {
+    if (!current || isNewerContinuationRow(session, current)) {
       newestByLineage.set(lineageId, session);
     }
   }

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -190,21 +190,11 @@ export function useSessionMenuItems({
     () => createSidebarRosterMatcher(pagination),
     [pagination]
   );
-  const continuationWinners = useMemo(
-    () => continuationWinnerIds(sortedSessions, revealedSessionIds),
-    [revealedSessionIds, sortedSessions]
-  );
-
-  const visibleSessions = useMemo(
+  const eligibleSessions = useMemo(
     () =>
       sortedSessions.filter((session) => {
         const explicitlyRevealed = revealedSessionIds.has(session.session_id);
-        const hiddenRosterSibling = isHiddenContinuationSibling(
-          session,
-          continuationWinners
-        );
         return (
-          !hiddenRosterSibling &&
           isPrimarySessionListSession(session) &&
           (explicitlyRevealed ||
             (isInSidebarRoster(session) &&
@@ -219,10 +209,20 @@ export function useSessionMenuItems({
       includeExternal,
       isInSidebarRoster,
       revealedSessionIds,
-      continuationWinners,
       selectedOrgIds,
       sortedSessions,
     ]
+  );
+  const continuationWinners = useMemo(
+    () => continuationWinnerIds(eligibleSessions, revealedSessionIds),
+    [eligibleSessions, revealedSessionIds]
+  );
+  const visibleSessions = useMemo(
+    () =>
+      eligibleSessions.filter(
+        (session) => !isHiddenContinuationSibling(session, continuationWinners)
+      ),
+    [continuationWinners, eligibleSessions]
   );
 
   useEffect(() => {

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -19,8 +19,8 @@ import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
 import { isPrimarySessionListSession } from "@src/util/session/sessionVisibility";
 
 import {
-  continuationLineagesForRevealedSessions,
-  isRosterSiblingOfRevealedContinuation,
+  continuationWinnerIds,
+  isHiddenContinuationSibling,
 } from "./continuationVisibility";
 import { type DateGroupKey } from "./dateGroupingHelpers";
 import { buildSessionMenuItem, separator } from "./menuItemBuilders";
@@ -190,12 +190,8 @@ export function useSessionMenuItems({
     () => createSidebarRosterMatcher(pagination),
     [pagination]
   );
-  const revealedContinuationLineages = useMemo(
-    () =>
-      continuationLineagesForRevealedSessions(
-        sortedSessions,
-        revealedSessionIds
-      ),
+  const continuationWinners = useMemo(
+    () => continuationWinnerIds(sortedSessions, revealedSessionIds),
     [revealedSessionIds, sortedSessions]
   );
 
@@ -203,10 +199,9 @@ export function useSessionMenuItems({
     () =>
       sortedSessions.filter((session) => {
         const explicitlyRevealed = revealedSessionIds.has(session.session_id);
-        const hiddenRosterSibling = isRosterSiblingOfRevealedContinuation(
+        const hiddenRosterSibling = isHiddenContinuationSibling(
           session,
-          revealedSessionIds,
-          revealedContinuationLineages
+          continuationWinners
         );
         return (
           !hiddenRosterSibling &&
@@ -224,7 +219,7 @@ export function useSessionMenuItems({
       includeExternal,
       isInSidebarRoster,
       revealedSessionIds,
-      revealedContinuationLineages,
+      continuationWinners,
       selectedOrgIds,
       sortedSessions,
     ]

--- a/src/store/session/sessionAtom/__tests__/loaders.test.ts
+++ b/src/store/session/sessionAtom/__tests__/loaders.test.ts
@@ -16,6 +16,7 @@ import type { Session } from "../types";
 
 const {
   createSidebarLoadCoordinator,
+  mergeAuthoritativeSessions,
   mergeSessions,
   replaceExternalHistorySourceFirstPage,
 } = __TESTS_ONLY;
@@ -86,7 +87,7 @@ describe("mergeSessions", () => {
   });
 });
 
-describe("mergeSessions superseded siblings", () => {
+describe("mergeAuthoritativeSessions superseded siblings", () => {
   function lineageSession(
     id: string,
     updatedAt: string,
@@ -98,7 +99,7 @@ describe("mergeSessions superseded siblings", () => {
     };
   }
 
-  it("drops a held sibling once a newer row of its lineage arrives", () => {
+  it("drops a held sibling once the listing returns another row of its lineage", () => {
     // A Codex resend: gen1 was loaded and listed, the backend then elected
     // gen2 and stopped listing gen1. Two rows for one thread must not stay.
     const prev = [lineageSession("gen1", "2026-09-11T00:18:38", "thread-a")];
@@ -106,8 +107,24 @@ describe("mergeSessions superseded siblings", () => {
       lineageSession("gen2", "2026-09-11T00:29:51", "thread-a"),
     ];
     expect(
-      mergeSessions(prev, incoming).map((session) => session.session_id)
+      mergeAuthoritativeSessions(prev, incoming).map(
+        (session) => session.session_id
+      )
     ).toEqual(["gen2"]);
+  });
+
+  it("lets a re-promoted older generation displace a newer cached one", () => {
+    // gen2's file was removed and the backend re-promoted gen1; the
+    // listing is authoritative, so the newer cached gen2 must go.
+    const prev = [lineageSession("gen2", "2026-09-11T00:29:51", "thread-a")];
+    const incoming = [
+      lineageSession("gen1", "2026-09-11T00:18:38", "thread-a"),
+    ];
+    expect(
+      mergeAuthoritativeSessions(prev, incoming).map(
+        (session) => session.session_id
+      )
+    ).toEqual(["gen1"]);
   });
 
   it("keeps the open session even when it is the demoted generation", () => {
@@ -116,7 +133,7 @@ describe("mergeSessions superseded siblings", () => {
       lineageSession("gen2", "2026-09-11T00:29:51", "thread-a"),
     ];
     expect(
-      mergeSessions(prev, incoming, new Set(["gen1"])).map(
+      mergeAuthoritativeSessions(prev, incoming, new Set(["gen1"])).map(
         (session) => session.session_id
       )
     ).toEqual(["gen2", "gen1"]);
@@ -131,11 +148,14 @@ describe("mergeSessions superseded siblings", () => {
       lineageSession("gen2", "2026-09-11T00:29:51", "thread-a"),
     ];
     expect(
-      mergeSessions(prev, incoming).map((session) => session.session_id)
+      mergeAuthoritativeSessions(prev, incoming).map(
+        (session) => session.session_id
+      )
     ).toEqual(["gen2", "other", "plain"]);
   });
 
-  it("never drops a held row that is newer than the incoming sibling", () => {
+  it("does not prune on a plain merge, which loads by explicit id", () => {
+    // Opening an older generation by id must not evict the roster winner.
     const prev = [lineageSession("gen2", "2026-09-11T00:29:51", "thread-a")];
     const incoming = [
       lineageSession("gen1", "2026-09-11T00:18:38", "thread-a"),

--- a/src/store/session/sessionAtom/__tests__/loaders.test.ts
+++ b/src/store/session/sessionAtom/__tests__/loaders.test.ts
@@ -86,6 +86,66 @@ describe("mergeSessions", () => {
   });
 });
 
+describe("mergeSessions superseded siblings", () => {
+  function lineageSession(
+    id: string,
+    updatedAt: string,
+    lineage: string
+  ): Session {
+    return {
+      ...makeSession(id, updatedAt),
+      continuationLineageId: lineage,
+    };
+  }
+
+  it("drops a held sibling once a newer row of its lineage arrives", () => {
+    // A Codex resend: gen1 was loaded and listed, the backend then elected
+    // gen2 and stopped listing gen1. Two rows for one thread must not stay.
+    const prev = [lineageSession("gen1", "2026-09-11T00:18:38", "thread-a")];
+    const incoming = [
+      lineageSession("gen2", "2026-09-11T00:29:51", "thread-a"),
+    ];
+    expect(
+      mergeSessions(prev, incoming).map((session) => session.session_id)
+    ).toEqual(["gen2"]);
+  });
+
+  it("keeps the open session even when it is the demoted generation", () => {
+    const prev = [lineageSession("gen1", "2026-09-11T00:18:38", "thread-a")];
+    const incoming = [
+      lineageSession("gen2", "2026-09-11T00:29:51", "thread-a"),
+    ];
+    expect(
+      mergeSessions(prev, incoming, new Set(["gen1"])).map(
+        (session) => session.session_id
+      )
+    ).toEqual(["gen2", "gen1"]);
+  });
+
+  it("keeps rows of other lineages and rows without a lineage", () => {
+    const prev = [
+      lineageSession("other", "2026-09-10T00:00:00", "thread-b"),
+      makeSession("plain", "2026-09-09T00:00:00"),
+    ];
+    const incoming = [
+      lineageSession("gen2", "2026-09-11T00:29:51", "thread-a"),
+    ];
+    expect(
+      mergeSessions(prev, incoming).map((session) => session.session_id)
+    ).toEqual(["gen2", "other", "plain"]);
+  });
+
+  it("never drops a held row that is newer than the incoming sibling", () => {
+    const prev = [lineageSession("gen2", "2026-09-11T00:29:51", "thread-a")];
+    const incoming = [
+      lineageSession("gen1", "2026-09-11T00:18:38", "thread-a"),
+    ];
+    expect(
+      mergeSessions(prev, incoming).map((session) => session.session_id)
+    ).toEqual(["gen2", "gen1"]);
+  });
+});
+
 describe("replaceExternalHistorySourceFirstPage", () => {
   const codexSource = {
     sourceId: "codex_app",

--- a/src/store/session/sessionAtom/importedHistoryPaging.ts
+++ b/src/store/session/sessionAtom/importedHistoryPaging.ts
@@ -19,7 +19,10 @@ import {
 } from "@src/util/session/sessionDateBuckets";
 
 import type { FetchPageResult } from "./loaderShared";
-import { mergeDateBucketPagination, mergeSessions } from "./mergeSessions";
+import {
+  mergeAuthoritativeSessions,
+  mergeDateBucketPagination,
+} from "./mergeSessions";
 import {
   type DateBucketPaginationMap,
   emptyDateBucketPagination,
@@ -33,7 +36,7 @@ export function replaceImportedFirstPage(
   keepSessionIds?: ReadonlySet<string>
 ): Session[] {
   const retained = prev.filter((session) => !shouldReplace(session));
-  return mergeSessions(retained, incoming, keepSessionIds);
+  return mergeAuthoritativeSessions(retained, incoming, keepSessionIds);
 }
 
 export function replaceExternalHistorySourceFirstPage(

--- a/src/store/session/sessionAtom/importedHistoryPaging.ts
+++ b/src/store/session/sessionAtom/importedHistoryPaging.ts
@@ -29,24 +29,27 @@ import type { Session } from "./types";
 export function replaceImportedFirstPage(
   prev: readonly Session[],
   incoming: readonly Session[],
-  shouldReplace: (session: Session) => boolean
+  shouldReplace: (session: Session) => boolean,
+  keepSessionIds?: ReadonlySet<string>
 ): Session[] {
   const retained = prev.filter((session) => !shouldReplace(session));
-  return mergeSessions(retained, incoming);
+  return mergeSessions(retained, incoming, keepSessionIds);
 }
 
 export function replaceExternalHistorySourceFirstPage(
   prev: readonly Session[],
   incoming: readonly Session[],
   source: ImportedHistorySource,
-  preserveChildren = true
+  preserveChildren = true,
+  keepSessionIds?: ReadonlySet<string>
 ): Session[] {
   return replaceImportedFirstPage(
     prev,
     incoming,
     (session) =>
       (!preserveChildren || !session.parentSessionId) &&
-      isImportedHistorySourceSession(session.session_id, source)
+      isImportedHistorySourceSession(session.session_id, source),
+    keepSessionIds
   );
 }
 

--- a/src/store/session/sessionAtom/loaderShared.ts
+++ b/src/store/session/sessionAtom/loaderShared.ts
@@ -7,6 +7,7 @@ import type { NativeSidebarSessionCursor } from "@src/api/tauri/session";
 import { createLogger } from "@src/hooks/logger";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
+import { activeSessionIdAtom } from "../viewAtom";
 import type { DateBucketPaginationMap } from "./paginationAtoms";
 import type { Session } from "./types";
 
@@ -20,4 +21,10 @@ export interface FetchPageResult {
   hasMore: boolean;
   nextCursor?: NativeSidebarSessionCursor | null;
   dateBuckets?: DateBucketPaginationMap;
+}
+
+/** Rows the roster merge must never prune: the session the user has open. */
+export function openSessionKeepIds(): ReadonlySet<string> {
+  const activeSessionId = getStore().get(activeSessionIdAtom);
+  return activeSessionId ? new Set([activeSessionId]) : new Set();
 }

--- a/src/store/session/sessionAtom/loaders.ts
+++ b/src/store/session/sessionAtom/loaders.ts
@@ -43,7 +43,12 @@ import {
   importedPageHasProgress,
   replaceExternalHistorySourceFirstPage,
 } from "./importedHistoryPaging";
-import { BULK_CACHE_DURATION_MS, getStore, log } from "./loaderShared";
+import {
+  BULK_CACHE_DURATION_MS,
+  getStore,
+  log,
+  openSessionKeepIds,
+} from "./loaderShared";
 import {
   type LoadSessionsOptions,
   loadSessionsCacheSignature,
@@ -207,7 +212,7 @@ export function refreshRecentNativeSessions(): Promise<void> {
     );
     let merged: Session[] = [];
     store.set(sessionsAtom, (previous) => {
-      merged = mergeSessions(previous, incoming);
+      merged = mergeSessions(previous, incoming, openSessionKeepIds());
       return merged;
     });
     const membershipChanges = incoming.filter((session) => {
@@ -274,7 +279,9 @@ export function loadSidebarSessionsByIds(
     );
     if (loaded.length === 0) return [];
 
-    store.set(sessionsAtom, (previous) => mergeSessions(previous, loaded));
+    store.set(sessionsAtom, (previous) =>
+      mergeSessions(previous, loaded, openSessionKeepIds())
+    );
     persistSessions(store.get(sessionsAtom));
     return loaded;
   })();
@@ -376,7 +383,9 @@ export const loadMoreCategory = async (
     const sessionIds = replacingFirstPage
       ? returnedIds
       : [...current.sessionIds, ...newSessionIds];
-    store.set(sessionsAtom, (prev) => mergeSessions(prev, primarySessions));
+    store.set(sessionsAtom, (prev) =>
+      mergeSessions(prev, primarySessions, openSessionKeepIds())
+    );
     setPaginationFor(category, {
       sessionIds,
       cursor: imported ? null : (nextCursor ?? current.cursor),

--- a/src/store/session/sessionAtom/loaders.ts
+++ b/src/store/session/sessionAtom/loaders.ts
@@ -52,6 +52,7 @@ import {
 import {
   type LoadSessionsOptions,
   loadSessionsCacheSignature,
+  mergeAuthoritativeSessions,
   mergeSessions,
   preserveImportedReplayRows,
   setPaginationFor,
@@ -212,7 +213,11 @@ export function refreshRecentNativeSessions(): Promise<void> {
     );
     let merged: Session[] = [];
     store.set(sessionsAtom, (previous) => {
-      merged = mergeSessions(previous, incoming, openSessionKeepIds());
+      merged = mergeAuthoritativeSessions(
+        previous,
+        incoming,
+        openSessionKeepIds()
+      );
       return merged;
     });
     const membershipChanges = incoming.filter((session) => {
@@ -279,9 +284,7 @@ export function loadSidebarSessionsByIds(
     );
     if (loaded.length === 0) return [];
 
-    store.set(sessionsAtom, (previous) =>
-      mergeSessions(previous, loaded, openSessionKeepIds())
-    );
+    store.set(sessionsAtom, (previous) => mergeSessions(previous, loaded));
     persistSessions(store.get(sessionsAtom));
     return loaded;
   })();
@@ -384,7 +387,7 @@ export const loadMoreCategory = async (
       ? returnedIds
       : [...current.sessionIds, ...newSessionIds];
     store.set(sessionsAtom, (prev) =>
-      mergeSessions(prev, primarySessions, openSessionKeepIds())
+      mergeAuthoritativeSessions(prev, primarySessions, openSessionKeepIds())
     );
     setPaginationFor(category, {
       sessionIds,
@@ -441,6 +444,7 @@ export function registerNewNativeSidebarSession(session: Session): void {
 
 export const __TESTS_ONLY = {
   createSidebarLoadCoordinator,
+  mergeAuthoritativeSessions,
   mergeSessions,
   replaceExternalHistorySourceFirstPage,
 };

--- a/src/store/session/sessionAtom/mergeSessions.ts
+++ b/src/store/session/sessionAtom/mergeSessions.ts
@@ -66,8 +66,7 @@ export function preserveImportedReplayRows(
 
 export function mergeSessions(
   prev: readonly Session[],
-  incoming: readonly Session[],
-  keepSessionIds: ReadonlySet<string> = EMPTY_IDS
+  incoming: readonly Session[]
 ): Session[] {
   if (incoming.length === 0) return prev.slice();
   const incomingMap = new Map(
@@ -86,48 +85,54 @@ export function mergeSessions(
   merged.sort((sessionA, sessionB) =>
     (sessionB.updated_at || "").localeCompare(sessionA.updated_at || "")
   );
-  return pruneSupersededSiblings(merged, incoming, keepSessionIds);
+  return merged;
 }
 
 const EMPTY_IDS: ReadonlySet<string> = new Set();
 
 /**
- * The backend lists one row per continuation lineage: the elected winner.
- * A row already held here that shares a lineage with a newer incoming row
- * is a sibling the election demoted since it was loaded (a Codex resend or
- * a Claude compact). Keeping it would list two rows for one thread until
- * the next restart. Rows in `keepSessionIds` (the open session) survive so
- * a deliberately opened older generation stays reachable.
+ * Merge an authoritative listing page: the backend lists exactly one row
+ * per continuation lineage (the elected winner), so any held row of a
+ * listed lineage that the page did not return is a sibling the election
+ * demoted, whatever its `updated_at` says — a re-promoted older generation
+ * must displace a newer one whose file is gone. Loads by explicit id are
+ * not authoritative and must use `mergeSessions`.
+ */
+export function mergeAuthoritativeSessions(
+  prev: readonly Session[],
+  incoming: readonly Session[],
+  keepSessionIds: ReadonlySet<string> = EMPTY_IDS
+): Session[] {
+  return mergeSessions(
+    pruneSupersededSiblings(prev, incoming, keepSessionIds),
+    incoming
+  );
+}
+
+/**
+ * Drop held rows that share a lineage with an incoming (authoritative) row
+ * but were not returned themselves. Rows in `keepSessionIds` (the open
+ * session) survive so a deliberately opened older generation stays
+ * reachable; rows without a lineage are untouched.
  */
 export function pruneSupersededSiblings(
   sessions: readonly Session[],
   incoming: readonly Session[],
   keepSessionIds: ReadonlySet<string> = EMPTY_IDS
 ): Session[] {
-  const newestIncomingByLineage = new Map<string, Session>();
+  const listedLineages = new Set<string>();
   for (const session of incoming) {
-    const lineageId = session.continuationLineageId;
-    if (!lineageId) continue;
-    const current = newestIncomingByLineage.get(lineageId);
-    if (
-      !current ||
-      (session.updated_at || "").localeCompare(current.updated_at || "") > 0
-    ) {
-      newestIncomingByLineage.set(lineageId, session);
+    if (session.continuationLineageId) {
+      listedLineages.add(session.continuationLineageId);
     }
   }
-  if (newestIncomingByLineage.size === 0) return sessions.slice();
+  if (listedLineages.size === 0) return sessions.slice();
   const incomingIds = new Set(incoming.map((session) => session.session_id));
   return sessions.filter((session) => {
     const lineageId = session.continuationLineageId;
-    if (!lineageId) return true;
+    if (!lineageId || !listedLineages.has(lineageId)) return true;
     if (incomingIds.has(session.session_id)) return true;
-    if (keepSessionIds.has(session.session_id)) return true;
-    const winner = newestIncomingByLineage.get(lineageId);
-    if (!winner) return true;
-    return (
-      (session.updated_at || "").localeCompare(winner.updated_at || "") >= 0
-    );
+    return keepSessionIds.has(session.session_id);
   });
 }
 

--- a/src/store/session/sessionAtom/mergeSessions.ts
+++ b/src/store/session/sessionAtom/mergeSessions.ts
@@ -66,7 +66,8 @@ export function preserveImportedReplayRows(
 
 export function mergeSessions(
   prev: readonly Session[],
-  incoming: readonly Session[]
+  incoming: readonly Session[],
+  keepSessionIds: ReadonlySet<string> = EMPTY_IDS
 ): Session[] {
   if (incoming.length === 0) return prev.slice();
   const incomingMap = new Map(
@@ -85,7 +86,49 @@ export function mergeSessions(
   merged.sort((sessionA, sessionB) =>
     (sessionB.updated_at || "").localeCompare(sessionA.updated_at || "")
   );
-  return merged;
+  return pruneSupersededSiblings(merged, incoming, keepSessionIds);
+}
+
+const EMPTY_IDS: ReadonlySet<string> = new Set();
+
+/**
+ * The backend lists one row per continuation lineage: the elected winner.
+ * A row already held here that shares a lineage with a newer incoming row
+ * is a sibling the election demoted since it was loaded (a Codex resend or
+ * a Claude compact). Keeping it would list two rows for one thread until
+ * the next restart. Rows in `keepSessionIds` (the open session) survive so
+ * a deliberately opened older generation stays reachable.
+ */
+export function pruneSupersededSiblings(
+  sessions: readonly Session[],
+  incoming: readonly Session[],
+  keepSessionIds: ReadonlySet<string> = EMPTY_IDS
+): Session[] {
+  const newestIncomingByLineage = new Map<string, Session>();
+  for (const session of incoming) {
+    const lineageId = session.continuationLineageId;
+    if (!lineageId) continue;
+    const current = newestIncomingByLineage.get(lineageId);
+    if (
+      !current ||
+      (session.updated_at || "").localeCompare(current.updated_at || "") > 0
+    ) {
+      newestIncomingByLineage.set(lineageId, session);
+    }
+  }
+  if (newestIncomingByLineage.size === 0) return sessions.slice();
+  const incomingIds = new Set(incoming.map((session) => session.session_id));
+  return sessions.filter((session) => {
+    const lineageId = session.continuationLineageId;
+    if (!lineageId) return true;
+    if (incomingIds.has(session.session_id)) return true;
+    if (keepSessionIds.has(session.session_id)) return true;
+    const winner = newestIncomingByLineage.get(lineageId);
+    if (!winner) return true;
+    return (
+      (session.updated_at || "").localeCompare(winner.updated_at || "") >= 0
+    );
+  });
 }
 
 export function setPaginationFor(

--- a/src/store/session/sessionAtom/sidebarLoad.ts
+++ b/src/store/session/sessionAtom/sidebarLoad.ts
@@ -37,6 +37,7 @@ import {
   type FetchPageResult,
   getStore,
   log,
+  openSessionKeepIds,
 } from "./loaderShared";
 import { mergeSessions, setPaginationFor } from "./mergeSessions";
 import {
@@ -223,7 +224,9 @@ export const performSidebarSessionLoad = async (
     // Entity cache and stream window are deliberately separate. The first
     // authoritative page replaces only `sessionIds`; older cached entities
     // remain available for active/deep-link overlays.
-    store.set(sessionsAtom, (prev) => mergeSessions(prev, primarySessions));
+    store.set(sessionsAtom, (prev) =>
+      mergeSessions(prev, primarySessions, openSessionKeepIds())
+    );
     setPaginationFor(category, {
       sessionIds,
       cursor: nextCursor ?? null,

--- a/src/store/session/sessionAtom/sidebarLoad.ts
+++ b/src/store/session/sessionAtom/sidebarLoad.ts
@@ -39,7 +39,7 @@ import {
   log,
   openSessionKeepIds,
 } from "./loaderShared";
-import { mergeSessions, setPaginationFor } from "./mergeSessions";
+import { mergeAuthoritativeSessions, setPaginationFor } from "./mergeSessions";
 import {
   BASE_SESSION_LIST_CATEGORIES,
   type DateBucketPaginationMap,
@@ -225,7 +225,7 @@ export const performSidebarSessionLoad = async (
     // authoritative page replaces only `sessionIds`; older cached entities
     // remain available for active/deep-link overlays.
     store.set(sessionsAtom, (prev) =>
-      mergeSessions(prev, primarySessions, openSessionKeepIds())
+      mergeAuthoritativeSessions(prev, primarySessions, openSessionKeepIds())
     );
     setPaginationFor(category, {
       sessionIds,


### PR DESCRIPTION
## Problem

The backend continuation election lists one row per lineage, but the frontend roster (`sessionsAtom`) is built by `mergeSessions`, a union that never drops rows, and is rehydrated from persistence. When a Codex resend or a Claude compact demotes the generation the sidebar already holds, the sidebar keeps listing both generations until the app restarts. Seen live on 2026-09-11: after the election ran, the primary listed `查明发生了什么` and `检查队友文件共享状态` twice while the cache had exactly one listable row each; the duplicates vanished only after a restart. The menu builder's existing continuation filter only hides siblings of an explicitly revealed row, so an ordinary demotion is not covered.

## Solution

Two layers, both keyed on `continuationLineageId`:

- `mergeSessions` (and the imported first-page replace that wraps it) now prunes a held row when an incoming row of the same lineage is newer by `updated_at`, unless the row is in `keepSessionIds`. Loaders pass `openSessionKeepIds()` (the active session), so an older generation the user deliberately opened stays in the roster. Rows without a lineage are untouched; a held row newer than the incoming sibling is never dropped.
- `continuationWinnerIds` picks the visible row per lineage: every explicitly revealed row of that lineage, otherwise the newest. `useSessionMenuItems` uses it in place of `isRosterSiblingOfRevealedContinuation`, which it subsumes (a revealed row still wins and its siblings still hide). This covers the window between a backend demotion and the next roster merge.

Invariant: the sidebar shows one row per continuation lineage; a revealed older generation is the one exception and still hides its siblings.

Stacked on #1594 (base `fix/roster-drop-superseded-siblings`); together they make the roster honest for both the sidebar and the cloud engine.

## Potential risks

- A revealed older generation now stays in the roster only while it is the active session; once the user moves on, the next merge prunes it and the sidebar lists the winner. That is the intended reading of "revealed".
- Ties on `updated_at` are broken by `session_id`, the same order the backend election uses within a source.
- `loaderShared` now imports `activeSessionIdAtom` from `viewAtom`; `viewAtom` does not import the session atom module, so no cycle. Typecheck and the full sidebar/session/cloud suites pass.
- No backend, wire, or persistence-format change. Persisted rosters written before this change are pruned by the first merge after boot.
- The demotion-without-restart flow was observed live only through a Runtime-panel rescan of the Codex source (see the live section below); the sidebar's own refresh icon could not be used on the test machine because a pre-existing failure of the Warp source aborts that rescan before the roster reload, which is tracked separately.

## Verification

- `vitest run src/store/session/sessionAtom/ src/scaffold/NavigationSidebar/ src/features/Org2Cloud/`: 215 test files passed.
- New `mergeSessions superseded siblings` cases (drop on newer sibling, keep the open session, leave other lineages and lineage-less rows, never drop a newer held row); with the `mergeSessions.ts` change reverted the first case fails.
- New `continuationWinnerIds` cases (newest wins with nothing revealed; a revealed older generation wins and hides the newer sibling).
- `tsc --noEmit`: clean. `eslint --max-warnings 0` on all changed files: clean.


## Live check (2026-09-11, primary build `178806b6e` = live branch + this PR)

A third Codex resend of the probe thread was ingested by the running primary without a restart (04:29:15; cache shows generations 1 and 2 demoted, 3 listable). The sidebar showed exactly one `Run cloud sync probe` row throughout; opening it still rendered generation 2 because the "My sessions" first page had not been refetched in the following six minutes, including after a workspace switch and a "Load more". So the moment where the winner merges into a roster that still holds the demoted row was not captured live in this window; that transition is covered by the `mergeSessions` and `continuationWinnerIds` tests, which reproduce the roster states recorded earlier in this run. No duplicate row was observed at any point on this build.


## Review follow-up (third round)

Finding 1 (shared with #1594): `continuationWinnerIds` broke `updated_at` ties by insertion order while the backend elects by `(updated_at, source_session_id)`. Fixed: ties are broken by `session_id`, which orders the same way within a source. Test: two rows with identical `updated_at`, the higher id wins regardless of order.

Finding 2: a newer cached generation whose file was gone survived `pruneSupersededSiblings` (age rule), then won the lineage in `continuationWinnerIds` over the whole atom while being hidden by the roster filter, so the re-promoted older generation (#1582) was hidden as its sibling and the thread vanished. Fixed in three parts: (a) `mergeAuthoritativeSessions` (used by the sidebar roster page, category pages, the imported first-page replace and the recent-native refresh) drops every held sibling of a lineage the listing returned, whatever its age, except the open session; `mergeSessions` itself no longer prunes, so loads by explicit id (opening an older generation) cannot evict the winner; (b) `useSessionMenuItems` first computes the display-eligible rows (roster membership, org and external filters, explicit reveal) and only then elects one winner per lineage among them, so a cached row that left the authoritative roster can never outrank the row the backend returned; (c) the id tie-break above. Tests: "lets a re-promoted older generation displace a newer cached one" (cached gen2, listing returns gen1 → gen1 only; with the merge change reverted it fails), "does not prune on a plain merge" (by-id load keeps both), and the existing open-session exemption. Suites: 215 files / 1771 tests pass, `tsc` and `eslint` clean.

Rebased onto #1594's tie fix (`f5ccad3ce`). The live build on the primary predates this commit; the live check above stands for the earlier revision only.

## Live check on the final revision (2026-09-11, primary build `2813481dc` = all seven PR tips merged)

The primary was running with the sidebar showing the probe thread's generation 3 (`rollout-…04-28-26…_…23c98bec`, Created/Last updated 04:28) while the backend listing already held only generation 4 (`…08-59-16…_…8d378878`, ingested at 08:59 without a restart). A rescan of the Codex source from Runtime → Scanning (which ends in `loadSessionRoster({ forceRefresh: true })`) replaced the row in place: the tooltip switched to Session ID `…8d378878`, Created/Last updated 08:59, and the sidebar showed exactly one `Run cloud sync probe` row before, during and after the swap. The engine then pushed generation 4 to both orgs on its next pass (ledger rows `…08-59-16…` created 16:17:30Z/16:17:42Z) and judged generation 3 as a superseded-continuation suspect, which is #1594's path.

The sidebar's own refresh icon logged `Failed to rescan sidebar sessions: Failed to open Warp database …` and never reached the roster reload; that ordering predates this stack (`5ef46ec2d`) and is not changed here.
