### PR TITLE
refactor(sidebar): remove the cloud-only session badge

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/cloud-row-indicator.md
+++ b/docs/frontend-ui-audit-2026-09-13/cloud-row-indicator.md
@@ -1,0 +1,11 @@
+# cloud-row-indicator UI audit
+
+| Line                                                                                                               | Element       | Verdict          | Reason                                                                                               | Suggested change |
+| ------------------------------------------------------------------------------------------------------------------ | ------------- | ---------------- | ---------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.tsx:93` | Session badge | keep with reason | Removes the cloud-only indicator and its local-copy lookup; download progress and row actions remain | None             |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.
+
+Source inspection only; no desktop screenshots or live visual verification because computer control is explicitly opt-in.
+
+Performance: removes per-row local-copy lookup and associated inputs. Existing download/presence subscriptions remain unchanged. No new idle or hidden work; runtime performance was not measured.

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.test.ts
@@ -4,12 +4,8 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
-import type { Session } from "@src/store/session";
 
-import {
-  cloudSessionHasLocalCopy,
-  useCloudSessionRowItemBuilder,
-} from "./cloudSessionsSection.rowItemBuilder";
+import { useCloudSessionRowItemBuilder } from "./cloudSessionsSection.rowItemBuilder";
 
 vi.mock("@src/config/agentIcons", () => ({
   resolveAgentIcon: () => (props: { size?: number }) =>
@@ -21,7 +17,6 @@ vi.mock("@src/config/agentIcons", () => ({
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111";
 const OWNER_USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-const SOURCE_ENDPOINT = "https://cloud.example.com";
 
 const remoteRow: RemoteTeammateSessionMetadata = {
   id: "remote-row-1",
@@ -38,35 +33,11 @@ const remoteRow: RemoteTeammateSessionMetadata = {
   eventsTailHash: "hash",
 };
 
-function importedCopy(sourceEndpointUrl = SOURCE_ENDPOINT): Session {
-  return {
-    session_id: "imported-session-1",
-    importedFrom: {
-      orgId: ORG_ID,
-      sourceSessionId: remoteRow.sourceSessionId,
-      sourceEndpointUrl,
-      ownerMemberId: remoteRow.ownerMemberId,
-      epoch: 1,
-      seq: 0,
-      count: 1,
-    },
-  } as Session;
-}
-
-function renderCloudRowAccessory(
-  options: {
-    sessions?: readonly Session[];
-    selfUserId?: string | null;
-    localOwnSessionIds?: ReadonlySet<string>;
-  } = {}
-): string {
+function renderCloudRowAccessory(): string {
   const Probe = () => {
     const buildRowItem = useCloudSessionRowItemBuilder({
       presenceMap: {},
-      selfUserId: options.selfUserId ?? null,
-      sessions: options.sessions ?? [],
-      localOwnSessionIds: options.localOwnSessionIds ?? new Set<string>(),
-      sourceEndpointUrl: SOURCE_ENDPOINT,
+      selfUserId: null,
       t: ((key: string) => key) as never,
       tCommon: ((key: string) => key) as never,
       runFork: vi.fn(),
@@ -88,54 +59,8 @@ function renderCloudRowAccessory(
   );
 }
 
-describe("cloud session local-copy indicator", () => {
-  it("shows a trailing cloud icon when the remote row has no local copy", () => {
-    const markup = renderCloudRowAccessory();
-
-    expect(markup).toContain('data-icon="cloud"');
-    expect(markup).toContain('aria-label="sidebar.groups.cloud"');
-  });
-
-  it("hides the cloud icon once an imported replay copy exists locally", () => {
-    const sessions = [importedCopy()];
-
-    expect(
-      cloudSessionHasLocalCopy(
-        remoteRow,
-        sessions,
-        null,
-        new Set(),
-        SOURCE_ENDPOINT
-      )
-    ).toBe(true);
-    expect(renderCloudRowAccessory({ sessions })).not.toContain(
-      'data-icon="cloud"'
-    );
-  });
-
-  it("hides the cloud icon for the viewer's writable local original", () => {
-    expect(
-      renderCloudRowAccessory({
-        selfUserId: OWNER_USER_ID,
-        localOwnSessionIds: new Set([remoteRow.sourceSessionId]),
-      })
-    ).not.toContain('data-icon="cloud"');
-  });
-
-  it("does not reuse a copy imported from another cloud deployment", () => {
-    const sessions = [importedCopy("https://other-cloud.example.com")];
-
-    expect(
-      cloudSessionHasLocalCopy(
-        remoteRow,
-        sessions,
-        null,
-        new Set(),
-        SOURCE_ENDPOINT
-      )
-    ).toBe(false);
-    expect(renderCloudRowAccessory({ sessions })).toContain(
-      'data-icon="cloud"'
-    );
+describe("team session accessories", () => {
+  it("omits the cloud icon and empty accessory wrapper", () => {
+    expect(renderCloudRowAccessory()).toBe("<div></div>");
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.tsx
@@ -33,9 +33,7 @@ import {
 import type { Org2CloudPresenceEntry } from "@src/features/Org2Cloud/org2CloudPresenceAtom";
 import { viewersForSession } from "@src/features/Org2Cloud/org2CloudPresenceAtom";
 import { useCloudSessionDownloadProgressEntry } from "@src/features/Org2Cloud/useCloudSessionDownloadSurface";
-import { findImportedSession } from "@src/features/TeamCollaboration/engine/collabSyncEngineHelpers";
 import {
-  CloudIcon,
   GitForkIcon,
   HugeiconsIcon,
   Loading03Icon,
@@ -45,7 +43,6 @@ import {
 } from "@src/icons";
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
-import type { Session } from "@src/store/session";
 import {
   type NativeMenuItemOptions,
   popupNativeMenu,
@@ -96,11 +93,6 @@ const RowBusyIndicator: React.FC<{
 interface UseCloudSessionRowItemBuilderParams {
   presenceMap: Record<string, Record<string, Org2CloudPresenceEntry>>;
   selfUserId: string | null;
-  sessions: readonly Session[];
-  /** Source ids proven to be writable originals on this device. */
-  localOwnSessionIds: ReadonlySet<string>;
-  /** Cloud deployment identity used by imported replay copies. */
-  sourceEndpointUrl: string | undefined;
   t: TFunction;
   tCommon: TFunction;
   runFork: (row: RemoteTeammateSessionMetadata) => void;
@@ -114,34 +106,6 @@ interface UseCloudSessionRowItemBuilderParams {
   toggleRemoteSessionPin: (orgId: string, rowId: string) => void;
 }
 
-/**
- * Whether a cloud row already has a usable local identity on this device.
- * Own originals and imported replay copies are separate persistence shapes,
- * so both must participate in the sidebar's cloud-only indicator.
- */
-export function cloudSessionHasLocalCopy(
-  row: RemoteTeammateSessionMetadata,
-  sessions: readonly Session[],
-  selfUserId: string | null,
-  localOwnSessionIds: ReadonlySet<string>,
-  sourceEndpointUrl: string | undefined
-): boolean {
-  if (
-    row.ownerUserId === selfUserId &&
-    localOwnSessionIds.has(row.sourceSessionId)
-  ) {
-    return true;
-  }
-  return Boolean(
-    findImportedSession(
-      sessions,
-      row.orgId,
-      row.sourceSessionId,
-      sourceEndpointUrl
-    )
-  );
-}
-
 export type BuildCloudSessionRowItem = (
   threadRow: CloudSessionThreadRow,
   /** Family members folded into this row (badge aggregation only). */
@@ -151,9 +115,6 @@ export type BuildCloudSessionRowItem = (
 export function useCloudSessionRowItemBuilder({
   presenceMap,
   selfUserId,
-  sessions,
-  localOwnSessionIds,
-  sourceEndpointUrl,
   t,
   tCommon,
   runFork,
@@ -288,34 +249,13 @@ export function useCloudSessionRowItemBuilder({
           aria-label="Pinned"
         />
       ) : null;
-      const cloudOnlyIndicator = cloudSessionHasLocalCopy(
-        row,
-        sessions,
-        selfUserId,
-        localOwnSessionIds,
-        sourceEndpointUrl
-      ) ? null : (
-        <HugeiconsIcon
-          icon={CloudIcon}
-          data-icon="cloud"
-          size={12}
-          strokeWidth={2}
-          className="shrink-0 text-text-3"
-          aria-label={t("sidebar.groups.cloud")}
-        />
-      );
       const trailingElement =
-        pinIndicator ||
-        busyIndicator ||
-        viewerChips ||
-        commentsBadge ||
-        cloudOnlyIndicator ? (
+        pinIndicator || busyIndicator || viewerChips || commentsBadge ? (
           <span className="inline-flex items-center gap-1">
             {pinIndicator}
             {busyIndicator}
             {viewerChips}
             {commentsBadge}
-            {cloudOnlyIndicator}
           </span>
         ) : undefined;
       // Strip fork glyph(s) baked into pushed titles; the GitFork icon carries provenance.
@@ -383,10 +323,7 @@ export function useCloudSessionRowItemBuilder({
     [
       busySessionRows,
       buildNativeMenuItems,
-      localOwnSessionIds,
       pinnedRemoteSessionIds,
-      sessions,
-      sourceEndpointUrl,
       toggleRemoteSessionPin,
       presenceMap,
       runFork,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
@@ -645,9 +645,6 @@ export function useCloudSessionsSection({
   const buildRowItem = useCloudSessionRowItemBuilder({
     presenceMap,
     selfUserId,
-    sessions,
-    localOwnSessionIds,
-    sourceEndpointUrl: auth?.supabaseUrl,
     t,
     tCommon,
     runFork,


### PR DESCRIPTION
## Problem

Cloud session rows compute and display a cloud-only badge by consulting local originals and imported copies, adding a separate local-copy presentation path.

## Solution

Remove the cloud-only badge and its local-copy helper/inputs. Keep download progress, presence, pinning, fork and context-menu behavior.

## Potential risks

Users no longer see that badge as a local-copy hint. Download behavior and persistence are unchanged. The focused test covers row building; live cloud sync and runtime performance were not exercised.

## Verification

- `pnpm test src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.test.ts` — 1 tests passed in the isolated branch worktree
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed where applicable
- Commit hook `npx tsgo --noEmit --pretty false` — passed for TypeScript changes; commitlint passed
- `git diff --cached --check` — passed before commit
- Reviewed the scoped diff for unrelated changes, secrets, private paths and generated artifacts
- No new screenshots or live desktop validation: computer control is explicitly opt-in in this workspace, and was not requested
