### PR TITLE
fix(page-notice): keep notice copy selectable

### DIFF
--- a/src/components/PageNotice/PageNotice.test.ts
+++ b/src/components/PageNotice/PageNotice.test.ts
@@ -56,6 +56,8 @@ describe("PageNotice", () => {
 
     const selectableCount = markup.split("allow-select-deep").length - 1;
     expect(selectableCount).toBe(3);
+    expect(markup.split("page-notice__text").length - 1).toBe(3);
+    expect(markup).toContain('class="page-notice ');
   });
 
   it("lets the icon inherit the alert title color", () => {

--- a/src/components/PageNotice/index.scss
+++ b/src/components/PageNotice/index.scss
@@ -1,0 +1,19 @@
+// Alert copy must remain selectable even inside chat's inert layout wrappers.
+// Scope this override to copy regions so pill toggles and actions stay controls.
+.page-notice .page-notice__text.allow-select-deep {
+  &,
+  * {
+    -webkit-user-select: text !important;
+    user-select: text !important;
+  }
+
+  &::selection,
+  *::selection {
+    background-color: var(--text-selection, var(--color-primary-2)) !important;
+  }
+
+  :is(button, button *, .select-none, .select-none *) {
+    -webkit-user-select: none !important;
+    user-select: none !important;
+  }
+}

--- a/src/components/PageNotice/index.tsx
+++ b/src/components/PageNotice/index.tsx
@@ -27,6 +27,8 @@ import {
   UnfoldMoreIcon,
 } from "@src/icons";
 
+import "./index.scss";
+
 /**
  * Shared neutral surface — flat outline, no tone accent, and a half-strength
  * Workstation-trail shadow for a little lift.
@@ -76,7 +78,7 @@ const DEFAULT_ICONS: Record<string, React.ReactNode> = {
  * global `* { user-select: none }` so users can select/copy titles, bodies and
  * technical details. Interactive children opt out again with `select-none`.
  */
-const SELECTABLE_TEXT_CLASS = "allow-select-deep";
+const SELECTABLE_TEXT_CLASS = "allow-select-deep page-notice__text";
 
 const PAGE_NOTICE_BASE_TEXT = {
   title: "block text-[13px] font-medium leading-[14px]",
@@ -265,7 +267,7 @@ const PageNotice: React.FC<PageNoticeProps> = ({
     <div
       role={role}
       data-testid={dataTestId}
-      className={`${ALERT_SURFACE_CLASS} ${isPill ? `inline-block w-fit max-w-full ${expanded ? ALERT_RADIUS_CLASS : "rounded-full"} px-3 py-2` : `${ALERT_RADIUS_CLASS} ${cardPaddingClass}`} ${className ?? ""}`}
+      className={`page-notice ${ALERT_SURFACE_CLASS} ${isPill ? `inline-block w-fit max-w-full ${expanded ? ALERT_RADIUS_CLASS : "rounded-full"} px-3 py-2` : `${ALERT_RADIUS_CLASS} ${cardPaddingClass}`} ${className ?? ""}`}
     >
       <div className={`flex items-center ${isPill ? "gap-1" : "gap-3"}`}>
         {isPill ? (


### PR DESCRIPTION
## Problem

PageNotice text can inherit nonselectable styling from enclosing chat/layout wrappers, preventing users from copying diagnostic text.

## Solution

Add scoped PageNotice text-selection styles and selection color. Keep buttons and explicitly nonselectable descendants as controls; extend the component regression assertion.

## Potential risks

The CSS uses scoped important declarations to override enclosing selection rules. Browser/platform selection behavior still needs live validation. No network, data, dependencies or lifecycle changes.

## Verification

- `pnpm test src/components/PageNotice/PageNotice.test.ts` — 6 tests passed in the isolated branch worktree
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed where applicable
- Commit hook `npx tsgo --noEmit --pretty false` — passed for TypeScript changes; commitlint passed
- `git diff --cached --check` — passed before commit
- Reviewed the scoped diff for unrelated changes, secrets, private paths and generated artifacts
- No new screenshots or live desktop validation: computer control is explicitly opt-in in this workspace, and was not requested
