### PR TITLE
fix(connections): restore add and refresh header actions

### DIFF
--- a/src/modules/MainApp/Integrations/Connections/Table/ConnectionsTable.tsx
+++ b/src/modules/MainApp/Integrations/Connections/Table/ConnectionsTable.tsx
@@ -7,6 +7,7 @@ import {
 } from "@src/api/http/integrations";
 import Button from "@src/components/Button";
 import IntegrationIcon from "@src/components/IntegrationIcon";
+import Message from "@src/components/Message";
 import { Placeholder } from "@src/components/Placeholder";
 import SettingsTable, {
   SETTINGS_TABLE_CELL,
@@ -14,7 +15,12 @@ import SettingsTable, {
   type SettingsTableColumn,
 } from "@src/components/SettingsTable";
 import TabPill from "@src/components/TabPill";
-import { Delete02Icon, HugeiconsIcon } from "@src/icons";
+import {
+  Add01Icon,
+  Delete02Icon,
+  HugeiconsIcon,
+  Refresh04Icon,
+} from "@src/icons";
 import {
   DETAIL_PANEL_TOKENS,
   DetailPanelContainer,
@@ -87,6 +93,7 @@ interface ConnectionsTableProps {
   selectedRowId?: string | null;
   onSelectChannel: (compositeId: string | null, mode?: DetailMode) => void;
   onAdd: () => void;
+  onRefresh: () => Promise<void>;
   onRemoveChannel?: (channelType: string, accountId: string) => Promise<void>;
   onRemoveProjectConnection?: (
     connectionId: string,
@@ -101,6 +108,7 @@ export const ConnectionsTable: React.FC<ConnectionsTableProps> = ({
   selectedRowId,
   onSelectChannel,
   onAdd,
+  onRefresh,
   onRemoveChannel,
   onRemoveProjectConnection,
 }) => {
@@ -325,6 +333,52 @@ export const ConnectionsTable: React.FC<ConnectionsTableProps> = ({
                   searchValue: searchQuery,
                   onSearchChange: setSearchQuery,
                   searchPlaceholder: t("integrations.searchPlaceholder"),
+                  rightContent: (
+                    <>
+                      <Button
+                        variant="secondary"
+                        size="default"
+                        icon={
+                          <HugeiconsIcon
+                            icon={Refresh04Icon}
+                            data-icon="refresh-cw"
+                            size={14}
+                            className={loading ? "animate-spin" : undefined}
+                          />
+                        }
+                        iconOnly
+                        disabled={loading}
+                        onClick={() => {
+                          void onRefresh().catch((error: unknown) => {
+                            Message.error(
+                              error instanceof Error
+                                ? error.message
+                                : String(error)
+                            );
+                          });
+                        }}
+                        aria-label={tCommon("actions.refresh")}
+                        title={tCommon("actions.refresh")}
+                        data-testid="connections-refresh-button"
+                      />
+                      <Button
+                        variant="secondary"
+                        size="default"
+                        icon={
+                          <HugeiconsIcon
+                            icon={Add01Icon}
+                            data-icon="plus"
+                            size={14}
+                          />
+                        }
+                        iconOnly
+                        onClick={onAdd}
+                        aria-label={t("integrations.addAccount")}
+                        title={t("integrations.addAccount")}
+                        data-testid="connections-add-button"
+                      />
+                    </>
+                  ),
                 }}
                 emptyTitle={t("integrations.noConnections")}
                 emptyAction={{

--- a/src/modules/MainApp/Integrations/Connections/categoryTableProps.ts
+++ b/src/modules/MainApp/Integrations/Connections/categoryTableProps.ts
@@ -21,6 +21,7 @@ export function getConnectionsCategoryTableProps(params: {
       !params.channels.loaded || params.channels.projectConnectionsLoading,
     onSelectChannel: params.onSelectChannel,
     onAdd: () => params.onAddAction("add-connection"),
+    onRefresh: params.channels.refreshProjectConnections,
     onRemoveChannel: params.channels.handleRemoveChannelRow,
     onRemoveProjectConnection: params.channels.handleRemoveProjectConnection,
   };

--- a/src/modules/MainApp/Integrations/categoryTableRouting.test.ts
+++ b/src/modules/MainApp/Integrations/categoryTableRouting.test.ts
@@ -247,6 +247,7 @@ describe("integration category table contracts", () => {
         selectedChannel: { type: "telegram", accountId: "bot" },
         handleRemoveChannelRow: vi.fn(),
         handleRemoveProjectConnection: vi.fn(),
+        refreshProjectConnections: vi.fn().mockResolvedValue(undefined),
       });
       const onAddAction = vi.fn();
       const onSelectChannel = vi.fn();
@@ -273,6 +274,8 @@ describe("integration category table contracts", () => {
       );
       table.onSelectChannel("telegram:bot", "full");
       expect(onSelectChannel).toHaveBeenCalledWith("telegram:bot", "full");
+      await table.onRefresh();
+      expect(channels.refreshProjectConnections).toHaveBeenCalledOnce();
       table.onAdd();
       expect(onAddAction).toHaveBeenCalledWith("add-connection");
     }


### PR DESCRIPTION
## Problem

The Connections table only exposes Add through its empty state, so a populated table has no Add control. Its existing refresh operation is not passed into the table header.

## Solution

Add localized icon-only Refresh and Add buttons beside table search, using the same button treatment as the Keys table. Wire Add to the existing connection wizard and Refresh to the existing project-connection reload. Disable refresh while loading and report failures through Message.

## Potential risks

Refresh reloads GitHub/Linear project connections through the existing API; it does not add a separate channel-configuration or gateway-status reload. The action introduces no polling, subscriptions or persistence changes. Existing loading state controls the icon animation and button disabling.

Live desktop verification and new screenshots across themes, viewports and error states are unavailable because computer control is explicitly opt-in. The regression suite verifies callback routing; it does not exercise real account APIs or rendered header clicks.

## Verification

- `pnpm test src/modules/MainApp/Integrations/categoryTableRouting.test.ts` — 17 tests passed in the isolated PR worktree, including Add and Refresh callback routing
- `pnpm typecheck:fast` — passed
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed; hook typecheck and commitlint passed
- `git diff --cached --check` — passed before commit
- Scoped diff reviewed for unrelated changes, secrets, private paths and generated artifacts
- No Rust, dependency, schema, RPC or wire changes; live visual/account-API verification was not run
