### PR TITLE
refactor(cloud): reuse canonical session scope resolver

### DIFF
--- a/src/features/Org2Cloud/CloudSessionShareDialog/useCloudSessionShareDialog.ts
+++ b/src/features/Org2Cloud/CloudSessionShareDialog/useCloudSessionShareDialog.ts
@@ -9,11 +9,8 @@
 import { useAtomValue, useStore } from "jotai";
 import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
 
-import { persistedScopeKeysForImportedSession } from "@src/features/TeamCollaboration/importedSessionScopeMatch";
 import {
   getShareableScopeKeyVersion,
-  peekShareableScopeKeys,
-  primeShareableScopeKey,
   subscribeShareableScopeKeys,
 } from "@src/features/TeamCollaboration/repoScopeResolver";
 import { sessionOrgTagsAtom } from "@src/features/TeamCollaboration/sessionOrgTagsAtom";
@@ -27,22 +24,8 @@ import {
 } from "../org2CloudOrgsAtom";
 import { org2CloudRepoScopesAtom } from "../org2CloudSyncAtoms";
 import { isCloudPushCandidate } from "../org2CloudSyncEngine";
+import { getSessionScopeKeys } from "../org2CloudSyncEngine.repoScopeSync";
 import { getActiveCloudShareOrgsForSession } from "./shareEligibility";
-
-/**
- * Resolved scope keys for one session, backed by the module-level resolver
- * cache the sync engine also feeds (same idiom as useSessionShareDialog:
- * `undefined` = still resolving → not eligible yet; the subscription
- * re-renders the consumer when the keys land).
- */
-function getSessionScopeKeys(session: Session): string[] | null | undefined {
-  const persistedKeys = persistedScopeKeysForImportedSession(session);
-  if (persistedKeys !== undefined) return persistedKeys;
-  if (!session.repoPath) return null;
-  const keys = peekShareableScopeKeys(session.repoPath);
-  if (keys === undefined) primeShareableScopeKey(session.repoPath);
-  return keys;
-}
 
 export interface UseCloudSessionShareDialogResult {
   /** Session the dialog is open for; null = closed. */

--- a/src/features/Org2Cloud/org2CloudSyncEngine.repoScopeSync.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.repoScopeSync.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  peekShareableScopeKeys,
+  primeShareableScopeKey,
+} from "../TeamCollaboration/repoScopeResolver";
+import { getSessionScopeKeys } from "./org2CloudSyncEngine.repoScopeSync";
+
+vi.mock("../TeamCollaboration/repoScopeResolver", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../TeamCollaboration/repoScopeResolver")
+    >();
+  return {
+    ...actual,
+    peekShareableScopeKeys: vi.fn(),
+    primeShareableScopeKey: vi.fn(),
+  };
+});
+
+const peekMock = vi.mocked(peekShareableScopeKeys);
+const primeMock = vi.mocked(primeShareableScopeKey);
+
+const REPO_PATH = "/Users/me/org2";
+
+function nativeSession(repoPath: string | undefined) {
+  return {
+    session_id: "native-1",
+    repoPath,
+    repoRemoteUrls: undefined,
+    parentSessionId: undefined,
+  };
+}
+
+beforeEach(() => {
+  peekMock.mockReset();
+  primeMock.mockReset();
+});
+
+describe("getSessionScopeKeys", () => {
+  describe("imported history (persisted remotes, never probes the checkout)", () => {
+    it("returns the normalized persisted remote keys", () => {
+      expect(
+        getSessionScopeKeys({
+          session_id: "claudecodeapp-1",
+          repoPath: REPO_PATH,
+          repoRemoteUrls: [
+            "git@github.com:org2ai/org2.git",
+            "https://github.com/org2ai/org2.git",
+            "https://github.com/yorgai/org2.git",
+          ],
+          parentSessionId: undefined,
+        })
+      ).toEqual(["github.com/org2ai/org2", "github.com/yorgai/org2"]);
+      expect(peekMock).not.toHaveBeenCalled();
+      expect(primeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns null for an imported session with no cached remote", () => {
+      expect(
+        getSessionScopeKeys({
+          session_id: "claudecodeapp-4",
+          repoPath: REPO_PATH,
+          repoRemoteUrls: undefined,
+          parentSessionId: undefined,
+        })
+      ).toBeNull();
+      expect(peekMock).not.toHaveBeenCalled();
+      expect(primeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns null for a spawned child even when its remotes are shareable", () => {
+      expect(
+        getSessionScopeKeys({
+          session_id: "claudecodeapp-agent-a5",
+          repoPath: REPO_PATH,
+          repoRemoteUrls: ["git@github.com:org2ai/org2.git"],
+          parentSessionId: "claudecodeapp-1",
+        })
+      ).toBeNull();
+      expect(peekMock).not.toHaveBeenCalled();
+      expect(primeMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("native session without a checkout", () => {
+    it.each([undefined, ""])(
+      "returns null for repoPath %j without touching the resolver",
+      (repoPath) => {
+        expect(getSessionScopeKeys(nativeSession(repoPath))).toBeNull();
+        expect(peekMock).not.toHaveBeenCalled();
+        expect(primeMock).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe("native session with a checkout (resolver cache)", () => {
+    it("returns cached keys without re-priming", () => {
+      peekMock.mockReturnValue(["github.com/org2ai/org2"]);
+      expect(getSessionScopeKeys(nativeSession(REPO_PATH))).toEqual([
+        "github.com/org2ai/org2",
+      ]);
+      expect(peekMock).toHaveBeenCalledWith(REPO_PATH);
+      expect(primeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns the cached not-shareable null without re-priming", () => {
+      peekMock.mockReturnValue(null);
+      expect(getSessionScopeKeys(nativeSession(REPO_PATH))).toBeNull();
+      expect(peekMock).toHaveBeenCalledWith(REPO_PATH);
+      expect(primeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined and primes exactly once while resolution is in flight", () => {
+      peekMock.mockReturnValue(undefined);
+      expect(getSessionScopeKeys(nativeSession(REPO_PATH))).toBeUndefined();
+      expect(peekMock).toHaveBeenCalledWith(REPO_PATH);
+      expect(primeMock).toHaveBeenCalledTimes(1);
+      expect(primeMock).toHaveBeenCalledWith(REPO_PATH);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`useCloudSessionShareDialog.ts` carried a private copy of the sync engine's session scope-key resolver. `org2CloudSyncEngine.repoScopeSync.ts` already exports the canonical `getSessionScopeKeys` (persisted keys for imported history → `null` without a checkout → resolver-cache peek, priming on a miss), and the push pass, retract-reconcile and coverage passes all use it. The share dialog's copy was identical today, but two copies of the eligibility rule can drift silently, and nothing pinned the resolver's three-way (`string[] | null | undefined`) return on either side.

This re-lands commit `ad33b0f2ba` ("refactor(cloud): unify session scope resolution") of #780 on current develop, per the Neonforge98 audit of that PR ("still needed, behavior-preserving, fallback matrix identical"; "adds no test; nothing pins `getSessionScopeKeys`' three-way return on either side").

## Solution

- `src/features/Org2Cloud/CloudSessionShareDialog/useCloudSessionShareDialog.ts`: delete the local `getSessionScopeKeys` and its now-unused imports (`persistedScopeKeysForImportedSession`, `peekShareableScopeKeys`, `primeShareableScopeKey`); import `getSessionScopeKeys` from `../org2CloudSyncEngine.repoScopeSync`. Both call sites (`orgsForSession`, `isCloudShareEligible`) are untouched. The `exhaustive-deps` disable comment still names `getSessionScopeKeys`, which is still the function whose module-cache read `scopeKeyVersion` invalidates.
- New `src/features/Org2Cloud/org2CloudSyncEngine.repoScopeSync.test.ts` (colocated, matching the directory's style) pins every fallback branch of the canonical resolver with `peekShareableScopeKeys` / `primeShareableScopeKey` mocked on top of the real module:
  - imported history: normalized, deduped persisted remote keys; `null` when no remote is cached; `null` for a spawned child even with shareable remotes — and the checkout resolver is never peeked or primed;
  - native session with `repoPath` `undefined` / `""`: `null`, resolver untouched;
  - native session with a checkout: cached keys returned without re-priming; cached not-shareable `null` returned without re-priming; `undefined` returned and `primeShareableScopeKey` called exactly once while resolution is in flight.

Fallback matrix re-verified line by line against the deleted copy on develop: the two bodies were identical; the only signature difference is that the canonical resolver accepts `Pick<Session, "session_id" | "repoPath" | "repoRemoteUrls" | "parentSessionId">`, which a full `Session` satisfies.

Versus `ad33b0f2ba`: same source change (the file paths did not move); the test file is new.

## Potential risks

- Behavior: none expected. The share gate now resolves keys through the exact same function the sync passes use; the removed body was byte-for-byte the same logic. No UI, IPC, persistence or wire change.
- The share-dialog hook itself has no existing test, and a new hook-level test (jotai store + several atoms + `useSyncExternalStore` rendering) was judged not cheap for a re-land whose source change is a pure import swap, so "the hook derives its keys from the resolver" is verified by review of the diff and the full typecheck, not by a render test.
- Pre-commit hook was skipped in the fresh worktree (`.husky/_/husky.sh` is absent there), so the commit carries no `Pre-commit hook ran.` trailer; prettier / oxlint / eslint were run by hand on the two changed files instead.

## Verification

Run from a fresh worktree of `origin/develop` (`5abb618177`):

- `npx prettier --write <2 files>` — unchanged after write.
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <2 files>` — exit 0.
- `npx eslint --max-warnings 0 --report-unused-disable-directives <2 files>` — exit 0 (the retained `react-hooks/exhaustive-deps` disable is still used).
- `npx vitest run --config config/vitest.config.ts src/features/Org2Cloud/org2CloudSyncEngine.repoScopeSync.test.ts src/features/Org2Cloud/CloudSessionShareDialog/shareEligibility.test.ts src/features/TeamCollaboration/importedSessionScopeMatch.test.ts src/features/Org2Cloud/org2CloudSyncCoverage.test.ts src/features/Org2Cloud/org2CloudSyncEngine.retractReconcile.test.ts` — 5 files, 55 tests passed (8 new).
- `pnpm run check:test-placement` — "Test placement is consistent across 554 directories."
- `npx tsgo --noEmit --pretty false` — exit 0, no errors.

Did not run: `pnpm check:typed-lint` (no promise-bearing line was added or rewritten in source; the test's `vi.mock` factory awaits `importOriginal`), the full vitest suite, Rust checks (no Rust touched), and the pre-commit hook (skipped in worktree, see risks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
