### PR TITLE
fix(sidebar): keep collapsed section chevrons visible

### DIFF
--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -330,7 +330,9 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
                         <span className="min-w-0 truncate text-[11px] font-medium tracking-wider text-text-2 uppercase">
                           {section.title}
                         </span>
-                        <span className="hidden shrink-0 items-center leading-none text-text-2 group-hover/section-title:inline-flex">
+                        <span
+                          className={`${isSectionCollapsed ? "inline-flex" : "hidden"} shrink-0 items-center leading-none text-text-2 group-hover/section-title:inline-flex`}
+                        >
                           <NavigationMenuRowActionButton
                             icon={
                               isSectionCollapsed
@@ -408,7 +410,9 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
                         <span className="min-w-0 truncate text-[11px] font-medium tracking-wider text-text-2 uppercase">
                           {section.title}
                         </span>
-                        <span className="hidden shrink-0 items-center leading-none text-text-2 group-hover/section-title:inline-flex">
+                        <span
+                          className={`${isSectionCollapsed ? "inline-flex" : "hidden"} shrink-0 items-center leading-none text-text-2 group-hover/section-title:inline-flex`}
+                        >
                           <NavigationMenuRowActionButton
                             icon={
                               isSectionCollapsed


### PR DESCRIPTION
## Problem

Collapsed sidebar section chevrons were hidden until hover, making collapsed sections harder to discover.

## Solution

Show right chevrons at rest for collapsed regular and pinned sections. Expanded sections retain their existing hover behavior.

## Potential risks

The change only affects presentation in this sidebar surface; there are no persistence, API, dependency, or background lifecycle changes. Native Windows/Linux/macOS and browser visual behavior has not been manually verified. Reverting this commit restores the previous presentation.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/variants/NavigationSidebar.test.ts` — 5 tests passed on the isolated branch based on latest develop.
- `pnpm exec eslint src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx --max-warnings 0` — passed.
- `git diff --check` — passed.
- Commit hooks: lint-staged (oxlint, ESLint, Prettier) and `npx tsgo --noEmit --pretty false` — passed.
- Inspected the scoped diff: one source file, with no unrelated changes, secrets, generated files, or private configuration.
- Updated screenshots and desktop visual checks were not captured because computer control is not authorized. Existing tests cover the component behavior but do not replace cross-platform visual verification.
