### PR TITLE
fix(memory): abandon pending learnings whose account is gone

### DIFF
--- a/src-tauri/crates/agent-core/src/specialization/memory/consolidation/entry.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/consolidation/entry.rs
@@ -91,11 +91,6 @@ pub async fn consolidate(
     for (account_id, batch) in groups {
         let started_at = Utc::now().to_rfc3339();
         let pending_input = batch.len() as u32;
-        // A batch billed to an account that left the key vault can never
-        // resolve a consolidation model; it would fail on every trigger
-        // and keep the scope pending forever. Drain it instead. Only a
-        // confirmed absence is terminal: a credential store that cannot be
-        // read right now keeps the rows pending for the next trigger.
         if let Some(acct) = account_id.as_deref() {
             let outcome = reconcile_orphaned_account(&conn, scope, acct, |id| {
                 key_vault::key_store::KEY_SERVICE
@@ -134,6 +129,7 @@ pub async fn consolidate(
                         ..Default::default()
                     },
                 );
+                totals.abandoned += abandoned as u32;
                 continue;
             }
         }
@@ -298,15 +294,12 @@ mod tests {
         insert_learning(&conn, &pending_learning("acct-1", "one")).unwrap();
         insert_learning(&conn, &pending_learning("acct-1", "two")).unwrap();
 
-        // The store cannot be read: nothing may be abandoned.
         let outcome = reconcile_orphaned_account(&conn, "agent:builtin:sde", "acct-1", |_| {
             Err("credentials file unreadable".to_string())
         });
         assert!(outcome.is_err());
         assert_eq!(pending_count(&conn), 2);
 
-        // The store is readable again and the account is present: the
-        // batch takes the normal path with every row still queued.
         let outcome =
             reconcile_orphaned_account(&conn, "agent:builtin:sde", "acct-1", |_| Ok(true));
         assert_eq!(outcome.unwrap(), None);

--- a/src-tauri/crates/agent-core/src/specialization/memory/consolidation/entry.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/consolidation/entry.rs
@@ -2,6 +2,7 @@
 //! groups them by `account_id`, and runs one batch per group.
 
 use chrono::Utc;
+use rusqlite::Connection;
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
@@ -92,28 +93,49 @@ pub async fn consolidate(
         let pending_input = batch.len() as u32;
         // A batch billed to an account that left the key vault can never
         // resolve a consolidation model; it would fail on every trigger
-        // and keep the scope pending forever. Drain it instead.
-        if let Some(acct) = account_id.as_deref().filter(|acct| !account_exists(acct)) {
-            let abandoned = learnings::abandon_pending_for_account(&conn, scope, acct).unwrap_or(0);
-            let finished_at = Utc::now().to_rfc3339();
-            let _ = learnings::record_consolidation_run(
-                &conn,
-                &ConsolidationRunRecord {
-                    agent_scope: scope.to_string(),
-                    account_id: account_id.clone(),
-                    trigger: trigger.as_str().to_string(),
-                    mode: mode.as_str().to_string(),
-                    pending_input,
-                    abandoned: abandoned as u32,
-                    error: Some(format!(
+        // and keep the scope pending forever. Drain it instead. Only a
+        // confirmed absence is terminal: a credential store that cannot be
+        // read right now keeps the rows pending for the next trigger.
+        if let Some(acct) = account_id.as_deref() {
+            let outcome = reconcile_orphaned_account(&conn, scope, acct, |id| {
+                key_vault::key_store::KEY_SERVICE
+                    .get_key_by_id_checked(id)
+                    .map(|key| key.is_some())
+            });
+            let (abandoned, error) = match outcome {
+                Ok(None) => (0, None),
+                Ok(Some(abandoned)) => (
+                    abandoned,
+                    Some(format!(
                         "account '{acct}' no longer exists; abandoned {abandoned} pending learning(s)"
                     )),
-                    started_at,
-                    finished_at,
-                    ..Default::default()
-                },
-            );
-            continue;
+                ),
+                Err(err) => (
+                    0,
+                    Some(format!(
+                        "account '{acct}' lookup failed, {pending_input} learning(s) kept pending: {err}"
+                    )),
+                ),
+            };
+            if let Some(error) = error {
+                let finished_at = Utc::now().to_rfc3339();
+                let _ = learnings::record_consolidation_run(
+                    &conn,
+                    &ConsolidationRunRecord {
+                        agent_scope: scope.to_string(),
+                        account_id: account_id.clone(),
+                        trigger: trigger.as_str().to_string(),
+                        mode: mode.as_str().to_string(),
+                        pending_input,
+                        abandoned: abandoned as u32,
+                        error: Some(error),
+                        started_at,
+                        finished_at,
+                        ..Default::default()
+                    },
+                );
+                continue;
+            }
         }
         let info = match resolve_batch_provider_info(&conn, scope, &batch, account_id.as_deref()) {
             Ok(info) => info,
@@ -210,18 +232,103 @@ pub async fn consolidate(
     Ok(totals)
 }
 
-/// Whether the key vault still holds `account_id`. Consolidation bills the
-/// model call to the learning's account, so a missing account is terminal
-/// for that batch, unlike a transient auth failure of an existing one.
-fn account_exists(account_id: &str) -> bool {
-    key_vault::key_store::KEY_SERVICE
-        .get_key_by_id(account_id)
-        .is_some()
+/// Decide what to do with a batch billed to `account_id`. `lookup` answers
+/// whether the key vault still holds the account: `Ok(true)` keeps the
+/// batch on the normal path (`Ok(None)`), `Ok(false)` is a confirmed
+/// absence and drains the account's pending rows for `scope`
+/// (`Ok(Some(abandoned))`), and `Err` is an unreadable store, which must
+/// leave every row pending (`Err`).
+fn reconcile_orphaned_account(
+    conn: &Connection,
+    scope: &str,
+    account_id: &str,
+    lookup: impl FnOnce(&str) -> Result<bool, String>,
+) -> Result<Option<u64>, String> {
+    match lookup(account_id) {
+        Ok(true) => Ok(None),
+        Ok(false) => learnings::abandon_pending_for_account(conn, scope, account_id)
+            .map(Some)
+            .map_err(|err| format!("abandon pending learnings for '{account_id}': {err}")),
+        Err(err) => Err(err),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::load_embedding_config_for_consolidation;
+    use super::{load_embedding_config_for_consolidation, reconcile_orphaned_account};
+    use crate::specialization::memory::learnings::{
+        self, init_learnings_table, insert_learning, Learning, LearningCategory, LearningSource,
+        LearningStatus,
+    };
+    use rusqlite::Connection;
+
+    fn pending_learning(account_id: &str, content: &str) -> Learning {
+        Learning {
+            id: String::new(),
+            agent_scope: "agent:builtin:sde".into(),
+            content: content.into(),
+            takeaway: None,
+            category: LearningCategory::Pattern,
+            importance: 0.5,
+            confidence: 0.5,
+            embedding: Vec::new(),
+            embedding_model: None,
+            status: LearningStatus::Pending,
+            content_hash: None,
+            reinforcement_count: 1,
+            source: LearningSource::Reflection,
+            account_id: Some(account_id.into()),
+            evolution_type: crate::specialization::memory::learnings::EvolutionType::Original,
+            parent_id: None,
+            last_recalled_at: None,
+            source_session_id: None,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    fn pending_count(conn: &Connection) -> u64 {
+        learnings::count_pending_for_scope(conn, "agent:builtin:sde").unwrap()
+    }
+
+    #[test]
+    fn unreadable_credential_store_keeps_learnings_pending() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_learnings_table(&conn).unwrap();
+        insert_learning(&conn, &pending_learning("acct-1", "one")).unwrap();
+        insert_learning(&conn, &pending_learning("acct-1", "two")).unwrap();
+
+        // The store cannot be read: nothing may be abandoned.
+        let outcome = reconcile_orphaned_account(&conn, "agent:builtin:sde", "acct-1", |_| {
+            Err("credentials file unreadable".to_string())
+        });
+        assert!(outcome.is_err());
+        assert_eq!(pending_count(&conn), 2);
+
+        // The store is readable again and the account is present: the
+        // batch takes the normal path with every row still queued.
+        let outcome =
+            reconcile_orphaned_account(&conn, "agent:builtin:sde", "acct-1", |_| Ok(true));
+        assert_eq!(outcome.unwrap(), None);
+        assert_eq!(pending_count(&conn), 2);
+    }
+
+    #[test]
+    fn confirmed_missing_account_drains_its_batch() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_learnings_table(&conn).unwrap();
+        insert_learning(&conn, &pending_learning("gone", "one")).unwrap();
+        insert_learning(&conn, &pending_learning("gone", "two")).unwrap();
+        insert_learning(&conn, &pending_learning("live", "three")).unwrap();
+
+        let outcome = reconcile_orphaned_account(&conn, "agent:builtin:sde", "gone", |_| Ok(false));
+        assert_eq!(outcome.unwrap(), Some(2));
+        assert_eq!(
+            pending_count(&conn),
+            1,
+            "the other account's row stays queued"
+        );
+    }
 
     #[test]
     fn embedding_config_reads_through_integrations_store() {

--- a/src-tauri/crates/agent-core/src/specialization/memory/consolidation/entry.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/consolidation/entry.rs
@@ -90,6 +90,31 @@ pub async fn consolidate(
     for (account_id, batch) in groups {
         let started_at = Utc::now().to_rfc3339();
         let pending_input = batch.len() as u32;
+        // A batch billed to an account that left the key vault can never
+        // resolve a consolidation model; it would fail on every trigger
+        // and keep the scope pending forever. Drain it instead.
+        if let Some(acct) = account_id.as_deref().filter(|acct| !account_exists(acct)) {
+            let abandoned = learnings::abandon_pending_for_account(&conn, scope, acct).unwrap_or(0);
+            let finished_at = Utc::now().to_rfc3339();
+            let _ = learnings::record_consolidation_run(
+                &conn,
+                &ConsolidationRunRecord {
+                    agent_scope: scope.to_string(),
+                    account_id: account_id.clone(),
+                    trigger: trigger.as_str().to_string(),
+                    mode: mode.as_str().to_string(),
+                    pending_input,
+                    abandoned: abandoned as u32,
+                    error: Some(format!(
+                        "account '{acct}' no longer exists; abandoned {abandoned} pending learning(s)"
+                    )),
+                    started_at,
+                    finished_at,
+                    ..Default::default()
+                },
+            );
+            continue;
+        }
         let info = match resolve_batch_provider_info(&conn, scope, &batch, account_id.as_deref()) {
             Ok(info) => info,
             Err(err) => {
@@ -183,6 +208,15 @@ pub async fn consolidate(
         scope, totals.added, totals.updated, totals.deleted, totals.none, totals.abandoned
     );
     Ok(totals)
+}
+
+/// Whether the key vault still holds `account_id`. Consolidation bills the
+/// model call to the learning's account, so a missing account is terminal
+/// for that batch, unlike a transient auth failure of an existing one.
+fn account_exists(account_id: &str) -> bool {
+    key_vault::key_store::KEY_SERVICE
+        .get_key_by_id(account_id)
+        .is_some()
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/agent-core/src/specialization/memory/learnings/lifecycle.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/learnings/lifecycle.rs
@@ -151,6 +151,26 @@ pub fn abandon_pending(conn: &Connection, learning_id: &str) -> SqliteResult<boo
     Ok(true)
 }
 
+/// Abandon every pending learning of `agent_scope` that is billed to
+/// `account_id`. Used when the key-vault account no longer exists: no
+/// consolidation model can ever be resolved for those rows, so leaving
+/// them pending would re-fail on every trigger forever. Returns the number
+/// of rows moved out of the queue.
+pub fn abandon_pending_for_account(
+    conn: &Connection,
+    agent_scope: &str,
+    account_id: &str,
+) -> SqliteResult<u64> {
+    let now = Utc::now().to_rfc3339();
+    let rows = conn.execute(
+        "UPDATE learnings
+         SET status = 'abandoned', updated_at = ?1
+         WHERE agent_scope = ?2 AND account_id = ?3 AND status = 'pending'",
+        params![now, agent_scope, account_id],
+    )?;
+    Ok(rows as u64)
+}
+
 /// Feedback loop — mark a learning as just-recalled. Updates
 /// `last_recalled_at` (and `updated_at`) so the §4.1 decay formula treats
 /// the learning as "fresh". Deliberately does NOT bump

--- a/src-tauri/crates/agent-core/src/specialization/memory/learnings/mod.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/learnings/mod.rs
@@ -51,10 +51,10 @@ pub use crud::{
 };
 pub(crate) use lifecycle::touch_recall;
 pub use lifecycle::{
-    abandon_pending, count_pending_for_scope, count_pending_learnings, delete_learning,
-    deprecate_learning, last_consolidation_at, load_active_candidates, load_pending_learnings,
-    mark_merged, promote_pending_to_active, reactivate_learning, record_consolidation_run,
-    update_learning_body, ConsolidationRunRecord,
+    abandon_pending, abandon_pending_for_account, count_pending_for_scope, count_pending_learnings,
+    delete_learning, deprecate_learning, last_consolidation_at, load_active_candidates,
+    load_pending_learnings, mark_merged, promote_pending_to_active, reactivate_learning,
+    record_consolidation_run, update_learning_body, ConsolidationRunRecord,
 };
 pub use prompt::{inject_learnings_into_prompt, learning_prompt_revision};
 pub use ranking::{salience_score, search_similar};
@@ -286,6 +286,76 @@ mod tests {
         assert!(
             msg.contains("no such table") || msg.contains("learnings"),
             "expected sqlite \"no such table\" error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn abandon_pending_for_account_drains_only_that_account() {
+        let conn = setup_db();
+        let mut orphan_a =
+            make_learning("agent:builtin:sde", "orphan a", LearningCategory::Pattern);
+        orphan_a.status = LearningStatus::Pending;
+        orphan_a.account_id = Some("gone-account".into());
+        let mut orphan_b =
+            make_learning("agent:builtin:sde", "orphan b", LearningCategory::Pattern);
+        orphan_b.status = LearningStatus::Pending;
+        orphan_b.account_id = Some("gone-account".into());
+        let mut live = make_learning(
+            "agent:builtin:sde",
+            "live account",
+            LearningCategory::Pattern,
+        );
+        live.status = LearningStatus::Pending;
+        live.account_id = Some("live-account".into());
+        let mut active = make_learning(
+            "agent:builtin:sde",
+            "already active",
+            LearningCategory::Pattern,
+        );
+        active.account_id = Some("gone-account".into());
+        let mut other_scope = make_learning(
+            "agent:builtin:other",
+            "other scope",
+            LearningCategory::Pattern,
+        );
+        other_scope.status = LearningStatus::Pending;
+        other_scope.account_id = Some("gone-account".into());
+        let ids: Vec<String> = [&orphan_a, &orphan_b, &live, &active, &other_scope]
+            .into_iter()
+            .map(|learning| insert_learning(&conn, learning).unwrap())
+            .collect();
+
+        let drained =
+            abandon_pending_for_account(&conn, "agent:builtin:sde", "gone-account").unwrap();
+        assert_eq!(drained, 2);
+
+        let status_of = |id: &str| -> String {
+            conn.query_row("SELECT status FROM learnings WHERE id = ?1", [id], |row| {
+                row.get(0)
+            })
+            .unwrap()
+        };
+        assert_eq!(status_of(&ids[0]), "abandoned");
+        assert_eq!(status_of(&ids[1]), "abandoned");
+        assert_eq!(
+            status_of(&ids[2]),
+            "pending",
+            "another account's rows stay queued"
+        );
+        assert_eq!(
+            status_of(&ids[3]),
+            "active",
+            "only pending rows are touched"
+        );
+        assert_eq!(status_of(&ids[4]), "pending", "other scopes are untouched");
+        assert_eq!(
+            count_pending_for_scope(&conn, "agent:builtin:sde").unwrap(),
+            1
+        );
+        // The queue is now drained for that account: a second call is a no-op.
+        assert_eq!(
+            abandon_pending_for_account(&conn, "agent:builtin:sde", "gone-account").unwrap(),
+            0
         );
     }
 }


### PR DESCRIPTION
## Problem

`consolidation::tick` runs every 60 s and, once per 24 h per scope (the lazy cooldown), drains pending learnings grouped by `account_id`. Each group resolves a provider through the key vault; when the account no longer exists, `create_provider` fails with `Auth error: Account '<id>' not found`, the run is recorded with that error, and the rows remain `pending`. Nothing ever changes their state, so the same batches fail on every daily run and the scope never leaves the tick's pending scan.

On the primary machine: scope `agent:builtin:sde` has 43 pending learnings billed to three accounts that were removed from the key vault (31 + 8 + 4, oldest from 2026-06-13). `consolidation_runs` shows 26 of the last 27 runs failing with exactly that error; the tick logged 690 scans with `pending_scope_count=1` in one day. The cost per minute is small (one `SELECT DISTINCT` plus two trigger probes), but the queue is permanently stuck and three provider resolutions are attempted for nothing every day.

## Solution

Before resolving a provider for a batch, `consolidate` checks `KEY_SERVICE.get_key_by_id(account_id)`. If the account is gone, the batch's pending rows for that scope are moved to `abandoned` through the new `learnings::abandon_pending_for_account`, and a `consolidation_runs` row records `abandoned = N` with the reason. The scope then drains on its next run and the tick's pending scan goes quiet.

Only a missing account is treated as terminal. A transient auth failure on an existing account still takes the existing path (recorded error, rows stay pending, retried next trigger). Rows are not deleted; `abandoned` keeps them queryable, the same state `abandon_pending` already uses for failed consolidation attempts.

Hooking account deletion itself (the producing boundary) was considered: `delete_key` lives in `key-vault`, which does not depend on `agent-core`, so a hook would need app-layer wiring. The consumer-side check converges within one daily run and needs no new dependency direction; the hook can follow separately if wanted.

Per request, no new WARN-level logging was added; the outcome is recorded in `consolidation_runs` only.

## Potential risks

- Learnings billed to an account that is temporarily absent from the key vault (removed and re-added under the same id) would be abandoned in between. Re-adding an account does not restore them; they remain visible as `abandoned` for audit.
- Rows with `account_id = NULL` are not affected (no account to check); they keep the existing path.
- The check uses the global `KEY_SERVICE`, so `consolidate` itself is not unit-tested end to end here; the bulk-abandon query is, and the entry change is a guarded early `continue` next to the existing failure branches.
- No schema change (`abandoned` is an existing status and `consolidation_runs.abandoned` an existing column). No frontend or wire change.

## Verification

- `cargo test -p agent_core specialization::memory`: 192 passed, including new `abandon_pending_for_account_drains_only_that_account` (two pending rows of the gone account abandoned; another account's pending row, an active row of the gone account, and another scope's row untouched; second call is a no-op).
- `cargo test -p agent_core`: 3550 passed, 0 failed, 3 ignored. `rustfmt --check` on the three changed files: clean. `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- Live evidence for the mechanism: `~/.orgii/sessions.db` `learnings` (43 pending in `agent:builtin:sde` for accounts `00703796`, `4692e644`, `c4a7d947`), `consolidation_runs` errors `no provider for consolidation model=…: Auth error: Account '…' not found` daily since at least 2026-09-01, and 690 `[consolidation] tick scanned pending scopes … pending_scope_count=1` lines on 2026-09-11.
- Live (2026-09-11, primary build `2813481dc` with this branch merged, over the real `~/.orgii/sessions.db`): the first idle trigger after boot (`15:54:42Z`, 59 s after launch) logged `scope=agent:builtin:sde trigger=idle pending=43` and wrote three `consolidation_runs` rows, `account '00703796' no longer exists; abandoned 31 pending learning(s)`, `'4692e644' … 4`, `'c4a7d947' … 8`; the `learnings` table now holds 0 pending rows for the scope (64 abandoned, 483 active, 303 merged) and no later tick has re-entered the scope. The previous run row for the same account (`2026-09-10 13:40:01`) still shows the old `Auth error: Account '00703796' not found` failure.


## Review follow-up

Finding (P1): `account_exists` used `KEY_SERVICE.get_key_by_id`, which goes through `load_store()`; that returns an empty default store when the credentials file cannot be read or parsed and drops invalid entries, so `None` also meant "unreadable right now", and the branch would have abandoned learnings permanently for a transient failure. Confirmed.

Fix (follow-up commit): the decision is `reconcile_orphaned_account(conn, scope, account_id, lookup)` with the lookup injected; production passes `KEY_SERVICE.get_key_by_id_checked(id).map(|key| key.is_some())`. `Ok(true)` takes the normal path, `Ok(false)` (confirmed absent) drains the account's pending rows for the scope, and `Err` records a `consolidation_runs` row with the lookup error and keeps every row pending, skipping that batch for this trigger only. The unchecked helper is removed. Tests at the entry: an unreadable store leaves both pending rows untouched and a later successful lookup still finds them queued; a confirmed missing account drains its two rows and leaves another account's row queued. `cargo test -p agent_core`: 3552 passed, 0 failed, 3 ignored; `rustfmt --check` on `entry.rs`: clean; `cargo clippy --workspace --all-targets -- -D warnings`: passed.

## Follow-up: totals and comments

The live summary line read `done added=0 updated=0 deleted=0 none=0 abandoned=0` while 43 rows had just been drained, because the orphan branch recorded the count only in `consolidation_runs` and skipped the per-scope totals. `fca4bc70d` adds the drained count to `totals.abandoned` before the batch is skipped, and removes the explanatory inline comments this branch had introduced (the doc comments on the two helpers stay). `cargo test -p agent_core specialization::memory`: 194 passed; `cargo clippy -p agent_core --all-targets -- -D warnings`: clean; `rustfmt --check` on `entry.rs`: clean. No new test: `consolidate()` is not unit-testable without the key vault and provider resolution, and the count itself is covered by the run-record assertions.
