### PR TITLE
fix(dropdown): autofocus search inputs by default

### DIFF
--- a/docs/frontend-ui-audit-2026-09-11/DropdownSearchAutofocus.md
+++ b/docs/frontend-ui-audit-2026-09-11/DropdownSearchAutofocus.md
@@ -1,0 +1,29 @@
+# DropdownSearch autofocus UI audit
+
+| Line                                             | Element                         | Verdict          | Reason                                                                                                                                                                                         | Suggested change                                                     |
+| ------------------------------------------------ | ------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `src/components/Dropdown/DropdownSearch.tsx:103` | Shared search focus default     | fix              | Searchable custom menus, including SourceControlScopeToolbar, previously required an extra click because autofocus defaulted to false. The requested standard belongs in the shared primitive. | Applied: default autofocus to true; preserve explicit false opt-out. |
+| `src/components/Dropdown/DropdownSearch.tsx:134` | Focus lifecycle                 | keep with reason | One existing 10 ms timeout per mount, cancelled on unmount or opt-out; query updates do not rerun the effect. Standard Dropdown's duplicate timer was removed.                                 | Keep ownership in DropdownSearch.                                    |
+| `src/components/Dropdown/DropdownSearch.tsx:194` | Native input and shared styling | keep with reason | This is the design-system input primitive; its native input, localized accessible name, and existing tokens remain appropriate. No visual layout changes.                                      | None.                                                                |
+
+Verdict totals: **1 fix**, **2 keep with reason**, **0 abstract**.
+
+## Performance guard
+
+| Area               | Verdict | Evidence                                                                                          | Change or reason kept                                          | Verification                                                                     |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Background work    | fix     | DropdownMenuSurface returns null when closed; DropdownSearch owns a cancellable one-shot timeout. | Removed duplicate parent focus timer; no recurring work.       | Default focus, close-before-focus cancellation, repeated click open/close tests. |
+| Memory             | keep    | One input ref and at most one pending timeout per mounted search.                                 | No caches or growing retained state.                           | Pending timer cleanup test.                                                      |
+| Scope/isolation    | keep    | Ref and timer are component-local.                                                                | No identity, network, persistence, or shared resource changes. | Explicit opt-out test.                                                           |
+| Rendering/hot path | keep    | Effect depends only on autofocus.                                                                 | Search value changes do not refocus.                           | Update-with-external-focus test.                                                 |
+
+Native Tauri verification and CPU/RSS measurements were not run: desktop control is not authorized. Automated DOM tests cover the focus behavior; no measured runtime performance improvement is claimed.
+
+## Verification
+
+- `pnpm test src/components/Dropdown src/components/Select/index.test.ts`: 65 tests passed across 11 files.
+- `pnpm run typecheck:fast`: passed.
+- `pnpm exec eslint src/components/Dropdown/DropdownSearch.tsx src/components/Dropdown/DropdownSearch.test.ts src/components/Dropdown/DropdownOptionsContent.tsx src/components/Dropdown/index.tsx src/components/Dropdown/index.test.ts`: passed.
+- `git diff --check`: passed.
+
+Performance verdict: blocked for native runtime measurement under the user's desktop-control restriction; automated focus lifecycle checks pass.

--- a/src/components/Dropdown/DropdownOptionsContent.tsx
+++ b/src/components/Dropdown/DropdownOptionsContent.tsx
@@ -10,7 +10,6 @@ interface DropdownOptionsContentProps {
   searchPlaceholder?: string;
   searchValue: string;
   onSearchChange: (value: string) => void;
-  searchInputRef: React.RefObject<HTMLInputElement | null>;
   filteredOptions: DropdownOption[];
   value?: DropdownSelectValue;
   mode: "single" | "multiple";
@@ -31,7 +30,6 @@ const DropdownOptionsContent: React.FC<DropdownOptionsContentProps> = ({
   searchPlaceholder,
   searchValue,
   onSearchChange,
-  searchInputRef,
   filteredOptions,
   value,
   mode,
@@ -49,7 +47,6 @@ const DropdownOptionsContent: React.FC<DropdownOptionsContentProps> = ({
     <>
       {showSearch && (
         <DropdownSearch
-          ref={searchInputRef}
           type="text"
           placeholder={
             searchPlaceholder ?? t("common:common.searchPlaceholder")

--- a/src/components/Dropdown/DropdownSearch.test.ts
+++ b/src/components/Dropdown/DropdownSearch.test.ts
@@ -33,6 +33,7 @@ describe("DropdownSearch", () => {
   });
 
   beforeEach(() => {
+    vi.useFakeTimers();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -41,10 +42,64 @@ describe("DropdownSearch", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.useRealTimers();
   });
 
   afterAll(() => {
     Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("focuses by default on each mount without refocusing on updates", () => {
+    const renderSearch = (value: string) =>
+      root.render(createElement(DropdownSearch, { value, onChange: vi.fn() }));
+
+    act(() => renderSearch(""));
+    act(() => vi.advanceTimersByTime(10));
+    expect(document.activeElement).toBe(container.querySelector("input"));
+
+    const button = document.createElement("button");
+    container.appendChild(button);
+    button.focus();
+    act(() => renderSearch("query"));
+    act(() => vi.advanceTimersByTime(10));
+    expect(document.activeElement).toBe(button);
+    button.remove();
+
+    act(() => root.render(null));
+    act(() => renderSearch(""));
+    act(() => vi.advanceTimersByTime(10));
+    expect(document.activeElement).toBe(container.querySelector("input"));
+    act(() => vi.runAllTimers());
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("allows callers to opt out of autofocus", () => {
+    act(() => {
+      root.render(
+        createElement(DropdownSearch, {
+          value: "",
+          onChange: vi.fn(),
+          autoFocus: false,
+        })
+      );
+    });
+    act(() => vi.advanceTimersByTime(10));
+    expect(document.activeElement).not.toBe(container.querySelector("input"));
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels pending focus when closed before the delay finishes", () => {
+    act(() => {
+      root.render(
+        createElement(DropdownSearch, { value: "", onChange: vi.fn() })
+      );
+    });
+    const input = container.querySelector("input")!;
+    const focus = vi.spyOn(input, "focus");
+    act(() => root.render(null));
+    act(() => vi.advanceTimersByTime(10));
+    expect(focus).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("uses the concise localized search label by default", () => {

--- a/src/components/Dropdown/DropdownSearch.tsx
+++ b/src/components/Dropdown/DropdownSearch.tsx
@@ -12,7 +12,6 @@
  *     value={searchValue}
  *     onChange={setSearchValue}
  *     placeholder="Search options..."
- *     autoFocus
  *   />
  *   <div className="p-1">
  *     {filteredOptions.map(opt => (
@@ -78,8 +77,8 @@ export interface DropdownSearchProps extends NativeSearchInputProps {
   testId?: string;
 
   /**
-   * Auto-focus the input when mounted
-   * @default false
+   * Auto-focus the input when the dropdown mounts on open. Pass false to opt out.
+   * @default true
    */
   autoFocus?: boolean;
 
@@ -101,7 +100,7 @@ const DropdownSearch = forwardRef<HTMLInputElement, DropdownSearchProps>(
       leading,
       containerClassName,
       testId,
-      autoFocus = false,
+      autoFocus = true,
       stopMouseDownPropagation = true,
       type = "search",
       autoComplete = "off",

--- a/src/components/Dropdown/index.test.ts
+++ b/src/components/Dropdown/index.test.ts
@@ -16,6 +16,7 @@ import {
 import { activeOverlayCountAtom } from "@src/store/ui/overlayLayerAtom";
 
 import Dropdown from ".";
+import DropdownSearch from "./DropdownSearch";
 
 describe("Dropdown", () => {
   let container: HTMLDivElement;
@@ -42,6 +43,38 @@ describe("Dropdown", () => {
   afterAll(() => {
     Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
   });
+
+  it.each(["options", "custom"])(
+    "focuses search on click and reopen in %s dropdowns",
+    async (mode) => {
+      const props: React.ComponentProps<typeof Dropdown> = {
+        ...(mode === "options"
+          ? { options: [{ value: "one", label: "One" }], showSearch: true }
+          : {
+              droplist: React.createElement(DropdownSearch, {
+                value: "",
+                onChange: () => {},
+              }),
+            }),
+        children: React.createElement("button", null, "Open"),
+      };
+      await act(async () => {
+        root.render(React.createElement(Dropdown, props));
+      });
+      const trigger = container.querySelector("button")!;
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        act(() => trigger.click());
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+        });
+        const input = container.querySelector("input");
+        expect(input).not.toBeNull();
+        expect(document.activeElement).toBe(input);
+        act(() => trigger.click());
+        expect(container.querySelector("input")).toBeNull();
+      }
+    }
+  );
 
   it.each([
     { label: "options", options: [{ value: "one", label: "One" }] },

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -197,7 +197,6 @@ const Dropdown: React.FC<DropdownProps> = ({
   });
   const triggerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const searchInputRef = useRef<HTMLInputElement>(null);
   const positionFrameRef = useRef<number | null>(null);
 
   const isControlled = controlledVisible !== undefined;
@@ -427,13 +426,6 @@ const Dropdown: React.FC<DropdownProps> = ({
     return () => cancelAnimationFrame(id);
   }, [visible, position]);
 
-  useEffect(() => {
-    if (visible && isOptionsMode && showSearch) {
-      const timer = setTimeout(() => searchInputRef.current?.focus(), 10);
-      return () => clearTimeout(timer);
-    }
-  }, [visible, isOptionsMode, showSearch]);
-
   const handleTriggerClick = useCallback(() => {
     if (trigger === "click" && !disabled) {
       setVisible(!visible);
@@ -455,7 +447,6 @@ const Dropdown: React.FC<DropdownProps> = ({
       searchPlaceholder={searchPlaceholder}
       searchValue={searchValue}
       onSearchChange={handleSearchChange}
-      searchInputRef={searchInputRef}
       filteredOptions={filteredOptions}
       value={value}
       mode={mode}


### PR DESCRIPTION
## Problem

Searchable custom dropdowns, including the source-control workspace picker, open without focusing the search field because DropdownSearch defaults autofocus to false. Users must click the field again before typing.

## Solution

Default DropdownSearch autofocus to true while preserving autoFocus={false} as an explicit opt-out. Remove the standard Dropdown's duplicate focus timer and ref plumbing so the shared search primitive owns focus. Add regression coverage for click-to-open and reopen in standard and custom menus, opt-out, query updates, and closing before delayed focus. Include the focused UI audit.

## Potential risks

Consumers that omit autoFocus now move keyboard focus into search when mounted, including hover-open menus; callers requiring different focus behavior can opt out. The existing 10 ms focus delay remains and is cancelled on unmount. Native macOS/Tauri focus behavior has not been manually verified. No dependency, persistence, or wire-format changes are involved; reverting this commit restores the previous default.

## Verification

- `pnpm test src/components/Dropdown src/components/Select/index.test.ts`: 65 tests passed across 11 files on the fresh develop-based worktree.
- `pnpm test src/components/Dropdown/index.test.ts`: 12 tests passed after correcting the test's required children prop typing.
- `pnpm run typecheck:fast`: passed after the test typing correction.
- `pnpm exec eslint src/components/Dropdown/DropdownSearch.tsx src/components/Dropdown/DropdownSearch.test.ts src/components/Dropdown/DropdownOptionsContent.tsx src/components/Dropdown/index.tsx src/components/Dropdown/index.test.ts`: passed; the corrected test was linted again.
- `git diff --check`: passed.
- Native app/E2E and CPU/RSS measurements were not run; desktop control was not authorized. Static screenshots would not demonstrate the focus transition, and styling/layout are unchanged. DOM tests assert actual focus after opening and reopening.

## Audit

UI audit: 1 fix, 2 keep with reason, 0 abstractions. Automated focus lifecycle checks pass; native performance verification remains unrun.
