### PR TITLE
fix(agent-station): use AI search icon for Explore

### DIFF
--- a/docs/frontend-ui-audit-2026-09-11/FileSidebar.md
+++ b/docs/frontend-ui-audit-2026-09-11/FileSidebar.md
@@ -1,0 +1,7 @@
+# FileSidebar UI audit
+
+| Line                                                                   | Element          | Verdict          | Reason                                                                                                                                    | Suggested change |
+| ---------------------------------------------------------------------- | ---------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/WorkStation/CodeEditor/SessionReplay/FileSidebar.tsx:326` | Explore tab icon | keep with reason | Uses the requested `AiSearch01Icon` through the shared icon barrel and preserves the existing tab size, translated label, and tab control | None             |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -29,6 +29,7 @@ export { default as Add01Icon } from "@hugeicons/core-free-icons/Add01Icon";
 export { default as AiGenerativeIcon } from "@hugeicons/core-free-icons/AiGenerativeIcon";
 export { default as AiNetworkIcon } from "@hugeicons/core-free-icons/AiNetworkIcon";
 export { default as AiProgrammingIcon } from "@hugeicons/core-free-icons/AiProgrammingIcon";
+export { default as AiSearch01Icon } from "@hugeicons/core-free-icons/AiSearch01Icon";
 export { default as AiSettingIcon } from "@hugeicons/core-free-icons/AiSettingIcon";
 export { default as Airplane01Icon } from "@hugeicons/core-free-icons/Airplane01Icon";
 export { default as Alert01Icon } from "@hugeicons/core-free-icons/Alert01Icon";

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/FileSidebar.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/FileSidebar.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from "react-i18next";
 import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
 import { resolveToolName } from "@src/engines/SessionCore/rendering/registry/toolAliases";
 import {
-  CompassIcon,
+  AiSearch01Icon,
   ComputerTerminal01Icon,
   HierarchyFilesIcon,
   HugeiconsIcon,
@@ -324,8 +324,8 @@ const FileSidebarComponent: React.FC<FileSidebarProps> = ({
         label: t("simulator.replay.ide.fileSidebar.tabExplore"),
         icon: (
           <HugeiconsIcon
-            icon={CompassIcon}
-            data-icon="compass"
+            icon={AiSearch01Icon}
+            data-icon="ai-search-01"
             size={PANEL_CONSTANTS.TAB_ICON_SIZE}
           />
         ),


### PR DESCRIPTION
## Problem

Agent Station’s Explore tab uses a compass glyph where the requested AI-search glyph better identifies the action.

## Solution

Use AiSearch01Icon through the existing icon barrel. Preserve the tab’s size, translated label, selected styling, and navigation behavior.

## Potential risks

The visible glyph changes. Native visual evidence was not captured because desktop computer control was not authorized. No dependency, persistence, IPC, or lifecycle behavior changes. Reverting this commit restores the compass.

## Verification

- `pnpm run typecheck:fast` — passed in the isolated branch
- `pnpm exec eslint src/icons.ts src/modules/WorkStation/CodeEditor/SessionReplay/FileSidebar.tsx --max-warnings 0` — passed
- `git diff --check` — passed
- Normal pre-commit checks and commit-message validation ran successfully
- UI audit: 0 fix, 1 keep with reason, 0 abstract
- Screenshots, theme/viewport checks, and native interaction checks were not run under the user’s no-computer-control preference
