### PR TITLE
refactor(agent): centralize external mcp config loading

### DIFF
--- a/src-tauri/crates/agent-core/src/specialization/external_import/commands.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/commands.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use super::detect::detect_all;
+use super::mcp_config::load_external_mcp_config;
 use super::types::{
     frontmatter_declares_readonly, readonly_excluded_tool_names, DetectedItem, ImportItemReport,
     ImportReport, ImportSelection, ImportStatus, ItemKind, SourceScope,
@@ -10,7 +11,7 @@ use super::types::{
 use crate::core::definitions::schema::{AgentDefinition, AgentTier, AgentToolSelection};
 use crate::core::definitions::store::AgentDefinitionsStore;
 use crate::specialization::mcp::config::{
-    global_config_path, update_config_file, workspace_config_path, McpConfigFile,
+    global_config_path, update_config_file, workspace_config_path,
 };
 use crate::specialization::policies::config::PolicyConfig;
 use crate::specialization::policies::{
@@ -367,50 +368,6 @@ fn copy_dir_recursive(from: &Path, to: &Path) -> Result<(), String> {
 // ============================================================
 // MCP import
 // ============================================================
-
-fn load_external_mcp_config(path: &Path) -> Result<McpConfigFile, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|err| format!("Failed to read MCP config {}: {}", path.display(), err))?;
-    let mut value: serde_json::Value = serde_json::from_str(&raw)
-        .map_err(|err| format!("Failed to parse MCP config {}: {}", path.display(), err))?;
-    let Some(servers) = value
-        .get_mut("mcpServers")
-        .and_then(|entry| entry.as_object_mut())
-    else {
-        return Ok(McpConfigFile::default());
-    };
-
-    for server in servers.values_mut() {
-        let Some(server_obj) = server.as_object_mut() else {
-            continue;
-        };
-        if !server_obj.contains_key("type") {
-            let inferred = if server_obj.contains_key("url") {
-                "streamableHttp"
-            } else {
-                "stdio"
-            };
-            server_obj.insert(
-                "type".to_string(),
-                serde_json::Value::String(inferred.to_string()),
-            );
-        }
-        if server_obj.get("type").and_then(|entry| entry.as_str()) == Some("http") {
-            server_obj.insert(
-                "type".to_string(),
-                serde_json::Value::String("streamableHttp".to_string()),
-            );
-        }
-    }
-
-    serde_json::from_value(value).map_err(|err| {
-        format!(
-            "Failed to parse MCP server entries {}: {}",
-            path.display(),
-            err
-        )
-    })
-}
 
 fn apply_mcp_import(
     selection: &ImportSelection,

--- a/src-tauri/crates/agent-core/src/specialization/external_import/detect/mcp.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/detect/mcp.rs
@@ -6,9 +6,10 @@
 
 use std::path::Path;
 
+use super::super::mcp_config::load_external_mcp_config;
 use super::super::types::{DetectedItem, ItemKind, ItemPreview, SourceAgent, SourceScope};
 use super::helpers::{home_dir, orgii_mcp_exists, path_has_denied_ancestor, MAX_ITEMS_PER_BATCH};
-use crate::specialization::mcp::config::{McpConfigFile, McpTransportType};
+use crate::specialization::mcp::config::McpTransportType;
 
 pub(super) fn detect_mcp_servers(repo_path: Option<&Path>) -> Vec<DetectedItem> {
     let mut out = Vec::new();
@@ -68,50 +69,6 @@ pub(super) fn detect_mcp_servers(repo_path: Option<&Path>) -> Vec<DetectedItem> 
 
     out.sort_by(|a, b| a.suggested_name.cmp(&b.suggested_name));
     out
-}
-
-fn load_external_mcp_config(path: &Path) -> Result<McpConfigFile, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|err| format!("Failed to read MCP config {}: {}", path.display(), err))?;
-    let mut value: serde_json::Value = serde_json::from_str(&raw)
-        .map_err(|err| format!("Failed to parse MCP config {}: {}", path.display(), err))?;
-    let Some(servers) = value
-        .get_mut("mcpServers")
-        .and_then(|entry| entry.as_object_mut())
-    else {
-        return Ok(McpConfigFile::default());
-    };
-
-    for server in servers.values_mut() {
-        let Some(server_obj) = server.as_object_mut() else {
-            continue;
-        };
-        if !server_obj.contains_key("type") {
-            let inferred = if server_obj.contains_key("url") {
-                "streamableHttp"
-            } else {
-                "stdio"
-            };
-            server_obj.insert(
-                "type".to_string(),
-                serde_json::Value::String(inferred.to_string()),
-            );
-        }
-        if server_obj.get("type").and_then(|entry| entry.as_str()) == Some("http") {
-            server_obj.insert(
-                "type".to_string(),
-                serde_json::Value::String("streamableHttp".to_string()),
-            );
-        }
-    }
-
-    serde_json::from_value(value).map_err(|err| {
-        format!(
-            "Failed to parse MCP server entries {}: {}",
-            path.display(),
-            err
-        )
-    })
 }
 
 fn scan_mcp_config_file(

--- a/src-tauri/crates/agent-core/src/specialization/external_import/mcp_config.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/mcp_config.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+use crate::specialization::mcp::config::McpConfigFile;
+
+/// Load an MCP config authored by another agent and normalize the transport
+/// spellings that ORGII accepts before deserializing it into the canonical
+/// config model.
+pub(super) fn load_external_mcp_config(path: &Path) -> Result<McpConfigFile, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|err| format!("Failed to read MCP config {}: {}", path.display(), err))?;
+    let mut value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|err| format!("Failed to parse MCP config {}: {}", path.display(), err))?;
+    let Some(servers) = value
+        .get_mut("mcpServers")
+        .and_then(|entry| entry.as_object_mut())
+    else {
+        return Ok(McpConfigFile::default());
+    };
+
+    for server in servers.values_mut() {
+        let Some(server_obj) = server.as_object_mut() else {
+            continue;
+        };
+        if !server_obj.contains_key("type") {
+            let inferred = if server_obj.contains_key("url") {
+                "streamableHttp"
+            } else {
+                "stdio"
+            };
+            server_obj.insert(
+                "type".to_string(),
+                serde_json::Value::String(inferred.to_string()),
+            );
+        }
+        if server_obj.get("type").and_then(|entry| entry.as_str()) == Some("http") {
+            server_obj.insert(
+                "type".to_string(),
+                serde_json::Value::String("streamableHttp".to_string()),
+            );
+        }
+    }
+
+    serde_json::from_value(value).map_err(|err| {
+        format!(
+            "Failed to parse MCP server entries {}: {}",
+            path.display(),
+            err
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::specialization::mcp::config::McpTransportType;
+    use tempfile::TempDir;
+
+    #[test]
+    fn normalizes_external_transport_variants() {
+        let temp = TempDir::new().expect("create temp dir");
+        let path = temp.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "implicit-stdio": { "command": "server" },
+                    "implicit-http": { "url": "https://example.com/mcp" },
+                    "legacy-http": { "type": "http", "url": "https://example.com/legacy" },
+                    "explicit-sse": { "type": "sse", "url": "https://example.com/sse" }
+                }
+            }"#,
+        )
+        .expect("write config");
+
+        let config = load_external_mcp_config(&path).expect("load config");
+
+        assert_eq!(
+            config.mcp_servers["implicit-stdio"].transport_type,
+            McpTransportType::Stdio
+        );
+        assert_eq!(
+            config.mcp_servers["implicit-http"].transport_type,
+            McpTransportType::StreamableHttp
+        );
+        assert_eq!(
+            config.mcp_servers["legacy-http"].transport_type,
+            McpTransportType::StreamableHttp
+        );
+        assert_eq!(
+            config.mcp_servers["explicit-sse"].transport_type,
+            McpTransportType::Sse
+        );
+    }
+
+    #[test]
+    fn treats_missing_mcp_servers_as_empty() {
+        let temp = TempDir::new().expect("create temp dir");
+        let path = temp.path().join("mcp.json");
+        std::fs::write(&path, r#"{ "other": true }"#).expect("write config");
+
+        let config = load_external_mcp_config(&path).expect("load config");
+
+        assert!(config.mcp_servers.is_empty());
+    }
+}

--- a/src-tauri/crates/agent-core/src/specialization/external_import/mod.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/mod.rs
@@ -20,6 +20,7 @@
 
 pub mod commands;
 pub mod detect;
+mod mcp_config;
 pub mod types;
 
 // Wildcard re-export needed: `#[tauri::command]` generates hidden


### PR DESCRIPTION
## Problem

`load_external_mcp_config` — the loader that reads another agent's `mcpServers` JSON and normalizes its transport spellings (`type` missing → `stdio` / `streamableHttp` by presence of `url`; legacy `"http"` → `streamableHttp`) before deserializing into `McpConfigFile` — exists twice in `agent_core`, byte-for-byte identical:

- `src-tauri/crates/agent-core/src/specialization/external_import/commands.rs` (used by `apply_mcp_import`, the import path)
- `src-tauri/crates/agent-core/src/specialization/external_import/detect/mcp.rs` (used by `scan_mcp_config_file`, the detection path)

Any future change to the normalization rules has to be made in two places, and the two paths can silently drift so that a server detected as importable fails to import (or vice versa). Neither copy had unit coverage.

This re-lands commit `0f5b13f8a2` ("refactor(agent): unify external MCP config loading") from #780 as a standalone scoped PR, per the Neonforge98 audit of that PR, which found this piece "still needed, byte-identical extraction". I re-verified on current `develop` (`5abb618177`) that both duplicates still exist and are still identical to each other and to the body the original commit extracted.

## Solution

Pure extraction, no behavior change:

- New private module `external_import/mcp_config.rs` holds the single `pub(super) fn load_external_mcp_config`. The function body is copied verbatim from the two duplicates (same normalization, same error strings, same `McpConfigFile::default()` fallback when `mcpServers` is absent).
- `commands.rs` and `detect/mcp.rs` drop their local copies and import the shared one (`use super::mcp_config::…` / `use super::super::mcp_config::…`). Call sites are unchanged.
- `mod.rs` registers `mod mcp_config;` (private — the loader is an internal detail of `external_import`, not part of the crate's public surface).
- Two inline `#[cfg(test)]` unit tests (from the original commit) pin the shared loader: transport normalization for implicit-stdio / implicit-http / legacy-`http` / explicit-`sse` entries, and the missing-`mcpServers` → empty-config path. They use `tempfile`, which is already a dev-dependency.

Difference versus the original commit `0f5b13f8a2`: `commands.rs` also drops `McpConfigFile` from its `use crate::specialization::mcp::config::{…}` list, because on current develop nothing else in that file references it and leaving it would fail `clippy -D warnings` with an unused-import error. Everything else is identical to the original diff.

## Potential risks

- Low. The extracted function is byte-identical to both removed copies, so both call sites see exactly the same parsing, normalization and error messages as before. No public API, IPC, wire, schema, dependency or config change.
- Module visibility: `mcp_config` is private to `external_import` and the fn is `pub(super)`; if a future caller outside `external_import` needs it, visibility has to be widened then. That is intentional (matches the original commit).
- Not exercised end-to-end through the Tauri commands (`detect_external_artifacts` / `import_external_artifacts`); coverage is the crate's existing `external_import` tests plus the two new loader tests.

## Verification

Worktree `/private/tmp/orgii-pr780-mcp-config` on `origin/develop` @ `5abb618177`, private `CARGO_TARGET_DIR=/private/tmp/orgii-target-mcp-config`, all `nice -n 10`:

- `rustfmt --edition 2021 --check` on the four touched files → exit 0.
- `cargo check -p agent_core` → exit 0, no warnings.
- `cargo test -p agent_core external_import` → `test result: ok. 25 passed; 0 failed; 0 ignored` (includes `specialization::external_import::mcp_config::tests::normalizes_external_transport_variants` and `…::treats_missing_mcp_servers_as_empty`).
- `cargo clippy -p agent_core --all-targets -- -D warnings` → exit 0, no warnings (so no pre-existing clippy baseline to report for this crate).
- Manual: `diff` of the two removed function bodies against each other and against the original commit's `mcp_config.rs` body → identical.

Did not run: the full `cargo test --workspace`, the frontend suites (no `src/**` files touched), and the Tauri app end-to-end. The pre-commit hook was skipped in the fresh worktree (`.husky/_/husky.sh` is absent there), so this commit carries no `Pre-commit hook ran.` trailer; lint/format were run manually as listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
