### PR TITLE
style(file-header): remove the more settings gear icon

### DIFF
--- a/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.tsx
+++ b/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.tsx
@@ -47,7 +47,6 @@ import {
   Layers01Icon,
   Refresh04Icon,
   Search01Icon,
-  Settings01Icon,
   Undo03Icon,
 } from "@src/icons";
 import { getFileManagerRevealLabelKey } from "@src/util/platform/fileManagerLabels";
@@ -511,13 +510,6 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
                     role="menuitem"
                     fullWidth
                     tabIndex={0}
-                    icon={
-                      <HugeiconsIcon
-                        icon={Settings01Icon}
-                        data-icon="settings"
-                        size={HEADER_ICON_SIZE.sm}
-                      />
-                    }
                     disabled={!showMoreSettingsAction}
                     onClick={onMoreSettingsClick}
                     suffix={


### PR DESCRIPTION
## Problem

The Page Display submenu's More settings row includes a leading gear icon that the requested UI should omit.

## Solution

Remove the leading icon and its unused import from the shared FileHeader menu. Keep the label, trailing navigation arrow, and settings action.

## Potential risks

The visual change applies to all FileHeader consumers with More settings enabled. Click behavior and keyboard semantics are unchanged. No dependency, storage, or API changes are involved; reverting the commit restores the icon. Live theme and viewport alignment has not been visually checked because desktop control requires user opt-in.

## Verification

- `pnpm typecheck:fast` — passed in the isolated branch.
- `pnpm exec eslint $(git diff --name-only -- '*.ts' '*.tsx') --max-warnings 0` — passed for the changed file.
- `pnpm test src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts` — 6 tests passed.
- `git diff --check` — passed.
- Reviewed the diff: only the leading icon and unused import are removed.
- No new screenshots captured; desktop control was not authorized.
