### PR TITLE
fix(spotlight): reserve horizontal arrows for search text

### DIFF
--- a/src/hooks/keyboard/__tests__/useListNavigation.disclosure.test.ts
+++ b/src/hooks/keyboard/__tests__/useListNavigation.disclosure.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { useListNavigation } from "../useListNavigation";
+
+it("disables disclosure arrows for Spotlight in both input and global handlers, retaining Enter and listener cleanup", () => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  const select = vi.fn();
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  const inputRef = createRef<HTMLInputElement>();
+  function Harness() {
+    const { handleKeyDown } = useListNavigation({
+      items: [{ data: { showDisclosureChevron: true } }],
+      selectedIndex: 0,
+      onSelectedIndexChange: vi.fn(),
+      onSelect: select,
+      onClose: vi.fn(),
+      enableAutoScroll: false,
+      enableGlobalListener: true,
+      enableDisclosureArrowNavigation: false,
+      inputRef,
+    });
+    return createElement("input", { ref: inputRef, onKeyDown: handleKeyDown });
+  }
+  function press(target: Element, key: string) {
+    const event = new KeyboardEvent("keydown", {
+      key,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => target.dispatchEvent(event));
+    return event;
+  }
+  const remove = vi.spyOn(document, "removeEventListener");
+  try {
+    act(() => root.render(createElement(Harness)));
+    const input = container.querySelector("input")!;
+    expect(press(input, "ArrowRight").defaultPrevented).toBe(false);
+    expect(press(document.body, "ArrowRight").defaultPrevented).toBe(false);
+    expect(select).not.toHaveBeenCalled();
+    press(input, "Enter");
+    expect(select).toHaveBeenCalledOnce();
+  } finally {
+    act(() => root.unmount());
+    expect(remove).toHaveBeenCalledWith("keydown", expect.any(Function), true);
+    remove.mockRestore();
+    container.remove();
+  }
+});

--- a/src/hooks/keyboard/useListNavigation.ts
+++ b/src/hooks/keyboard/useListNavigation.ts
@@ -59,6 +59,8 @@ export interface UseListNavigationOptions<T extends ListItem> {
     (event: ReactKeyboardEvent) => boolean | void
   >;
   enableGlobalListener?: boolean;
+  /** Allow Right Arrow to activate disclosure rows outside text-only search. */
+  enableDisclosureArrowNavigation?: boolean;
   inputRef?: RefObject<HTMLInputElement | null>;
   hasModalState?: boolean;
   onGoBack?: () => void;
@@ -151,6 +153,7 @@ export function useListNavigation<T extends ListItem>(
     scrollContainerRef: externalScrollRef,
     additionalKeyHandlers = {},
     enableGlobalListener = false,
+    enableDisclosureArrowNavigation = true,
     inputRef,
     hasModalState = false,
     onGoBack,
@@ -316,7 +319,10 @@ export function useListNavigation<T extends ListItem>(
         return;
       }
 
-      if (keyboardEvent.key === "ArrowRight") {
+      if (
+        enableDisclosureArrowNavigation &&
+        keyboardEvent.key === "ArrowRight"
+      ) {
         if (isFormInput && !isOurInput) return;
 
         const selectedItem = state.items[state.selectedIndex];
@@ -385,7 +391,12 @@ export function useListNavigation<T extends ListItem>(
 
     document.addEventListener("keydown", handler, true);
     return () => document.removeEventListener("keydown", handler, true);
-  }, [enableGlobalListener, inputRef, findNextSelectableIndexFromRef]);
+  }, [
+    enableGlobalListener,
+    enableDisclosureArrowNavigation,
+    inputRef,
+    findNextSelectableIndexFromRef,
+  ]);
 
   // ============================================
   // Main keyboard handler (for focused input)
@@ -433,6 +444,7 @@ export function useListNavigation<T extends ListItem>(
         case "Enter":
         case "ArrowRight": {
           if (event.key === "ArrowRight") {
+            if (!enableDisclosureArrowNavigation) break;
             const itemData = items[selectedIndex]?.data as
               | Record<string, unknown>
               | undefined;
@@ -505,6 +517,7 @@ export function useListNavigation<T extends ListItem>(
       isItemSelectable,
       searchQuery,
       additionalKeyHandlers,
+      enableDisclosureArrowNavigation,
       findNextSelectableIndexInItems,
       onEscape,
       hasModalState,

--- a/src/scaffold/GlobalSpotlight/components/SpotlightSearchBar.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightSearchBar.tsx
@@ -15,6 +15,7 @@ import { ArrowLeft01Icon, BlushBrush01Icon, HugeiconsIcon } from "@src/icons";
 import { ICONS } from "../config";
 import { SPOTLIGHT_CLASSES, SPOTLIGHT_TOKENS } from "../constants";
 import type { PathSegment } from "../types";
+import { handleSpotlightHorizontalArrow } from "./spotlightSearchKeyboard";
 
 // ============ PROPS ============
 
@@ -179,7 +180,9 @@ export const SpotlightSearchBar: React.FC<SpotlightSearchBarProps> = ({
             type="text"
             value={searchQuery}
             onChange={(event) => onSearchQueryChange(event.target.value)}
-            onKeyDown={onKeyDown}
+            onKeyDown={(event) => {
+              if (!handleSpotlightHorizontalArrow(event)) onKeyDown(event);
+            }}
             placeholder={placeholder}
             aria-label={ariaLabel}
             className={`min-w-0 flex-1 bg-transparent text-ellipsis ${inputFontSize} text-text-1 placeholder:text-text-1 focus:outline-none`}

--- a/src/scaffold/GlobalSpotlight/components/spotlightSearchKeyboard.test.ts
+++ b/src/scaffold/GlobalSpotlight/components/spotlightSearchKeyboard.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { SpotlightSearchBar } from "./SpotlightSearchBar";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/components/AnyIcon", () => ({ default: () => null }));
+vi.mock("@src/components/Button", () => ({ default: () => null }));
+vi.mock("@src/components/KeyboardShortcut/ToolbarTooltip", () => ({
+  ToolbarTooltip: () => null,
+}));
+
+let root: Root;
+let container: HTMLDivElement;
+let input: HTMLInputElement;
+const navigate = vi.fn();
+const writeQuery = vi.fn();
+
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  act(() =>
+    root.render(
+      createElement(SpotlightSearchBar, {
+        inputRef: createRef<HTMLInputElement>(),
+        searchQuery: "asdf",
+        onSearchQueryChange: writeQuery,
+        onKeyDown: navigate,
+        placeholder: "Search",
+        path: [],
+      })
+    )
+  );
+  input = container.querySelector("input")!;
+  input.focus();
+  input.setSelectionRange(2, 2);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+function press(key: string, options: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...options,
+  });
+  act(() => input.dispatchEvent(event));
+  return event;
+}
+it.each(["ArrowLeft", "ArrowRight", "\uF702", "\uF703"])(
+  "consumes %s before navigation or native insertion",
+  (key) => {
+    expect(press(key).defaultPrevented).toBe(true);
+    expect(input.selectionStart).toBe(
+      key === "ArrowLeft" || key === "\uF702" ? 1 : 3
+    );
+    expect(input.value).toBe("asdf");
+    expect(writeQuery).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  }
+);
+it("extends, shrinks, and collapses selections", () => {
+  press("ArrowLeft", { shiftKey: true });
+  expect([
+    input.selectionStart,
+    input.selectionEnd,
+    input.selectionDirection,
+  ]).toEqual([1, 2, "backward"]);
+  press("ArrowRight", { shiftKey: true });
+  expect([input.selectionStart, input.selectionEnd]).toEqual([2, 2]);
+  input.setSelectionRange(1, 3);
+  press("ArrowLeft");
+  expect([input.selectionStart, input.selectionEnd]).toEqual([1, 1]);
+});
+it("supports word and whole-query navigation", () => {
+  input.value = "hello world";
+  input.setSelectionRange(11, 11);
+  press("ArrowLeft", { altKey: true });
+  expect(input.selectionStart).toBe(6);
+  press("ArrowLeft", { ctrlKey: true });
+  expect(input.selectionStart).toBe(0);
+  press("ArrowRight", { metaKey: true, shiftKey: true });
+  expect([input.selectionStart, input.selectionEnd]).toEqual([0, 11]);
+});
+it("moves across whole graphemes and clamps at boundaries", () => {
+  input.value = "a👩‍💻e\u0301";
+  input.setSelectionRange(1, 1);
+  press("ArrowRight");
+  expect(input.selectionStart).toBe(6);
+  press("ArrowRight");
+  press("ArrowRight");
+  expect(input.selectionStart).toBe(8);
+  input.value = "";
+  press("ArrowLeft");
+  expect(input.selectionStart).toBe(0);
+});
+it("leaves composition to the IME and delegates other keys", () => {
+  expect(press("ArrowLeft", { isComposing: true }).defaultPrevented).toBe(
+    false
+  );
+  expect(navigate).not.toHaveBeenCalled();
+  press("Enter");
+  expect(navigate).toHaveBeenCalledOnce();
+});

--- a/src/scaffold/GlobalSpotlight/components/spotlightSearchKeyboard.ts
+++ b/src/scaffold/GlobalSpotlight/components/spotlightSearchKeyboard.ts
@@ -1,0 +1,67 @@
+/// <reference lib="es2022.intl" />
+import type { KeyboardEvent } from "react";
+
+/** Own horizontal navigation before palette handlers or WebKit text insertion. */
+export function handleSpotlightHorizontalArrow(
+  event: KeyboardEvent<HTMLInputElement>
+): boolean {
+  const left = event.key === "ArrowLeft" || event.key === "\uF702";
+  const right = event.key === "ArrowRight" || event.key === "\uF703";
+  if (!left && !right) return false;
+  // The IME owns candidate navigation during composition.
+  if (event.nativeEvent.isComposing) return true;
+  if (event.defaultPrevented) return true;
+
+  const input = event.currentTarget;
+  const start = input.selectionStart;
+  const end = input.selectionEnd;
+  if (start === null || end === null) return false;
+
+  // Prevent the native arrow function-key characters from becoming query text.
+  event.preventDefault();
+  event.stopPropagation();
+  const backward = input.selectionDirection === "backward";
+  const anchor = backward ? end : start;
+  const cursor = backward ? start : end;
+  let next: number;
+  if (event.metaKey) {
+    next = left ? 0 : input.value.length;
+  } else if (event.altKey || event.ctrlKey) {
+    const words = Array.from(
+      new Intl.Segmenter(undefined, { granularity: "word" }).segment(
+        input.value
+      )
+    ).filter((segment) => segment.isWordLike);
+    next = left
+      ? (words.filter((word) => word.index < cursor).at(-1)?.index ?? 0)
+      : (words
+          .map((word) => word.index + word.segment.length)
+          .find((boundary) => boundary > cursor) ?? input.value.length);
+  } else if (!event.shiftKey && start !== end) {
+    next = left ? start : end;
+  } else {
+    const boundaries = [
+      ...Array.from(
+        new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(
+          input.value
+        ),
+        (segment) => segment.index
+      ),
+      input.value.length,
+    ];
+    next = left
+      ? (boundaries.filter((boundary) => boundary < cursor).at(-1) ?? 0)
+      : (boundaries.find((boundary) => boundary > cursor) ??
+        input.value.length);
+  }
+  if (event.shiftKey) {
+    input.setSelectionRange(
+      Math.min(anchor, next),
+      Math.max(anchor, next),
+      next < anchor ? "backward" : "forward"
+    );
+  } else {
+    input.setSelectionRange(next, next);
+  }
+  return true;
+}

--- a/src/scaffold/GlobalSpotlight/hooks/selectors/useSelector.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/selectors/useSelector.ts
@@ -294,6 +294,7 @@ export function useSelector(options: UseSelectorOptions): UseSelectorReturn {
       ((item, _index) => isItemSelectable(item as unknown as SpotlightItem)),
     searchQuery: effectiveSearchQuery,
     enableGlobalListener: isOpen,
+    enableDisclosureArrowNavigation: false,
     inputRef,
     hasModalState,
   });


### PR DESCRIPTION
## Problem

Spotlight's shared list handler used Right Arrow to activate disclosure rows, so moving the search caret could enter a nested result. Reported box characters are consistent with macOS arrow function-key characters reaching text insertion; their native origin has not been reproduced directly.

## Solution

Reserve Left/Right at the Spotlight search input boundary for caret movement and selection, consuming both browser arrow names and macOS raw arrow characters before palette actions or native insertion. Preserve word jumps, whole-query jumps, Shift selection, grapheme boundaries, and IME ownership. Disable disclosure-arrow activation in Spotlight's input and global list paths while retaining Enter activation and the default behavior of other list consumers.

## Potential risks

Manual caret handling may differ from native WebKit behavior for bidirectional text or platform-specific modifier conventions; these paths and the original macOS tofu reproduction still need native validation. Intl.Segmenter must be available in the host webview. No dependency, persistence, schema, IPC, or wire changes are introduced. Existing query contents are not cleaned or migrated. Reverting this commit restores the previous behavior.

## Verification

- `pnpm test src/scaffold/GlobalSpotlight/components/spotlightSearchKeyboard.test.ts src/hooks/keyboard/__tests__/useListNavigation.test.ts src/hooks/keyboard/__tests__/useListNavigation.disclosure.test.ts` — 24 tests passed in the isolated branch. Coverage includes the rendered search input, native raw arrow characters, selection/modifiers/Unicode/IME, disabled global disclosure activation, Enter activation, and listener cleanup.
- `pnpm run typecheck:fast` — passed in the isolated branch.
- `git diff --cached --check` — passed before commit.
- Normal pre-commit hooks — oxlint, ESLint, Prettier, and TypeScript checks passed; hooks were not bypassed.
- Native Tauri interaction, recordings, and screenshots were not captured: desktop control was not authorized. A still screenshot would not demonstrate caret behavior; native keyboard validation remains unverified.
- Full test suite and Rust checks were not run; the change is confined to frontend keyboard behavior.

## Performance review

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Existing keydown listener | No new listener or timer; cleanup retained | Unmount cleanup regression test |
| Memory | keep | Temporary segmentation arrays | No retained collection or cache added | Source inspection |
| Scope/isolation | keep | Selector disables disclosure navigation | Other list consumers retain their default | Input/global path regression test |
| Rendering/hot path | keep | Segmentation only on horizontal keypress | No idle work added | Input regression tests; no runtime performance claim |

Performance verdict: pass for the inspected event lifecycle; native runtime measurements were not run.
