### PR TITLE
fix(memory-monitor): normalize non-atomic macOS peak samples

### DIFF
--- a/docs/org2-performance-guard-2026-09-12/MacosMemoryPeak.md
+++ b/docs/org2-performance-guard-2026-09-12/MacosMemoryPeak.md
@@ -1,0 +1,37 @@
+# macOS memory peak sampling
+
+## Failure and authoritative boundary
+
+The macOS workspace test failed because it assumed that two raw `proc_pid_rusage(RUSAGE_INFO_V4)` fields form an atomic snapshot. Apple's XNU [`gather_rusage_info`](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/kern/kern_resource.c#L3348) reads the lifetime peak in its V4 case before falling through to V0. That later calls [`fill_task_rusage`](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/osfmk/kern/bsd_kern.c#L1249), which reads the current footprint. Concurrent allocations can therefore make the second field exceed the earlier peak.
+
+A bounded native C probe reproduced this on macOS 26.2 / Apple M3 Pro: one thread touched a 64 MiB allocation while another made 100,000 V4 calls. In 1,236 samples the raw peak was below current, with a maximum gap of 16,408 bytes. The first pair was peak 950,584 / current 966,968. The process then joined its allocation thread and exited. This verifies the invalid test assumption independently of ORG2; the frequency is scheduling-dependent, not a benchmark.
+
+Production path: `get_app_memory_snapshot_v1` → existing blocking snapshot worker → `build_process` → macOS `collect_effective_memory` → `effective_memory_from_rusage`. That conversion now returns `max(reported_peak, current)` when the OS reported a nonzero peak. The current footprint is itself an observation of the process lifetime, so it belongs in a known lifetime maximum. A zero peak still produces `None`, preserving the unavailable contract. The raw `rusage_info_v4` stays unchanged.
+
+There are no persistence writes or historical records to clean. The IPC field and schema version stay unchanged. The existing UI describes this field as the lifetime peak, so the conversion restores that invariant without changing UI rendering or inventing a peak for unsupported metrics.
+
+## Performance and lifecycle review
+
+| Area               | Verdict | Evidence                                                 | Change or reason kept                                                                               | Verification                                                        |
+| ------------------ | ------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Background work    | keep    | Existing demand-driven snapshot worker owns all OS reads | No new read, retry, timer, task, or polling cadence                                                 | Production call-chain inspection                                    |
+| Memory             | fix     | Native peak/current counters are read at different times | One stateless maximum operation; no allocation, cache, or retained state                            | Deterministic reordered-counter fixture and live process conversion |
+| Scope/isolation    | keep    | Conversion consumes one process's existing sample        | Birth token and process attribution unchanged; no cross-process or cross-instance aggregation added | Fixture asserts birth token and current value unchanged             |
+| Rendering/hot path | keep    | UI receives existing schema-v2 fields                    | No component, subscription, streaming, or serialization-shape changes                               | Existing wire-contract tests                                        |
+
+Visible/hidden/focus, online/offline, identity and endpoint switches, session deletion, and primary/secondary lifecycle retain the existing sampler behavior: this change owns no lifecycle resource. Only macOS V4 conversion changes; Linux and Windows implementations are untouched. No CPU or RAM improvement is claimed, and a new full Tauri lifecycle benchmark would not measure the changed integer operation meaningfully.
+
+Architecture scope: compilation and production call-chain wiring, peak terminology, unavailable default, platform ownership, IPC compatibility, real-sample test parity, and field preservation were reviewed. Unrelated UI, agent/provider state machines, and session persistence were intentionally excluded from this focused fix.
+
+## Verification
+
+- Native C probe: reproduced the raw counter ordering violation and exited cleanly as described above.
+- Deterministic regression covers peak below/equal/above current and zero/unavailable, while checking the current metric, process identity, breakdown, and raw sample remain unchanged.
+- The existing live-process smoke test checks both positive native counters and the normalized production `AppMemoryProcess` invariant.
+- `cargo test --manifest-path src-tauri/Cargo.toml -p perf_utils --lib`: **65 passed, 1 ignored** (the existing opt-in live-PID probe). This includes the conversion regression, live process smoke test, region walk, ownership, aggregation, and wire-contract tests.
+- `cargo clippy --manifest-path src-tauri/Cargo.toml -p perf_utils --all-targets -- -D warnings`: **passed**. Both Cargo commands used an isolated target directory and `CARGO_BUILD_JOBS=2`.
+- `rustfmt --edition 2021 --check src-tauri/crates/perf-utils/src/app_memory/platform/macos.rs`: **passed**.
+- `git diff --check`: **passed**.
+- No frontend source changed, so TypeScript lint/typecheck and UI screenshots are not applicable. Full workspace tests are left to CI; Windows/Linux execution was not repeated because their platform implementations are unchanged.
+
+Performance verdict: pass for this bounded macOS conversion change. The production collector and live OS sample are covered; no runtime resource lifecycle changed and no performance improvement is claimed.

--- a/src-tauri/crates/perf-utils/src/app_memory/platform/macos.rs
+++ b/src-tauri/crates/perf-utils/src/app_memory/platform/macos.rs
@@ -120,15 +120,66 @@ pub(super) fn process_instance_key(descriptor: &ProcessDescriptor) -> ProcessIns
 
 pub(super) fn collect_effective_memory(descriptor: &ProcessDescriptor) -> EffectiveProcessMemory {
     if let Some(usage) = macos_rusage(descriptor.pid) {
-        EffectiveProcessMemory {
-            bytes: usage.ri_phys_footprint,
-            kind: MemoryMetricKind::PhysicalFootprint,
-            birth_token: usage.ri_proc_start_abstime,
-            breakdown: macos_region_breakdown(descriptor.pid),
-            peak_bytes: (usage.ri_lifetime_max_phys_footprint > 0)
-                .then_some(usage.ri_lifetime_max_phys_footprint),
-        }
+        effective_memory_from_rusage(&usage, macos_region_breakdown(descriptor.pid))
     } else {
         EffectiveProcessMemory::rss_fallback(descriptor, descriptor.start_time_secs)
+    }
+}
+
+fn effective_memory_from_rusage(
+    usage: &libc::rusage_info_v4,
+    breakdown: MemoryBreakdown,
+) -> EffectiveProcessMemory {
+    // XNU gather_rusage_info reads the lifetime peak before the current
+    // footprint. A process can grow between those reads, so the raw fields
+    // are not an atomic snapshot. A known lifetime peak must include the
+    // current observation; zero still means the OS peak is unavailable.
+    let peak_bytes = (usage.ri_lifetime_max_phys_footprint > 0).then_some(
+        usage
+            .ri_lifetime_max_phys_footprint
+            .max(usage.ri_phys_footprint),
+    );
+    EffectiveProcessMemory {
+        bytes: usage.ri_phys_footprint,
+        kind: MemoryMetricKind::PhysicalFootprint,
+        birth_token: usage.ri_proc_start_abstime,
+        breakdown,
+        peak_bytes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rusage_conversion_handles_non_atomic_peak_samples() {
+        for (current, reported_peak, expected_peak) in [
+            (200, 100, Some(200)),
+            (100, 200, Some(200)),
+            (100, 100, Some(100)),
+            (100, 0, None),
+        ] {
+            let mut usage =
+                unsafe { std::mem::MaybeUninit::<libc::rusage_info_v4>::zeroed().assume_init() };
+            usage.ri_phys_footprint = current;
+            usage.ri_lifetime_max_phys_footprint = reported_peak;
+            usage.ri_proc_start_abstime = 42;
+            let breakdown = MemoryBreakdown {
+                resident_private_bytes: 10,
+                resident_shared_bytes: 20,
+                swapped_bytes: 30,
+                kind: MemoryBreakdownKind::VmRegionWalk,
+            };
+
+            let effective = effective_memory_from_rusage(&usage, breakdown);
+
+            assert_eq!(effective.peak_bytes, expected_peak);
+            assert_eq!(effective.bytes, current);
+            assert_eq!(effective.birth_token, 42);
+            assert_eq!(effective.kind, MemoryMetricKind::PhysicalFootprint);
+            assert_eq!(effective.breakdown, breakdown);
+            assert_eq!(usage.ri_lifetime_max_phys_footprint, reported_peak);
+        }
     }
 }

--- a/src-tauri/crates/perf-utils/src/app_memory/tests.rs
+++ b/src-tauri/crates/perf-utils/src/app_memory/tests.rs
@@ -264,7 +264,28 @@ fn macos_current_process_has_physical_footprint() {
     let usage = macos_rusage(std::process::id()).expect("current process rusage");
     assert!(usage.ri_phys_footprint > 0);
     assert!(usage.ri_proc_start_abstime > 0);
-    assert!(usage.ri_lifetime_max_phys_footprint >= usage.ri_phys_footprint);
+    assert!(usage.ri_lifetime_max_phys_footprint > 0);
+
+    // Peak/current ordering is guaranteed by our conversion boundary,
+    // not by the kernel's separate reads of the live process counters.
+    let descriptor = ProcessDescriptor {
+        pid: std::process::id(),
+        parent_pid: None,
+        start_time_secs: 0,
+        name: "memory-test".to_string(),
+        executable: None,
+        rss_bytes: 0,
+        belongs_to_current_user: true,
+    };
+    let process = platform::build_process(&descriptor, AppMemoryProcessRole::Backend);
+    assert_eq!(process.metric_kind, MemoryMetricKind::PhysicalFootprint);
+    assert!(process.effective_memory_bytes > 0);
+    assert!(
+        process
+            .peak_effective_memory_bytes
+            .expect("current process lifetime peak")
+            >= process.effective_memory_bytes
+    );
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Problem

The macOS workspace test intermittently fails on `ri_lifetime_max_phys_footprint >= ri_phys_footprint`, including [PR #1631's CI run](https://github.com/org2AI/ORG2/actions/runs/34675744826/job/103505214484). The same raw values also reach the memory monitor, so it can display a lifetime peak below the current footprint.

This ordering is not guaranteed by `proc_pid_rusage(RUSAGE_INFO_V4)`: Apple's XNU [reads the peak first](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/kern/kern_resource.c#L3348), then later [reads current footprint](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/osfmk/kern/bsd_kern.c#L1249). Concurrent allocation can increase memory between those reads. A native C probe reproduced 1,236 such samples out of 100,000 on macOS 26.2, with one thread touching a bounded 64 MiB buffer. This is a sampling race, not a reason to retry CI until it passes.

## Solution

Normalize at the macOS measurement conversion boundary: an available lifetime peak includes the current observation, using `max(reported_peak, current)`. A zero OS peak still maps to `None`; the raw native sample, current footprint, birth token, and memory breakdown remain unchanged.

Add deterministic coverage for peak below/equal/above current and unavailable peak. The live-process test now checks the production `AppMemoryProcess` invariant instead of requiring an atomic relationship between raw kernel fields. The accompanying report records the authoritative source, reproduction, and bounded resource review.

## Potential risks

During a growth race the normalized peak can exceed the earlier raw peak by the newly observed allocation; this is consistent with the existing lifetime-peak meaning. The change adds one stateless integer comparison and no retry, syscall, timer, cache, or lifecycle owner. Windows/Linux collectors are unchanged and were not re-executed locally. No database, configuration, dependency, IPC field, or schema changes are involved; rollback is a normal revert with no data recovery step.

The macOS full-workspace CI has passed; Windows/Linux runtime execution remains unverified by this PR. Screenshots add no useful evidence for this numerical ingestion invariant; deterministic conversion and real-process checks cover the source of the displayed value.

## Verification

Commands ran with an isolated Cargo target and `CARGO_BUILD_JOBS=2`:

- `cargo test --manifest-path src-tauri/Cargo.toml -p perf_utils --lib` — **65 passed, 1 existing ignored opt-in live-PID probe**. Includes conversion, live process, VM regions, process ownership, aggregation, and wire contracts.
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p perf_utils --all-targets -- -D warnings` — **passed**.
- `rustfmt --edition 2021 --check src-tauri/crates/perf-utils/src/app_memory/platform/macos.rs` — **passed**.
- `git diff --check` — **passed**.
- Normal pre-commit hooks — **passed**, including scoped `perf_utils` Clippy and documentation formatting.
- Independent native C probe using `proc_pid_rusage(V4)` during concurrent page touches — reproduced raw peak/current inversion; process joined its worker and exited normally. Largest observed gap: **16,408 bytes**. The frequency is scheduling-dependent, not a benchmark.

[GitHub CI run 34679784998](https://github.com/org2AI/ORG2/actions/runs/34679784998) on `8efd0514f4a38caf0fe59ea7b3cb393670aad932` completed with **SUCCESS**. The [completed Rust job log](https://github.com/org2AI/ORG2/actions/runs/34679784998/job/103516181892) explicitly records both `macos_current_process_has_physical_footprint ... ok` and `rusage_conversion_handles_non_atomic_peak_samples ... ok`; `perf_utils` reports **65 passed, 0 failed, 1 existing ignored**. Both strict all-targets Clippy and full-workspace tests passed. The frontend CI job also passed.

No frontend source changed; TypeScript lint/typecheck and rendered UI testing are not applicable. Local full-workspace tests were not rerun; the remote full-workspace run above completed successfully. Performance verdict: **pass for this bounded conversion change**, with no CPU/RAM improvement claimed.
