### PR TITLE
fix(source-control): simplify header refresh and filters

### DIFF
--- a/docs/frontend-ui-audit-2026-09-11/SourceControlFilterHeader.md
+++ b/docs/frontend-ui-audit-2026-09-11/SourceControlFilterHeader.md
@@ -1,0 +1,13 @@
+# SourceControlFilterHeader UI audit
+
+| Line                                | Element                   | Verdict          | Reason                                                                                                                     | Suggested change |
+| ----------------------------------- | ------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `SourceControlFilterHeader.tsx:114` | Staging filter visibility | keep with reason | Explicit product requirement: hide Staged and Unstaged only when staged count is zero; unknown counts retain the options   | None             |
+| `SourceControlFilterHeader.tsx:117` | Selection reconciliation  | keep with reason | An active hidden staging filter returns to Uncommitted through the existing owner callback; other selections are preserved | None             |
+| `SourceControlFilterHeader.tsx:188` | Filter control            | keep with reason | Existing shared Select and theme tokens are reused                                                                         | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+No source data is malformed or removed. This is an explicitly requested presentation rule. No new polling, listeners, scans, network requests, or retained resources are introduced. Reconciliation is keyed to the hidden-selection condition and does not run while an available filter remains selected. Existing Git operations and data ownership remain unchanged.
+
+Tests cover positive/zero/unknown staged counts, hidden active selections, and preservation of history selection. Native visual verification was not performed because computer control was not authorized.

--- a/docs/frontend-ui-audit-2026-09-11/SourceControlRefresh.md
+++ b/docs/frontend-ui-audit-2026-09-11/SourceControlRefresh.md
@@ -1,0 +1,30 @@
+# SourceControlRefresh UI audit
+
+| Line                                    | Element                | Verdict          | Reason                                                                                                                                                   | Suggested change |
+| --------------------------------------- | ---------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `useSourceControlActions.tsx:38`        | Sidebar header actions | keep with reason | Keeps shared search/view actions and removes the duplicate refresh as explicitly requested                                                               | None             |
+| `useSourceControlPaneActions.ts:79`     | Top refresh action     | keep with reason | Existing header button and spin primitive call the mounted sidebar's scoped refresh; shared status is the fallback only when no pane handles the request | None             |
+| `SourceControlTabSidebarContent.tsx:64` | Handler registration   | keep with reason | One per-store handler delegates through the current pane ref and removes its own registration on unmount; no new UI primitive                            | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+D1–D5 reviewed. No added colors, sizes, or raw interactive HTML. History, PR, and issue refresh actions are separate domain operations and remain available.
+
+## Architecture review
+
+Layers 1–7 and 9: source-control-specific handler type, one publisher/consumer path, explicit missing-pane fallback, current ref lookup after scope changes, and cleanup reviewed. Existing backend handlers continue owning Git status and stash refreshes. Layers 8 and 10 are not applicable: no wire/serialization changes or multi-field resolvers. Typecheck has an unrelated error in `src/components/Dropdown/index.test.ts:54`; no changed-file errors were reported.
+
+## Performance guard
+
+| Area               | Verdict | Evidence                                                                                        | Change or reason kept                                                           | Verification                                                                     |
+| ------------------ | ------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Background work    | keep    | Only an explicit header click calls refresh; no timer, watcher, or retry added                  | Delegate to the existing pane refresh without an additional primary-repo scan   | Routing test checks exactly one call and no fallback call when handled           |
+| Memory             | keep    | One nullable handler per Jotai store                                                            | Registration cleanup checks ownership; current ref avoids retaining an old pane | Unmount test verifies null registration                                          |
+| Scope/isolation    | keep    | Pane ref resolves selected repo/worktree; existing shared Git store keys status by repo id/path | Scope switches use the latest imperative handle                                 | Routing test switches main repo to worktree; existing pane behavior suite passes |
+| Rendering/hot path | keep    | Removed sidebar refresh spin hook; existing top spin remains                                    | No new high-frequency work                                                      | Source inspection and lint; no measured CPU/RSS claim                            |
+
+Lifecycle matrix: startup has no handler until sidebar mounts; idle/hidden causes no new work; click invokes the current pane; missing pane falls back; scope change follows current ref; unmount releases registration. Network failures, cache bounds, backend generation handling, and multi-root refresh concurrency remain owned by existing implementations. No new network/provider/session lifecycle was introduced.
+
+Verification: 5 tests passed across `useSourceControlPaneActions.test.ts` and `SourceControlTabPanels.behavior.test.ts`; targeted ESLint, test placement, and diff whitespace checks pass. Desktop visual checks and CPU/RSS measurements were not run because computer control was not authorized.
+
+Performance verdict: blocked for desktop measurement; routing and cleanup checks pass. Visible/hidden idle, active refresh, and post-close runtime measurements remain unverified.

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import type { TFunction } from "i18next";
+import { Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { useSourceControlActions } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlActions";
+import SourceControlTabSidebarContent from "@src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlTabSidebarContent";
+import type { TabSidebarProps } from "@src/modules/WorkStation/shared/SidebarModules/registry";
+import { sourceControlRefreshHandlerAtom } from "@src/store/workstation/codeEditor/sourceControlRefreshAtom";
+
+import { useSourceControlPaneActions } from "./useSourceControlPaneActions";
+
+const mocks = vi.hoisted(() => ({
+  pane: { current: null as { refresh: () => Promise<void> } | null },
+}));
+vi.mock(
+  "@src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule",
+  () => ({
+    useSourceControlSidebarModule: () => ({
+      tab: { key: "source-control" },
+      ref: mocks.pane,
+    }),
+  })
+);
+vi.mock("@src/modules/WorkStation/shared/PrimarySidebarLayout", () => ({
+  PrimarySidebarLayoutWithSections: () => null,
+}));
+vi.mock("@src/hooks/git/useRepoSelection", () => ({
+  useRepoSelection: () => ({ currentBranch: "develop" }),
+}));
+vi.mock("@src/hooks/ui/useRefreshSpin", () => ({
+  useRefreshSpin: (refresh: () => void) => ({ handleClick: refresh }),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("../config", () => ({ createSourceControlQuickActions: () => [] }));
+
+it("routes the header to the mounted scope, avoids duplicate refresh, and falls back after unmount", () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  const store = createStore();
+  const fallback = vi.fn(async () => {});
+  const mainRepo = vi.fn(async () => {});
+  const worktree = vi.fn(async () => {});
+  mocks.pane.current = { refresh: mainRepo };
+  let refresh!: () => void;
+  let actionKeys: string[] = [];
+  const Harness = () => {
+    const paneActions = useSourceControlPaneActions({
+      t: ((key: string) => key) as TFunction,
+      updatePaneState: vi.fn(),
+      forceRefresh: fallback,
+      gitDiffLoading: false,
+      sourceControlFilterMode: "uncommitted",
+    }).handleSourceControlRefresh;
+    const actions = useSourceControlActions({
+      showFilter: false,
+      viewMode: "list-tree",
+      onToggleFilter: vi.fn(),
+      onToggleViewMode: vi.fn(),
+    }).map((action) => action.key);
+    useEffect(() => {
+      refresh = paneActions;
+      actionKeys = actions;
+    }, [paneActions, actions]);
+    return null;
+  };
+  const render = (sidebar: boolean) =>
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          sidebar
+            ? createElement(SourceControlTabSidebarContent, {
+                context: { repoId: "repo", repoPath: "/repo" },
+              } as TabSidebarProps)
+            : null,
+          createElement(Harness)
+        )
+      )
+    );
+  try {
+    render(true);
+    expect(actionKeys).toEqual(["filter-git", "view-mode-toggle"]);
+    act(() => refresh());
+    expect(mainRepo).toHaveBeenCalledOnce();
+    expect(fallback).not.toHaveBeenCalled();
+    mocks.pane.current = { refresh: worktree };
+    act(() => refresh());
+    expect(worktree).toHaveBeenCalledOnce();
+    expect(mainRepo).toHaveBeenCalledOnce();
+    mocks.pane.current = null;
+    act(() => refresh());
+    expect(fallback).toHaveBeenCalledOnce();
+    render(false);
+    expect(store.get(sourceControlRefreshHandlerAtom)).toBeNull();
+    act(() => refresh());
+    expect(fallback).toHaveBeenCalledTimes(2);
+  } finally {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.test.ts
@@ -38,7 +38,7 @@ vi.mock("react-i18next", () => ({
 }));
 vi.mock("../config", () => ({ createSourceControlQuickActions: () => [] }));
 
-it("routes the header to the mounted scope, avoids duplicate refresh, and falls back after unmount", () => {
+it("routes the header to the mounted scope, avoids duplicate refresh, and falls back after unmount", async () => {
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   const container = document.createElement("div");
   const root = createRoot(container);
@@ -94,6 +94,19 @@ it("routes the header to the mounted scope, avoids duplicate refresh, and falls 
     act(() => refresh());
     expect(worktree).toHaveBeenCalledOnce();
     expect(mainRepo).toHaveBeenCalledOnce();
+    const failure = new Error("Refresh failed");
+    const logError = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      mocks.pane.current = { refresh: vi.fn(() => Promise.reject(failure)) };
+      await act(async () => refresh());
+      expect(logError).toHaveBeenCalledWith(
+        "[SourceControl] Failed to refresh Git status",
+        failure
+      );
+      expect(fallback).not.toHaveBeenCalled();
+    } finally {
+      logError.mockRestore();
+    }
     mocks.pane.current = null;
     act(() => refresh());
     expect(fallback).toHaveBeenCalledOnce();

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.ts
@@ -22,6 +22,7 @@ import {
   gitReviewNavigationAtom,
 } from "@src/store/workstation/codeEditor/gitReviewNavigationAtom";
 import { sourceControlFilterModeHandlerAtom } from "@src/store/workstation/codeEditor/sourceControlFilterModeAtom";
+import { sourceControlRefreshHandlerAtom } from "@src/store/workstation/codeEditor/sourceControlRefreshAtom";
 import {
   type PanelState,
   type SourceControlHistorySelection,
@@ -75,9 +76,12 @@ export function useSourceControlPaneActions({
   gitDiffLoading,
   sourceControlFilterMode,
 }: UseSourceControlPaneActionsOptions): UseSourceControlPaneActionsReturn {
+  const refreshSidebar = useAtomValue(sourceControlRefreshHandlerAtom);
   const refreshSourceControl = useCallback(() => {
-    void forceRefresh();
-  }, [forceRefresh]);
+    // A scoped sidebar refresh already updates shared status. Do not also scan
+    // the primary repository when a worktree or multi-root pane handled it.
+    void (refreshSidebar?.() ?? forceRefresh());
+  }, [forceRefresh, refreshSidebar]);
   const {
     spinClass: sourceControlRefreshSpinClass,
     handleClick: handleSourceControlRefresh,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.ts
@@ -80,7 +80,9 @@ export function useSourceControlPaneActions({
   const refreshSourceControl = useCallback(() => {
     // A scoped sidebar refresh already updates shared status. Do not also scan
     // the primary repository when a worktree or multi-root pane handled it.
-    void (refreshSidebar?.() ?? forceRefresh());
+    (refreshSidebar?.() ?? forceRefresh()).catch((error: unknown) => {
+      console.error("[SourceControl] Failed to refresh Git status", error);
+    });
   }, [forceRefresh, refreshSidebar]);
   const {
     spinClass: sourceControlRefreshSpinClass,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlActions.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlActions.tsx
@@ -10,13 +10,11 @@ import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
 import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
-import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
 
 import { ICON_CONFIG, PANEL_CONSTANTS } from "../config";
 
 const {
   search: SearchIcon,
-  refresh: RefreshIcon,
   listTree: ListTreeIcon,
   list: ListIcon,
 } = ICON_CONFIG;
@@ -26,9 +24,6 @@ export interface UseSourceControlActionsOptions {
   viewMode: "list-tree" | "list";
   onToggleFilter: () => void;
   onToggleViewMode: () => void;
-  onRefresh: () => void;
-  /** Whether refresh is in progress (drives spin animation). */
-  refreshLoading?: boolean;
 }
 
 export function useSourceControlActions({
@@ -36,12 +31,8 @@ export function useSourceControlActions({
   viewMode,
   onToggleFilter,
   onToggleViewMode,
-  onRefresh,
-  refreshLoading = false,
 }: UseSourceControlActionsOptions): SectionHeaderAction[] {
   const { t } = useTranslation("common");
-  const { spinClass: refreshSpinClass, handleClick: handleRefreshClick } =
-    useRefreshSpin(onRefresh, refreshLoading);
 
   return useMemo<SectionHeaderAction[]>(() => {
     const actions: SectionHeaderAction[] = [
@@ -80,29 +71,8 @@ export function useSourceControlActions({
             : "Switch to tree view",
         onClick: onToggleViewMode,
       },
-      {
-        key: "refresh-git",
-        icon: (
-          <AnyIcon
-            icon={RefreshIcon}
-            size={PANEL_CONSTANTS.ACTION_ICON_SIZE}
-            strokeWidth={PANEL_CONSTANTS.ACTION_ICON_STROKE}
-            className={refreshSpinClass}
-          />
-        ),
-        tooltip: t("actions.refresh", "Refresh"),
-        onClick: handleRefreshClick,
-      },
     ];
 
     return actions;
-  }, [
-    showFilter,
-    viewMode,
-    onToggleFilter,
-    onToggleViewMode,
-    refreshSpinClass,
-    handleRefreshClick,
-    t,
-  ]);
+  }, [showFilter, viewMode, onToggleFilter, onToggleViewMode, t]);
 }

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.test.ts
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import SourceControlFilterHeader, {
+  type SourceControlFilterHeaderProps,
+} from "./SourceControlFilterHeader";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/components/Select", () => ({
+  default: ({
+    options,
+    value,
+  }: {
+    options: { value: string }[];
+    value: string;
+  }) =>
+    createElement(
+      "select",
+      { value, readOnly: true },
+      options.map((option) =>
+        createElement(
+          "option",
+          { key: option.value, value: option.value },
+          option.value
+        )
+      )
+    ),
+}));
+
+it.each(["staged", "unstaged"] as const)(
+  "hides redundant filters and leaves %s when the last staged change disappears",
+  (mode) => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const onChangeMode = vi.fn();
+    let props: SourceControlFilterHeaderProps = {
+      mode,
+      onChangeMode,
+      onRefresh: vi.fn(),
+      showRefresh: false,
+      counts: { uncommitted: 3, unstaged: 2, staged: 1, stashed: 0 },
+    };
+    const render = () =>
+      act(() => root.render(createElement(SourceControlFilterHeader, props)));
+    const values = () =>
+      [...container.querySelectorAll("option")].map((option) => option.value);
+    try {
+      render();
+      expect(values()).toEqual([
+        "uncommitted",
+        "unstaged",
+        "staged",
+        "stashed",
+        "history",
+        "pr",
+        "issues",
+      ]);
+      expect(onChangeMode).not.toHaveBeenCalled();
+      props = {
+        ...props,
+        counts: { uncommitted: 3, unstaged: 3, staged: 0, stashed: 0 },
+      };
+      render();
+      expect(values()).toEqual([
+        "uncommitted",
+        "stashed",
+        "history",
+        "pr",
+        "issues",
+      ]);
+      expect(container.querySelector("select")!.value).toBe("uncommitted");
+      expect(onChangeMode).toHaveBeenCalledWith("uncommitted");
+      props = { ...props, mode: "history", counts: undefined };
+      onChangeMode.mockClear();
+      render();
+      expect(values()).toContain("staged");
+      expect(values()).toContain("unstaged");
+      expect(onChangeMode).not.toHaveBeenCalled();
+      props = {
+        ...props,
+        counts: { uncommitted: 0, unstaged: 0, staged: 0, stashed: 0 },
+      };
+      render();
+      expect(container.querySelector("select")!.value).toBe("history");
+      expect(onChangeMode).not.toHaveBeenCalled();
+    } finally {
+      act(() => root.unmount());
+      vi.unstubAllGlobals();
+    }
+  }
+);

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.tsx
@@ -8,7 +8,7 @@
  *
  * Repo-agnostic: all state is owned by the caller (`useSourceControlSidebarModule`).
  */
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
@@ -105,8 +105,18 @@ const SourceControlFilterHeader: React.FC<SourceControlFilterHeaderProps> =
         [t]
       );
 
+      const hideStageFilters = counts?.staged === 0;
+      const stageModeHidden =
+        hideStageFilters && (mode === "staged" || mode === "unstaged");
+      useEffect(() => {
+        if (stageModeHidden) onChangeMode("uncommitted");
+      }, [stageModeHidden, onChangeMode]);
+
       const options = useMemo<DropdownOption[]>(() => {
-        const fileOptions = FILE_FILTER_ROWS.map((row) => {
+        const fileOptions = FILE_FILTER_ROWS.filter(
+          (row) =>
+            !hideStageFilters || (row.id !== "staged" && row.id !== "unstaged")
+        ).map((row) => {
           const label = t(row.labelKey);
           const count = getModeCount(row.id);
           const triggerLabel =
@@ -148,7 +158,7 @@ const SourceControlFilterHeader: React.FC<SourceControlFilterHeaderProps> =
             triggerLabel: t("common:labels.issues", "Issues"),
           },
         ];
-      }, [getCountLabel, getModeCount, t]);
+      }, [getCountLabel, getModeCount, hideStageFilters, t]);
 
       const [moreMenuVisible, setMoreMenuVisible] = useState(false);
 
@@ -170,7 +180,7 @@ const SourceControlFilterHeader: React.FC<SourceControlFilterHeaderProps> =
       return (
         <div className="flex flex-none items-center gap-1 overflow-visible">
           <Select
-            value={mode}
+            value={stageModeHidden ? "uncommitted" : mode}
             onChange={handleSelect}
             options={options}
             size="small"

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlTabSidebarContent.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlTabSidebarContent.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useState } from "react";
+import { useSetAtom } from "jotai";
+import { useCallback, useEffect, useState } from "react";
 
 import type { GitWorktreeEntry } from "@src/api/http/git/types";
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
+import { sourceControlRefreshHandlerAtom } from "@src/store/workstation/codeEditor/sourceControlRefreshAtom";
 
 import { PrimarySidebarLayoutWithSections } from "../../PrimarySidebarLayout";
 import type { TabSidebarProps } from "../registry";
@@ -41,7 +43,7 @@ const SourceControlTabSidebarContent: React.FC<TabSidebarProps> = ({
     ? (sourceControlContext?.hasWorktrees ?? false)
     : undefined;
 
-  const { tab } = useSourceControlSidebarModule({
+  const { tab, ref: sourceControlRef } = useSourceControlSidebarModule({
     repoPath: context.repoPath,
     repoId: context.repoId,
     branchName: currentBranch,
@@ -58,6 +60,14 @@ const SourceControlTabSidebarContent: React.FC<TabSidebarProps> = ({
     worktreesLoading: sourceControlContext?.worktreesLoading,
     refreshWorktrees: sourceControlContext?.refreshWorktrees,
   });
+
+  const setRefreshHandler = useSetAtom(sourceControlRefreshHandlerAtom);
+  useEffect(() => {
+    const refresh = () => sourceControlRef.current?.refresh();
+    setRefreshHandler(() => refresh);
+    return () =>
+      setRefreshHandler((current) => (current === refresh ? null : current));
+  }, [setRefreshHandler, sourceControlRef, context.repoId, context.repoPath]);
 
   const [activeTab] = useState(tab.key);
   const handleTabChange = useCallback(() => {

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
@@ -169,9 +169,6 @@ export function useSourceControlSidebarModule({
   const handleToggleViewMode = useCallback(() => {
     setViewMode((prev) => (prev === "list-tree" ? "list" : "list-tree"));
   }, []);
-  const handleRefresh = useCallback(() => {
-    sourceControlRef.current?.refresh();
-  }, []);
   const handleHistoryRefreshReady = useCallback((refresh: () => void) => {
     historyRefreshRef.current = refresh;
   }, []);
@@ -184,7 +181,6 @@ export function useSourceControlSidebarModule({
     viewMode,
     onToggleFilter: handleToggleFilter,
     onToggleViewMode: handleToggleViewMode,
-    onRefresh: handleRefresh,
   });
 
   const {

--- a/src/store/workstation/codeEditor/sourceControlRefreshAtom.ts
+++ b/src/store/workstation/codeEditor/sourceControlRefreshAtom.ts
@@ -1,0 +1,9 @@
+import { atom } from "jotai";
+
+/** The mounted sidebar refreshes its selected repo/worktree, including stashes.
+ * Returning undefined means no pane is mounted; the header uses shared status.
+ */
+export type SourceControlRefreshHandler = () => Promise<void> | undefined;
+export const sourceControlRefreshHandlerAtom =
+  atom<SourceControlRefreshHandler | null>(null);
+sourceControlRefreshHandlerAtom.debugLabel = "sourceControlRefreshHandlerAtom";


### PR DESCRIPTION
## Problem

Source control exposes two overlapping refresh buttons, but the top one only refreshes shared Git status rather than the sidebar's selected repository/worktree. The filter dropdown also shows Staged and Unstaged when the staged count is zero, even though Uncommitted already covers the useful file view.

## Solution

Simplify source control header actions in two separate feature commits, grouped in this PR at the author's request:

1. Route the top refresh button through the mounted sidebar's scoped refresh handler and remove the duplicate sidebar refresh. Fall back to shared Git status only when no pane handles the request. Release the handler on unmount and resolve the current pane on each click. Separate history, PR, and issue refresh actions remain available.
2. Hide Staged and Unstaged when the known staged count equals zero. Preserve all other filters and retain the two options when counts are unknown or positive. If an active staging filter becomes unavailable, return to Uncommitted through the existing selection callback.

A follow-up CI fix explicitly catches refresh promise rejections and tests that a failed scoped refresh does not trigger the fallback refresh.

Includes focused regression tests and UI audits (combined: 0 fixes, 6 kept with reasons, 0 abstractions). The commit modal change remains in separate PR #1619.

## Potential risks

Desktop visual verification and CPU/RSS measurements were not run because computer control was not authorized. Real Git refresh behavior across hidden/visible surfaces and remote connections remains unmeasured; automated checks cover routing, scope changes, fallback, and cleanup. No new polling or backend Git implementation is introduced.

The filter intentionally changes the active view when the last staged change disappears. Unknown counts preserve existing options. No persistence, schema, dependency, IPC, or wire changes are included. Each commit can be reverted independently.

## Verification

Run in an isolated worktree; the latest `origin/develop` was fetched and a merge-tree check found no conflicts:

- `pnpm test src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/SourceControlTabPanels.behavior.test.ts` — passed, 7 tests
- `pnpm check:typed-lint` — passed after the CI fix: 0 new or increased findings
- `pnpm run check:test-placement` — passed
- Commit hooks: `npx lint-staged` (oxlint, ESLint, Prettier) and `npx tsgo --noEmit --pretty false` — passed on both commits
- `pnpm typecheck:fast` — passed
- `git diff --check origin/develop...HEAD` — passed

Full suite, native/E2E testing, screenshots, and runtime performance measurements were not run. The refresh audit records the main working tree's unrelated Dropdown test error; typechecking passes on this isolated PR branch. Draft follows the author's existing preference.

