### PR TITLE
fix(launchpad): share Spotlight row styling

### DIFF
--- a/docs/frontend-ui-audit-2026-09-12/WorkStationStartPage.md
+++ b/docs/frontend-ui-audit-2026-09-12/WorkStationStartPage.md
@@ -1,0 +1,12 @@
+# WorkStationStartPage UI audit
+
+| Line                                                      | Element                             | Verdict          | Reason                                                                                                                                                             | Suggested change                                             |
+| --------------------------------------------------------- | ----------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `src/modules/WorkStation/AppShell/StartPage/index.tsx:55` | Row geometry and label/icon styling | fix              | Launchpad duplicated Spotlight styling with different padding, weight and tones. Both now consume shared `SPOTLIGHT_CLASSES` and `SPOTLIGHT_TOKENS`.               | Applied shared row, icon, typography, height and gap tokens. |
+| `src/modules/WorkStation/AppShell/StartPage/index.tsx:52` | Native action button                | keep with reason | This full-width action row needs native keyboard activation and custom inline diff content; standard Button chrome would override the shared Spotlight row layout. | None.                                                        |
+| `src/modules/WorkStation/AppShell/StartPage/index.tsx:73` | Diff statistics                     | keep with reason | Uses the existing DiffStatsBadge primitive and preserves Review metadata.                                                                                          | None.                                                        |
+| `src/modules/WorkStation/AppShell/StartPage/index.tsx:84` | Shortcut hint                       | keep with reason | Uses KeyboardShortcut with Spotlight's default presentation and original rendering.                                                                                | None.                                                        |
+
+Verdict totals: **1 fix**, **3 keep with reason**, **0 abstract**.
+
+Scope: launchpad styling and the Spotlight row tokens extracted for it. No background work or state lifecycle changes. Existing Spotlight selection and danger overrides remain intact. Desktop visual verification was not performed because computer control was not requested.

--- a/src/modules/WorkStation/AppShell/StartPage/index.tsx
+++ b/src/modules/WorkStation/AppShell/StartPage/index.tsx
@@ -14,15 +14,16 @@ import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
-import {
-  KEYBOARD_SHORTCUT_VARIANT,
-  KeyboardShortcut,
-} from "@src/components/KeyboardShortcut";
+import { KeyboardShortcut } from "@src/components/KeyboardShortcut";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
 import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { useActiveRepoRef } from "@src/hooks/git/useActiveRepoRef";
 import { useWorkingTreeDiffTotals } from "@src/hooks/git/useWorkingTreeDiffTotals";
 import { Infinity01Icon, type IconSvgElement } from "@src/icons";
+import {
+  SPOTLIGHT_CLASSES,
+  SPOTLIGHT_TOKENS,
+} from "@src/scaffold/GlobalSpotlight/constants";
 import { hasActiveSessionAtom } from "@src/store/session/viewAtom";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 
@@ -51,16 +52,21 @@ const StartActionRow = memo<StartActionRowProps>(
       <button
         type="button"
         onClick={onClick}
-        className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${SURFACE_TOKENS.hover} active:bg-fill-3`}
+        className={`${SPOTLIGHT_CLASSES.itemRow} w-full text-left transition-colors ${SURFACE_TOKENS.hover} active:bg-fill-3`}
+        style={{ height: SPOTLIGHT_TOKENS.itemHeight }}
       >
-        <span className="flex min-w-0 items-center gap-2.5">
+        <span className={SPOTLIGHT_CLASSES.itemIcon}>
           <AnyIcon
             icon={icon}
-            size={16}
-            strokeWidth={1.75}
-            className="shrink-0 text-text-3"
+            size={SPOTLIGHT_TOKENS.iconSize}
+            strokeWidth={2}
+            className={SPOTLIGHT_CLASSES.itemIconTone}
           />
-          <span className="truncate text-[14px] font-medium text-text-2">
+        </span>
+        <span className="flex min-w-0 flex-1 items-center gap-2">
+          <span
+            className={`truncate leading-none ${SPOTLIGHT_TOKENS.labelFontSize} ${SPOTLIGHT_CLASSES.itemLabelWeight} ${SPOTLIGHT_CLASSES.itemLabelTone}`}
+          >
             {label}
           </span>
           {showDiff ? (
@@ -75,10 +81,7 @@ const StartActionRow = memo<StartActionRowProps>(
           ) : null}
         </span>
         {shortcutId ? (
-          <KeyboardShortcut
-            shortcutId={shortcutId}
-            variant={KEYBOARD_SHORTCUT_VARIANT.dropdown}
-          />
+          <KeyboardShortcut shortcutId={shortcutId} rendering="original" />
         ) : null}
       </button>
     );
@@ -104,7 +107,10 @@ export const WorkStationStartPage: React.FC = memo(() => {
       className={`flex h-full w-full items-center justify-center overflow-auto p-8 ${EDITOR_TAB_CANVAS_BG_CLASS}`}
     >
       <div className="w-full max-w-[420px]">
-        <div className="flex flex-col gap-0.5">
+        <div
+          className="flex flex-col"
+          style={{ gap: SPOTLIGHT_TOKENS.itemGap }}
+        >
           {hasActiveSession ? (
             <>
               <StartActionRow

--- a/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx
@@ -33,7 +33,7 @@ import {
 } from "@src/util/platform/tauri/nativeMenuPopup";
 
 import { ICONS } from "../config";
-import { SPOTLIGHT_TOKENS } from "../constants";
+import { SPOTLIGHT_CLASSES, SPOTLIGHT_TOKENS } from "../constants";
 import type { SpotlightItem, SpotlightItemData } from "../types";
 import { SpotlightDetailPane } from "./SpotlightDetailPane";
 import { HighlightText } from "./highlightUtils";
@@ -268,7 +268,9 @@ export const SpotlightItemRow = memo<SpotlightItemRowProps>(
     const ArrowRightIcon = ICONS.arrowRight;
     const DisclosureIcon =
       data.disclosureIcon === "arrowRight" ? ArrowRightIcon : ArrowRight01Icon;
-    const itemTextClassName = isDanger ? "text-danger-6" : "text-text-1";
+    const itemTextClassName = isDanger
+      ? "text-danger-6"
+      : SPOTLIGHT_CLASSES.itemLabelTone;
     const iconTone =
       typeof data.iconTone === "string" ? data.iconTone : undefined;
     const itemIconClassName = isDanger
@@ -277,9 +279,11 @@ export const SpotlightItemRow = memo<SpotlightItemRowProps>(
         ? "text-primary-6"
         : iconTone === "text1"
           ? "text-text-1"
-          : "text-text-2";
+          : SPOTLIGHT_CLASSES.itemIconTone;
     // Only the currently-checked option uses medium weight; regular rows are normal.
-    const labelWeightClass = isCurrentSelection ? "font-medium" : "font-normal";
+    const labelWeightClass = isCurrentSelection
+      ? "font-medium"
+      : SPOTLIGHT_CLASSES.itemLabelWeight;
     const modelSection =
       typeof data.modelSection === "string" ? data.modelSection : undefined;
     const modelId = typeof data.modelId === "string" ? data.modelId : undefined;
@@ -382,7 +386,7 @@ export const SpotlightItemRow = memo<SpotlightItemRowProps>(
         data-source-account-id={sourceAccountId}
         data-source-model-type={sourceModelType}
         data-source-type={sourceType}
-        className={`spotlight-item group relative mx-2 flex items-center gap-2.5 rounded-lg px-2 ${
+        className={`spotlight-item group relative mx-2 ${SPOTLIGHT_CLASSES.itemRow} ${
           isDisabled
             ? "cursor-not-allowed opacity-50"
             : `cursor-pointer ${isCurrentSelection ? "is-current-selection" : ""} ${isSelected ? "selected" : ""}`
@@ -423,7 +427,7 @@ export const SpotlightItemRow = memo<SpotlightItemRowProps>(
         )}
 
         {item.icon && (
-          <div className="flex h-6 w-6 shrink-0 items-center justify-center">
+          <div className={SPOTLIGHT_CLASSES.itemIcon}>
             {isCurrentSelection ? (
               <HugeiconsIcon
                 icon={Tick01Icon}

--- a/src/scaffold/GlobalSpotlight/constants.ts
+++ b/src/scaffold/GlobalSpotlight/constants.ts
@@ -41,6 +41,12 @@ export const SPOTLIGHT_TOKENS = {
 } as const;
 
 export const SPOTLIGHT_CLASSES = {
+  /** Shared option-row geometry and default typography, also used by launchpad. */
+  itemRow: "flex items-center gap-2.5 rounded-lg px-2",
+  itemIcon: "flex h-6 w-6 shrink-0 items-center justify-center",
+  itemIconTone: "text-text-2",
+  itemLabelWeight: "font-normal",
+  itemLabelTone: "text-text-1",
   panel: "overflow-hidden rounded-2xl border border-border-2 bg-bg-2 shadow-xl",
   /** Primary contextual pill used by palette navigation and active state badges. */
   primaryPill:


### PR DESCRIPTION
## Problem

My Station launchpad rows use different padding, label weight, icon tones, and shortcut chrome from Spotlight. Duplicated styling lets the two surfaces drift, and inherited label line-height leaves excess space around the launchpad text.

## Solution

Extract Spotlight row geometry and default label/icon styles into shared constants consumed by both components. Apply Spotlight's 34px row height, 3px gap, 16px icons, normal-weight labels, and shortcut presentation to the launchpad. Give launchpad labels explicit compact line-height while preserving native button activation, Review diff statistics, and existing action handlers.

## Potential risks

The denser launchpad rows and changed shortcut presentation need visual review across themes, narrow viewports, and platform fonts. Optical text/icon alignment has not been verified in the desktop app. Spotlight's existing selected, disabled, and danger overrides are preserved. No dependencies, persistence formats, APIs, or background lifecycles change; rollback is a revert of this styling change.

## Verification

Run in an isolated worktree based on the latest fetched `origin/develop`:

- `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/AppShell/StartPage/StartPage.test.ts src/scaffold/GlobalSpotlight/components/SpotlightItemRow.test.ts` — 7 tests passed.
- `pnpm exec eslint src/scaffold/GlobalSpotlight/constants.ts src/scaffold/GlobalSpotlight/components/SpotlightItemRow.tsx src/modules/WorkStation/AppShell/StartPage/index.tsx` — passed.
- `pnpm typecheck:fast` — passed.
- `git diff --check` — passed.
- Inspected the scoped diff for unrelated changes, secrets, personal paths, generated artifacts, and debug logs; none included.

Desktop visual checks and updated screenshots were not produced because the user's standing preference requires explicit opt-in for computer control. Existing tests verify action behavior, not visual alignment.

## Audit

Frontend UI audit: 1 fixed, 3 kept with reasons, 0 abstractions. Report: `docs/frontend-ui-audit-2026-09-12/WorkStationStartPage.md`.
