### PR TITLE
fix(agent-core): sandbox tests that reach sessions.db unguarded

### DIFF
--- a/src-tauri/crates/agent-core/src/core/session/prompt/section_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/session/prompt/section_tests.rs
@@ -102,6 +102,12 @@ fn materialize_prompt_test_run(context: &AgentOrgRunContext) -> String {
 
 #[test]
 fn agent_org_prompt_uses_only_runtime_member_id_for_identity() {
+    // `build_agent_org_context_section` loads the Task board through
+    // `AgentOrgTaskStore::list_operational` -> `database::db::get_connection()`,
+    // which resolves `ORGII_HOME` at call time. Hold the sandbox so this test
+    // never opens a sibling test's fresh sandbox database (a race SQLite
+    // reports as an immediate "database is locked") or the real `~/.orgii`.
+    let _sandbox = prompt_task_sandbox();
     let mut context = prompt_test_agent_org_context();
     context.coordinator_agent_id = "builtin:sde".to_string();
     context.members[0].agent_id = "builtin:sde".to_string();
@@ -124,6 +130,12 @@ fn agent_org_prompt_uses_only_runtime_member_id_for_identity() {
 
 #[test]
 fn agent_org_prompt_uses_task_board_for_roster_delegation() {
+    // `build_agent_org_context_section` loads the Task board through
+    // `AgentOrgTaskStore::list_operational` -> `database::db::get_connection()`,
+    // which resolves `ORGII_HOME` at call time. Hold the sandbox so this test
+    // never opens a sibling test's fresh sandbox database (a race SQLite
+    // reports as an immediate "database is locked") or the real `~/.orgii`.
+    let _sandbox = prompt_task_sandbox();
     let section = build_agent_org_context_section(
         &prompt_test_agent_org_context(),
         "agent-coord",
@@ -218,6 +230,12 @@ fn agent_org_prompt_uses_task_board_for_roster_delegation() {
 
 #[test]
 fn agent_org_prompt_worker_cannot_confuse_peer_chat_with_delegation() {
+    // `build_agent_org_context_section` loads the Task board through
+    // `AgentOrgTaskStore::list_operational` -> `database::db::get_connection()`,
+    // which resolves `ORGII_HOME` at call time. Hold the sandbox so this test
+    // never opens a sibling test's fresh sandbox database (a race SQLite
+    // reports as an immediate "database is locked") or the real `~/.orgii`.
+    let _sandbox = prompt_task_sandbox();
     let context = prompt_test_agent_org_context();
     let section = build_agent_org_context_section(&context, "agent-worker", Some("member-worker"));
     assert!(
@@ -385,6 +403,12 @@ fn coordinator_without_active_episode_is_told_idle_team_accepts_new_missions() {
 
 #[test]
 fn agent_org_prompt_lists_llm_callable_message_kinds() {
+    // `build_agent_org_context_section` loads the Task board through
+    // `AgentOrgTaskStore::list_operational` -> `database::db::get_connection()`,
+    // which resolves `ORGII_HOME` at call time. Hold the sandbox so this test
+    // never opens a sibling test's fresh sandbox database (a race SQLite
+    // reports as an immediate "database is locked") or the real `~/.orgii`.
+    let _sandbox = prompt_task_sandbox();
     let section =
         build_agent_org_context_section(&prompt_test_agent_org_context(), "agent-coord", None);
 
@@ -405,6 +429,12 @@ fn agent_org_prompt_lists_llm_callable_message_kinds() {
 
 #[test]
 fn agent_org_prompt_explains_member_plan_protocol() {
+    // `build_agent_org_context_section` loads the Task board through
+    // `AgentOrgTaskStore::list_operational` -> `database::db::get_connection()`,
+    // which resolves `ORGII_HOME` at call time. Hold the sandbox so this test
+    // never opens a sibling test's fresh sandbox database (a race SQLite
+    // reports as an immediate "database is locked") or the real `~/.orgii`.
+    let _sandbox = prompt_task_sandbox();
     let section =
         build_agent_org_context_section(&prompt_test_agent_org_context(), "agent-coord", None);
 

--- a/src-tauri/crates/agent-core/src/core/tools/impls/plan_mode/create_plan.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/plan_mode/create_plan.rs
@@ -781,6 +781,17 @@ mod tests {
     /// (`crates/e2e-test/src/sde/exec_modes.rs`), not here.
     #[tokio::test]
     async fn llm_description_includes_live_pending_plan_snapshot() {
+        // `mark_ready` reads and writes `pending_plan_approvals` through
+        // `database::db::get_connection()`, which resolves `ORGII_HOME` at
+        // call time. Without holding the sandbox this test opens whichever
+        // sibling sandbox is live (or the real `~/.orgii`) and races that
+        // sibling's fresh `PRAGMA journal_mode = WAL`, which SQLite refuses
+        // with an immediate "database is locked" (no busy handler) —
+        // observed as a `test_env::sandbox()` test failing on its first
+        // `get_connection()`. `lock_and_prepare` serializes on the same
+        // lock every other `mark_ready` test uses and primes the schema.
+        let _sandbox =
+            crate::interaction::plan_approval::persistence::test_support::lock_and_prepare();
         let manager = Arc::new(PlanApprovalManager::new());
         manager
             .mark_ready(

--- a/src-tauri/crates/agent-core/src/tests/turn_executor_retry_tests.rs
+++ b/src-tauri/crates/agent-core/src/tests/turn_executor_retry_tests.rs
@@ -559,6 +559,12 @@ async fn owned_background_result_converges_inside_the_same_turn() {
 
 #[tokio::test]
 async fn task_terminal_mutation_waits_for_owned_job_result_consumption() {
+    // The owned-job finality check snapshots the Task through
+    // `AgentOrgTaskStore::get` -> `database::db::get_connection()`, which
+    // resolves `ORGII_HOME` at call time. Hold the sandbox so this test never
+    // opens a sibling test's fresh sandbox database (a race SQLite reports as
+    // an immediate "database is locked") or the real `~/.orgii`.
+    let _sandbox = test_helpers::test_env::sandbox();
     let owner = TurnProcessOwner {
         session_id: "owned-task-finality-session".to_string(),
         turn_intent_id: "owned-task-finality-intent".to_string(),


### PR DESCRIPTION
## Problem

PR #1611's CI run (`cargo test --workspace`, macOS, [job 103327186011](https://github.com/org2AI/ORG2/actions/runs/34618746531/job/103327186011)) failed one agent_core test out of 3551:

```
core::tools::impls::orchestration::member_idle::tests::routine_member_idle_persists_without_coordinator_provider_wake
panicked at crates/agent-core/src/core/tools/impls/orchestration/member_idle/tests.rs:124:47:
test connection: SqliteFailure(Error { code: DatabaseBusy, extended_code: 5 }, Some("database is locked"))
```

Line 124 is the test's very first `database::db::get_connection()`, immediately after `test_env::sandbox()`. The CI timestamps show the previous sandboxed test finished at `16:31:06.0955` and this one failed at `16:31:06.0968` — 1.3 ms later, so the 15 s `busy_timeout` was never consulted.

**Root cause: tests that reach `sessions.db` without holding the sandbox share the sandbox owner's database file.** `get_connection()` resolves `ORGII_HOME` at call time. A test that calls DB-backed production code without `test_env::sandbox()` therefore opens whichever sibling sandbox is live at that instant (or, when none is, the developer's real `~/.orgii/sessions.db`). On CI the unsandboxed `create_plan::tests::llm_description_includes_live_pending_plan_snapshot` (`PlanApprovalManager::mark_ready` -> `pending_plan_approvals` via `get_connection()`) was running from `06.07` to `06.12`, bracketing the failure.

Two connections opening the same brand-new file both run `PRAGMA journal_mode = WAL` (`configure_connection`). SQLite performs that conversion by upgrading an already-open read transaction to a write transaction (`sqlite3BtreeSetVersion`), a path where the busy handler is deliberately skipped to avoid deadlock, so the loser gets an immediate `SQLITE_BUSY` regardless of `busy_timeout`. The sandbox owner lost that race on CI.

`test_env.rs` and `database::db::connection` are not at fault: the pool is keyed by path + inode, the sandbox lock serializes every *sandboxed* test, and each sandbox gets its own tempdir. The violated invariant is the one `test_env.rs` and `plan_approval/tests.rs` already document ("every test that hits the real sqlite DB serializes on the sandbox — no exceptions").

Fixing only the create_plan test was not enough: a local full-crate run then hit the identical failure in `persistence::sidebar::tests::native_sidebar_query_uses_bounded_order_and_membership_indexes`, victim of a different unsandboxed test. So the whole class was enumerated deterministically: run the crate single-threaded with `HOME` pointed at an empty tempdir and `ORGII_HOME` unset, with a temporary (not committed) trace in `open_pooled` that prints the calling thread whenever no sandbox is live. Seven tests escape:

| Test | DB path reached |
| --- | --- |
| `create_plan::tests::llm_description_includes_live_pending_plan_snapshot` | `PlanApprovalManager::mark_ready` -> `PlanApprovalStore::load_by_session` / `upsert` |
| `prompt::section_tests::agent_org_prompt_uses_only_runtime_member_id_for_identity` | `build_agent_org_context_section` -> `AgentOrgTaskStore::list_operational` |
| `prompt::section_tests::agent_org_prompt_uses_task_board_for_roster_delegation` | same |
| `prompt::section_tests::agent_org_prompt_worker_cannot_confuse_peer_chat_with_delegation` | same |
| `prompt::section_tests::agent_org_prompt_lists_llm_callable_message_kinds` | same |
| `prompt::section_tests::agent_org_prompt_explains_member_plan_protocol` | same |
| `turn_executor::retry_tests::task_terminal_mutation_waits_for_owned_job_result_consumption` | owned-job finality -> `AgentOrgTaskStore::get` |

## Solution

Each escaping test now holds, for its whole duration, the guard its own module already uses for the same access:

- `create_plan`: `plan_approval::persistence::test_support::lock_and_prepare()` (as every other `mark_ready` test and the sibling test in the same module);
- `section_tests`: the file's own `prompt_task_sandbox()` (as the two existing sandboxed tests there);
- `retry_tests`: plain `test_helpers::test_env::sandbox()`.

That serializes them on the canonical process-wide home lock so they can never open another test's sandbox database, points them at their own tempdir so they never touch the developer's real `~/.orgii`, and (where the helper primes a schema) makes the exercised persistence path actually succeed instead of silently returning "no such table". The fix sits at the boundary that produced the shared state — the tests that escaped the sandbox — not as a retry in the victim tests. Resulting invariant, verified by the scan: no agent_core test reaches `get_connection()` while no sandbox is live. Three test files, +47 lines (guards plus comments), no production code touched.

## Potential risks

- Holding the non-`Send` `SandboxGuard` across `.await` in the two `#[tokio::test]` tests is fine: the default `#[tokio::test]` runtime is current-thread and `block_on` does not require a `Send` future; `plan_approval/tests.rs` already does this in ~20 tests.
- The seven tests now serialize with the other sandboxed tests instead of running fully in parallel; each takes well under 100 ms, so no measurable suite-time impact (full crate: 42 s before, 43 s after, locally).
- The section_tests now see `Ok(vec![])` from the Task-board snapshot instead of the previous `Err("no such table")`/real-DB mix; all five assertions pass either way (they passed under both outcomes on CI before), and the prompt text they assert on is unchanged.
- The scan detects escapes only while no sandbox is live (single-threaded run), i.e. tests that reach the DB on their own thread or a `spawn_blocking` thread during the test. A test that leaks DB work onto a background task after returning would not be caught; none of the observed failures point at such a leak. A permanent `cfg(test)` assertion in `get_connection()` would be a separate, larger change.
- The exact CI interleaving could not be reproduced locally (see Verification); the mechanism and the escape set are reproduced deterministically instead.

## Verification

Worktree `/private/tmp/orgii-pr780-member-idle-flake` on `origin/develop` (68df23656d), private `CARGO_TARGET_DIR`, everything `nice -n 10`.

Evidence for the root cause:
- CI log timeline (`ci-1611.log`): the unsandboxed create_plan test's alphabetical neighbours complete between `06.0975` and `06.1196` and `llm_description_includes_live_pending_plan_snapshot` completes at `06.1233`, bracketing the `06.0968` failure of the sandboxed member_idle test.
- Deterministic sandbox-escape proof on the pre-fix test binary, `ORGII_HOME` unset, `HOME` = empty tempdir, `--test-threads=1`: the crate creates `$HOME/.orgii/sessions.db`, `-wal`, `-shm` (journal_mode=wal, no tables) and the trace attributes the seven `open_pooled` calls to the seven tests listed above. Post-fix, same run: 0 escapes, no `$HOME/.orgii` created. (The 7 insta snapshot tests fail under the fake `HOME` in both runs — an artifact of relocating `HOME`, they pass in every normal-`HOME` run below.)
- Deterministic SQLite mechanism proof (`wal_race.py`, two threads, `busy_timeout = 15000`, concurrent `PRAGMA journal_mode = WAL` on one fresh file): `229/300` conversions failed with `database is locked`, max elapsed on failure 0.5 ms (busy handler bypassed).
- Local reproduction of the class: pre-fix `cargo test -p agent_core` on develop had already passed 3550/3551 on CI; after fixing only create_plan, one local full run failed `persistence::sidebar::tests::native_sidebar_query_uses_bounded_order_and_membership_indexes` with the same `database is locked` on its first `get_connection()`.
- Exact CI interleaving NOT reproduced locally: pre-fix binary, member_idle + create_plan tests, `--test-threads=2` x 400 runs: 0 failures; pre-fix binary, `core::tools::impls` filter, `--test-threads=8` x 25 runs: 0 failures. The window is the sub-millisecond fresh-file WAL conversion.

Commands run on the final tree (all exit 0 unless noted):
- `cargo test -p agent_core -- create_plan section_tests retry_tests orchestration::member_idle persistence::sidebar` -> `47 passed; 0 failed`.
- `cargo test -p agent_core` (full crate, default threads) -> `3549 passed; 0 failed; 3 ignored`, 0 "database is locked".
- post-fix binary, `core::tools::impls`, `--test-threads=8` x 25 runs -> 0 failures, 0 "database is locked".
- `cargo clippy -p agent_core --all-targets -- -D warnings` -> `Finished`, no warnings.
- `rustfmt --edition 2021 --check` on the three changed files -> clean.

Not run: the frontend toolchain (no `src/**` changes); `cargo test --workspace` (only agent_core test files are touched). Pre-commit hook skipped in the worktree (`.husky/_/husky.sh` absent), so there is no `Pre-commit hook ran.` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
