### PR TITLE
fix(codemirror): simplify short collapsed-gap controls

### DIFF
--- a/src/features/CodeMirror/Diff/collapsedGutter.test.ts
+++ b/src/features/CodeMirror/Diff/collapsedGutter.test.ts
@@ -9,7 +9,7 @@ import { diffLineNumbers } from "./diffLineNumbers";
 const original = Array.from({ length: 100 }, (_, i) => `line ${i}`).join("\n");
 const modified = original
   .replace("line 30\n", "changed 30\n")
-  .replace("line 70\n", "changed 70\n");
+  .replace("line 80\n", "changed 80\n");
 const extensions = [
   collapsedGutterBackground,
   diffLineNumbers({ formatNumber: String }),
@@ -22,6 +22,52 @@ afterEach(() => {
 });
 
 describe("collapsed gutter controls", () => {
+  it.each([10, 20, 21, 40, 41])(
+    "uses a single expand-all control for a short middle gap (%i lines)",
+    (lines) => {
+      const doc = original
+        .replace("line 30\n", "changed 30\n")
+        .replace(`line ${37 + lines}\n`, `changed ${37 + lines}\n`);
+      const merge = new MergeView({
+        parent: document.body,
+        a: { doc: original, extensions },
+        b: { doc, extensions },
+        collapseUnchanged: { margin: 3, minSize: 10 },
+      });
+      mounted.push(merge);
+      for (const view of [merge.a, merge.b]) {
+        const control = view.dom.querySelectorAll(".cm-collapseControl")[1];
+        expect(control.children).toHaveLength(lines <= 40 ? 1 : 2);
+        expect(
+          control.parentElement?.classList.contains("cm-collapsedGutter--split")
+        ).toBe(lines > 40);
+        expect(
+          view.dom.querySelectorAll(".cm-collapsedLines")[1].textContent
+        ).toBe(`${lines} unchanged lines`);
+      }
+      if (lines > 40) return;
+      const button = merge.a.dom.querySelector<HTMLButtonElement>(
+        ".cm-collapseArrow--all"
+      )!;
+      expect(button.getAttribute("aria-label")).toBe(
+        `${lines} unchanged lines`
+      );
+      button.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+      expect(
+        merge.a.dom
+          .querySelectorAll(".cm-collapsedLines")[1]
+          .classList.contains("cm-collapsedRowHovered")
+      ).toBe(true);
+      button.click();
+      for (const view of [merge.a, merge.b]) {
+        expect(view.dom.querySelectorAll(".cm-collapsedLines")).toHaveLength(2);
+        expect(
+          view.dom.querySelectorAll(".cm-collapseArrow--all")
+        ).toHaveLength(0);
+      }
+    }
+  );
+
   it("highlights only the matching whole row from either half and removes listeners on close", () => {
     const view = new EditorView({
       parent: document.body,

--- a/src/features/CodeMirror/Diff/collapsedGutter.ts
+++ b/src/features/CodeMirror/Diff/collapsedGutter.ts
@@ -12,8 +12,17 @@ import {
   incrementalCollapse,
 } from "./incrementalCollapse";
 
+// Separate directions only when two expansion steps cannot reveal the whole gap.
+const COLLAPSE_SPLIT_THRESHOLD = COLLAPSE_EXPAND_STEP * 2;
+
 function isCollapsed(widget: WidgetType) {
   return "type" in widget && widget.type === "collapsed-unchanged-code";
+}
+
+function hiddenLineCount(view: EditorView, from: number, to: number) {
+  return (
+    view.state.doc.lineAt(to).number - view.state.doc.lineAt(from).number + 1
+  );
 }
 
 class CollapsedRow extends GutterMarker {
@@ -77,7 +86,10 @@ export const collapsedGutterBackground = [
     isCollapsed(widget)
       ? new CollapsedRow(
           block.from,
-          block.from > 0 && block.to < view.state.doc.length
+          block.from > 0 &&
+            block.to < view.state.doc.length &&
+            hiddenLineCount(view, block.from, block.to) >
+              COLLAPSE_SPLIT_THRESHOLD
         )
       : null
   ),
@@ -121,16 +133,15 @@ class CollapseControl extends GutterMarker {
   toDOM(view: EditorView) {
     const control = document.createElement("div");
     control.className = "cm-collapseControl";
-    const lines =
-      view.state.doc.lineAt(this.to).number -
-      view.state.doc.lineAt(this.from).number +
-      1;
+    const lines = hiddenLineCount(view, this.from, this.to);
     const directions =
       this.from === 0
         ? ["up"]
         : this.to === view.state.doc.length
           ? ["down"]
-          : ["down", "up"];
+          : lines <= COLLAPSE_SPLIT_THRESHOLD
+            ? ["all"]
+            : ["down", "up"];
     for (const direction of directions) {
       const button = control.appendChild(document.createElement("button"));
       button.type = "button";
@@ -139,14 +150,14 @@ class CollapseControl extends GutterMarker {
         "aria-label",
         view.state.phrase(
           "$ unchanged lines",
-          Math.min(COLLAPSE_EXPAND_STEP, lines)
+          direction === "all" ? lines : Math.min(COLLAPSE_EXPAND_STEP, lines)
         )
       );
       button.addEventListener("click", () => {
         expandCollapsedRange(
           view,
           { from: this.from, to: this.to },
-          direction === "down" ? "start" : "end"
+          direction === "all" ? "all" : direction === "down" ? "start" : "end"
         );
       });
     }

--- a/src/features/CodeMirror/Diff/incrementalCollapse.test.ts
+++ b/src/features/CodeMirror/Diff/incrementalCollapse.test.ts
@@ -36,7 +36,11 @@ const labels = (view: EditorView) =>
     view.dom.querySelectorAll(".cm-collapsedLines"),
     (node) => node.textContent
   );
-function click(view: EditorView, index: number, direction: "up" | "down") {
+function click(
+  view: EditorView,
+  index: number,
+  direction: "up" | "down" | "all"
+) {
   view.dom
     .querySelectorAll(".cm-collapseControl")
     [index].querySelector<HTMLButtonElement>(`.cm-collapseArrow--${direction}`)!
@@ -64,9 +68,10 @@ describe("incremental collapse", () => {
     expect(view.state.doc.lineAt(range.from).number).toBe(75);
     expect(view.state.doc.lineAt(range.to).number).toBe(107);
     expect(labels(view)[1]).toBe("33 unchanged lines");
-    click(view, 1, "down");
-    expect(labels(view)[1]).toBe("13 unchanged lines");
-    click(view, 1, "up");
+    expect(
+      view.dom.querySelectorAll(".cm-collapseControl")[1].children
+    ).toHaveLength(1);
+    click(view, 1, "all");
     expect(labels(view)).toEqual(["47 unchanged lines", "26 unchanged lines"]);
   });
 

--- a/src/features/CodeMirror/Diff/index.scss
+++ b/src/features/CodeMirror/Diff/index.scss
@@ -493,6 +493,25 @@
   &--down::before {
     transform: translateY(-2px) rotate(135deg);
   }
+
+  &--all {
+    flex-direction: column;
+    gap: 3px;
+
+    &::before,
+    &::after {
+      content: "";
+      width: 5px;
+      height: 5px;
+      border-top: 2px solid currentColor;
+      border-right: 2px solid currentColor;
+      transform: translateY(1px) rotate(-45deg);
+    }
+
+    &::after {
+      transform: translateY(-1px) rotate(135deg);
+    }
+  }
 }
 
 .codemirror-diff .cm-editor .cm-collapsedLines {


### PR DESCRIPTION
## Problem

CodeMirror diff views show two stacked directional buttons for every collapsed middle gap, including ten-line gaps where either button opens the entire range. This adds redundant controls and a divider for small gaps.

## Solution

Use one chevron-up/down button to reveal all hidden lines in middle gaps of 40 lines or fewer. The cutoff is twice the existing 20-line expansion step. Larger gaps retain separate controls that each reveal 20 lines from the selected end, and switch to the single control once the remainder reaches the cutoff. Keep the gutter background, hover/focus treatment, and accessible line count consistent with the selected control. Boundary gaps keep their existing directional behavior.

Add coverage for 10, 20, 21, 40, and 41 hidden lines, synchronized split panes, and the transition from incremental expansion to expand-all.

## Potential risks

The combined control reveals up to 40 lines at once, changing the interaction for middle gaps of 21–40 lines. Chevron alignment across themes and viewport sizes has not been visually verified in the desktop app; computer control was not authorized. No dependencies, persistence formats, public APIs, or background-work lifecycles change.

## Verification

Run in the isolated PR worktree based on the latest fetched `origin/develop`:

- `pnpm test src/features/CodeMirror/Diff/collapsedGutter.test.ts src/features/CodeMirror/Diff/incrementalCollapse.test.ts` — passed, 12 tests.
- `pnpm exec eslint src/features/CodeMirror/Diff/collapsedGutter.ts src/features/CodeMirror/Diff/collapsedGutter.test.ts src/features/CodeMirror/Diff/incrementalCollapse.test.ts` — passed.
- `git diff --check` — passed.
- Commit hooks: lint-staged (oxlint, ESLint, Prettier) and `tsgo --noEmit --pretty false` — passed.
- Inspected the four-file diff for scope, secrets, debug output, personal paths, and generated churn; none found.

Desktop screenshots and manual theme/viewport checks were not performed because computer control requires explicit opt-in. Full application and Rust suites were not run for this localized frontend control change.
