### PR TITLE
fix(source-control): remove the last row bottom border

### DIFF
--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/AllChangesView.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/AllChangesView.tsx
@@ -202,6 +202,7 @@ const AllChangesView: React.FC<AllChangesViewProps> = ({
       showRenamePath
       compactHeaderGutter
       hideBottomPadding
+      hideLastBottomBorder
     />
   );
 };

--- a/src/modules/WorkStation/shared/DiffSectionList/index.tsx
+++ b/src/modules/WorkStation/shared/DiffSectionList/index.tsx
@@ -54,6 +54,7 @@ interface DiffSectionListProps<TFile extends DiffFileSectionData> {
   onExpansionChange?: (file: TFile, expanded: boolean) => void;
   sectionKeySuffix?: (section: DiffSectionListItem<TFile>) => string | number;
   showBottomBorder?: boolean;
+  hideLastBottomBorder?: boolean;
   /** Show the original path after renamed files in each section header. */
   showRenamePath?: boolean;
   /** When true, each section renders a flat FileHeader instead of the collapsible chevron button. */
@@ -101,6 +102,7 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
   onExpansionChange,
   sectionKeySuffix,
   showBottomBorder,
+  hideLastBottomBorder = false,
   showRenamePath = false,
   flat = false,
   compactHeaderGutter = false,
@@ -336,7 +338,7 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
           isScrolling={handleIsScrolling}
           scrollerRef={handleScrollerRef}
           {...(hideBottomPadding ? {} : { components: DIFF_LIST_COMPONENTS })}
-          itemContent={(_index, { section, renderKey }) => {
+          itemContent={(index, { section, renderKey }) => {
             const isFocused = focusedPath === section.file.path;
             const expansionSignal =
               collapseSignal + (isFocused ? focusedNonce : 0);
@@ -385,7 +387,11 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
                     expanded
                   )
                 }
-                showBottomBorder={showBottomBorder}
+                showBottomBorder={
+                  hideLastBottomBorder && index === sections.length - 1
+                    ? false
+                    : showBottomBorder
+                }
                 showRenamePath={showRenamePath}
                 flat={flat}
                 compactHeaderGutter={compactHeaderGutter}


### PR DESCRIPTION
## Problem

The last file row in Source Control draws a bottom border next to the pane boundary, producing a double divider.

## Solution

Add an opt-in `hideLastBottomBorder` property to the shared diff section list and enable it in Source Control. The final item omits its bottom border, while separators between files and other callers retain their existing behavior. The check uses the item index in the complete list so virtualization does not hide intermediate separators.

## Potential risks

The final section loses its outer bottom border in both collapsed and expanded states. Runtime appearance across themes and viewport sizes has not been visually verified. This is a presentation-only change with no persistence, dependency, wire, or lifecycle changes; reverting the commit restores the prior border behavior.

## Verification

- `pnpm exec eslint src/modules/WorkStation/shared/DiffSectionList/index.tsx src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/AllChangesView.tsx --max-warnings 0` — passed during implementation.
- Commit hook `npx lint-staged` — passed `oxlint -c .oxlintrc.json --max-warnings 0`, `eslint --fix`, and `prettier --write` on both changed files in the isolated worktree.
- Commit hook `npx tsgo --noEmit --pretty false` — passed in the isolated worktree.
- `git diff --cached --check` — passed; reviewed the full two-file diff for scope and accidental sensitive data or generated files.
- No new tests were added for this small border presentation change. Source inspection confirms only the final item opts out and the shared default remains unchanged.
- UI verification and screenshots were not performed because computer control was not authorized; theme, viewport, and expanded/collapsed visual checks remain unverified.
