### PR TITLE
fix(auth): coalesce oauth retries and make close idempotent

### DIFF
--- a/src/features/SessionSetup/components/ClaudeCodeSessionSetup/index.tsx
+++ b/src/features/SessionSetup/components/ClaudeCodeSessionSetup/index.tsx
@@ -101,6 +101,7 @@ const ClaudeCodeSessionSetup: React.FC<ClaudeCodeSessionSetupProps> = ({
         loading: t("keyVault.loadingText"),
         failedToLoadBrowser: t("keyVault.failedToLoadBrowser"),
         retry: t("common:actions.retry"),
+        close: t("common:actions.close"),
         errorHint: t("keyVault.claudeCodeSignInErrorHint"),
       }}
       debugContent={

--- a/src/features/SessionSetup/components/CodexSessionSetup/index.tsx
+++ b/src/features/SessionSetup/components/CodexSessionSetup/index.tsx
@@ -86,6 +86,7 @@ const CodexSessionSetup: React.FC<CodexSessionSetupProps> = ({
         loading: t("keyVault.loadingText"),
         failedToLoadBrowser: t("keyVault.failedToLoadBrowser"),
         retry: t("common:actions.retry"),
+        close: t("common:actions.close"),
         errorHint: t("keyVault.codexSignInErrorHint"),
       }}
       debugContent={

--- a/src/features/SessionSetup/components/OAuthSessionSetupShell.test.ts
+++ b/src/features/SessionSetup/components/OAuthSessionSetupShell.test.ts
@@ -36,6 +36,7 @@ const copy: OAuthSessionSetupCopy = {
   loading: "Loading",
   failedToLoadBrowser: "Browser failed",
   retry: "Retry",
+  close: "Close",
   errorHint: "Try signing in again",
 };
 
@@ -314,5 +315,198 @@ describe("OAuthSessionSetupShell idle notices", () => {
     });
 
     expect(container.textContent).toContain("Id Token: null");
+  });
+});
+
+describe("OAuthSessionSetupShell retry coalescing and close idempotency", () => {
+  it("ignores a second retry while the first startLogin is still in flight", async () => {
+    let resolveStart: () => void = () => {};
+    const startLogin = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStart = resolve;
+        })
+    );
+    const capture = makeCapture({ error: "network unavailable", startLogin });
+    renderShell({ capture, initiallyOpen: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(startLogin).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveStart();
+    });
+
+    const retry = query<HTMLButtonElement>('button[aria-label="Retry"]');
+    expect(retry).not.toBeNull();
+    act(() => {
+      retry?.click();
+      retry?.click();
+    });
+    expect(capture.reset).toHaveBeenCalledTimes(1);
+    expect(startLogin).toHaveBeenCalledTimes(2);
+
+    // Still in flight: a later click is coalesced too.
+    act(() => query<HTMLButtonElement>('button[aria-label="Retry"]')?.click());
+    expect(startLogin).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveStart();
+      await Promise.resolve();
+    });
+    act(() => query<HTMLButtonElement>('button[aria-label="Retry"]')?.click());
+    expect(startLogin).toHaveBeenCalledTimes(3);
+    expect(capture.reset).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the retry guard when startLogin rejects", async () => {
+    const startLogin = vi.fn(() => Promise.resolve());
+    startLogin
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("boom"));
+    const capture = makeCapture({ startLogin });
+    renderShell({ capture, initiallyOpen: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(startLogin).toHaveBeenCalledTimes(1);
+
+    const retry = () => query<HTMLButtonElement>('button[aria-label="Retry"]');
+    await act(async () => {
+      retry()?.click();
+      await Promise.resolve();
+    });
+    expect(startLogin).toHaveBeenCalledTimes(2);
+
+    await flushMicrotasks();
+    act(() => retry()?.click());
+    expect(startLogin).toHaveBeenCalledTimes(3);
+  });
+
+  it("issues one native close for a double X click", () => {
+    const capture = makeCapture({ isWebviewOpen: true });
+    const onBrowserStateChange = vi.fn();
+    renderShell({ capture, initiallyOpen: true, onBrowserStateChange });
+
+    const close = closeButton();
+    expect(close).not.toBeNull();
+    act(() => {
+      close?.click();
+      close?.click();
+    });
+
+    expect(capture.closeWebview).toHaveBeenCalledTimes(1);
+    expect(browserShell()).toBeNull();
+    expect(onBrowserStateChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("does not close natively again when a closeSignal follows an X close", async () => {
+    const capture = makeCapture({ isWebviewOpen: true });
+    renderShell({ capture, initiallyOpen: true, closeSignal: 0 });
+
+    act(() => closeButton()?.click());
+    expect(capture.closeWebview).toHaveBeenCalledTimes(1);
+
+    renderShell({ capture, initiallyOpen: true, closeSignal: 1 });
+    await flushMicrotasks();
+    expect(capture.closeWebview).toHaveBeenCalledTimes(1);
+    expect(browserShell()).toBeNull();
+  });
+
+  it("closes once when a closeSignal and an X click land in the same turn", async () => {
+    const capture = makeCapture({ isWebviewOpen: true });
+    renderShell({ capture, initiallyOpen: true, closeSignal: 0 });
+
+    const close = closeButton();
+    act(() => {
+      root.render(
+        createElement(OAuthSessionSetupShell, {
+          providerId: "provider",
+          containerRef: createRef<HTMLDivElement>(),
+          hasToken: false,
+          copy,
+          capture,
+          initiallyOpen: true,
+          closeSignal: 1,
+        })
+      );
+      close?.click();
+    });
+    await flushMicrotasks();
+
+    expect(capture.closeWebview).toHaveBeenCalledTimes(1);
+    expect(browserShell()).toBeNull();
+  });
+
+  it("clears timers on unmount after a retry reopened the browser", async () => {
+    const capture = makeCapture({ isWebviewOpen: true });
+    renderShell({ capture, initiallyOpen: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    expect(capture.startLogin).toHaveBeenCalledTimes(1);
+
+    act(() => closeButton()?.click());
+    expect(browserShell()).toBeNull();
+    act(() => signInButton()?.click());
+    expect(vi.getTimerCount()).toBe(1);
+
+    act(() => root.unmount());
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(capture.startLogin).toHaveBeenCalledTimes(1);
+
+    root = createRoot(container);
+  });
+});
+
+describe("OAuthSessionSetupShell accessibility semantics", () => {
+  it("labels the icon-only refresh and close controls", () => {
+    renderShell({ capture: makeCapture(), initiallyOpen: true });
+
+    const retry = query<HTMLButtonElement>('button[aria-label="Retry"]');
+    const close = closeButton();
+    expect(retry?.getAttribute("title")).toBe("Retry");
+    expect(close?.getAttribute("aria-label")).toBe("Close");
+    expect(close?.getAttribute("title")).toBe("Close");
+  });
+
+  it("exposes the loading overlay as a status region", () => {
+    renderShell({
+      capture: makeCapture({ isSigningIn: true }),
+      initiallyOpen: true,
+    });
+
+    const status = query('[role="status"]');
+    expect(status?.textContent).toContain("Loading");
+    expect(query('[role="alert"]')).toBeNull();
+  });
+
+  it("exposes the error overlay as an alert", () => {
+    renderShell({
+      capture: makeCapture({ error: "network unavailable" }),
+      initiallyOpen: true,
+    });
+
+    const alert = query('[role="alert"]');
+    expect(alert?.textContent).toContain("Browser failed");
+    expect(alert?.textContent).toContain("network unavailable");
+    expect(query('[role="status"]')).toBeNull();
+  });
+
+  it("marks the active step with aria-current", () => {
+    renderShell({ capture: makeCapture(), initiallyOpen: true });
+    let current = container.querySelectorAll('[aria-current="step"]');
+    expect(current).toHaveLength(1);
+    expect(current[0].textContent).toBe("1");
+
+    renderShell({
+      capture: makeCapture(),
+      initiallyOpen: true,
+      hasToken: true,
+    });
+    current = container.querySelectorAll('[aria-current="step"]');
+    expect(current).toHaveLength(1);
+    expect(current[0].parentElement?.textContent).toContain("Signed in");
   });
 });

--- a/src/features/SessionSetup/components/OAuthSessionSetupShell.tsx
+++ b/src/features/SessionSetup/components/OAuthSessionSetupShell.tsx
@@ -3,6 +3,7 @@ import {
   type RefObject,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from "react";
 
@@ -43,6 +44,7 @@ export interface OAuthSessionSetupCopy {
   loading: string;
   failedToLoadBrowser: string;
   retry: string;
+  close: string;
   errorHint: string;
 }
 
@@ -94,6 +96,10 @@ export interface OAuthSessionSetupShellProps {
  * retry, X-button close, and the wizard's external `closeSignal`. Token
  * capture, callback handling and provider metadata stay in the provider
  * component and its capture hook.
+ *
+ * Retry and close are guarded: a retry while a `startLogin` is still in
+ * flight is ignored, and a close (X button or `closeSignal`) while the
+ * browser is already closed does not issue a second native close.
  */
 export function OAuthSessionSetupShell({
   providerId,
@@ -121,6 +127,16 @@ export function OAuthSessionSetupShell({
     reset,
   } = capture;
   const [showBrowser, setShowBrowser] = useState(initiallyOpen);
+  // Mirrors `showBrowser` synchronously so two closes inside one event loop
+  // turn (double click, X click racing a closeSignal) collapse to one native
+  // close before React re-renders.
+  const showBrowserRef = useRef(initiallyOpen);
+  const retryInFlightRef = useRef(false);
+
+  const setBrowserVisibility = useCallback((isOpen: boolean) => {
+    showBrowserRef.current = isOpen;
+    setShowBrowser(isOpen);
+  }, []);
 
   useEffect(() => {
     onBrowserStateChange?.(showBrowser);
@@ -128,16 +144,17 @@ export function OAuthSessionSetupShell({
 
   useEffect(() => {
     if (!isWebviewOpen && isSignedIn) {
-      queueMicrotask(() => setShowBrowser(false));
+      queueMicrotask(() => setBrowserVisibility(false));
     }
-  }, [isSignedIn, isWebviewOpen]);
+  }, [isSignedIn, isWebviewOpen, setBrowserVisibility]);
 
   useOAuthBrowserAutoStart(showBrowser, startLogin);
 
   const handleCloseBrowser = useCallback(() => {
+    if (!showBrowserRef.current) return;
+    setBrowserVisibility(false);
     void closeWebview().catch(() => undefined);
-    setShowBrowser(false);
-  }, [closeWebview]);
+  }, [closeWebview, setBrowserVisibility]);
 
   useEffect(() => {
     if (closeSignal <= 0 || !showBrowser) return;
@@ -145,10 +162,16 @@ export function OAuthSessionSetupShell({
   }, [closeSignal, handleCloseBrowser, showBrowser]);
 
   const handleRetry = useCallback(() => {
+    if (retryInFlightRef.current) return;
+    retryInFlightRef.current = true;
     reset();
-    setShowBrowser(true);
-    void startLogin().catch(() => undefined);
-  }, [reset, startLogin]);
+    setBrowserVisibility(true);
+    void startLogin()
+      .finally(() => {
+        retryInFlightRef.current = false;
+      })
+      .catch(() => undefined);
+  }, [reset, setBrowserVisibility, startLogin]);
 
   const displayError = error ?? tokenError;
   const currentStep = hasToken ? 2 : 1;
@@ -173,7 +196,7 @@ export function OAuthSessionSetupShell({
               size="default"
               loading={isSigningIn || isWebviewLoading}
               disabled={isSigningIn || isWebviewLoading}
-              onClick={() => setShowBrowser(true)}
+              onClick={() => setBrowserVisibility(true)}
               className="h-8 min-h-8"
               data-testid={`${providerId}-oauth-signin`}
             >
@@ -204,6 +227,8 @@ export function OAuthSessionSetupShell({
                 />
               }
               iconOnly
+              aria-label={copy.retry}
+              title={copy.retry}
               onClick={handleRetry}
             />
             <Button
@@ -213,6 +238,8 @@ export function OAuthSessionSetupShell({
                 <HugeiconsIcon icon={Cancel01Icon} data-icon="x" size={14} />
               }
               iconOnly
+              aria-label={copy.close}
+              title={copy.close}
               onClick={handleCloseBrowser}
               data-testid={`${providerId}-oauth-browser-close`}
             />
@@ -252,7 +279,10 @@ export function OAuthSessionSetupShell({
             data-testid={`${providerId}-oauth-webview-container`}
           >
             {(isSigningIn || isWebviewLoading) && (
-              <div className="absolute inset-0 flex items-center justify-center bg-bg-1">
+              <div
+                className="absolute inset-0 flex items-center justify-center bg-bg-1"
+                role="status"
+              >
                 <HugeiconsIcon
                   icon={Loading03Icon}
                   data-icon="loader-2"
@@ -263,7 +293,10 @@ export function OAuthSessionSetupShell({
               </div>
             )}
             {displayError && (
-              <div className="absolute inset-0 flex flex-col items-center justify-center bg-bg-1 p-6 text-center">
+              <div
+                className="absolute inset-0 flex flex-col items-center justify-center bg-bg-1 p-6 text-center"
+                role="alert"
+              >
                 <HugeiconsIcon
                   icon={AlertCircleIcon}
                   data-icon="alert-circle"

--- a/src/features/SessionSetup/components/SessionSetupStepIndicator.test.ts
+++ b/src/features/SessionSetup/components/SessionSetupStepIndicator.test.ts
@@ -28,6 +28,7 @@ describe("SessionSetupStepIndicator", () => {
     const markup = renderIndicator({ step: 1, currentStep: 1 });
 
     expect(markup).toContain("bg-primary-6 text-text-white");
+    expect(markup).toContain('aria-current="step"');
     expect(markup).toContain("font-medium text-text-1");
     expect(markup).toContain(">1</div>");
     expect(markup).toContain("Step 1");
@@ -50,6 +51,7 @@ describe("SessionSetupStepIndicator", () => {
 
     expect(markup).toContain("border border-border-2 bg-bg-2 text-text-3");
     expect(markup).toContain("font-normal text-text-3");
+    expect(markup).not.toContain("aria-current");
     expect(markup).toContain(">2</div>");
   });
 });

--- a/src/features/SessionSetup/components/SessionSetupStepIndicator.tsx
+++ b/src/features/SessionSetup/components/SessionSetupStepIndicator.tsx
@@ -27,6 +27,7 @@ const SessionSetupStepIndicator: FC<SessionSetupStepIndicatorProps> = ({
               ? "bg-primary-6 text-text-white"
               : "border border-border-2 bg-bg-2 text-text-3",
         ].join(" ")}
+        aria-current={isActive ? "step" : undefined}
       >
         {isPast ? <span className="text-[10px]">✓</span> : step}
       </div>


### PR DESCRIPTION
**Stacked on #1609 (`refactor/auth-oauth-session-setup-shell`).** Base is that branch, not `develop`; GitHub retargets this PR to `develop` automatically when the base PR merges. Review only the top commit (`ef94b2b0ef`).

## Problem

With the shared `OAuthSessionSetupShell` in place, two duplicate-action holes and one accessibility gap remain, all inherited verbatim from the pre-extraction `ClaudeCodeSessionSetup` / `CodexSessionSetup`:

- **Retry is not coalesced.** `handleRetry` runs `reset()` + `startLogin()` on every click. A double click (or a click while the previous `startLogin` is still awaiting `create_*_oauth_webview`) creates a second PKCE state and a second native webview; the callback then mismatches one of them.
- **Close is not idempotent.** The X button and the wizard's `closeSignal` each call `closeWebview()` unconditionally. A double click, or a `closeSignal` landing in the same turn as an X click (the wizard bumps the signal from `onCancel` while `browserOpen`), issues two `close_*_oauth_webview` commands.
- **No assistive-technology semantics.** The refresh and close controls are icon-only `Button`s with no accessible name; the loading and error overlays are plain `div`s; the two-step indicator marks the active step only by color.

The Neonforge98 audit of #780 found these three changes smuggled into the refactor commit `ba4fbc1a23` without any test rendering the shell ("the shell component with the timer, refs and effects is never rendered, so unmount cleanup, double-close and retry coalescing have no coverage"), and asked for them to ship as separate fixes with real lifecycle tests.

## Solution

All in `OAuthSessionSetupShell.tsx`, re-derived against the shell landed by the base PR:

- `retryInFlightRef`: `handleRetry` returns early while a retry-initiated `startLogin` is pending; the flag is released in `.finally`, so a rejection releases it too. Invariant: at most one retry-initiated `startLogin` in flight per shell instance.
- `showBrowserRef` + `setBrowserVisibility`: every writer of `showBrowser` (sign-in click, retry, X close, collapse-on-success) goes through one setter that updates the ref synchronously. `handleCloseBrowser` returns early when the ref is already `false`, so the X button and `closeSignal` (which routes through the same handler) together issue exactly one native close per open. Invariant: `closeWebview` is called at most once per browser open, regardless of how many close requests arrive before React re-renders.
- A11y: `aria-label` + `title` from `common:actions.retry` / `common:actions.close` (existing keys, no locale change) on the two icon buttons; `role="status"` on the loading overlay; `role="alert"` on the error overlay; `SessionSetupStepIndicator` sets `aria-current="step"` on the active step (the indicator's other consumer, `CopilotSessionSetup`, gets this too, which is the intended shared-component fix). `OAuthSessionSetupCopy` gains `close`; both providers pass it.
- Not carried over from `ba4fbc1a23`: moving `onBrowserStateChange` from the post-commit effect into the setter. The effect-based sync is unchanged in both PRs.

Tests (rendered shell, `react-dom/client` + `act`, jsdom, fake timers) added to `OAuthSessionSetupShell.test.ts` (20 total, 10 new) and `SessionSetupStepIndicator.test.ts`:
- double retry -> one `reset`, one extra `startLogin`; a third click while still pending is ignored; after resolve the next click starts again (deferred promise controlled by the test);
- the guard is released when `startLogin` rejects;
- double X click -> one `closeWebview` (fails on the base shell: 2 calls); `closeSignal` after an X close -> still one, and `closeSignal` plus an X click inside one `act` -> one (these two already pass on the base shell because React commits the click's state update before the signal effect runs; they stay as regression guards);
- unmount after close -> reopen clears the pending auto-start timer (`vi.getTimerCount() === 0`, no extra `startLogin`);
- `aria-label`/`title` on both icon buttons, `role="status"` only while loading, `role="alert"` only on error, exactly one `aria-current="step"` that moves from step 1 to step 2 with `hasToken`;
- step indicator markup carries `aria-current` only on the active step.

Differential check: the same 20-test file copied onto the base branch's shell (PR #1609, worktree `/private/tmp/orgii-pr780-oauth-shell`, temporary copy removed afterwards) -> **7 failed | 13 passed**; the 7 failures are exactly the double-retry, reject-release, double-close and four a11y tests, i.e. every test that encodes behavior this PR adds.

## Potential risks

- **Live native OAuth on macOS for Claude Code and Codex was NOT re-verified in this session**; the double-click and signal-race paths are covered in jsdom with the capture hooks mocked. A device run should include: double-clicking Retry after a failed load, double-clicking X, and cancelling the wizard while the browser is open.
- Retry coalescing keys on the promise `startLogin` returns. `useOAuthCapture.startLogin` resolves after `openWebview` settles, so the window is the native create call; it does not extend over the user's time on the login page.
- The auto-start attempt from `useOAuthBrowserAutoStart` is not counted by `retryInFlightRef` (it is not a retry). A user can still click Retry during the initial 100 ms auto-start window and get a second `startLogin`; that matches develop today and is left for a separate decision.
- `role="alert"` makes the error overlay announce on appearance; that is the intent.
- Stacked PR: do not merge before the base PR; GitHub retargets it to `develop` when the base merges.

## Verification

All commands run from a sibling worktree `/private/tmp/orgii-pr780-oauth-shell-fix` created from the base branch commit `0c8971119e`, with the main checkout's `node_modules` symlinked.

- `npx prettier --write <6 changed src files>` -> clean.
- `npx oxlint -c .oxlintrc.json --max-warnings 0 <6 changed src files>` -> exit 0.
- `npx eslint --max-warnings 0 --report-unused-disable-directives <6 changed src files>` -> exit 0.
- `npx vitest run --config config/vitest.config.ts src/features/SessionSetup` -> **8 files, 71 tests passed** (20 in `OAuthSessionSetupShell.test.ts`).
- `pnpm run check:test-placement` -> "Test placement is consistent across 556 directories." (exit 0).
- `pnpm check:typed-lint` -> "1143 existing findings; 0 new or increased findings." (exit 0; whole-`src` typed ESLint pass).
- `npx tsgo --noEmit --pretty false` -> no diagnostics, exit 0 (full typecheck, run once at the end).
- Not run: live macOS OAuth (see risks), the full vitest suite, e2e. The pre-commit hook was skipped in the worktree (`.husky/_/husky.sh` is absent there), so the commit carries no `Pre-commit hook ran.` trailer; lint/format were run by hand as listed above.

Re-lands the behavior-changing half of commit `ba4fbc1a23` of #780 per the Neonforge98 audit, split out of the refactor and covered by rendered lifecycle tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
