### PR TITLE
fix(spotlight): localize the system theme suffix

### DIFF
--- a/src/config/appearance/globalThemes.test.ts
+++ b/src/config/appearance/globalThemes.test.ts
@@ -5,6 +5,7 @@ import {
   APPEARANCE_MODE_OPTIONS,
   GLOBAL_THEMES,
   getAppearanceModeForTheme,
+  getFollowSystemThemeLabel,
   getGlobalTheme,
   isThemeCssPathDark,
   normalizeAppearanceMode,
@@ -13,6 +14,17 @@ import {
 } from "./globalThemes";
 
 describe("global themes", () => {
+  it.each([
+    [APPEARANCE_MODE.LIGHT, "跟随系统 (浅色)"],
+    [APPEARANCE_MODE.DARK, "跟随系统 (深色)"],
+  ])("localizes the system theme suffix for %s", (scheme, expected) => {
+    expect(
+      getFollowSystemThemeLabel(scheme, "跟随系统", {
+        light: "浅色",
+        dark: "深色",
+      })
+    ).toBe(expected);
+  });
   it("ships exactly one stylesheet per variant", () => {
     expect(Object.keys(GLOBAL_THEMES).sort()).toEqual(["dark", "light"]);
     expect(GLOBAL_THEMES.light.baseCssPath).toBe("/orgii_main.css");

--- a/src/config/appearance/globalThemes.ts
+++ b/src/config/appearance/globalThemes.ts
@@ -103,17 +103,12 @@ export function getSystemThemeId(): GlobalThemeId {
   return getSystemColorScheme() === APPEARANCE_MODE.DARK ? "dark" : "light";
 }
 
-export function getSystemThemeEnglishLabel(
-  colorScheme: SystemColorScheme = getSystemColorScheme()
-): "Light" | "Dark" {
-  return colorScheme === APPEARANCE_MODE.DARK ? "Dark" : "Light";
-}
-
 export function getFollowSystemThemeLabel(
-  colorScheme: SystemColorScheme = getSystemColorScheme(),
-  followSystemLabel = "Follow system"
+  colorScheme: SystemColorScheme,
+  followSystemLabel: string,
+  themeLabels: Record<SystemColorScheme, string>
 ): string {
-  return `${followSystemLabel} (${getSystemThemeEnglishLabel(colorScheme)})`;
+  return `${followSystemLabel} (${themeLabels[colorScheme]})`;
 }
 
 export function normalizeGlobalThemeId(

--- a/src/modules/MainApp/Settings/sections/useAppearanceState.ts
+++ b/src/modules/MainApp/Settings/sections/useAppearanceState.ts
@@ -94,7 +94,8 @@ export function useAppearanceState() {
   const systemColorScheme = useAtomValue(systemColorSchemeAtom);
   const followSystemThemeLabel = getFollowSystemThemeLabel(
     systemColorScheme,
-    t("general.followSystem")
+    t("general.followSystem"),
+    { light: t("general.light"), dark: t("general.dark") }
   );
 
   const appearanceMode = useMemo(

--- a/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightItemBuilders.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightItemBuilders.test.ts
@@ -118,6 +118,30 @@ describe("Spotlight settings item builders", () => {
     ]);
   });
 
+  it.each([
+    [APPEARANCE_MODE.LIGHT, "浅色"],
+    [APPEARANCE_MODE.DARK, "深色"],
+  ])(
+    "localizes the system theme suffix and matches it in search for %s",
+    (scheme, label) => {
+      const labels: Record<string, string> = {
+        "settings:general.followSystem": "跟随系统",
+        "settings:general.light": "浅色",
+        "settings:general.dark": "深色",
+      };
+      const items = buildThemeItems(
+        APPEARANCE_MODE.SYSTEM,
+        scheme,
+        label,
+        vi.fn(),
+        (key) => labels[key] ?? key
+      );
+      expect(items.find((item) => item.id === "theme-system")?.label).toBe(
+        `跟随系统 (${label})`
+      );
+    }
+  );
+
   it("offers the same system, light, and dark modes as Settings", () => {
     const onSelectTheme = vi.fn<(theme: GlobalThemePreference) => void>();
     const items = buildThemeItems(

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts
@@ -206,7 +206,11 @@ export function buildThemeItems(
       value: APPEARANCE_MODE.SYSTEM,
       label: getFollowSystemThemeLabel(
         systemColorScheme,
-        translate("settings:general.followSystem")
+        translate("settings:general.followSystem"),
+        {
+          light: translate("settings:general.light"),
+          dark: translate("settings:general.dark"),
+        }
       ),
       icon: ComputerSettingsIcon,
     },


### PR DESCRIPTION
## Problem

The Follow system entry combines a translated label with a hardcoded English Light/Dark suffix, producing mixed-language text in Spotlight and Settings.

## Solution

Require the shared label formatter to receive the existing translated light/dark labels from both callers. Add light/dark Chinese regression cases at the formatter and Spotlight builder, including localized search matching.

## Potential risks

The formatter signature changes internally; both production callers are updated. No persisted data or locale-key changes are needed. Reverting restores the old label behavior. Non-English and English logic is covered by tests, but actual desktop rendering has not been captured because computer control was not authorized.

## Verification

- `pnpm test -- src/config/appearance/globalThemes.test.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightItemBuilders.test.ts` — 19 tests passed on the isolated branch based on latest develop
- `pnpm exec eslint src/config/appearance/globalThemes.ts src/config/appearance/globalThemes.test.ts src/modules/MainApp/Settings/sections/useAppearanceState.ts src/scaffold/GlobalSpotlight/hooks/features/spotlightItemBuilders.ts src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightItemBuilders.test.ts` — passed on the isolated branch
- `pnpm typecheck:fast` — passed on the isolated branch
- `git diff --cached --check` — passed
- Inspected the staged file list and diff for scope, credentials, personal paths and generated artifacts
- Desktop screenshots and manual visual checks not run, as noted above
