### PR TITLE
refactor(lsp): unify command detection via which

### DIFF
--- a/src-tauri/crates/lsp/src/command_detection.rs
+++ b/src-tauri/crates/lsp/src/command_detection.rs
@@ -1,0 +1,48 @@
+//! Shared "is this tool on PATH?" probe for every LSP / lint discovery surface.
+//!
+//! Resolved in-process via `which::which` (the same lookup
+//! `install_pipeline::find_binary` already uses) instead of spawning
+//! `which` / `where`. Semantics:
+//!
+//! - `PATH` is read from the process environment at call time with
+//!   `std::env::var_os`, so the login-shell PATH that
+//!   `app_paths::shell_path` installs at startup is visible and non-UTF-8
+//!   entries are walked rather than dropped; an unset or empty `PATH` yields
+//!   `false`.
+//! - On Windows, `PATHEXT` is honoured, so `tsc` finds `tsc.cmd`.
+//! - Only names without a path separator are searched on `PATH`; a name that
+//!   contains one is resolved relative to the current directory, mirroring
+//!   the `which` binary.
+//! - No child process is spawned, so no console window can flash on Windows.
+
+/// Check whether `command_name` resolves to an executable on the current
+/// process `PATH`.
+pub(crate) fn command_exists(command_name: &str) -> bool {
+    which::which(command_name).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::command_exists;
+
+    #[test]
+    fn finds_a_platform_shell() {
+        #[cfg(unix)]
+        assert!(command_exists("sh"));
+
+        #[cfg(windows)]
+        assert!(command_exists("cmd"));
+    }
+
+    #[test]
+    fn rejects_a_missing_command() {
+        assert!(!command_exists(
+            "orgii-command-detection-test-definitely-missing"
+        ));
+    }
+
+    #[test]
+    fn rejects_an_empty_name() {
+        assert!(!command_exists(""));
+    }
+}

--- a/src-tauri/crates/lsp/src/commands/discovery.rs
+++ b/src-tauri/crates/lsp/src/commands/discovery.rs
@@ -2,9 +2,8 @@
 //!
 //! Tauri commands for detecting installed language servers and lint tools.
 
-use std::process::Command;
-
 use super::cache;
+use crate::command_detection::command_exists;
 use crate::lint_tools::LintToolInfo;
 use crate::server_defs::{servers, servers_for_language_id};
 
@@ -54,32 +53,6 @@ pub const LANGUAGE_DISPLAY_NAMES: &[(&str, &str)] = &[
     ("svelte", "Svelte"),
     ("zig", "Zig"),
 ];
-
-/// Check if a command exists in PATH
-pub fn command_exists(cmd: &str) -> bool {
-    // Explicitly forward PATH so the login-shell-augmented PATH is visible.
-    let current_path = std::env::var("PATH").unwrap_or_default();
-    #[cfg(unix)]
-    {
-        Command::new("which")
-            .arg(cmd)
-            .env("PATH", &current_path)
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-    #[cfg(windows)]
-    {
-        let mut command = Command::new("where");
-        command.arg(cmd).env("PATH", &current_path);
-        // Suppress console window on Windows.
-        app_platform::hide_console(&mut command);
-        command
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-}
 
 /// Check if uninstall is supported based on install hint
 fn is_uninstall_supported(install_hint: &str) -> bool {

--- a/src-tauri/crates/lsp/src/commands/package_manager.rs
+++ b/src-tauri/crates/lsp/src/commands/package_manager.rs
@@ -3,7 +3,7 @@
 //! Utilities for detecting installed package managers and extracting
 //! package names from install hints.
 
-use super::discovery::command_exists;
+use crate::command_detection::command_exists;
 
 #[cfg(test)]
 #[path = "tests/package_manager_tests.rs"]

--- a/src-tauri/crates/lsp/src/install_pipeline.rs
+++ b/src-tauri/crates/lsp/src/install_pipeline.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::process::Command;
 
-use super::commands::discovery::command_exists;
+use super::command_detection::command_exists;
 use super::commands::package_manager::detect_package_manager;
 use app_paths::lsp_bin_dir;
 

--- a/src-tauri/crates/lsp/src/lib.rs
+++ b/src-tauri/crates/lsp/src/lib.rs
@@ -6,6 +6,7 @@
 //! Also includes ESLint integration for style/formatting diagnostics.
 
 pub mod codec;
+mod command_detection;
 pub mod commands;
 pub mod config;
 pub mod eslint;

--- a/src-tauri/crates/lsp/src/lint_tools.rs
+++ b/src-tauri/crates/lsp/src/lint_tools.rs
@@ -5,6 +5,8 @@
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 
+use crate::command_detection::command_exists;
+
 /// Information about a lint tool
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -360,29 +362,6 @@ const LINT_TOOLS: &[LintToolConfig] = &[
         install_hint: "cargo install taplo-cli",
     },
 ];
-
-/// Check if a command exists in PATH
-fn command_exists(cmd: &str) -> bool {
-    #[cfg(unix)]
-    {
-        Command::new("which")
-            .arg(cmd)
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-    #[cfg(windows)]
-    {
-        let mut command = Command::new("where");
-        command.arg(cmd);
-        // Suppress console window on Windows.
-        app_platform::hide_console(&mut command);
-        command
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-}
 
 /// Get version of a tool
 fn get_tool_version(config: &LintToolConfig) -> Option<String> {

--- a/src-tauri/crates/lsp/src/workspace_scan/mod.rs
+++ b/src-tauri/crates/lsp/src/workspace_scan/mod.rs
@@ -24,8 +24,9 @@ use std::path::Path;
 
 use types::{AvailableTool, SingleToolResult};
 
+use super::command_detection::command_exists;
 use super::workspace_config::is_lint_tool_enabled;
-use process::{command_exists, eslint_available};
+use process::eslint_available;
 
 // ============================================
 // Helpers for tool detection

--- a/src-tauri/crates/lsp/src/workspace_scan/orchestrator.rs
+++ b/src-tauri/crates/lsp/src/workspace_scan/orchestrator.rs
@@ -21,11 +21,12 @@ use super::clippy;
 use super::css;
 use super::eslint;
 use super::golangci_lint;
-use super::process::{command_exists, eslint_available};
+use super::process::eslint_available;
 use super::python;
 use super::shell;
 use super::types::{AvailableTool, SingleToolResult, WorkspaceDiagnostic};
 use super::typescript;
+use crate::command_detection::command_exists;
 use crate::workspace_config::is_lint_tool_enabled;
 
 // ============================================

--- a/src-tauri/crates/lsp/src/workspace_scan/process.rs
+++ b/src-tauri/crates/lsp/src/workspace_scan/process.rs
@@ -61,34 +61,11 @@ pub fn run_command_with_custom_timeout(
     }
 }
 
-/// Check whether a command-line tool is available on the system PATH.
-pub fn command_exists(cmd: &str) -> bool {
-    #[cfg(unix)]
-    {
-        Command::new("which")
-            .arg(cmd)
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-    #[cfg(windows)]
-    {
-        let mut command = Command::new("where");
-        command.arg(cmd);
-        // Suppress console window on Windows.
-        app_platform::hide_console(&mut command);
-        command
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-}
-
 /// Check whether ESLint is available (local node_modules or global).
 pub fn eslint_available(workspace_path: &str) -> bool {
     let local = Path::new(workspace_path)
         .join("node_modules")
         .join(".bin")
         .join("eslint");
-    local.exists() || command_exists("eslint")
+    local.exists() || crate::command_detection::command_exists("eslint")
 }


### PR DESCRIPTION
## Problem

The `lsp` crate carries three copies of an "is this tool on PATH?" probe, each spawning `which` / `where` with different env handling:

- `commands/discovery.rs::command_exists` — `std::env::var("PATH").unwrap_or_default()` forwarded unconditionally, so an unset or non-UTF-8 `PATH` runs the child with `PATH=""`.
- `lint_tools.rs::command_exists` and `workspace_scan/process.rs::command_exists` — no env handling; the child inherits the parent's `PATH` as-is.

Commit e1ed463a70 of #780 tried to fold these into one helper, but the Neonforge98 audit of that PR found (a) the extraction was not behavior-preserving (`var` → `var_os`, unconditional → conditional `env("PATH")`, PATH newly forwarded by the lint/workspace variants, none of it documented or tested), (b) 4 of the 6 call sites are unreachable since cdf5a3a35 made LSP/lint agent-only, and (c) its `lsp/src/lib.rs` hunk conflicts with develop. This PR re-lands that commit on current develop the way the audit asked.

## Solution

One `command_detection::command_exists` (crate-private) that resolves in-process with `which::which` — the crate already depends on `which = "8"` and `install_pipeline::find_binary` already uses it — so there is no hand-rolled PATH walk and no child process. All three copies are deleted and every caller is rewired to the shared helper. `lib.rs` was re-derived on develop (`mod command_detection;` next to `pub mod codec;`, no `broadcast` module); the old hunk was not ported.

Exact before/after semantics:

| Situation | discovery.rs before | lint_tools / workspace_scan before | Now (`which::which`) |
| --- | --- | --- | --- |
| `PATH` set, UTF-8 | child `which`/`where` searches it | child inherits it | walked in-process; same result, plus PATHEXT on Windows (`tsc` finds `tsc.cmd`) |
| `PATH` unset or empty | child spawned with `PATH=""` → `false` unless the tool sits in cwd | child inherits no `PATH`; `which` falls back to its own default search list | `false` |
| `PATH` contains non-UTF-8 entries | `var()` errors → `unwrap_or_default` → child gets `PATH=""` → `false` | child inherits and searches them | walked correctly (`var_os`) → found |
| login-shell PATH installed by `app_paths::shell_path` at startup | visible (forwarded explicitly) | visible (inherited) | visible (read from the process env at call time) |
| name containing a path separator | passed to `which`, resolved relative to cwd | same | resolved relative to cwd; no caller passes one |
| Windows console window | suppressed via `hide_console` | suppressed via `hide_console` | no child process, nothing to suppress |

Reachability on develop (`src-tauri/src/commands/handler_list.inc` registers zero `lsp_*` / `lint_*` commands after cdf5a3a35):

- **Reachable**: `commands/discovery.rs` (`lsp_check_installed` ← agent-core `manage_lsp`), `commands/package_manager.rs` (`detect_install_type` / `detect_package_manager` ← discovery + install pipeline) and `install_pipeline.rs` (`ensure_binary` ← `LspManager`). These are the survivors and now use `which::which`.
- **Unreachable** (no caller anywhere in `src-tauri`, only `pub` through `lib.rs` re-exports): `lint_tools.rs` (`check_lint_tools` ← `lint_check_installed`, which nothing calls), `workspace_scan/mod.rs` (`lint_scan_get_tools`), `workspace_scan/orchestrator.rs` (`get_available_tools` ← `lint_scan_orchestrated`) and `workspace_scan/process.rs` (`eslint_available`). The two private `command_exists` variants that lived here (`lint_tools.rs`, `process.rs`) are deleted. The dead public functions that called them are only re-pointed at the shared helper, not deleted: removing them cascades into the entire `workspace_scan` module (11 files) and half of the lint-tool catalog plus its cache and tests, which is a separate dead-code PR. cargo emits no dead-code warning for them because they are `pub` through `pub mod`.

`lsp::commands::command_exists` (the glob re-export of the discovery copy) is no longer part of the crate's public API; `grep` across `src-tauri` finds no importer (the only external `use lsp::commands::{…}` is agent-core's `manage_lsp`, which imports `lsp_check_installed` and friends).

Sweep: `Command::new("which")` / `Command::new("where")` has no other occurrence in `src-tauri` after this change.

## Potential risks

- Behavior change in the reachable path (`lsp_check_installed`, package-manager detection, `ensure_binary` prerequisite checks) when `PATH` is unset or non-UTF-8, as tabled above. In the app `PATH` is always set (`shell_path` installs the login-shell PATH at startup), and non-UTF-8 entries now resolve instead of being dropped, so the practical direction is "more tools detected", never fewer.
- `which::which` requires the candidate to be executable and, on Windows, to match a `PATHEXT` extension; the `where` binary reports any matching file. A tool present on `PATH` as an extensionless script on Windows would now be reported missing. No shipped server or package-manager binary is in that category.
- Dead lint/workspace-scan code stays in the crate (scope discipline); its behavior is unverified beyond compiling and the existing `check_lint_tools` unit test.
- Windows and Linux branches were not run; verification below is macOS only. The Windows branch has no `cfg(windows)`-specific code left in the helper, so the risk is limited to the semantic differences above.
- Public-API narrowing: `lsp::commands::command_exists` / `lsp::commands::discovery::command_exists` removed. No importer exists.

## Verification

Worktree `/private/tmp/orgii-pr780-lsp-cmd` on `origin/develop` (5abb618177), private `CARGO_TARGET_DIR=/private/tmp/orgii-target-lsp-cmd`, all commands prefixed with `nice -n 10`:

- `cargo check -p lsp` — exit 0, 0 warnings.
- `cargo test -p lsp` — exit 0, `113 passed; 0 failed` (includes the three new `command_detection::tests`: `sh` resolves, a random name does not, an empty name does not).
- `cargo clippy -p lsp --all-targets -- -D warnings` — exit 0, 0 warnings, no baseline warnings in untouched files.
- `cargo check -p agent_core` (the only crate that imports `lsp::commands::*`) — exit 0, 0 warnings, `Finished` in 5m 53s.
- `rustfmt --edition 2021 --check` on every changed file — exit 0.
- `git -C ORGII show cdf5a3a35 --stat` + `grep` over `src-tauri` and `handler_list.inc` for every function named above — used to derive the reachability table.

Did not run: Windows / Linux builds; the full `cargo test --workspace`; the pre-commit hook (skipped in the fresh worktree, so there is no `Pre-commit hook ran.` trailer — `rustfmt`, `clippy` and tests were run by hand instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
