### PR TITLE
feat(selection-grid): add optional vertical rows and radios

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/SelectionGrid.md
+++ b/docs/frontend-ui-audit-2026-09-13/SelectionGrid.md
@@ -1,0 +1,16 @@
+# SelectionGrid UI audit
+
+| Line                                                                 | Element                     | Verdict          | Reason                                                                                                                                                                                                                                    | Suggested change |
+| -------------------------------------------------------------------- | --------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/scaffold/WizardSystem/primitives/SelectionGrid.tsx:212`         | Shared selection indicators | keep with reason | Leading radios are opt-in through showRadio and reuse ActionCard. Default grids retain their existing trailing checks and surface tokens                                                                                                  | None             |
+| `src/scaffold/WizardSystem/variants/Channel/ChannelSections.tsx:582` | Detected credential choices | keep with reason | Uses SelectionGrid with vertical and showRadio as a one-column description list instead of an independent button style. Uses candidate indices for DOM identifiers rather than credential contents. Duplicate-name disabling stays intact | None             |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+Only the lower detected-credential rows opt into leading radios. Top auth-method and provider grids keep their previous appearance. No new competing component or global token change was needed. ActionCard retains native button focus, Enter/Space activation and pressed-state semantics; its leading radio is a visual indicator. Credential selection now follows single-choice behavior: clicking the selected option keeps it selected.
+
+Architecture review covers component ownership, single/multiple selection defaults and consumer callback mapping. Persistence, backend wire types, async lifecycle and initialization are unchanged. No new timer, subscription or retained cache is introduced.
+
+Verification: `pnpm test src/scaffold/WizardSystem/primitives/__tests__/SelectionGrid.test.ts src/components/ActionCard/ActionCard.test.ts` — 10 tests passed. `pnpm typecheck:fast` passed. `pnpm exec eslint src/scaffold/WizardSystem/primitives/SelectionGrid.tsx src/scaffold/WizardSystem/primitives/__tests__/SelectionGrid.test.ts src/scaffold/WizardSystem/variants/Channel/ChannelSections.tsx --max-warnings 0` passed. No live desktop visual verification: computer control was not requested.
+
+The independent `vertical` prop overrides column sizing with one shrinkable full-width column and defaults to content-height rows, including options without descriptions. `showRadio` remains independently optional; the default grid appearance is unchanged. Tests cover vertical layout precedence, optional radios and unchanged default pill sizing.

--- a/src/scaffold/WizardSystem/primitives/SelectionGrid.tsx
+++ b/src/scaffold/WizardSystem/primitives/SelectionGrid.tsx
@@ -79,6 +79,8 @@ interface SharedGridProps<T extends string = string> {
   columnMinWidth?: number;
   /** Fixed number of columns — each option fills equal width. */
   columns?: number;
+  /** Stack full-width, content-height rows; overrides column sizing. */
+  vertical?: boolean;
   /** Compact mode — shows inline label + "Switch method" button instead of grid. */
   compact?: boolean;
   /** Label shown in compact mode (defaults to selected option label). */
@@ -89,8 +91,10 @@ interface SharedGridProps<T extends string = string> {
   cardLayout?: ActionCardLayout;
   /** Optional class name applied to every card. */
   cardClassName?: string;
-  /** When using showSelect on cards, show the trailing checkmark (default true). */
+  /** Show the trailing selection checkmark (default true). */
   showSelectionCheck?: boolean;
+  /** Use a leading radio for single-choice description rows. */
+  showRadio?: boolean;
   /** Use 36px inline pills; defaults on for grids without descriptions. */
   compactCards?: boolean;
   /** Optional class name for the grid wrapper. */
@@ -138,13 +142,15 @@ function SelectionGrid<T extends string = string>(
     selected,
     columnMinWidth = 180,
     columns,
+    vertical = false,
     compact = false,
     compactLabel,
     cardVariant = "default",
     cardLayout = "inline",
     cardClassName = "",
     showSelectionCheck = true,
-    compactCards = !options.some((option) => option.description),
+    showRadio = false,
+    compactCards = !vertical && !options.some((option) => option.description),
     className = "",
   } = props;
 
@@ -175,8 +181,9 @@ function SelectionGrid<T extends string = string>(
     );
   }
 
-  const gridStyle =
-    columns != null
+  const gridStyle = vertical
+    ? { gridTemplateColumns: "minmax(0, 1fr)" }
+    : columns != null
       ? { gridTemplateColumns: `repeat(${columns}, 1fr)` }
       : {
           gridTemplateColumns: `repeat(auto-fill, minmax(${columnMinWidth}px, 1fr))`,
@@ -210,6 +217,7 @@ function SelectionGrid<T extends string = string>(
             iconPreserveColor={option.iconPreserveColor}
             showSelect
             showSelectionCheck={showSelectionCheck}
+            showRadio={!isMulti && showRadio}
             selected={isSelected}
             disabled={option.disabled}
             variant={cardVariant}

--- a/src/scaffold/WizardSystem/primitives/__tests__/SelectionGrid.test.ts
+++ b/src/scaffold/WizardSystem/primitives/__tests__/SelectionGrid.test.ts
@@ -5,6 +5,57 @@ import { describe, expect, it } from "vitest";
 import SelectionGrid from "../SelectionGrid";
 
 describe("SelectionGrid pill sizing", () => {
+  it("uses leading radio indicators and shared surfaces for description choices", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SelectionGrid, {
+        options: [
+          { key: "cli", label: "CLI", description: "Account" },
+          { key: "ssh", label: "SSH" },
+        ],
+        selected: "cli",
+        onSelect: () => undefined,
+        vertical: true,
+        columns: 3,
+        showRadio: true,
+      })
+    );
+    expect(
+      html.match(/shrink-0 items-center justify-center rounded-full border/g)
+    ).toHaveLength(2);
+    expect(html.match(/h-2 w-2 rounded-full bg-primary-6/g)).toHaveLength(1);
+    expect(html).toContain("border-primary-6 bg-bg-2");
+    expect(html).toContain("border-border-2 bg-bg-2");
+    expect(html).not.toContain("bg-primary-1");
+    expect(html).toContain("grid-template-columns:minmax(0, 1fr)");
+  });
+
+  it("supports vertical rows without radios or descriptions", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SelectionGrid, {
+        options: [{ key: "a", label: "A" }],
+        selected: "a",
+        onSelect: () => undefined,
+        vertical: true,
+      })
+    );
+    expect(html).toContain("grid-template-columns:minmax(0, 1fr)");
+    expect(html).not.toContain("h-9 px-2 py-0");
+    expect(html).not.toContain("h-2 w-2 rounded-full bg-primary-6");
+  });
+
+  it("honors hidden indicators for specialized consumers", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SelectionGrid, {
+        options: [{ key: "cli", label: "CLI" }],
+        selected: "cli",
+        onSelect: () => undefined,
+        showSelectionCheck: false,
+      })
+    );
+    expect(html).not.toContain("h-2 w-2 rounded-full bg-primary-6");
+    expect(html).toContain('aria-pressed="true"');
+  });
+
   it("defaults selected and unselected pills to 36px across card variants", () => {
     for (const cardVariant of [
       "default",
@@ -26,6 +77,7 @@ describe("SelectionGrid pill sizing", () => {
       expect(html.match(/h-9 px-2 py-0/g)).toHaveLength(2);
       expect(html).toContain('aria-pressed="true"');
       expect(html).toContain('aria-pressed="false"');
+      expect(html).not.toContain("h-2 w-2 rounded-full bg-primary-6");
     }
   });
 

--- a/src/scaffold/WizardSystem/variants/Channel/ChannelSections.tsx
+++ b/src/scaffold/WizardSystem/variants/Channel/ChannelSections.tsx
@@ -579,35 +579,28 @@ const GitScanPanel: React.FC<GitScanPanelProps> = ({
         layout="vertical"
         required
       >
-        <div className="flex flex-col gap-1.5">
-          {candidates.map((candidate) => {
-            const isSelected =
-              !!selected &&
-              selected.kind === candidate.kind &&
-              selected.secret === candidate.secret;
-            return (
-              <button
-                key={`${candidate.kind}:${candidate.secret}`}
-                type="button"
-                onClick={() => onSelect(isSelected ? null : candidate)}
-                disabled={isDuplicateName}
-                className={`flex items-center justify-between rounded-md border px-3 py-2 text-left text-[12px] transition-colors ${
-                  isSelected
-                    ? "border-primary-6 bg-primary-1 text-text-1"
-                    : "border-border-2 text-text-2 hover:border-border-3"
-                } disabled:cursor-not-allowed disabled:opacity-50`}
-              >
-                <span className="flex flex-col">
-                  <span className="font-medium">{candidate.label}</span>
-                  {candidate.username && (
-                    <span className="text-text-3">{candidate.username}</span>
-                  )}
-                </span>
-                {isSelected && <span className="text-primary-6">✓</span>}
-              </button>
-            );
-          })}
-        </div>
+        <SelectionGrid
+          vertical
+          showRadio
+          options={candidates.map((candidate, index) => ({
+            key: String(index),
+            label: candidate.label,
+            description: candidate.username,
+            disabled: isDuplicateName,
+          }))}
+          selected={
+            selected
+              ? String(
+                  candidates.findIndex(
+                    (candidate) =>
+                      candidate.kind === selected.kind &&
+                      candidate.secret === selected.secret
+                  )
+                )
+              : null
+          }
+          onSelect={(key) => onSelect(candidates[Number(key)])}
+        />
       </SectionRow>
     </SectionContainer>
   );


### PR DESCRIPTION
## Problem

Detected credential rows rebuild a selectable-card style with a blue fill and trailing check, diverging from the settings selection pills. The shared grid cannot explicitly request vertical rows with optional leading radios.

## Solution

Add independent optional `vertical` and `showRadio` props to SelectionGrid. Vertical mode uses a full-width column and defaults to content-height cards. Adopt both props only for detected credential rows, reusing ActionCard idle/selected styles. Top provider/auth-method grids retain their existing appearance.

## Potential risks

Clicking an already selected credential keeps it selected, consistent with a single-choice control. Radios remain visual indicators on accessible pressed-state buttons, not native radio inputs. Existing callers retain default behavior; no persistence, dependencies, network lifecycle or wire formats change.

Live visual verification across themes and narrow viewports was not performed because desktop computer control is explicitly opt-in. No new screenshots are attached; this limitation remains for review.

## Verification

- `pnpm test src/scaffold/WizardSystem/primitives/__tests__/SelectionGrid.test.ts src/components/ActionCard/ActionCard.test.ts` — 10 tests passed in the isolated PR worktree
- `pnpm typecheck:fast` — passed
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed; hook typecheck and commitlint passed
- `git diff --cached --check` — passed before commit
- Scoped diff reviewed for unrelated changes, secrets, private paths and generated artifacts
- Live desktop interaction and visual verification not run, as described above

## Audit

UI audit included: 0 fixes, 2 keeps with reasons, 0 abstractions. No new background work or retained cache.
