### PR TITLE
fix(spotlight): hide global search results before typing

### DIFF
--- a/docs/frontend-ui-audit-2026-09-12/GlobalSearchEmptyQuery.md
+++ b/docs/frontend-ui-audit-2026-09-12/GlobalSearchEmptyQuery.md
@@ -1,0 +1,14 @@
+# Global search empty-query UI audit
+
+Product requirement: the user explicitly requested no content/results area in global searches before typing, matching file search. This is presentation behavior, not malformed domain-data remediation.
+
+| Line                                                                            | Element               | Verdict          | Reason                                                                                                                                                                                              | Suggested change |
+| ------------------------------------------------------------------------------- | --------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/scaffold/GlobalSpotlight/palettes/AllSessionsSearchPalette/index.tsx:227`  | Full-text search body | keep with reason | Uses PaletteBody's existing contentOverride contract to omit the list for empty/whitespace queries. Its keyboard items are also empty immediately, including while the previous search is clearing. | None             |
+| `src/scaffold/GlobalSpotlight/palettes/AgentSessionSearchPalette/index.tsx:225` | Session search body   | keep with reason | Uses the same existing body contract, preserving the input and navigation. No cached session results can be selected while hidden.                                                                  | None             |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+Verification: ESLint for both changed files passed; `git diff --check` passed. `pnpm test -- src/scaffold/GlobalSpotlight/palettes/AllSessionsSearchPalette src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightSessionSearch.test.ts` passed 13 existing tests. These tests cover search runners and item builders, not the rendered empty-query layout. Desktop visual verification was not run, per the user's computer-control preference.
+
+Lifecycle review: no changes to timers, requests, subscriptions, cache ownership or search runner generation handling. Omitting SpotlightItemList also avoids mounting its empty-state timers before a query exists. Runtime measurements are not claimed.

--- a/src/scaffold/GlobalSpotlight/palettes/AgentSessionSearchPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/AgentSessionSearchPalette/index.tsx
@@ -56,6 +56,7 @@ export const AgentSessionSearchPalette: React.FC<
   const cloudAuth = useAtomValue(org2CloudAuthAtom);
   const cloudRemoteSessions = useAtomValue(org2CloudRemoteSessionsAtom);
   const [query, setQuery] = useState("");
+  const hasSearchQuery = query.trim().length > 0;
   const resolvedSearchInput = useMemo(
     () => resolveAgentSessionSearchInput(query),
     [query]
@@ -116,6 +117,7 @@ export const AgentSessionSearchPalette: React.FC<
   );
 
   const items = useMemo<SpotlightItem[]>(() => {
+    if (!hasSearchQuery) return [];
     if (resolvedSearchInput.reference) {
       const reference = resolvedSearchInput.reference;
       return [
@@ -144,6 +146,7 @@ export const AgentSessionSearchPalette: React.FC<
       onSelect: handleOpenSession,
     });
   }, [
+    hasSearchQuery,
     fallbackSessionLabel,
     filteredItems,
     cloudAuth,
@@ -219,7 +222,8 @@ export const AgentSessionSearchPalette: React.FC<
       )}
       path={path}
       onRemoveSegment={handleGoBack}
-      isLoading={sessionsLoading && sessions.length === 0}
+      isLoading={hasSearchQuery && sessionsLoading && sessions.length === 0}
+      contentOverride={hasSearchQuery ? undefined : null}
       containerHeight={400}
     />
   );

--- a/src/scaffold/GlobalSpotlight/palettes/AllSessionsSearchPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/AllSessionsSearchPalette/index.tsx
@@ -50,6 +50,7 @@ export const AllSessionsSearchPalette: React.FC<
   const sessionMap = useAtomValue(sessionMapAtom);
 
   const [query, setQuery] = useState("");
+  const hasSearchQuery = query.trim().length > 0;
   const [hits, setHits] = useState<CrossSessionSearchHit[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const prevIsOpenRef = useRef(isOpen);
@@ -155,13 +156,15 @@ export const AllSessionsSearchPalette: React.FC<
 
   const items = useMemo<SpotlightItem[]>(
     () =>
-      buildAllSessionsSearchItems({
-        hits,
-        sessionMap,
-        fallbackSessionLabel: t("chat.session", "Session"),
-        onNavigate: handleNavigate,
-      }),
-    [handleNavigate, hits, sessionMap, t]
+      hasSearchQuery
+        ? buildAllSessionsSearchItems({
+            hits,
+            sessionMap,
+            fallbackSessionLabel: t("chat.session", "Session"),
+            onNavigate: handleNavigate,
+          })
+        : [],
+    [hasSearchQuery, handleNavigate, hits, sessionMap, t]
   );
 
   const handleExternalKeyDown = useCallback(
@@ -221,7 +224,8 @@ export const AllSessionsSearchPalette: React.FC<
       )}
       path={path}
       onRemoveSegment={handleGoBack}
-      isLoading={isLoading}
+      isLoading={hasSearchQuery && isLoading}
+      contentOverride={hasSearchQuery ? undefined : null}
       containerHeight={400}
     />
   );


### PR DESCRIPTION
## Problem

Global session searches display a large empty-state area or cached session rows before a query is entered, unlike file search.

## Solution

Use the existing PaletteBody contentOverride contract to omit the results area for empty and whitespace-only queries in both session search palettes. Also provide no selectable items and suppress the loading indicator while the query is empty, so clearing the input cannot activate hidden stale results.

## Potential risks

The initial session list is intentionally removed from these two search palettes; typing restores the existing results and empty-result behavior. Existing search requests, debounce and generation handling are unchanged. The current tests cover search runners and result builders, not the newly conditional rendered layout. Desktop visual/keyboard verification and screenshots were not run because computer control was not authorized. Reverting restores the previous initial view.

## Verification

- `pnpm test -- src/scaffold/GlobalSpotlight/palettes/AllSessionsSearchPalette src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightSessionSearch.test.ts` — 13 tests passed on the isolated branch based on latest develop
- `pnpm exec eslint src/scaffold/GlobalSpotlight/palettes/AgentSessionSearchPalette/index.tsx src/scaffold/GlobalSpotlight/palettes/AllSessionsSearchPalette/index.tsx` — passed on the isolated branch
- `pnpm typecheck:fast` — passed on the isolated branch
- `git diff --cached --check` — passed
- Inspected the staged file list and diff for scope, credentials, personal paths and generated artifacts
- Desktop screenshots and manual visual checks not run, as noted above

## Audit

UI: 0 fixes, 2 kept with reasons, 0 abstractions. The results-area exclusion is the explicit product requirement.
