### PR TITLE
fix(explorer): move refresh into the more menu

### DIFF
--- a/docs/frontend-ui-audit-2026-09-12/ExplorerRefresh.md
+++ b/docs/frontend-ui-audit-2026-09-12/ExplorerRefresh.md
@@ -1,0 +1,12 @@
+# Explorer Refresh UI audit
+
+Scope: moving the regular explorer refresh action from the file-tree section header to the existing three-dot menu. Reviewed changed markup and action wiring across D1–D5.
+
+| Line                                                                                                 | Element                          | Verdict          | Reason                                                                                                                       | Suggested change |
+| ---------------------------------------------------------------------------------------------------- | -------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeEditorDefaultHeader.tsx:67` | Refresh menu action              | keep with reason | Reuses FileHeader's existing localized DropdownItem, icon sizing, keyboard semantics, loading guard, and menu-close behavior | None             |
+| `src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useExplorerActions.tsx:52`     | Remaining section-header actions | keep with reason | Removes only Refresh; retains existing action configuration and shared header renderer without adding markup or styling      | None             |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+Verification: `pnpm typecheck:fast`, targeted ESLint on all seven changed source files, and `pnpm test src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts` passed (6 tests). Live visual verification was not run: user preferences prohibit computer control without explicit opt-in.

--- a/docs/org2-performance-guard-2026-09-12/ExplorerRefresh.md
+++ b/docs/org2-performance-guard-2026-09-12/ExplorerRefresh.md
@@ -1,0 +1,16 @@
+# Explorer refresh lifecycle review
+
+Production path: CodeEditor state.refresh → EditorContent.onExplorerRefresh → CodeEditorDefaultHeader.onRefresh → FileHeader.onReload. The file-tree sidebar no longer owns a refresh spin hook. The underlying tree refresh implementation is unchanged.
+
+| Area               | Verdict | Evidence                                                                                                                               | Change or reason kept                                                             | Verification                                            |
+| ------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Background work    | keep    | FileHeader owns click-triggered cooldown; useRefreshSpin owns one animation frame and a 1200 ms completion timer, with unmount cleanup | Reuse the existing menu action; no new polling, listeners, or scan implementation | Source inspection; typecheck and lint passed            |
+| Memory             | keep    | Existing spin persistence map capped at 200 entries                                                                                    | Supply repoPath so the default header's persistence key is repository scoped      | Source inspection                                       |
+| Scope/isolation    | keep    | Callback and loading flag come from the same CodeEditor state instance                                                                 | Preserve loading guard and menu cooldown                                          | Source trace; existing menu suite passed (6 tests)      |
+| Rendering/hot path | keep    | Adds callback/loading props; removes old header animation hook                                                                         | No new subscription or background computation                                     | Typecheck and lint passed; no runtime performance claim |
+
+Lifecycle matrix: start/idle creates no refresh request; visible click uses the existing action; loading blocks further clicks; hidden state introduces no recurring work (a prior click's bounded completion timer may finish); unmount cancels owned animation frame and timers. Repository changes update the callback and persistence key. No auth, provider ingestion, network recovery, or sync logic changes.
+
+Runtime measurements of visible/hidden idle and repeated mount/unmount were not run because computer control requires user opt-in. Static review found no additional recurring work. No CPU/RAM improvement is claimed.
+
+Performance verdict: blocked for runtime measurement; implementation and static checks complete.

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeEditorDefaultHeader.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeEditorDefaultHeader.tsx
@@ -19,11 +19,21 @@ interface CodeEditorDefaultHeaderProps {
   enabled: boolean;
   repoDisplayName: string;
   activeFilePath: string | null;
+  repoPath: string;
+  onRefresh?: () => void;
+  loading?: boolean;
 }
 
 export const CodeEditorDefaultHeader: React.FC<
   CodeEditorDefaultHeaderProps
-> = ({ enabled, repoDisplayName, activeFilePath }) => {
+> = ({
+  enabled,
+  repoDisplayName,
+  activeFilePath,
+  repoPath,
+  onRefresh,
+  loading,
+}) => {
   const [lineNumbers, setLineNumbers] = useAtom(editorLineNumbersAtom);
   const [wordWrap, setWordWrap] = useAtom(editorWordWrapAtom);
   const [showMinimap, setShowMinimap] = useAtom(editorShowMinimapAtom);
@@ -53,6 +63,9 @@ export const CodeEditorDefaultHeader: React.FC<
       publishToHost="code"
       publishEnabled={enabled}
       filePath="code-editor-default-header"
+      repoPath={repoPath}
+      onReload={onRefresh}
+      loading={loading}
       useFileTypeIcon={false}
       disableNavigation
       plainTitle

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
@@ -95,6 +95,8 @@ const EditorContent: React.FC<EditorContentProps> = memo(
     repoPath,
     repoId,
     repoDisplayName,
+    onExplorerRefresh,
+    explorerLoading,
     gitFilesByPath,
     gitDiffLoading,
     onFileSelect,
@@ -433,6 +435,9 @@ const EditorContent: React.FC<EditorContentProps> = memo(
             enabled={isExplorerHome}
             repoDisplayName={repoDisplayName}
             activeFilePath={activeFilePath}
+            repoPath={repoPath}
+            onRefresh={onExplorerRefresh}
+            loading={explorerLoading}
           />
           <div className="relative min-h-0 flex-1 overflow-hidden">
             {shouldMountTerminalContent && (

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/types.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/types.ts
@@ -24,6 +24,8 @@ export interface EditorContentProps {
   repoPath: string;
   repoId?: string | null;
   repoDisplayName: string;
+  onExplorerRefresh?: () => void;
+  explorerLoading?: boolean;
 
   // Git diff viewing
   gitDiffTabs: Set<string>;

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useExplorerActions.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useExplorerActions.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
 import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
-import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
 
 import { ICON_CONFIG, PANEL_CONSTANTS } from "../config";
 
@@ -17,7 +16,6 @@ const {
   search: SearchIcon,
   addFile: AddFileIcon,
   addFolder: AddFolderIcon,
-  refresh: RefreshIcon,
   collapseAll: CollapseAllIcon,
   openInTab: OpenInTabIcon,
 } = ICON_CONFIG;
@@ -25,8 +23,6 @@ const {
 export interface UseExplorerActionsOptions {
   showFilterFiles: boolean;
   onToggleFilterFiles: () => void;
-  onRefresh?: () => void;
-  filesRefreshLoading?: boolean;
   onCollapseAll?: () => void;
   onAddFile?: () => void;
   onAddFolder?: () => void;
@@ -44,8 +40,6 @@ export interface UseExplorerActionsResult {
 export function useExplorerActions({
   showFilterFiles,
   onToggleFilterFiles,
-  onRefresh,
-  filesRefreshLoading = false,
   onCollapseAll,
   onAddFile,
   onAddFolder,
@@ -55,11 +49,6 @@ export function useExplorerActions({
   onOpenSearchTab,
 }: UseExplorerActionsOptions): UseExplorerActionsResult {
   const { t } = useTranslation("common");
-  const {
-    spinClass: filesRefreshSpinClass,
-    handleClick: handleFilesRefreshClick,
-  } = useRefreshSpin(onRefresh ?? (() => {}), filesRefreshLoading);
-
   const filesActions = useMemo<SectionHeaderAction[]>(() => {
     const actions: SectionHeaderAction[] = [];
 
@@ -107,22 +96,6 @@ export function useExplorerActions({
       });
     }
 
-    if (onRefresh) {
-      actions.push({
-        key: "refresh",
-        icon: (
-          <AnyIcon
-            icon={RefreshIcon}
-            size={PANEL_CONSTANTS.ACTION_ICON_SIZE}
-            strokeWidth={PANEL_CONSTANTS.ACTION_ICON_STROKE}
-            className={filesRefreshSpinClass}
-          />
-        ),
-        tooltip: "Refresh Explorer",
-        onClick: handleFilesRefreshClick,
-      });
-    }
-
     if (onCollapseAll) {
       actions.push({
         key: "collapse-all",
@@ -144,9 +117,6 @@ export function useExplorerActions({
     onToggleFilterFiles,
     onAddFile,
     onAddFolder,
-    onRefresh,
-    filesRefreshSpinClass,
-    handleFilesRefreshClick,
     onCollapseAll,
     t,
   ]);

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/index.tsx
@@ -65,7 +65,6 @@ export const EditorPrimarySidebar: React.FC<EditorPrimarySidebarProps> = memo(
     onFileSelect,
     onFileSelectWithLine,
     onDirectoryToggle,
-    onRefresh,
     onCollapseAll,
     onFilterSearch,
     onClearSearch,
@@ -195,8 +194,6 @@ export const EditorPrimarySidebar: React.FC<EditorPrimarySidebarProps> = memo(
     const { filesActions, searchActions } = useExplorerActions({
       showFilterFiles: filterState.showFilterFiles,
       onToggleFilterFiles: filterState.handleToggleFilterFiles,
-      onRefresh,
-      filesRefreshLoading: loading,
       onCollapseAll: hasVisibleFileTreeItems ? onCollapseAll : undefined,
       onAddFile: handleAddFile,
       onAddFolder: handleAddFolder,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/types.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/types.ts
@@ -57,7 +57,6 @@ export interface EditorPrimarySidebarProps {
   /** Callback when search button is clicked */
   onSearchClick: () => void;
   /** Callback when refresh is clicked */
-  onRefresh?: () => void;
   /** Callback when collapse all is clicked */
   onCollapseAll?: () => void;
   /** Callback for filter search */

--- a/src/modules/WorkStation/CodeEditor/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/index.tsx
@@ -292,7 +292,6 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
           onFileSelectWithLine={handleFileSelectWithLine}
           onDirectoryToggle={handleDirectoryToggle}
           onSearchClick={handleSearchClick}
-          onRefresh={codeEditorState.refresh}
           onCollapseAll={codeEditorState.collapseAll}
           onFilterSearch={handleFilterSearch}
           onClearSearch={handleClearFilterSearch}
@@ -319,7 +318,6 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
         handleFileSelectWithLine,
         handleDirectoryToggle,
         handleSearchClick,
-        codeEditorState.refresh,
         codeEditorState.collapseAll,
         handleFilterSearch,
         handleClearFilterSearch,
@@ -423,6 +421,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
             repoPath={repoPath}
             repoId={selectedRepoId ?? repoPath}
             repoDisplayName={repoDisplayName}
+            onExplorerRefresh={codeEditorState.refresh}
+            explorerLoading={codeEditorState.loading}
             gitDiffTabs={gitDiffTabs}
             gitFilesByPath={gitFilesByPath}
             gitDiffLoading={gitDiffLoading}
@@ -457,6 +457,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
         repoPath,
         selectedRepoId,
         repoDisplayName,
+        codeEditorState.refresh,
+        codeEditorState.loading,
         gitDiffTabs,
         gitFilesByPath,
         gitDiffLoading,


### PR DESCRIPTION
## Problem

The regular explorer exposes Refresh as a file-tree section-header button instead of in the three-dot menu alongside Page Display.

## Solution

Move the existing explorer refresh callback and tree loading state into the default explorer FileHeader. Its existing localized Refresh menu item handles the click, loading guard, cooldown, and menu closing. Remove the old section-header action and unused refresh props. Scope the header animation key to the repository.

## Potential risks

Refresh is less immediately visible and is unavailable while the tree is loading, consistent with the existing menu behavior. This affects the regular explorer home header; file-specific menus keep their existing callbacks. No persistence formats, dependencies, IPC, or backend refresh logic change. Reverting this commit restores the original action placement. Live visual and lifecycle measurements were not performed because desktop control requires user opt-in; themes, narrow widths, and live loading transitions remain unverified.

## Verification

- `pnpm typecheck:fast` — passed in the isolated branch.
- `pnpm exec eslint $(git diff --name-only -- '*.ts' '*.tsx') --max-warnings 0` — passed for all changed source files.
- `pnpm test src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts` — 6 tests passed.
- `git diff --check` — passed.
- Inspected the callback wiring and final scoped diff; no unrelated working-tree changes included.
- No new screenshots or runtime CPU/RAM measurements; desktop control was not authorized.

## Audit

UI audit: 0 fix, 2 keep with reason, 0 abstract. Lifecycle source review found no new recurring work; runtime performance verification remains unmeasured. Reports are included.
