### PR TITLE
fix(navigation): preserve station layout when starting work

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/preserve-creation-layout.md
+++ b/docs/frontend-ui-audit-2026-09-13/preserve-creation-layout.md
@@ -1,0 +1,9 @@
+# preserve-creation-layout UI audit
+
+| Line                                                                                  | Element          | Verdict          | Reason                                                         | Suggested change |
+| ------------------------------------------------------------------------------------- | ---------------- | ---------------- | -------------------------------------------------------------- | ---------------- |
+| `src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx:376` | Creation routing | keep with reason | Removes obsolete reset callback plumbing; no new visual tokens | None             |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.
+
+Source inspection only; no desktop screenshots or live visual verification because computer control is explicitly opt-in.

--- a/src/hooks/navigation/useAppNavigation.test.ts
+++ b/src/hooks/navigation/useAppNavigation.test.ts
@@ -1,0 +1,80 @@
+import { Provider } from "jotai";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ROUTES } from "@src/config/routes";
+import {
+  activeSessionIdAtom,
+  workstationActiveSessionIdAtom,
+} from "@src/store/session";
+import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanel/surfaceAtoms";
+import { stationModeAtom } from "@src/store/ui/simulatorAtom";
+import { enterWorkstationRouteAtom } from "@src/store/workstation/routeEntryAtom";
+import { workstationLayoutAtom } from "@src/store/workstation/tabs";
+import { createInstrumentedStore } from "@src/util/core/state/instrumentedStore";
+
+import { useAppNavigation } from "./useAppNavigation";
+
+const mocks = vi.hoisted(() => ({ navigate: vi.fn() }));
+
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useNavigate: () => mocks.navigate,
+}));
+
+describe("new session navigation", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.navigate.mockReset();
+  });
+
+  it.each([
+    { mode: "my-station" as const, maximized: true },
+    { mode: "my-station" as const, maximized: false },
+    { mode: "agent-station" as const, maximized: true },
+    { mode: "agent-station" as const, maximized: false },
+  ])(
+    "preserves $mode layout with maximized=$maximized",
+    ({ mode, maximized }) => {
+      const store = createInstrumentedStore();
+      store.set(stationModeAtom, mode);
+      store.set(chatPanelMaximizedAtom, maximized);
+      store.set(activeSessionIdAtom, "previous-session");
+      store.set(workstationActiveSessionIdAtom, "previous-session");
+      const layout = store.get(workstationLayoutAtom);
+      // Exercise the actual route-entry writer, which previously reopened My Station.
+      mocks.navigate.mockImplementation((path: string) => {
+        store.set(enterWorkstationRouteAtom, path.split("?")[0]);
+      });
+
+      let navigation: ReturnType<typeof useAppNavigation> | undefined;
+      function HookProbe(): null {
+        // eslint-disable-next-line react-hooks/globals -- synchronous server-rendered hook probe
+        navigation = useAppNavigation();
+        return null;
+      }
+      renderToString(
+        React.createElement(Provider, { store }, React.createElement(HookProbe))
+      );
+      expect(navigation).toBeDefined();
+
+      for (const options of [
+        undefined,
+        { projectId: "project-1", workflowId: "workflow-1" },
+      ]) {
+        navigation!.goToNewSession(options);
+        expect(mocks.navigate).toHaveBeenLastCalledWith(
+          options
+            ? `${ROUTES.workStation.base.path}?projectId=project-1&workflowId=workflow-1`
+            : ROUTES.workStation.base.path
+        );
+        expect(store.get(chatPanelMaximizedAtom)).toBe(maximized);
+        expect(store.get(stationModeAtom)).toBe(mode);
+        expect(store.get(workstationLayoutAtom)).toEqual(layout);
+        expect(store.get(activeSessionIdAtom)).toBeNull();
+        expect(store.get(workstationActiveSessionIdAtom)).toBeNull();
+      }
+    }
+  );
+});

--- a/src/hooks/navigation/useAppNavigation.ts
+++ b/src/hooks/navigation/useAppNavigation.ts
@@ -190,9 +190,11 @@ export function useAppNavigation(): UseAppNavigationReturn {
         params.set("workflowId", options.workflowId);
       }
       const query = params.toString();
+      // Host-specific routes reopen My Station on entry. Session creation must
+      // preserve the current station and the user's chat-only/split layout.
       const path = query
-        ? `${ROUTES.workStation.code.path}?${query}`
-        : ROUTES.workStation.code.path;
+        ? `${ROUTES.workStation.base.path}?${query}`
+        : ROUTES.workStation.base.path;
       navigate(path);
     },
     [

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -375,21 +375,18 @@ export const WorkstationSidebarConnector: React.FC = () => {
     tSessions,
   });
 
-  const {
-    resetWorkManagementStateForProjectsContent,
-    activateMyStationRouteForProjectTabContent,
-    handleGoToNewSession,
-  } = useSidebarStationNavigation({
-    setStationMode,
-    setStationChatVisible,
-    openStartPageTab,
-    resetChatPanelSessionSurface,
-    setChatPanelCreateTarget,
-    goToNewSession,
-    location,
-    navigate,
-    t,
-  });
+  const { activateMyStationRouteForProjectTabContent, handleGoToNewSession } =
+    useSidebarStationNavigation({
+      setStationMode,
+      setStationChatVisible,
+      openStartPageTab,
+      resetChatPanelSessionSurface,
+      setChatPanelCreateTarget,
+      goToNewSession,
+      location,
+      navigate,
+      t,
+    });
 
   const {
     handleDeleteSession,
@@ -475,7 +472,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
     enabled: workItemsContentVisible,
     activeProjectOrgId,
     activateMyStationRouteForProjectTabContent,
-    resetWorkManagementStateForProjectsContent,
     handleOpenLinkedWorkItemSession,
   });
   const { selectedMenuItemId, handleSessionCollapsedSectionIdsChange } =

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useProjectsMenuItemClick.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useProjectsMenuItemClick.test.ts
@@ -1,35 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { PROJECTS_NEW_WORK_ITEM_MENU_ITEM_ID } from "../sidebarConnectorUtils";
-import {
-  openNewWorkItemFromSidebar,
-  tryOpenLinkedSessionFromSidebar,
-} from "./useProjectsMenuItemClick";
-
-describe("openNewWorkItemFromSidebar", () => {
-  it("opens the shared work-item creator from a sidebar action", () => {
-    const calls: string[] = [];
-    const resetWorkManagementStateForProjectsContent = vi.fn(() =>
-      calls.push("reset")
-    );
-    const setProjectsSelectedMenuItemId = vi.fn(() => calls.push("select"));
-    const openWorkItemCreator = vi.fn(() =>
-      calls.push("open-work-item-creator")
-    );
-
-    openNewWorkItemFromSidebar({
-      openWorkItemCreator,
-      resetWorkManagementStateForProjectsContent,
-      setProjectsSelectedMenuItemId,
-    });
-
-    expect(setProjectsSelectedMenuItemId).toHaveBeenCalledWith(
-      PROJECTS_NEW_WORK_ITEM_MENU_ITEM_ID
-    );
-    expect(openWorkItemCreator).toHaveBeenCalledOnce();
-    expect(calls).toEqual(["reset", "select", "open-work-item-creator"]);
-  });
-});
+import { tryOpenLinkedSessionFromSidebar } from "./useProjectsMenuItemClick";
 
 describe("tryOpenLinkedSessionFromSidebar", () => {
   it("selects and opens a linked-session child row", () => {

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useProjectsMenuItemClick.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useProjectsMenuItemClick.ts
@@ -7,7 +7,7 @@ import {
 } from "@src/scaffold/GlobalSpotlight/openSpotlight";
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import {
-  openCreateTargetInChatPanelStartPageAtom,
+  openChatPanelCreateTargetAtom,
   openOrganizationInChatPanelTabAtom,
   openProjectInChatPanelTabAtom,
   openWorkItemInChatPanelTabAtom,
@@ -55,19 +55,12 @@ interface UseProjectsMenuItemClickParams<
   projectsWorkItemMap: ReadonlyMap<string, WorkItem>;
   linkedSessionIds: ReadonlySet<string>;
   openLinkedSession: (item: NavigationMenuItem) => void;
-  resetWorkManagementStateForProjectsContent: () => void;
   setProjectsGroupVisibleCounts: React.Dispatch<
     React.SetStateAction<Map<string, number>>
   >;
   setProjectsSelectedMenuItemId: (id: string) => void;
   toChatPanelProject: (project: Project) => ChatPanelSelectedProject;
   toChatPanelWorkItem: (workItem: WorkItem) => ChatPanelSelectedWorkItem;
-}
-
-interface OpenNewWorkItemFromSidebarParams {
-  openWorkItemCreator: () => void;
-  resetWorkManagementStateForProjectsContent: () => void;
-  setProjectsSelectedMenuItemId: (id: string) => void;
 }
 
 interface TryOpenLinkedSessionFromSidebarParams {
@@ -89,16 +82,6 @@ export function tryOpenLinkedSessionFromSidebar({
   return true;
 }
 
-export function openNewWorkItemFromSidebar({
-  openWorkItemCreator,
-  resetWorkManagementStateForProjectsContent,
-  setProjectsSelectedMenuItemId,
-}: OpenNewWorkItemFromSidebarParams): void {
-  resetWorkManagementStateForProjectsContent();
-  setProjectsSelectedMenuItemId(PROJECTS_NEW_WORK_ITEM_MENU_ITEM_ID);
-  openWorkItemCreator();
-}
-
 export function useProjectsMenuItemClick<
   Project,
   WorkItem,
@@ -118,7 +101,6 @@ export function useProjectsMenuItemClick<
   projectsWorkItemMap,
   linkedSessionIds,
   openLinkedSession,
-  resetWorkManagementStateForProjectsContent,
   setProjectsGroupVisibleCounts,
   setProjectsSelectedMenuItemId,
   toChatPanelProject,
@@ -135,9 +117,7 @@ export function useProjectsMenuItemClick<
   const openWorkItemTab = useSetAtom(openWorkItemInChatPanelTabAtom);
   const openProjectTab = useSetAtom(openProjectInChatPanelTabAtom);
   const openOrganizationTab = useSetAtom(openOrganizationInChatPanelTabAtom);
-  const openCreateTargetInStartPage = useSetAtom(
-    openCreateTargetInChatPanelStartPageAtom
-  );
+  const openCreateTarget = useSetAtom(openChatPanelCreateTargetAtom);
   return useCallback(
     (_key: string, item: NavigationMenuItem) => {
       if (item.id === COLLAB_ADD_ORG_MENU_ITEM_ID) {
@@ -146,9 +126,7 @@ export function useProjectsMenuItemClick<
       }
 
       if (item.id === PROJECTS_NEW_PROJECT_MENU_ITEM_ID) {
-        resetWorkManagementStateForProjectsContent();
-        setProjectsSelectedMenuItemId(PROJECTS_NEW_PROJECT_MENU_ITEM_ID);
-        openCreateTargetInStartPage({
+        openCreateTarget({
           target: CHAT_PANEL_CREATE_TARGET.PROJECT,
         });
         return;
@@ -160,14 +138,7 @@ export function useProjectsMenuItemClick<
       }
 
       if (item.id === PROJECTS_NEW_WORK_ITEM_MENU_ITEM_ID) {
-        openNewWorkItemFromSidebar({
-          openWorkItemCreator: () =>
-            openCreateTargetInStartPage({
-              target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
-            }),
-          resetWorkManagementStateForProjectsContent,
-          setProjectsSelectedMenuItemId,
-        });
+        openCreateTarget({ target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM });
         return;
       }
 
@@ -214,12 +185,10 @@ export function useProjectsMenuItemClick<
 
       const createWorkItemOrgId = getProjectsWorkItemCreateOrgId(item.id);
       if (createWorkItemOrgId) {
-        resetWorkManagementStateForProjectsContent();
-        setProjectsSelectedMenuItemId(item.id);
         // The row is org-scoped, so the creation surface must carry the org:
         // NEW_WORK_ITEM without `createProjectContext` writes standalone
         // items under personal-org (see createWorkItemFromDraft).
-        openCreateTargetInStartPage({
+        openCreateTarget({
           target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
           createProjectContext: { orgId: createWorkItemOrgId },
         });
@@ -278,7 +247,7 @@ export function useProjectsMenuItemClick<
       getProjectsLoadMoreGroupId,
       loadProjectsLinearOrgWorkItems,
       linkedSessionIds,
-      openCreateTargetInStartPage,
+      openCreateTarget,
       openOrganizationTab,
       openProjectTab,
       openProjectsLinearOrg,
@@ -290,7 +259,6 @@ export function useProjectsMenuItemClick<
       projectsLocalOrgMap,
       projectsProjectMap,
       projectsWorkItemMap,
-      resetWorkManagementStateForProjectsContent,
       setProjectsGroupVisibleCounts,
       setProjectsSelectedMenuItemId,
       toChatPanelProject,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSidebarStationNavigation.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useSidebarStationNavigation.ts
@@ -32,13 +32,6 @@ export function useSidebarStationNavigation({
   navigate,
   t,
 }: SidebarStationNavigationParams) {
-  const resetWorkManagementStateForProjectsContent = useCallback(() => {
-    const stationMode: StationMode = "my-station";
-    setStationMode(stationMode);
-    setStationChatVisible(stationMode, true);
-    openStartPageTab({ title: t("routes.launchpad") });
-  }, [openStartPageTab, setStationChatVisible, setStationMode, t]);
-
   const activateMyStationRouteForProjectTabContent = useCallback(() => {
     const stationMode: StationMode = "my-station";
     const targetRoute = ROUTES.workStation.code.path;
@@ -59,7 +52,6 @@ export function useSidebarStationNavigation({
   });
 
   return {
-    resetWorkManagementStateForProjectsContent,
     activateMyStationRouteForProjectTabContent,
     handleGoToNewSession,
   };

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.test.ts
@@ -52,9 +52,8 @@ vi.mock("@src/store/chatPanel/chatPanelTabsAtom", async () => {
       null,
       (_get, _set, value: unknown) => mocks.openOrganization(value)
     ),
-    openCreateTargetInChatPanelStartPageAtom: atom(
-      null,
-      (_get, _set, value: unknown) => mocks.openCreator(value)
+    openChatPanelCreateTargetAtom: atom(null, (_get, _set, value: unknown) =>
+      mocks.openCreator(value)
     ),
   };
 });
@@ -92,7 +91,6 @@ describe("persistent work-item sidebar surface", () => {
       enabled,
       activeProjectOrgId: orgId,
       activateMyStationRouteForProjectTabContent: activateDetail,
-      resetWorkManagementStateForProjectsContent: reset,
       handleOpenLinkedWorkItemSession: openLinkedSession,
     });
     useEffect(() => {
@@ -217,9 +215,7 @@ describe("persistent work-item sidebar surface", () => {
       target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
       createProjectContext: { orgId: "org-a" },
     });
-    expect(reset).toHaveBeenCalledOnce();
-    expect(reset.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.openCreator.mock.invocationCallOrder[0]
-    );
+    expect(reset).not.toHaveBeenCalled();
+    expect(surface.selectedMenuItemId).toBe(linked.key);
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.ts
@@ -18,7 +18,6 @@ interface WorkItemsSidebarSurfaceParams {
     typeof useProjectsWorkItemMenuItems
   >[0]["selectedOrgId"];
   activateMyStationRouteForProjectTabContent: StationNavigation["activateMyStationRouteForProjectTabContent"];
-  resetWorkManagementStateForProjectsContent: StationNavigation["resetWorkManagementStateForProjectsContent"];
   handleOpenLinkedWorkItemSession: (item: NavigationMenuItem) => void;
 }
 
@@ -27,7 +26,6 @@ export function useWorkItemsSidebarSurface({
   enabled,
   activeProjectOrgId,
   activateMyStationRouteForProjectTabContent,
-  resetWorkManagementStateForProjectsContent,
   handleOpenLinkedWorkItemSession,
 }: WorkItemsSidebarSurfaceParams) {
   const [projectsSelectedMenuItemId, setProjectsSelectedMenuItemId] =
@@ -71,7 +69,6 @@ export function useWorkItemsSidebarSurface({
     projectsWorkItemMap,
     linkedSessionIds: projectsLinkedSessionIds,
     openLinkedSession: handleOpenLinkedWorkItemSession,
-    resetWorkManagementStateForProjectsContent,
     setProjectsGroupVisibleCounts,
     setProjectsSelectedMenuItemId,
     toChatPanelProject,


### PR DESCRIPTION
## Problem

Starting a session or creating work from the sidebar forces a host-specific route/start-page reset that can change the current station or layout.

## Solution

Navigate new sessions through the workstation base route and open project/work-item creation through the existing chat-panel creation target. Remove obsolete reset callback plumbing; retain organization context for scoped work-item creation.

## Potential risks

These creation entry points intentionally preserve the current station/layout. Existing viewing routes still activate the expected station. Tests cover routing and callback behavior; live UI interactions were not exercised. No persistence, RPC or dependency changes.

## Verification

- `pnpm test src/hooks/navigation/useAppNavigation.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useProjectsMenuItemClick.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkItemsSidebarSurface.test.ts` — 8 tests passed in the isolated branch worktree
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed where applicable
- Commit hook `npx tsgo --noEmit --pretty false` — passed for TypeScript changes; commitlint passed
- `git diff --cached --check` — passed before commit
- Reviewed the scoped diff for unrelated changes, secrets, private paths and generated artifacts
- No new screenshots or live desktop validation: computer control is explicitly opt-in in this workspace, and was not requested
