### PR TITLE
fix(find-card): align compact controls and hover styling

### DIFF
--- a/src/components/FindCard/index.tsx
+++ b/src/components/FindCard/index.tsx
@@ -168,7 +168,7 @@ export function FindCard({
     <ToolbarTooltip key={label} label={label} mouseEnterDelay={1000}>
       <Button
         variant="tertiary"
-        appearance={pressed === undefined ? undefined : "soft"}
+        className="aria-pressed:bg-surface-selected aria-pressed:text-primary-6"
         size="small"
         iconOnly
         onClick={onClick}
@@ -233,6 +233,8 @@ export function FindCard({
           <SegmentedTextPill
             ariaLabel={t("common:actions.find")}
             className="gap-px"
+            size="small"
+            tooltipPosition="bottom"
             value={scope}
             onChange={selectFindScope}
             options={[
@@ -261,7 +263,7 @@ export function FindCard({
             {extraControls}
           </>
         )}
-        <span className="ml-auto text-xs text-text-3" role="status">
+        <span className="mr-0.5 ml-auto text-xs text-text-3" role="status">
           {!query
             ? ""
             : isSearching

--- a/src/components/SegmentedTextPill/index.tsx
+++ b/src/components/SegmentedTextPill/index.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import Tooltip from "@src/components/Tooltip";
+import Tooltip, { type TooltipProps } from "@src/components/Tooltip";
 
 interface SegmentedTextPillOption<T extends string> {
   ariaLabel?: string;
@@ -19,6 +19,7 @@ export interface SegmentedTextPillProps<T extends string> {
   onChange: (value: T) => void;
   options: SegmentedTextPillOption<T>[];
   size?: SegmentedTextPillSize;
+  tooltipPosition?: TooltipProps["position"];
   /** When null, no segment is shown as selected (e.g. custom value outside presets). */
   value: T | null;
 }
@@ -41,6 +42,7 @@ export default function SegmentedTextPill<T extends string>({
   onChange,
   options,
   size = "default",
+  tooltipPosition = "top",
   value,
 }: SegmentedTextPillProps<T>) {
   return (
@@ -75,7 +77,7 @@ export default function SegmentedTextPill<T extends string>({
           <Tooltip
             key={option.value}
             content={option.tooltip}
-            position="top"
+            position={tooltipPosition}
             mouseEnterDelay={200}
             framedPanel
             smartPlacement

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeMirrorSearchPanel/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeMirrorSearchPanel/index.tsx
@@ -284,7 +284,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
           >
             <Button
               variant="tertiary"
-              appearance="soft"
+              className="aria-pressed:bg-surface-selected aria-pressed:text-primary-6"
               size="small"
               iconOnly
               aria-pressed={localReplaceMode}


### PR DESCRIPTION
## Problem

The Find card scope pills are too large, the match count sits too close to the navigation buttons, and scope tooltips open above the row. Search toggles and Replace use a different hover color from the close button.

## Solution

Use the small scope-pill size, add 2px between the count and navigation controls, and position scope tooltips below. Add an optional tooltipPosition prop to SegmentedTextPill with its existing top default. Use the close button’s default tertiary appearance for search toggles and Replace while preserving pressed-state colors.

## Potential risks

Hover and selected-state rendering across themes and constrained viewports has not been visually verified. Tooltip smart placement may still flip when space is limited. Other segmented-pill consumers retain their existing tooltip default. There are no persistence, dependency, or wire-format changes; reverting this commit restores the previous presentation.

## Verification

- `pnpm exec eslint src/components/FindCard/index.tsx src/components/SegmentedTextPill/index.tsx src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeMirrorSearchPanel/index.tsx --max-warnings 0` — passed.
- `pnpm test -- src/components/SegmentedTextPill/SegmentedTextPill.test.ts src/components/Button/index.test.ts src/components/FindCard/findCoordinator.test.ts` — 3 files, 26 tests passed.
- `git diff --check` — passed.
- Inspected the three-file diff for scope, secrets, private paths, and generated churn.
- No desktop visual checks or screenshots: computer control was not authorized. Full application and E2E suites were not run for this presentation-only change.
