### PR TITLE
refactor(database): share tauri sql provider lifecycle

### DIFF
--- a/src/engines/DatabaseCore/__tests__/TauriSqlProvider.test.ts
+++ b/src/engines/DatabaseCore/__tests__/TauriSqlProvider.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type TauriSqlDialect,
+  TauriSqlProvider,
+} from "../providers/TauriSqlProvider";
+import type { PostgresConnectionConfig } from "../types";
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+
+/**
+ * A deliberately odd dialect so every assertion below proves the base class
+ * routed through the dialect hooks instead of hard-coding either real dialect.
+ */
+const FAKE_DIALECT: TauriSqlDialect<PostgresConnectionConfig> = {
+  type: "postgres",
+  buildConnectionString: (config) => `fake://${config.host}/${config.database}`,
+  quoteIdentifier: (identifier) => `[${identifier}]`,
+  formatValue: (value) => `<${String(value)}>`,
+};
+
+class FakeProvider extends TauriSqlProvider<PostgresConnectionConfig> {
+  constructor(config: PostgresConnectionConfig) {
+    super(config, FAKE_DIALECT);
+  }
+}
+
+const config: PostgresConnectionConfig = {
+  id: "conn-1",
+  name: "Fake",
+  type: "postgres",
+  createdAt: 0,
+  updatedAt: 0,
+  host: "db.example.com",
+  port: 5432,
+  database: "app",
+  user: "admin",
+};
+
+async function connected(): Promise<FakeProvider> {
+  const provider = new FakeProvider(config);
+  invokeMock.mockResolvedValueOnce(undefined);
+  await provider.connect();
+  invokeMock.mockClear();
+  return provider;
+}
+
+/** Whitespace-normalised SQL of the nth invoke call. */
+function sqlAt(index: number): string {
+  const call = invokeMock.mock.calls[index];
+  return String((call[1] as { sql: string }).sql)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+describe("TauriSqlProvider connection lifecycle", () => {
+  it("takes its type and connection string from the dialect", async () => {
+    const provider = new FakeProvider(config);
+    invokeMock.mockResolvedValue(undefined);
+
+    expect(provider.type).toBe("postgres");
+    expect(provider.status).toEqual({ state: "disconnected" });
+    expect(provider.isConnected()).toBe(false);
+
+    await provider.connect();
+
+    expect(invokeMock).toHaveBeenCalledWith("db_sql_connect", {
+      connectionId: "conn-1",
+      dbType: "postgres",
+      connectionString: "fake://db.example.com/app",
+    });
+    expect(provider.status).toMatchObject({ state: "connected" });
+    expect(provider.isConnected()).toBe(true);
+  });
+
+  it("is idempotent once connected", async () => {
+    const provider = await connected();
+
+    await provider.connect();
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("records the error status and rethrows when the backend rejects", async () => {
+    const provider = new FakeProvider(config);
+    invokeMock.mockRejectedValueOnce(new Error("refused"));
+
+    await expect(provider.connect()).rejects.toThrow("refused");
+
+    expect(provider.status).toEqual({ state: "error", error: "refused" });
+    expect(provider.isConnected()).toBe(false);
+  });
+
+  it("disconnects best-effort and never invokes when not connected", async () => {
+    const provider = await connected();
+    invokeMock.mockRejectedValueOnce(new Error("already gone"));
+
+    await provider.disconnect();
+
+    expect(invokeMock).toHaveBeenCalledWith("db_sql_disconnect", {
+      connectionId: "conn-1",
+    });
+    expect(provider.status).toEqual({ state: "disconnected" });
+    expect(provider.isConnected()).toBe(false);
+
+    invokeMock.mockClear();
+    await provider.disconnect();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects data access before connect()", async () => {
+    const provider = new FakeProvider(config);
+    const notConnected = "Database not connected. Call connect() first.";
+
+    await expect(provider.getTables()).rejects.toThrow(notConnected);
+    await expect(provider.query("SELECT 1")).rejects.toThrow(notConnected);
+    await expect(provider.execute("DELETE FROM t")).rejects.toThrow(
+      notConnected
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("TauriSqlProvider SQL building through the dialect", () => {
+  const emptyQueryResult = { columns: [], rows: [], row_count: 0 };
+
+  it("quotes identifiers with the dialect in getTableData and tolerates count failures", async () => {
+    const provider = await connected();
+    invokeMock
+      .mockResolvedValueOnce({ columns: ["id"], rows: [[1]], row_count: 1 })
+      .mockRejectedValueOnce(new Error("count failed"));
+
+    const result = await provider.getTableData("users", {
+      page: 3,
+      pageSize: 20,
+      orderBy: "name",
+      orderDirection: "desc",
+    });
+
+    expect(sqlAt(0)).toBe(
+      "SELECT * FROM [users] ORDER BY [name] DESC LIMIT 20 OFFSET 40"
+    );
+    expect(sqlAt(1)).toBe("SELECT COUNT(*) as count FROM [users]");
+    expect(result).toMatchObject({
+      columns: ["id"],
+      values: [[1]],
+      rowCount: 1,
+      totalCount: undefined,
+    });
+  });
+
+  it("formats values with the dialect in insert, update and delete", async () => {
+    const provider = await connected();
+    invokeMock.mockResolvedValue({ rows_affected: 1 });
+
+    await provider.insert("users", { name: "Ada", age: 36 });
+    await provider.update("users", { name: "Grace" }, { id: 7 });
+    await provider.delete("users", { id: 7, name: "Grace" });
+
+    expect(sqlAt(0)).toBe(
+      "INSERT INTO [users] ([name], [age]) VALUES (<Ada>, <36>)"
+    );
+    expect(sqlAt(1)).toBe(
+      "UPDATE [users] SET [name] = <Grace> WHERE [id] = <7>"
+    );
+    expect(sqlAt(2)).toBe(
+      "DELETE FROM [users] WHERE [id] = <7> AND [name] = <Grace>"
+    );
+    expect(invokeMock).toHaveBeenNthCalledWith(
+      1,
+      "db_sql_execute",
+      expect.objectContaining({ connectionId: "conn-1" })
+    );
+  });
+
+  it("turns backend mutation failures into a failed ExecuteResult", async () => {
+    const provider = await connected();
+    invokeMock.mockRejectedValueOnce(new Error("constraint violated"));
+
+    const result = await provider.execute("INSERT INTO t VALUES (1)");
+
+    expect(result).toMatchObject({
+      success: false,
+      rowsAffected: 0,
+      error: "constraint violated",
+    });
+  });
+
+  it("passes raw query SQL through untouched", async () => {
+    const provider = await connected();
+    invokeMock.mockResolvedValueOnce(emptyQueryResult);
+
+    const result = await provider.query("SELECT 1");
+
+    expect(invokeMock).toHaveBeenCalledWith("db_sql_query", {
+      connectionId: "conn-1",
+      sql: "SELECT 1",
+    });
+    expect(result).toMatchObject({ columns: [], values: [], rowCount: 0 });
+  });
+});

--- a/src/engines/DatabaseCore/providers/MySQLProvider.ts
+++ b/src/engines/DatabaseCore/providers/MySQLProvider.ts
@@ -1,348 +1,11 @@
 /**
  * MySQL Database Provider
  *
- * Implements IDatabaseService for direct MySQL/MariaDB connections.
- * Delegates to Tauri backend commands (sqlx) for TCP connection handling.
+ * Defines MySQL-specific connection and SQL syntax while the shared
+ * TauriSqlProvider owns the sqlx command lifecycle.
  */
-import { invoke } from "@tauri-apps/api/core";
-
-import type {
-  ColumnInfo,
-  ConnectionStatus,
-  ExecuteResult,
-  IDatabaseService,
-  MySQLConnectionConfig,
-  QueryOptions,
-  QueryResult,
-  TableInfo,
-} from "../types";
-
-interface TauriQueryResult {
-  columns: string[];
-  rows: unknown[][];
-  row_count: number;
-}
-
-interface TauriExecuteResult {
-  rows_affected: number;
-}
-
-interface TauriTableInfo {
-  name: string;
-  table_type: string;
-  row_count: number | null;
-}
-
-interface TauriColumnInfo {
-  name: string;
-  data_type: string;
-  nullable: boolean;
-  primary_key: boolean;
-  default_value: string | null;
-  auto_increment: boolean;
-}
-
-function buildConnectionString(config: MySQLConnectionConfig): string {
-  const userPart = config.password
-    ? `${config.user}:${config.password}`
-    : config.user;
-  const sslMode = config.ssl ? "REQUIRED" : "PREFERRED";
-  return `mysql://${userPart}@${config.host}:${config.port}/${config.database}?ssl-mode=${sslMode}`;
-}
-
-export class MySQLProvider implements IDatabaseService {
-  readonly type = "mysql" as const;
-  readonly config: MySQLConnectionConfig;
-
-  private _status: ConnectionStatus = { state: "disconnected" };
-  private _connected = false;
-
-  constructor(config: MySQLConnectionConfig) {
-    this.config = config;
-  }
-
-  get status(): ConnectionStatus {
-    return this._status;
-  }
-
-  async connect(): Promise<void> {
-    if (this._connected) return;
-
-    this._status = { state: "connecting" };
-
-    try {
-      await invoke("db_sql_connect", {
-        connectionId: this.config.id,
-        dbType: "mysql",
-        connectionString: buildConnectionString(this.config),
-      });
-      this._connected = true;
-      this._status = { state: "connected", connectedAt: Date.now() };
-    } catch (error) {
-      this._connected = false;
-      const message = error instanceof Error ? error.message : String(error);
-      this._status = { state: "error", error: message };
-      throw new Error(message);
-    }
-  }
-
-  async disconnect(): Promise<void> {
-    if (this._connected) {
-      try {
-        await invoke("db_sql_disconnect", {
-          connectionId: this.config.id,
-        });
-      } catch {
-        // Best-effort disconnect
-      }
-    }
-    this._connected = false;
-    this._status = { state: "disconnected" };
-  }
-
-  isConnected(): boolean {
-    return this._connected && this._status.state === "connected";
-  }
-
-  async getTables(): Promise<TableInfo[]> {
-    this.ensureConnected();
-
-    const result = await invoke<TauriTableInfo[]>("db_sql_get_tables", {
-      connectionId: this.config.id,
-    });
-
-    return result.map((table) => ({
-      name: table.name,
-      type:
-        table.table_type === "VIEW" ? ("view" as const) : ("table" as const),
-      rowCount: table.row_count ?? undefined,
-    }));
-  }
-
-  async getTableSchema(tableName: string): Promise<ColumnInfo[]> {
-    this.ensureConnected();
-
-    const result = await invoke<TauriColumnInfo[]>("db_sql_get_table_schema", {
-      connectionId: this.config.id,
-      tableName,
-    });
-
-    return result.map((col) => ({
-      name: col.name,
-      type: col.data_type,
-      nullable: col.nullable,
-      primaryKey: col.primary_key,
-      defaultValue: col.default_value,
-      autoIncrement: col.auto_increment,
-    }));
-  }
-
-  async getTableData(
-    tableName: string,
-    options: QueryOptions = {}
-  ): Promise<QueryResult> {
-    this.ensureConnected();
-
-    const {
-      page = 1,
-      pageSize = 100,
-      orderBy,
-      orderDirection = "asc",
-    } = options;
-    const offset = (page - 1) * pageSize;
-    const startTime = performance.now();
-
-    let sql = `SELECT * FROM \`${tableName}\``;
-    if (orderBy) {
-      sql += ` ORDER BY \`${orderBy}\` ${orderDirection.toUpperCase()}`;
-    }
-    sql += ` LIMIT ${pageSize} OFFSET ${offset}`;
-
-    const result = await invoke<TauriQueryResult>("db_sql_query", {
-      connectionId: this.config.id,
-      sql,
-    });
-    const duration = performance.now() - startTime;
-
-    let totalCount: number | undefined;
-    try {
-      const countResult = await invoke<TauriQueryResult>("db_sql_query", {
-        connectionId: this.config.id,
-        sql: `SELECT COUNT(*) as count FROM \`${tableName}\``,
-      });
-      if (countResult.rows.length > 0) {
-        totalCount = Number(countResult.rows[0][0]);
-      }
-    } catch {
-      // Ignore count errors
-    }
-
-    return {
-      columns: result.columns,
-      values: result.rows,
-      rowCount: result.row_count,
-      totalCount,
-      duration,
-    };
-  }
-
-  async query(sql: string): Promise<QueryResult> {
-    this.ensureConnected();
-
-    const startTime = performance.now();
-    const result = await invoke<TauriQueryResult>("db_sql_query", {
-      connectionId: this.config.id,
-      sql,
-    });
-    const duration = performance.now() - startTime;
-
-    return {
-      columns: result.columns,
-      values: result.rows,
-      rowCount: result.row_count,
-      duration,
-    };
-  }
-
-  async execute(sql: string): Promise<ExecuteResult> {
-    this.ensureConnected();
-
-    const startTime = performance.now();
-    try {
-      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
-        connectionId: this.config.id,
-        sql,
-      });
-      return {
-        success: true,
-        rowsAffected: result.rows_affected,
-        duration: performance.now() - startTime,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        rowsAffected: 0,
-        duration: performance.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  async insert(
-    tableName: string,
-    data: Record<string, unknown>
-  ): Promise<ExecuteResult> {
-    this.ensureConnected();
-    const startTime = performance.now();
-
-    const columns = Object.keys(data);
-    const values = columns.map((col) => formatMySqlValue(data[col]));
-
-    const sql = `
-      INSERT INTO \`${tableName}\` (${columns.map((col) => `\`${col}\``).join(", ")})
-      VALUES (${values.join(", ")})
-    `;
-
-    try {
-      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
-        connectionId: this.config.id,
-        sql,
-      });
-      return {
-        success: true,
-        rowsAffected: result.rows_affected,
-        duration: performance.now() - startTime,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        rowsAffected: 0,
-        duration: performance.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  async update(
-    tableName: string,
-    data: Record<string, unknown>,
-    where: Record<string, unknown>
-  ): Promise<ExecuteResult> {
-    this.ensureConnected();
-    const startTime = performance.now();
-
-    const setClause = Object.entries(data)
-      .map(([col, val]) => `\`${col}\` = ${formatMySqlValue(val)}`)
-      .join(", ");
-    const whereClause = Object.entries(where)
-      .map(([col, val]) => `\`${col}\` = ${formatMySqlValue(val)}`)
-      .join(" AND ");
-
-    const sql = `UPDATE \`${tableName}\` SET ${setClause} WHERE ${whereClause}`;
-
-    try {
-      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
-        connectionId: this.config.id,
-        sql,
-      });
-      return {
-        success: true,
-        rowsAffected: result.rows_affected,
-        duration: performance.now() - startTime,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        rowsAffected: 0,
-        duration: performance.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  async delete(
-    tableName: string,
-    where: Record<string, unknown>
-  ): Promise<ExecuteResult> {
-    this.ensureConnected();
-    const startTime = performance.now();
-
-    const whereClause = Object.entries(where)
-      .map(([col, val]) => `\`${col}\` = ${formatMySqlValue(val)}`)
-      .join(" AND ");
-
-    const sql = `DELETE FROM \`${tableName}\` WHERE ${whereClause}`;
-
-    try {
-      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
-        connectionId: this.config.id,
-        sql,
-      });
-      return {
-        success: true,
-        rowsAffected: result.rows_affected,
-        duration: performance.now() - startTime,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        rowsAffected: 0,
-        duration: performance.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  async save(): Promise<void> {
-    // No-op for remote databases
-  }
-
-  private ensureConnected(): void {
-    if (!this._connected) {
-      throw new Error("Database not connected. Call connect() first.");
-    }
-  }
-}
+import type { MySQLConnectionConfig } from "../types";
+import { type TauriSqlDialect, TauriSqlProvider } from "./TauriSqlProvider";
 
 function formatMySqlValue(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
@@ -353,6 +16,27 @@ function formatMySqlValue(value: unknown): string {
     return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
   }
   return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+const MYSQL_DIALECT: TauriSqlDialect<MySQLConnectionConfig> = {
+  type: "mysql",
+  buildConnectionString(config) {
+    const userPart = config.password
+      ? `${config.user}:${config.password}`
+      : config.user;
+    const sslMode = config.ssl ? "REQUIRED" : "PREFERRED";
+    return `mysql://${userPart}@${config.host}:${config.port}/${config.database}?ssl-mode=${sslMode}`;
+  },
+  quoteIdentifier(identifier) {
+    return `\`${identifier}\``;
+  },
+  formatValue: formatMySqlValue,
+};
+
+export class MySQLProvider extends TauriSqlProvider<MySQLConnectionConfig> {
+  constructor(config: MySQLConnectionConfig) {
+    super(config, MYSQL_DIALECT);
+  }
 }
 
 export default MySQLProvider;

--- a/src/engines/DatabaseCore/providers/PostgresProvider.ts
+++ b/src/engines/DatabaseCore/providers/PostgresProvider.ts
@@ -1,350 +1,13 @@
 /**
  * PostgreSQL Database Provider
  *
- * Implements IDatabaseService for direct PostgreSQL connections.
- * Delegates to Tauri backend commands (sqlx) for TCP connection handling.
+ * Defines PostgreSQL-specific connection and SQL syntax while the shared
+ * TauriSqlProvider owns the sqlx command lifecycle.
  */
-import { invoke } from "@tauri-apps/api/core";
+import type { PostgresConnectionConfig } from "../types";
+import { type TauriSqlDialect, TauriSqlProvider } from "./TauriSqlProvider";
 
-import type {
-  ColumnInfo,
-  ConnectionStatus,
-  ExecuteResult,
-  IDatabaseService,
-  PostgresConnectionConfig,
-  QueryOptions,
-  QueryResult,
-  TableInfo,
-} from "../types";
-
-interface TauriQueryResult {
-  columns: string[];
-  rows: unknown[][];
-  row_count: number;
-}
-
-interface TauriExecuteResult {
-  rows_affected: number;
-}
-
-interface TauriTableInfo {
-  name: string;
-  table_type: string;
-  row_count: number | null;
-}
-
-interface TauriColumnInfo {
-  name: string;
-  data_type: string;
-  nullable: boolean;
-  primary_key: boolean;
-  default_value: string | null;
-  auto_increment: boolean;
-}
-
-function buildConnectionString(config: PostgresConnectionConfig): string {
-  const userPart = config.password
-    ? `${config.user}:${config.password}`
-    : config.user;
-  const sslMode = config.ssl ? "require" : "prefer";
-  return `postgres://${userPart}@${config.host}:${config.port}/${config.database}?sslmode=${sslMode}`;
-}
-
-export class PostgresProvider implements IDatabaseService {
-  readonly type = "postgres" as const;
-  readonly config: PostgresConnectionConfig;
-
-  private _status: ConnectionStatus = { state: "disconnected" };
-  private _connected = false;
-
-  constructor(config: PostgresConnectionConfig) {
-    this.config = config;
-  }
-
-  get status(): ConnectionStatus {
-    return this._status;
-  }
-
-  async connect(): Promise<void> {
-    if (this._connected) return;
-
-    this._status = { state: "connecting" };
-
-    try {
-      await invoke("db_sql_connect", {
-        connectionId: this.config.id,
-        dbType: "postgres",
-        connectionString: buildConnectionString(this.config),
-      });
-      this._connected = true;
-      this._status = { state: "connected", connectedAt: Date.now() };
-    } catch (error) {
-      this._connected = false;
-      const message = error instanceof Error ? error.message : String(error);
-      this._status = { state: "error", error: message };
-      throw new Error(message);
-    }
-  }
-
-  async disconnect(): Promise<void> {
-    if (this._connected) {
-      try {
-        await invoke("db_sql_disconnect", {
-          connectionId: this.config.id,
-        });
-      } catch {
-        // Best-effort disconnect
-      }
-    }
-    this._connected = false;
-    this._status = { state: "disconnected" };
-  }
-
-  isConnected(): boolean {
-    return this._connected && this._status.state === "connected";
-  }
-
-  async getTables(): Promise<TableInfo[]> {
-    this.ensureConnected();
-
-    const result = await invoke<TauriTableInfo[]>("db_sql_get_tables", {
-      connectionId: this.config.id,
-    });
-
-    return result.map((table) => ({
-      name: table.name,
-      type:
-        table.table_type === "VIEW" ? ("view" as const) : ("table" as const),
-      rowCount: table.row_count ?? undefined,
-    }));
-  }
-
-  async getTableSchema(tableName: string): Promise<ColumnInfo[]> {
-    this.ensureConnected();
-
-    const result = await invoke<TauriColumnInfo[]>("db_sql_get_table_schema", {
-      connectionId: this.config.id,
-      tableName,
-    });
-
-    return result.map((col) => ({
-      name: col.name,
-      type: col.data_type,
-      nullable: col.nullable,
-      primaryKey: col.primary_key,
-      defaultValue: col.default_value,
-      autoIncrement: col.auto_increment,
-    }));
-  }
-
-  async getTableData(
-    tableName: string,
-    options: QueryOptions = {}
-  ): Promise<QueryResult> {
-    this.ensureConnected();
-
-    const {
-      page = 1,
-      pageSize = 100,
-      orderBy,
-      orderDirection = "asc",
-    } = options;
-    const offset = (page - 1) * pageSize;
-    const startTime = performance.now();
-
-    let sql = `SELECT * FROM "${tableName}"`;
-    if (orderBy) {
-      sql += ` ORDER BY "${orderBy}" ${orderDirection.toUpperCase()}`;
-    }
-    sql += ` LIMIT ${pageSize} OFFSET ${offset}`;
-
-    const result = await invoke<TauriQueryResult>("db_sql_query", {
-      connectionId: this.config.id,
-      sql,
-    });
-    const duration = performance.now() - startTime;
-
-    let totalCount: number | undefined;
-    try {
-      const countResult = await invoke<TauriQueryResult>("db_sql_query", {
-        connectionId: this.config.id,
-        sql: `SELECT COUNT(*) as count FROM "${tableName}"`,
-      });
-      if (countResult.rows.length > 0) {
-        totalCount = Number(countResult.rows[0][0]);
-      }
-    } catch {
-      // Ignore count errors
-    }
-
-    return {
-      columns: result.columns,
-      values: result.rows,
-      rowCount: result.row_count,
-      totalCount,
-      duration,
-    };
-  }
-
-  async query(sql: string): Promise<QueryResult> {
-    this.ensureConnected();
-
-    const startTime = performance.now();
-    const result = await invoke<TauriQueryResult>("db_sql_query", {
-      connectionId: this.config.id,
-      sql,
-    });
-    const duration = performance.now() - startTime;
-
-    return {
-      columns: result.columns,
-      values: result.rows,
-      rowCount: result.row_count,
-      duration,
-    };
-  }
-
-  async execute(sql: string): Promise<ExecuteResult> {
-    this.ensureConnected();
-
-    const startTime = performance.now();
-    try {
-      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
-        connectionId: this.config.id,
-        sql,
-      });
-      return {
-        success: true,
-        rowsAffected: result.rows_affected,
-        duration: performance.now() - startTime,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        rowsAffected: 0,
-        duration: performance.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  async insert(
-    tableName: string,
-    data: Record<string, unknown>
-  ): Promise<ExecuteResult> {
-    this.ensureConnected();
-    const startTime = performance.now();
-
-    const columns = Object.keys(data);
-    const values = columns.map((col) => formatSqlValue(data[col]));
-
-    const sql = `
-      INSERT INTO "${tableName}" (${columns.map((col) => `"${col}"`).join(", ")})
-      VALUES (${values.join(", ")})
-    `;
-
-    try {
-      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
-        connectionId: this.config.id,
-        sql,
-      });
-      return {
-        success: true,
-        rowsAffected: result.rows_affected,
-        duration: performance.now() - startTime,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        rowsAffected: 0,
-        duration: performance.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  async update(
-    tableName: string,
-    data: Record<string, unknown>,
-    where: Record<string, unknown>
-  ): Promise<ExecuteResult> {
-    this.ensureConnected();
-    const startTime = performance.now();
-
-    const setClause = Object.entries(data)
-      .map(([col, val]) => `"${col}" = ${formatSqlValue(val)}`)
-      .join(", ");
-    const whereClause = Object.entries(where)
-      .map(([col, val]) => `"${col}" = ${formatSqlValue(val)}`)
-      .join(" AND ");
-
-    const sql = `UPDATE "${tableName}" SET ${setClause} WHERE ${whereClause}`;
-
-    try {
-      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
-        connectionId: this.config.id,
-        sql,
-      });
-      return {
-        success: true,
-        rowsAffected: result.rows_affected,
-        duration: performance.now() - startTime,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        rowsAffected: 0,
-        duration: performance.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  async delete(
-    tableName: string,
-    where: Record<string, unknown>
-  ): Promise<ExecuteResult> {
-    this.ensureConnected();
-    const startTime = performance.now();
-
-    const whereClause = Object.entries(where)
-      .map(([col, val]) => `"${col}" = ${formatSqlValue(val)}`)
-      .join(" AND ");
-
-    const sql = `DELETE FROM "${tableName}" WHERE ${whereClause}`;
-
-    try {
-      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
-        connectionId: this.config.id,
-        sql,
-      });
-      return {
-        success: true,
-        rowsAffected: result.rows_affected,
-        duration: performance.now() - startTime,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        rowsAffected: 0,
-        duration: performance.now() - startTime,
-        error: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }
-
-  async save(): Promise<void> {
-    // No-op for remote databases
-  }
-
-  private ensureConnected(): void {
-    if (!this._connected) {
-      throw new Error("Database not connected. Call connect() first.");
-    }
-  }
-}
-
-function formatSqlValue(value: unknown): string {
+function formatPostgresValue(value: unknown): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "number") return String(value);
   if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
@@ -353,6 +16,27 @@ function formatSqlValue(value: unknown): string {
     return `'${JSON.stringify(value).replace(/'/g, "''")}'::jsonb`;
   }
   return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+const POSTGRES_DIALECT: TauriSqlDialect<PostgresConnectionConfig> = {
+  type: "postgres",
+  buildConnectionString(config) {
+    const userPart = config.password
+      ? `${config.user}:${config.password}`
+      : config.user;
+    const sslMode = config.ssl ? "require" : "prefer";
+    return `postgres://${userPart}@${config.host}:${config.port}/${config.database}?sslmode=${sslMode}`;
+  },
+  quoteIdentifier(identifier) {
+    return `"${identifier}"`;
+  },
+  formatValue: formatPostgresValue,
+};
+
+export class PostgresProvider extends TauriSqlProvider<PostgresConnectionConfig> {
+  constructor(config: PostgresConnectionConfig) {
+    super(config, POSTGRES_DIALECT);
+  }
 }
 
 export default PostgresProvider;

--- a/src/engines/DatabaseCore/providers/TauriSqlProvider.ts
+++ b/src/engines/DatabaseCore/providers/TauriSqlProvider.ts
@@ -1,0 +1,321 @@
+import { invoke } from "@tauri-apps/api/core";
+
+import type {
+  ColumnInfo,
+  ConnectionStatus,
+  ExecuteResult,
+  IDatabaseService,
+  MySQLConnectionConfig,
+  PostgresConnectionConfig,
+  QueryOptions,
+  QueryResult,
+  TableInfo,
+} from "../types";
+
+type TauriSqlConnectionConfig =
+  | PostgresConnectionConfig
+  | MySQLConnectionConfig;
+
+export interface TauriSqlDialect<Config extends TauriSqlConnectionConfig> {
+  readonly type: Config["type"];
+  buildConnectionString(config: Config): string;
+  quoteIdentifier(identifier: string): string;
+  formatValue(value: unknown): string;
+}
+
+interface TauriQueryResult {
+  columns: string[];
+  rows: unknown[][];
+  row_count: number;
+}
+
+interface TauriExecuteResult {
+  rows_affected: number;
+}
+
+interface TauriTableInfo {
+  name: string;
+  table_type: string;
+  row_count: number | null;
+}
+
+interface TauriColumnInfo {
+  name: string;
+  data_type: string;
+  nullable: boolean;
+  primary_key: boolean;
+  default_value: string | null;
+  auto_increment: boolean;
+}
+
+/**
+ * Shared lifecycle and command adapter for the sqlx-backed database providers.
+ * Provider-specific connection strings and SQL syntax stay in a dialect object.
+ */
+export abstract class TauriSqlProvider<
+  Config extends TauriSqlConnectionConfig,
+> implements IDatabaseService {
+  readonly type: Config["type"];
+  readonly config: Config;
+
+  private _status: ConnectionStatus = { state: "disconnected" };
+  private _connected = false;
+
+  protected constructor(
+    config: Config,
+    private readonly dialect: TauriSqlDialect<Config>
+  ) {
+    this.config = config;
+    this.type = dialect.type;
+  }
+
+  get status(): ConnectionStatus {
+    return this._status;
+  }
+
+  async connect(): Promise<void> {
+    if (this._connected) return;
+
+    this._status = { state: "connecting" };
+
+    try {
+      await invoke("db_sql_connect", {
+        connectionId: this.config.id,
+        dbType: this.type,
+        connectionString: this.dialect.buildConnectionString(this.config),
+      });
+      this._connected = true;
+      this._status = { state: "connected", connectedAt: Date.now() };
+    } catch (error) {
+      this._connected = false;
+      const message = error instanceof Error ? error.message : String(error);
+      this._status = { state: "error", error: message };
+      throw new Error(message);
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this._connected) {
+      try {
+        await invoke("db_sql_disconnect", {
+          connectionId: this.config.id,
+        });
+      } catch {
+        // Best-effort disconnect
+      }
+    }
+    this._connected = false;
+    this._status = { state: "disconnected" };
+  }
+
+  isConnected(): boolean {
+    return this._connected && this._status.state === "connected";
+  }
+
+  async getTables(): Promise<TableInfo[]> {
+    this.ensureConnected();
+
+    const result = await invoke<TauriTableInfo[]>("db_sql_get_tables", {
+      connectionId: this.config.id,
+    });
+
+    return result.map((table) => ({
+      name: table.name,
+      type:
+        table.table_type === "VIEW" ? ("view" as const) : ("table" as const),
+      rowCount: table.row_count ?? undefined,
+    }));
+  }
+
+  async getTableSchema(tableName: string): Promise<ColumnInfo[]> {
+    this.ensureConnected();
+
+    const result = await invoke<TauriColumnInfo[]>("db_sql_get_table_schema", {
+      connectionId: this.config.id,
+      tableName,
+    });
+
+    return result.map((column) => ({
+      name: column.name,
+      type: column.data_type,
+      nullable: column.nullable,
+      primaryKey: column.primary_key,
+      defaultValue: column.default_value,
+      autoIncrement: column.auto_increment,
+    }));
+  }
+
+  async getTableData(
+    tableName: string,
+    options: QueryOptions = {}
+  ): Promise<QueryResult> {
+    this.ensureConnected();
+
+    const {
+      page = 1,
+      pageSize = 100,
+      orderBy,
+      orderDirection = "asc",
+    } = options;
+    const offset = (page - 1) * pageSize;
+    const startTime = performance.now();
+    const table = this.dialect.quoteIdentifier(tableName);
+    const orderColumn = orderBy
+      ? this.dialect.quoteIdentifier(orderBy)
+      : undefined;
+
+    let sql = `SELECT * FROM ${table}`;
+    if (orderColumn) {
+      sql += ` ORDER BY ${orderColumn} ${orderDirection.toUpperCase()}`;
+    }
+    sql += ` LIMIT ${pageSize} OFFSET ${offset}`;
+
+    const result = await invoke<TauriQueryResult>("db_sql_query", {
+      connectionId: this.config.id,
+      sql,
+    });
+    const duration = performance.now() - startTime;
+
+    let totalCount: number | undefined;
+    try {
+      const countResult = await invoke<TauriQueryResult>("db_sql_query", {
+        connectionId: this.config.id,
+        sql: `SELECT COUNT(*) as count FROM ${table}`,
+      });
+      if (countResult.rows.length > 0) {
+        totalCount = Number(countResult.rows[0][0]);
+      }
+    } catch {
+      // Count metadata is optional; return the requested page when it fails.
+    }
+
+    return {
+      columns: result.columns,
+      values: result.rows,
+      rowCount: result.row_count,
+      totalCount,
+      duration,
+    };
+  }
+
+  async query(sql: string): Promise<QueryResult> {
+    this.ensureConnected();
+
+    const startTime = performance.now();
+    const result = await invoke<TauriQueryResult>("db_sql_query", {
+      connectionId: this.config.id,
+      sql,
+    });
+
+    return {
+      columns: result.columns,
+      values: result.rows,
+      rowCount: result.row_count,
+      duration: performance.now() - startTime,
+    };
+  }
+
+  async execute(sql: string): Promise<ExecuteResult> {
+    this.ensureConnected();
+    return this.executeMutation(sql);
+  }
+
+  async insert(
+    tableName: string,
+    data: Record<string, unknown>
+  ): Promise<ExecuteResult> {
+    this.ensureConnected();
+    const startTime = performance.now();
+
+    const table = this.dialect.quoteIdentifier(tableName);
+    const columns = Object.keys(data);
+    const quotedColumns = columns.map((column) =>
+      this.dialect.quoteIdentifier(column)
+    );
+    const values = columns.map((column) =>
+      this.dialect.formatValue(data[column])
+    );
+    const sql = `
+      INSERT INTO ${table} (${quotedColumns.join(", ")})
+      VALUES (${values.join(", ")})
+    `;
+
+    return this.executeMutation(sql, startTime);
+  }
+
+  async update(
+    tableName: string,
+    data: Record<string, unknown>,
+    where: Record<string, unknown>
+  ): Promise<ExecuteResult> {
+    this.ensureConnected();
+    const startTime = performance.now();
+
+    const table = this.dialect.quoteIdentifier(tableName);
+    const setClause = this.formatAssignments(data, ", ");
+    const whereClause = this.formatAssignments(where, " AND ");
+    const sql = `UPDATE ${table} SET ${setClause} WHERE ${whereClause}`;
+
+    return this.executeMutation(sql, startTime);
+  }
+
+  async delete(
+    tableName: string,
+    where: Record<string, unknown>
+  ): Promise<ExecuteResult> {
+    this.ensureConnected();
+    const startTime = performance.now();
+
+    const table = this.dialect.quoteIdentifier(tableName);
+    const whereClause = this.formatAssignments(where, " AND ");
+    const sql = `DELETE FROM ${table} WHERE ${whereClause}`;
+
+    return this.executeMutation(sql, startTime);
+  }
+
+  async save(): Promise<void> {
+    // No-op for remote databases
+  }
+
+  private formatAssignments(
+    values: Record<string, unknown>,
+    separator: string
+  ): string {
+    return Object.entries(values)
+      .map(
+        ([column, value]) =>
+          `${this.dialect.quoteIdentifier(column)} = ${this.dialect.formatValue(value)}`
+      )
+      .join(separator);
+  }
+
+  private async executeMutation(
+    sql: string,
+    startTime = performance.now()
+  ): Promise<ExecuteResult> {
+    try {
+      const result = await invoke<TauriExecuteResult>("db_sql_execute", {
+        connectionId: this.config.id,
+        sql,
+      });
+      return {
+        success: true,
+        rowsAffected: result.rows_affected,
+        duration: performance.now() - startTime,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        rowsAffected: 0,
+        duration: performance.now() - startTime,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private ensureConnected(): void {
+    if (!this._connected) {
+      throw new Error("Database not connected. Call connect() first.");
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`src/engines/DatabaseCore/providers/PostgresProvider.ts` and `MySQLProvider.ts` each carried a full, near-verbatim copy of the sqlx-backed Tauri command lifecycle: `connect`/`disconnect`/`status`/`isConnected`, `getTables`, `getTableSchema`, `getTableData` (page/order/count), `query`, `execute`, `insert`, `update`, `delete`, `save`, and the `ensureConnected` guard, plus four copies of the `db_sql_*` result shapes. The only real differences were the connection string, identifier quoting (`"x"` vs `` `x` ``) and value formatting (`::jsonb` and `TRUE`/`FALSE` vs `1`/`0`). Every lifecycle fix has to be made twice, and nothing prevented the two copies from drifting.

This re-lands commit `c00a9c294a` of #780 on current develop, per the Neonforge98 audit ("code still needed, zero behavioral divergence"). Both provider files on develop are byte-identical to that commit's pre-images, so the extraction re-derives cleanly.

## Solution

- Add `providers/TauriSqlProvider.ts`: an abstract `TauriSqlProvider<Config>` that owns the shared lifecycle and command adapter, parameterised by a typed `TauriSqlDialect<Config>` (`type`, `buildConnectionString`, `quoteIdentifier`, `formatValue`).
- `PostgresProvider` and `MySQLProvider` become thin subclasses that pass their `POSTGRES_DIALECT` / `MYSQL_DIALECT` object to `super`. Their value formatters keep their existing bodies (`formatSqlValue` is renamed `formatPostgresValue`; `formatMySqlValue` unchanged).
- Invariant: the SQL text, `invoke` command names and argument objects, status transitions, error messages, and the `ExecuteResult`/`QueryResult` shapes are unchanged for both dialects. Public constructor signatures and `type` literals (`"postgres"` / `"mysql"`) are unchanged, so `factory.ts` and `providers/index.ts` need no edits.

**Versus the original commit:** the original `providers/__tests__/TauriSqlProvider.test.ts` is dropped as Neonforge98 requested (it duplicated the existing 1083-line `DatabaseCore/__tests__/{Postgres,MySQL}Provider.test.ts` and never imported `TauriSqlProvider`). Replaced by a 207-line `DatabaseCore/__tests__/TauriSqlProvider.test.ts` (placed where `check:test-placement` says DatabaseCore tests live) that imports the base class directly and drives it through a fake dialect with deliberately odd quoting (`[x]`) and formatting (`<v>`), so each assertion proves the base routes through the dialect hooks rather than hard-coding either real dialect. It pins: type/connection string from the dialect, connect idempotency, error-status + rethrow, best-effort disconnect, the not-connected guard, `getTableData` SQL + tolerated count failure, `insert`/`update`/`delete` SQL, mutation failure -> `success:false`, and raw `query` passthrough.

## Potential risks

- Pure refactor; the strongest evidence of preservation is that the 44 Postgres and 40 MySQL provider tests pass without any edit. Those suites cover connection strings, all SQL shapes, status transitions and error paths at the provider boundary.
- `type` moves from a class-literal initialiser (`readonly type = "postgres" as const`) to a constructor assignment typed `Config["type"]`. `Config["type"]` is the same literal for both configs, and `tsgo --noEmit` over the whole tree is clean, so no consumer narrowing changed.
- `performance.now()` for `getTableData` is now sampled before identifier quoting rather than after; the measured `duration` may differ by microseconds. No consumer asserts on it.
- The Tauri commands themselves (`db_sql_*`) are untouched; nothing on the Rust side or the wire changed.
- Not exercised against a live Postgres/MySQL server in this PR (the existing suites mock `invoke` the same way).

## Verification

Worktree `/private/tmp/orgii-pr780-tauri-sql` on `origin/develop` (`5abb618177`). The pre-commit hook was skipped in the worktree (`.husky/_/husky.sh` is absent there), so there is no `Pre-commit hook ran.` trailer; lint and format were run by hand instead:

- `npx prettier --write <4 changed files>` — clean (3 unchanged, test file formatted)
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <4 files>` — exit 0
- `npx eslint --max-warnings 0 --report-unused-disable-directives <4 files>` — exit 0
- `npx vitest run --config config/vitest.config.ts src/engines/DatabaseCore` — 11 files, 294 tests passed (PostgresProvider 44, MySQLProvider 40 unmodified; TauriSqlProvider 9 new)
- `pnpm run check:test-placement` — "Test placement is consistent across 554 directories."
- `npx tsgo --noEmit --pretty false` — exit 0, no output
- `pnpm check:typed-lint` — "1147 existing findings; 0 new or increased findings."

Did not run: the full vitest suite (only `src/engines/DatabaseCore`), e2e, and any live database connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
