### PR TITLE
fix(spotlight): use the screen mode icon for chat pagination

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -108,6 +108,7 @@ export { default as CaptionsIcon } from "@hugeicons/core-free-icons/CaptionsIcon
 export { default as Cardiogram01Icon } from "@hugeicons/core-free-icons/Cardiogram01Icon";
 export { default as CaseSensitiveIcon } from "@hugeicons/core-free-icons/CaseSensitiveIcon";
 export { default as CenterFocusIcon } from "@hugeicons/core-free-icons/CenterFocusIcon";
+export { default as ChangeScreenModeIcon } from "@hugeicons/core-free-icons/ChangeScreenModeIcon";
 export { default as ChartColumnIcon } from "@hugeicons/core-free-icons/ChartColumnIcon";
 export { default as ChartGanttIcon } from "@hugeicons/core-free-icons/ChartGanttIcon";
 export { default as ChartNoAxesGanttIcon } from "@hugeicons/core-free-icons/ChartNoAxesGanttIcon";

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.settings.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.settings.ts
@@ -15,7 +15,7 @@ import {
   ArrowBigRightDashIcon,
   ArrowLeftBigIcon,
   ArrowRightBigIcon,
-  LayoutTopIcon,
+  ChangeScreenModeIcon,
   Menu01Icon,
   SparklesIcon,
 } from "@src/icons";
@@ -66,7 +66,7 @@ export function buildChatPanelSettingsActions({
     labelKey: chatTurnPaginationEnabled
       ? "common:spotlightActions.disableChatPagination"
       : "common:spotlightActions.enableChatPagination",
-    icon: LayoutTopIcon,
+    icon: ChangeScreenModeIcon,
     keywords: ["chat pagination", "turn pagination", "chat rounds"],
     actionId: chatTurnPaginationEnabled
       ? ACTION_ID.CHAT_PANEL_DISABLE_PAGINATION


### PR DESCRIPTION
## Problem

The chat pagination toggle uses LayoutTopIcon rather than the requested screen-mode glyph.

## Solution

Re-export ChangeScreenModeIcon from the app icon barrel and use it for both enable and disable chat pagination actions.

## Potential risks

This is an icon-only change; action dispatch, labels and persistence are unchanged. The installed icon package already provides the glyph, so no dependency or lockfile change is needed. Desktop appearance has not been captured because computer control was not authorized. Reverting restores the former icon.

## Verification

- `pnpm test -- src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightActionDefinitions.settings.test.ts` — 2 tests passed on the isolated branch based on latest develop
- `pnpm exec eslint src/icons.ts src/scaffold/GlobalSpotlight/hooks/features/spotlightActionDefinitions.settings.ts` — passed on the isolated branch
- `pnpm typecheck:fast` — passed on the isolated branch
- `git diff --cached --check` — passed
- Inspected the staged file list and diff for scope, credentials, personal paths and generated artifacts
- Desktop screenshots and manual visual checks not run, as noted above
