### PR TITLE
fix(connections): simplify and order the provider picker

### DIFF
--- a/src/scaffold/WizardSystem/variants/Channel/IntegrationSelection.tsx
+++ b/src/scaffold/WizardSystem/variants/Channel/IntegrationSelection.tsx
@@ -5,7 +5,6 @@ import Input from "@src/components/Input";
 import IntegrationIcon from "@src/components/IntegrationIcon";
 import Select from "@src/components/Select";
 import type { SelectOption } from "@src/components/Select";
-import { HugeiconsIcon, Search01Icon } from "@src/icons";
 import {
   COMING_SOON_CHANNEL_TYPES,
   LIVE_CHANNEL_TYPES,
@@ -102,8 +101,8 @@ const IntegrationSelection: React.FC<IntegrationSelectionProps> = ({
   projectContent,
   gitContent,
 }) => {
-  const { t } = useTranslation("integrations");
-  const [connectionSearch, setConnectionSearch] = useState("");
+  const { t, i18n } = useTranslation("integrations");
+  const language = i18n.resolvedLanguage;
   const typeGroups: TypeOptionGroup[] = useMemo(() => {
     const channelOptions = LIVE_CHANNEL_TYPES.map((channel) => ({
       key: channel.type,
@@ -118,6 +117,10 @@ const IntegrationSelection: React.FC<IntegrationSelectionProps> = ({
         disabled: true,
       })
     );
+    const compareLabels = (a: SelectionGridOption, b: SelectionGridOption) =>
+      a.label.localeCompare(b.label, language, { sensitivity: "base" });
+    channelOptions.sort(compareLabels);
+    comingSoonChannelOptions.sort(compareLabels);
     const projectOptions = PROJECT_ADAPTER_TYPES.map((adapter) => ({
       key: adapter.type,
       label: t(
@@ -150,7 +153,7 @@ const IntegrationSelection: React.FC<IntegrationSelectionProps> = ({
         selectable: false,
       },
     ];
-  }, [t]);
+  }, [t, language]);
 
   const flatSelectOptions = useMemo(
     () => typeGroups.flatMap((group) => group.selectOptions),
@@ -167,23 +170,6 @@ const IntegrationSelection: React.FC<IntegrationSelectionProps> = ({
     }
     return lookup;
   }, [typeGroups]);
-
-  const filteredTypeGroups = useMemo(() => {
-    const query = connectionSearch.trim().toLowerCase();
-    if (!query) return typeGroups;
-    return typeGroups
-      .map((group) => {
-        const options = group.options.filter((option) =>
-          option.label.toLowerCase().includes(query)
-        );
-        return {
-          ...group,
-          options,
-          selectOptions: group.selectable ? toSelectOptions(options) : [],
-        };
-      })
-      .filter((group) => group.options.length > 0);
-  }, [connectionSearch, typeGroups]);
 
   const [accountNameTouched, setAccountNameTouched] = useState(false);
 
@@ -270,24 +256,8 @@ const IntegrationSelection: React.FC<IntegrationSelectionProps> = ({
               />
             ) : (
               <div className="flex flex-col gap-3">
-                <Input
-                  value={connectionSearch}
-                  onChange={setConnectionSearch}
-                  placeholder={t("integrations.searchPlaceholder")}
-                  autoComplete="off"
-                  autoCorrect="off"
-                  spellCheck={false}
-                  prefix={
-                    <HugeiconsIcon
-                      icon={Search01Icon}
-                      data-icon="search"
-                      size={14}
-                    />
-                  }
-                  style={{ width: "100%" }}
-                />
                 <div className="flex flex-col gap-3">
-                  {filteredTypeGroups.map((group) => (
+                  {typeGroups.map((group) => (
                     <div
                       key={`${group.category}:${group.label}`}
                       className="flex flex-col gap-2"

--- a/src/scaffold/WizardSystem/variants/Channel/IntegrationSelection.tsx
+++ b/src/scaffold/WizardSystem/variants/Channel/IntegrationSelection.tsx
@@ -129,6 +129,13 @@ const IntegrationSelection: React.FC<IntegrationSelectionProps> = ({
 
     return [
       {
+        category: "projects",
+        label: `${t("categories.git")} & ${t("categories.projects")}`,
+        options: projectOptions,
+        selectOptions: toSelectOptions(projectOptions),
+        selectable: true,
+      },
+      {
         category: "channels",
         label: t("categories.channels"),
         options: channelOptions,
@@ -141,13 +148,6 @@ const IntegrationSelection: React.FC<IntegrationSelectionProps> = ({
         options: comingSoonChannelOptions,
         selectOptions: [],
         selectable: false,
-      },
-      {
-        category: "projects",
-        label: `${t("categories.git")} & ${t("categories.projects")}`,
-        options: projectOptions,
-        selectOptions: toSelectOptions(projectOptions),
-        selectable: true,
       },
     ];
   }, [t]);


### PR DESCRIPTION
## Problem

The connection picker places Git & Projects below both channel groups, uses an unnecessary search field for the visible tiles, and lists Agent Channels without alphabetical ordering.

## Solution

Place Git & Projects first, then live Agent Channels, then coming-soon Agent Channels. Remove the tile-picker search field and its filtering state. Sort each Agent Channels group by its localized display label using the active language. The selected-provider dropdown inherits the ordering and retains its existing search.

## Potential risks

The tile picker always shows every group. Channel order may differ by language because it uses localized labels. Provider selection, disabled states and authentication behavior remain unchanged. No persistence, dependency, API or lifecycle changes. Live visual verification and updated screenshots were not captured because desktop computer control is explicitly opt-in.

## Verification

- `git diff --check` — passed
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed
- Commit hook `npx tsgo --noEmit --pretty false` and commitlint — passed
- Reviewed the one-file diff: projects stay first, channel groups sort independently, and only tile search is removed; no unrelated code, secrets or generated artifacts
- No new tests added for this small presentation change; live UI verification not run
