### PR TITLE
fix(sidebar): remove member viewing details from filter

### DIFF
--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "Ausgeblendete Sitzungen anzeigen ({{count}})",
       "viewerTooltip": "{{name}} sieht sich diese Sitzung an",
       "viewerOverflow": "und {{count}} weitere Betrachter",
-      "memberViewing": "sieht an: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Sitzung wird geladen…",

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -535,7 +535,6 @@
       "showHidden": "Show hidden sessions ({{count}})",
       "viewerTooltip": "{{name}} is viewing this session",
       "viewerOverflow": "and {{count}} more viewers",
-      "memberViewing": "viewing: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Loading session…",

--- a/src/i18n/locales/es/navigation.json
+++ b/src/i18n/locales/es/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "Mostrar sesiones ocultas ({{count}})",
       "viewerTooltip": "{{name}} está viendo esta sesión",
       "viewerOverflow": "y {{count}} espectadores más",
-      "memberViewing": "viendo: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Cargando sesión…",

--- a/src/i18n/locales/fr/navigation.json
+++ b/src/i18n/locales/fr/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "Afficher les sessions masquées ({{count}})",
       "viewerTooltip": "{{name}} consulte cette session",
       "viewerOverflow": "et {{count}} autres spectateurs",
-      "memberViewing": "regarde : {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Chargement de la session…",

--- a/src/i18n/locales/ja/navigation.json
+++ b/src/i18n/locales/ja/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "非表示のセッションを表示（{{count}}）",
       "viewerTooltip": "{{name}} がこのセッションを見ています",
       "viewerOverflow": "他 {{count}} 人が見ています",
-      "memberViewing": "閲覧中: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "セッションを読み込み中…",

--- a/src/i18n/locales/ko/navigation.json
+++ b/src/i18n/locales/ko/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "숨긴 세션 표시 ({{count}})",
       "viewerTooltip": "{{name}} 님이 이 세션을 보고 있습니다",
       "viewerOverflow": "외 {{count}}명이 보고 있습니다",
-      "memberViewing": "보는 중: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "세션 불러오는 중…",

--- a/src/i18n/locales/pl/navigation.json
+++ b/src/i18n/locales/pl/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "Pokaż ukryte sesje ({{count}})",
       "viewerTooltip": "{{name}} przegląda tę sesję",
       "viewerOverflow": "i jeszcze {{count}} oglądających",
-      "memberViewing": "ogląda: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Ładowanie sesji…",

--- a/src/i18n/locales/pt/navigation.json
+++ b/src/i18n/locales/pt/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "Mostrar sessões ocultas ({{count}})",
       "viewerTooltip": "{{name}} está vendo esta sessão",
       "viewerOverflow": "e mais {{count}} visualizando",
-      "memberViewing": "vendo: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Carregando sessão…",

--- a/src/i18n/locales/ru/navigation.json
+++ b/src/i18n/locales/ru/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "Показать скрытые сессии ({{count}})",
       "viewerTooltip": "{{name}} просматривает эту сессию",
       "viewerOverflow": "и ещё {{count}} смотрят",
-      "memberViewing": "смотрит: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Загрузка сессии…",

--- a/src/i18n/locales/tr/navigation.json
+++ b/src/i18n/locales/tr/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "Gizlenen oturumları göster ({{count}})",
       "viewerTooltip": "{{name}} bu oturumu görüntülüyor",
       "viewerOverflow": "ve {{count}} kişi daha izliyor",
-      "memberViewing": "görüntülüyor: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Oturum yükleniyor…",

--- a/src/i18n/locales/vi/navigation.json
+++ b/src/i18n/locales/vi/navigation.json
@@ -481,7 +481,6 @@
       "showHidden": "Hiện các phiên đã ẩn ({{count}})",
       "viewerTooltip": "{{name}} đang xem phiên này",
       "viewerOverflow": "và {{count}} người khác đang xem",
-      "memberViewing": "đang xem: {{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "Đang tải phiên…",

--- a/src/i18n/locales/zh-Hant/navigation.json
+++ b/src/i18n/locales/zh-Hant/navigation.json
@@ -480,7 +480,6 @@
       "showHidden": "顯示已隱藏的會話（{{count}}）",
       "viewerTooltip": "{{name}} 正在看這個會話",
       "viewerOverflow": "還有 {{count}} 人正在看",
-      "memberViewing": "正在看：{{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "正在載入會話…",

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -480,7 +480,6 @@
       "showHidden": "显示已隐藏的会话（{{count}}）",
       "viewerTooltip": "{{name}} 正在看这个会话",
       "viewerOverflow": "还有 {{count}} 人正在看",
-      "memberViewing": "正在看：{{title}}",
       "viewerOverflow_one": "and 1 more viewer",
       "viewerOverflow_other": "and {{count}} more viewers",
       "loadingSession": "正在加载会话…",

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.tsx
@@ -1,9 +1,9 @@
 /**
  * Team Sessions "who posted this" member-filter dropdown
  * (`cloudSessionsSection.tsx`): the portal-rendered option list (everyone /
- * directly shared with me / each roster member, with online dot + "viewing"
- * subtitle) plus the "show hidden" reveal row, and the state/handlers that
- * back it (filter selection and hidden-row count). Search, keyboard navigation,
+ * directly shared with me / each roster member, with online dot) plus the
+ * "show hidden" reveal row, and the state/handlers that back it (filter
+ * selection and hidden-row count). Search, keyboard navigation,
  * dismissal and scrolling use the shared Dropdown options API.
  */
 import type { TFunction } from "i18next";
@@ -129,37 +129,20 @@ export function useCloudMemberFilterDropdown({
     const presenceEntry = option.userId
       ? (orgId ? presenceMap[orgId] : undefined)?.[option.userId]
       : undefined;
-    const viewingRow = presenceEntry?.viewingSessionId
-      ? rows.find(
-          (row) => row.sourceSessionId === presenceEntry.viewingSessionId
-        )
-      : undefined;
-    const viewingTitle = viewingRow
-      ? viewingRow.title.replace(/^(?:⑂\s*)+/u, "")
-      : undefined;
 
     return {
       value: option.key,
       triggerLabel: option.displayName,
       dataTestId: `sidebar-cloud-filter-${option.key}`,
       label: (
-        <span className="flex min-w-0 flex-col">
-          <span className="flex min-w-0 items-center gap-1.5">
-            {presenceEntry && (
-              <span
-                data-testid="member-online-dot"
-                className="h-1.5 w-1.5 shrink-0 rounded-full bg-success-6"
-              />
-            )}
-            <span className="min-w-0 truncate">{option.displayName}</span>
-          </span>
-          {viewingTitle && (
-            <span className="min-w-0 truncate pl-3 text-[10px] text-text-3">
-              {t("cloud.sidebar.memberViewing", {
-                title: viewingTitle,
-              })}
-            </span>
+        <span className="flex min-w-0 items-center gap-1.5">
+          {presenceEntry && (
+            <span
+              data-testid="member-online-dot"
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-success-6"
+            />
           )}
+          <span className="min-w-0 truncate">{option.displayName}</span>
         </span>
       ),
     };


### PR DESCRIPTION
## Problem

The member filter dropdown displayed the session each online member was viewing, adding activity details that are not needed for choosing a member.

## Solution

Remove the viewing-session lookup and subtitle from dropdown options. Keep member names, online indicators, search, selection, and hidden-session recovery. Remove the now-unused `cloud.sidebar.memberViewing` key from all 13 locales, resolving the CI unused-key failure.

## Potential risks

The change only affects presentation in this sidebar surface; there are no persistence, API, dependency, or background lifecycle changes. Native Windows/Linux/macOS and browser visual behavior has not been manually verified. Reverting this commit restores the previous presentation.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.test.ts` — 2 tests passed on the isolated branch based on latest develop.
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.tsx --max-warnings 0` — passed.
- `git diff --check` — passed.
- Commit hooks: lint-staged (oxlint, ESLint, Prettier) and `npx tsgo --noEmit --pretty false` — passed.
- `pnpm run test:i18n-keys` — all 27 tests passed.
- `pnpm run check:i18n-keys` — passed with zero new findings and zero locale gaps, extras, or placeholder mismatches.
- Fetched latest develop and checked integration with `git merge-tree --write-tree HEAD origin/develop` — no conflicts.
- Inspected the scoped diff: the dropdown source and removal of its unused translation from all 13 locales; no unrelated changes, secrets, generated files, or private configuration.
- Updated screenshots and desktop visual checks were not captured because computer control is not authorized. Existing tests cover the component behavior but do not replace cross-platform visual verification.

