### PR TITLE
feat(spotlight): add persistent row pinning

### DIFF
--- a/docs/frontend-ui-audit-2026-09-12/SpotlightPinning.md
+++ b/docs/frontend-ui-audit-2026-09-12/SpotlightPinning.md
@@ -1,0 +1,13 @@
+# Spotlight pinning UI audit
+
+Scope: new pin control, main Spotlight integration, working-directory palette integration. Existing unrelated row styling is unchanged.
+
+| Line                                                                          | Element                          | Verdict          | Reason                                                                                                                                                                                                                              | Suggested change |
+| ----------------------------------------------------------------------------- | -------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx:493`            | Hover pin control                | keep with reason | Uses the shared Button, sidebar sizing, theme color tokens, existing translated Pin/Unpin labels, and aria-pressed. Appears directly after the label; keyboard focus reveals it. Click and activation keys do not activate the row. | None             |
+| `src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts:511`        | Main pinned section              | keep with reason | Uses the existing item/header renderer and list navigation; stable command identities deduplicate Recent entries.                                                                                                                   | None             |
+| `src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx:508` | Working-directory pinned section | keep with reason | Shares the same projection and row control; respects search results and disables pinning in add/manage mode. Existing current-selection metadata survives the move.                                                                 | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+Validation: rendered jsdom row tests cover button placement, click isolation, activation-key propagation and pinned accessibility state. No desktop UI control or screenshots were used, per user preference. Real visual hover, themes and viewport appearance remain unverified.

--- a/docs/org2-performance-guard-2026-09-12/SpotlightPinning.md
+++ b/docs/org2-performance-guard-2026-09-12/SpotlightPinning.md
@@ -1,0 +1,19 @@
+# Spotlight pinning performance guard
+
+| Area               | Verdict | Evidence                                                                                                        | Change or reason kept                                                                                      | Verification                                               |
+| ------------------ | ------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Background work    | keep    | No polling, network, filesystem scans, workers or timers added                                                  | Uses Jotai's existing storage subscription lifecycle                                                       | Fresh-store/remount test; source inspection                |
+| Memory             | keep    | Stores only unique IDs, at most 200 per palette through the producing toggle boundary                           | At capacity, new pin controls are disabled; unpin remains available; no automatic eviction of user choices | Limit/unpin regression test                                |
+| Scope/isolation    | keep    | Separate local storage keys for main commands and directories; resolves IDs against currently available rows    | No remote payloads or action closures persisted; unavailable/search-excluded rows do not render            | Missing-row/search test and independent-store remount test |
+| Rendering/hot path | keep    | Memoized projection depends on items, IDs and translation; per-projection Set/Map bounded by supplied rows/pins | Existing virtualized list and headers retained; pinning does not select/execute the row                    | Grouping/deduplication and rendered click tests            |
+
+Lifecycle: pin changes are explicit user writes; idle/hidden/offline adds no work. Closing unsubscribes via Jotai/React. Reopening restores IDs; search resolves only live matching rows. Removed or currently unavailable IDs retain a bounded preference and render nothing until available again. Account/org changes use the same local UI preference IDs with current source availability; no new account data is fetched or cached. No transport/provider/backend changes.
+
+Verification commands (27 focused tests, ESLint, typecheck and diff whitespace validation passed on the isolated PR branch):
+
+- `pnpm test -- src/scaffold/GlobalSpotlight/pinning src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/recentSpotlightActions.test.ts src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/workingDirectoryPaletteItems.test.ts`
+- `pnpm exec eslint src/store/ui/spotlightPinsAtom.ts src/scaffold/GlobalSpotlight/pinning/*.ts src/scaffold/GlobalSpotlight/shared/types.ts src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts`
+- `pnpm typecheck:fast`: passed on the isolated PR branch based on latest develop.
+- `git diff --check`
+
+Performance verdict: blocked for full runtime sign-off. Real Tauri visible/hidden idle CPU/RSS and visual interaction measurements were not run because computer control was not authorized. No runtime performance improvement is claimed.

--- a/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts
@@ -82,6 +82,39 @@ describe("SpotlightItemRow selectionState prop", () => {
     }
   );
 
+  it("pins from the right of the label without selecting the row or bubbling keys", () => {
+    const onToggle = vi.fn();
+    render({
+      item: { ...props.item, data: { pinState: { pinned: false, onToggle } } },
+    });
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-pressed="false"]'
+    )!;
+    expect(button).not.toBeNull();
+    expect(button.previousElementSibling?.textContent).toBe("Item");
+    expect(button.className).toContain("group-hover:opacity-100");
+    const keyListener = vi.fn();
+    document.addEventListener("keydown", keyListener);
+    act(() => {
+      button.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+      );
+      button.click();
+    });
+    document.removeEventListener("keydown", keyListener);
+    expect(keyListener).not.toHaveBeenCalled();
+    expect(onToggle).toHaveBeenCalledOnce();
+    expect(props.onSelect).not.toHaveBeenCalled();
+    render({
+      item: { ...props.item, data: { pinState: { pinned: true, onToggle } } },
+    });
+    expect(
+      container
+        .querySelector('button[aria-pressed="true"]')
+        ?.getAttribute("aria-label")
+    ).toBe("sessions:chat.unpinSession");
+  });
+
   it("does not make disabled rows selectable through the checkbox", () => {
     const onToggle = vi.fn();
     render({

--- a/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx
@@ -9,6 +9,7 @@ import React, { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
+import Button from "@src/components/Button";
 import Checkbox from "@src/components/Checkbox";
 import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
 import { KeyboardShortcut } from "@src/components/KeyboardShortcut";
@@ -20,6 +21,8 @@ import {
   HugeiconsIcon,
   InformationCircleIcon,
   LockIcon,
+  PinIcon,
+  PinOffIcon,
   Tick01Icon,
 } from "@src/icons";
 import { copyText } from "@src/util/data/clipboard";
@@ -486,6 +489,42 @@ export const SpotlightItemRow = memo<SpotlightItemRowProps>(
               >
                 <HighlightText text={item.label} query={searchQuery} />
               </span>
+            )}
+            {data.pinState && !isDisabled && (
+              <Button
+                variant="tertiary"
+                appearance="ghost"
+                size="sidebar"
+                iconOnly
+                aria-label={t(
+                  data.pinState.pinned
+                    ? "sessions:chat.unpinSession"
+                    : "sessions:chat.pinSession"
+                )}
+                aria-pressed={data.pinState.pinned}
+                disabled={data.pinState.disabled}
+                title={t(
+                  data.pinState.pinned
+                    ? "sessions:chat.unpinSession"
+                    : "sessions:chat.pinSession"
+                )}
+                className="shrink-0 opacity-0 group-hover:opacity-100 focus-visible:bg-fill-3 focus-visible:opacity-100 enabled:hover:bg-fill-3 enabled:active:bg-fill-4"
+                icon={
+                  <HugeiconsIcon
+                    icon={data.pinState.pinned ? PinOffIcon : PinIcon}
+                    size={14}
+                  />
+                }
+                onMouseDown={(event) => event.preventDefault()}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ")
+                    event.stopPropagation();
+                }}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  data.pinState?.onToggle();
+                }}
+              />
             )}
             {data.inlineTag && (
               <span className="shrink-0 text-[10px] text-text-3">

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts
@@ -72,6 +72,7 @@ function namespaceSectionItems(
   return items.map((item) => ({
     ...item,
     id: `${sectionId}-${item.id}`,
+    data: { ...item.data, pinId: item.data?.pinId ?? item.id },
   }));
 }
 

--- a/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts
@@ -62,6 +62,7 @@ import {
   buildRepoSpotlightItems,
   sortRepoItemsSelectedFirst,
 } from "../../palettes/adapters";
+import { usePinnedSpotlightItems } from "../../pinning/usePinnedSpotlightItems";
 import type {
   ActionDefinition,
   BranchItem,
@@ -507,8 +508,14 @@ export function useSpotlightItems(
     translate,
   ]);
 
-  return {
+  const pinnedItems = usePinnedSpotlightItems(
     items,
+    "commands",
+    !hasAction && !hasRepo
+  );
+
+  return {
+    items: pinnedItems,
     isLoading: false,
   };
 }

--- a/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx
@@ -39,6 +39,7 @@ import {
   useSharedRepoList,
 } from "../../hooks";
 import { usePathSegment } from "../../hooks/usePathSegment";
+import { usePinnedSpotlightItems } from "../../pinning/usePinnedSpotlightItems";
 import { PaletteBody, ShellFooterAction, SpotlightShell } from "../../shell";
 import type { RepoItem, SpotlightItem } from "../../types";
 import { AddWorkingDirectoryModalShell } from "../AddWorkingDirectoryModalShell";
@@ -446,7 +447,7 @@ export const WorkingDirectoryPalette: React.FC<
     [handleRemoveRepo, t]
   );
 
-  const mainItems = useMemo((): SpotlightItem[] => {
+  const unpinnedMainItems = useMemo((): SpotlightItem[] => {
     return buildSectionedWorkingDirectoryItems({
       addMenuActive: !!addMenuKind,
       sectionedAddItems,
@@ -503,6 +504,12 @@ export const WorkingDirectoryPalette: React.FC<
     toggleSelection,
     workspaceItems,
   ]);
+
+  const mainItems = usePinnedSpotlightItems(
+    unpinnedMainItems,
+    "directories",
+    !addMenuKind && !isManageMode
+  );
 
   const pinnedActionStartIndex = mainItems.length;
   const items = useMemo(

--- a/src/scaffold/GlobalSpotlight/pinning/pinnedItems.test.ts
+++ b/src/scaffold/GlobalSpotlight/pinning/pinnedItems.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SpotlightItem } from "../types";
+import {
+  MAX_SPOTLIGHT_PINS,
+  buildPinnedItems,
+  togglePinnedId,
+} from "./pinnedItems";
+
+const header = (id: string): SpotlightItem => ({
+  id,
+  label: id,
+  data: { isHeader: true },
+});
+const row = (id: string, pinId = id): SpotlightItem => ({
+  id,
+  label: id,
+  type: "action",
+  data: { pinId },
+  action: vi.fn(),
+});
+const canPin = (item: SpotlightItem) => item.type === "action";
+
+describe("Spotlight pins", () => {
+  it("bounds persisted pins without evicting user choices and still allows unpinning", () => {
+    const ids = Array.from({ length: MAX_SPOTLIGHT_PINS }, (_, index) =>
+      String(index)
+    );
+    expect(togglePinnedId(ids, "extra")).toEqual(ids);
+    expect(togglePinnedId(ids, "0")).toHaveLength(MAX_SPOTLIGHT_PINS - 1);
+    const items = buildPinnedItems(
+      [row("0"), row("extra")],
+      ids,
+      vi.fn(),
+      "Pinned",
+      canPin
+    );
+    expect(
+      items.find((item) => item.id === "extra")?.data?.pinState?.disabled
+    ).toBe(true);
+    expect(
+      items.find((item) => item.id === "0")?.data?.pinState?.disabled
+    ).toBe(false);
+  });
+  it("moves duplicate recent commands once, drops empty headers, and preserves the action", () => {
+    const recent = row("recent-open", "open");
+    const toggle = vi.fn();
+    const result = buildPinnedItems(
+      [
+        header("recent"),
+        recent,
+        header("main"),
+        row("main-open", "open"),
+        row("other"),
+      ],
+      ["open"],
+      toggle,
+      "Pinned",
+      canPin
+    );
+    expect(result.map((item) => item.id)).toEqual([
+      "section-user-pinned",
+      "recent-open",
+      "main",
+      "other",
+    ]);
+    expect(result[1].action).toBe(recent.action);
+    result[1].data?.pinState?.onToggle();
+    expect(toggle).toHaveBeenCalledWith("open");
+  });
+
+  it("only pins live search matches and keeps unpinnable path actions intact", () => {
+    const path: SpotlightItem = { id: "path", label: "Import", type: "hint" };
+    const result = buildPinnedItems(
+      [path, row("matching")],
+      ["missing"],
+      vi.fn(),
+      "Pinned",
+      canPin
+    );
+    expect(result.map((item) => item.id)).toEqual(["path", "matching"]);
+    expect(result[0].data?.pinState).toBeUndefined();
+    expect(result[1].data?.pinState?.pinned).toBe(false);
+  });
+
+  it("retains pin order and restores original groups when unpinned", () => {
+    const source = [header("main"), row("one"), row("two")];
+    const ids = togglePinnedId(togglePinnedId([], "two"), "one");
+    expect(
+      buildPinnedItems(source, ids, vi.fn(), "Pinned", canPin).map(
+        (item) => item.id
+      )
+    ).toEqual(["section-user-pinned", "two", "one"]);
+    expect(
+      buildPinnedItems(
+        source,
+        togglePinnedId(togglePinnedId(ids, "one"), "two"),
+        vi.fn(),
+        "Pinned",
+        canPin
+      ).map((item) => item.id)
+    ).toEqual(["main", "one", "two"]);
+    expect(ids).toEqual(["two", "one"]);
+  });
+});

--- a/src/scaffold/GlobalSpotlight/pinning/pinnedItems.ts
+++ b/src/scaffold/GlobalSpotlight/pinning/pinnedItems.ts
@@ -1,0 +1,64 @@
+import type { SpotlightItem } from "../types";
+
+export const MAX_SPOTLIGHT_PINS = 200;
+
+export function togglePinnedId(ids: readonly string[], id: string): string[] {
+  return ids.includes(id)
+    ? ids.filter((value) => value !== id)
+    : ids.length < MAX_SPOTLIGHT_PINS
+      ? [...ids, id]
+      : [...ids];
+}
+
+/** Move matching live rows, preserving their actions and section-relative order. */
+export function buildPinnedItems(
+  items: SpotlightItem[],
+  pinnedIds: readonly string[],
+  onToggle: (id: string) => void,
+  pinnedLabel: string,
+  canPin: (item: SpotlightItem) => boolean
+): SpotlightItem[] {
+  const pins = new Set(pinnedIds);
+  const pinned = new Map<string, SpotlightItem>();
+  const remaining: SpotlightItem[] = [];
+  for (const item of items) {
+    if (item.data?.isHeader || !canPin(item)) {
+      remaining.push(item);
+      continue;
+    }
+    const id = item.data?.pinId ?? item.id;
+    const row = {
+      ...item,
+      data: {
+        ...item.data,
+        pinState: {
+          pinned: pins.has(id),
+          disabled: !pins.has(id) && pinnedIds.length >= MAX_SPOTLIGHT_PINS,
+          onToggle: () => onToggle(id),
+        },
+      },
+    };
+    if (pins.has(id)) {
+      if (!pinned.has(id)) pinned.set(id, row);
+    } else {
+      remaining.push(row);
+    }
+  }
+  // A moved row may have been its section's only entry.
+  const populated = remaining.filter(
+    (item, index) =>
+      !item.data?.isHeader ||
+      (index + 1 < remaining.length && !remaining[index + 1].data?.isHeader)
+  );
+  if (!pinned.size) return populated;
+  return [
+    {
+      id: "section-user-pinned",
+      label: pinnedLabel,
+      type: "option",
+      data: { isHeader: true },
+    },
+    ...pinnedIds.flatMap((id) => pinned.get(id) ?? []),
+    ...populated,
+  ];
+}

--- a/src/scaffold/GlobalSpotlight/pinning/usePinnedSpotlightItems.test.ts
+++ b/src/scaffold/GlobalSpotlight/pinning/usePinnedSpotlightItems.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, expect, it, vi } from "vitest";
+
+import type { SpotlightItem } from "../types";
+import { usePinnedSpotlightItems } from "./usePinnedSpotlightItems";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+afterEach(() => {
+  localStorage.clear();
+  Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+});
+
+it("persists directory pins through remounts with a fresh store and isolates main command pins", () => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  const container = document.createElement("div");
+  const input: SpotlightItem[] = [
+    { id: "repo-1", label: "Repo", type: "repo" },
+  ];
+  let output: SpotlightItem[] = [];
+  function Harness({
+    scope,
+    enabled = true,
+  }: {
+    scope: "commands" | "directories";
+    enabled?: boolean;
+  }) {
+    const items = usePinnedSpotlightItems(input, scope, enabled);
+    useEffect(() => {
+      output = items;
+    }, [items]);
+    return null;
+  }
+  function mount(scope: "commands" | "directories", enabled = true) {
+    const root = createRoot(container);
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store: createStore() },
+          createElement(Harness, { scope, enabled })
+        )
+      )
+    );
+    return root;
+  }
+  let root = mount("directories");
+  act(() => output[0].data?.pinState?.onToggle());
+  expect(output[0].data?.isHeader).toBe(true);
+  expect(
+    JSON.parse(localStorage.getItem("orgii-spotlight-directory-pins")!)
+  ).toEqual(["repo-1"]);
+  act(() => root.unmount());
+  root = mount("directories");
+  expect(output[1].data?.pinState?.pinned).toBe(true);
+  act(() => root.unmount());
+  root = mount("commands");
+  expect(output).toHaveLength(1);
+  expect(output[0].data?.pinState).toBeUndefined();
+  act(() => root.unmount());
+  root = mount("directories", false);
+  expect(output).toBe(input);
+  act(() => root.unmount());
+});

--- a/src/scaffold/GlobalSpotlight/pinning/usePinnedSpotlightItems.ts
+++ b/src/scaffold/GlobalSpotlight/pinning/usePinnedSpotlightItems.ts
@@ -1,0 +1,43 @@
+import { useAtom } from "jotai";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  spotlightCommandPinsAtom,
+  spotlightDirectoryPinsAtom,
+} from "@src/store/ui/spotlightPinsAtom";
+
+import type { SpotlightItem } from "../types";
+import { buildPinnedItems, togglePinnedId } from "./pinnedItems";
+
+const canPinCommand = (item: SpotlightItem) =>
+  item.type === "action" || item.type === "page" || item.type === "command";
+const canPinDirectory = (item: SpotlightItem) => item.type === "repo";
+
+export function usePinnedSpotlightItems(
+  items: SpotlightItem[],
+  scope: "commands" | "directories",
+  enabled = true
+): SpotlightItem[] {
+  const [ids, setIds] = useAtom(
+    scope === "commands" ? spotlightCommandPinsAtom : spotlightDirectoryPinsAtom
+  );
+  const { t } = useTranslation();
+  const toggle = useCallback(
+    (id: string) => setIds((previous) => togglePinnedId(previous, id)),
+    [setIds]
+  );
+  return useMemo(
+    () =>
+      enabled
+        ? buildPinnedItems(
+            items,
+            ids,
+            toggle,
+            t("selectors.repo.sections.pinned"),
+            scope === "commands" ? canPinCommand : canPinDirectory
+          )
+        : items,
+    [items, ids, toggle, t, scope, enabled]
+  );
+}

--- a/src/scaffold/GlobalSpotlight/shared/types.ts
+++ b/src/scaffold/GlobalSpotlight/shared/types.ts
@@ -28,6 +28,9 @@ export type StatusType = "ongoing" | "completed" | "failed";
 
 /** Data object attached to SpotlightItem */
 export interface SpotlightItemData {
+  /** Stable identity across main and recent command sections. */
+  pinId?: string;
+  pinState?: { pinned: boolean; disabled?: boolean; onToggle: () => void };
   /** Structured members for multi-folder hover previews. */
   detailFolders?: { name: string; path: string }[];
   /** Whether this is an open tab */

--- a/src/store/ui/spotlightPinsAtom.ts
+++ b/src/store/ui/spotlightPinsAtom.ts
@@ -1,0 +1,11 @@
+import { atomWithStorage } from "jotai/utils";
+
+/** Local UI preferences; retain only identities, never rows or action closures. */
+export const spotlightCommandPinsAtom = atomWithStorage<string[]>(
+  "orgii-spotlight-command-pins",
+  []
+);
+export const spotlightDirectoryPinsAtom = atomWithStorage<string[]>(
+  "orgii-spotlight-directory-pins",
+  []
+);


### PR DESCRIPTION
## Problem

Main Spotlight commands and working directories cannot be kept at the top of their palettes. Users must repeatedly search or navigate to frequently used rows.

## Solution

Add pin/unpin controls immediately after row labels and a Pinned section above the existing groups. Both controls reveal on row hover or keyboard focus; their neutral fill-3 hover and fill-4 pressed states remain distinct from the row’s fill-2 highlight. Pin clicks do not execute the row. Deduplicate pinned Recent entries, preserve search filtering, and retain separate local pin preferences for commands and directories.

## Potential risks

Two new localStorage keys persist only row IDs, capped at 200 pins per palette without evicting existing choices. Unavailable IDs remain bounded preferences and render only if the row is available again. Older versions ignore these keys; reverting this PR restores the previous UI, and removing the two orgii-spotlight-command-pins / orgii-spotlight-directory-pins keys resets preferences. No database, dependency, RPC or remote-sync format changes. Real desktop hover/focus appearance, theme/viewport coverage and idle CPU/RSS are unverified because computer control was not authorized.

## Verification

- `pnpm test -- src/scaffold/GlobalSpotlight/pinning src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/recentSpotlightActions.test.ts src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/workingDirectoryPaletteItems.test.ts` — 27 tests passed on the isolated branch based on latest develop
- `pnpm exec eslint src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts src/scaffold/GlobalSpotlight/palettes/WorkingDirectoryPalette/index.tsx src/scaffold/GlobalSpotlight/shared/types.ts src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts src/store/ui/spotlightPinsAtom.ts src/scaffold/GlobalSpotlight/pinning/usePinnedSpotlightItems.test.ts src/scaffold/GlobalSpotlight/pinning/pinnedItems.test.ts src/scaffold/GlobalSpotlight/pinning/pinnedItems.ts src/scaffold/GlobalSpotlight/pinning/usePinnedSpotlightItems.ts` — passed on the isolated branch
- `pnpm typecheck:fast` — passed on the isolated branch
- `git diff --cached --check` — passed
- Inspected the staged file list and diff for scope, credentials, personal paths and generated artifacts
- Desktop screenshots and manual visual checks not run, as noted above

## Audit

UI: 0 fixes, 3 kept with reasons, 0 abstractions. Runtime performance sign-off remains unverified; no performance improvement is claimed. Reports are included in docs.
