### PR TITLE
feat(runtime): reveal hook configuration in the file manager

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/reveal-hook-config.md
+++ b/docs/frontend-ui-audit-2026-09-13/reveal-hook-config.md
@@ -1,0 +1,11 @@
+# reveal-hook-config UI audit
+
+| Line                                                                        | Element            | Verdict          | Reason                                                                                                               | Suggested change |
+| --------------------------------------------------------------------------- | ------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/shared/dataSource/SessionProvenanceHookPlatformsTable.tsx:369` | Config path action | keep with reason | Native button supports keyboard activation and focus indication; truncated path plus icon forms a custom text action | None             |
+
+Verdict totals: **0 fix**, **1 keep with reason**, **0 abstract**.
+
+Source inspection only; no desktop screenshots or live visual verification because computer control is explicitly opt-in.
+
+The existing show_in_folder command runs only after activation, with failures shown through Message. No polling, automatic file opening or retained state is introduced. Real file-manager behavior was not exercised.

--- a/src/modules/shared/dataSource/SessionProvenanceHookPlatformsTable.tsx
+++ b/src/modules/shared/dataSource/SessionProvenanceHookPlatformsTable.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { useAtomValue } from "jotai";
 import React, {
   useCallback,
@@ -14,6 +15,7 @@ import type {
   SessionProvenanceHookStatus,
 } from "@src/api/tauri/rpc/schemas/agentOrgs";
 import Button from "@src/components/Button";
+import Message from "@src/components/Message";
 import type { IconProvider } from "@src/components/ModelIcon";
 import PageNotice from "@src/components/PageNotice";
 import SettingsTable, {
@@ -25,7 +27,11 @@ import Switch from "@src/components/Switch";
 import Tag, { type TagProps } from "@src/components/Tag";
 import { INFO_CARD_TOKENS } from "@src/config/detailPanelTokens";
 import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
-import { ComputerTerminal01Icon, HugeiconsIcon } from "@src/icons";
+import {
+  ComputerTerminal01Icon,
+  FolderOpenIcon,
+  HugeiconsIcon,
+} from "@src/icons";
 import {
   SECTION_GAP_CLASSES,
   SectionContainer,
@@ -39,6 +45,7 @@ import {
 } from "@src/store/workspace";
 import { copyText } from "@src/util/data/clipboard";
 import { formatRelativeElapsedShort } from "@src/util/data/formatters/date";
+import { getFileManagerRevealLabelKey } from "@src/util/platform/fileManagerLabels";
 import { openFileInWorkStation } from "@src/util/ui/openFileInWorkStation";
 
 import { RuntimeRefreshButton } from "./RuntimeSectionHeader";
@@ -359,12 +366,34 @@ const SessionProvenanceHookPlatformsTable: React.FC = () => {
       }),
       renderCell: (row) =>
         row.status?.configPath ? (
-          <span
-            className="block truncate text-text-3"
+          <button
+            type="button"
+            className="flex max-w-full cursor-pointer items-center gap-1.5 text-left text-text-3 underline-offset-2 hover:underline focus-visible:underline focus-visible:ring-1 focus-visible:ring-primary-6 focus-visible:outline-none"
             title={row.status.configPath}
+            aria-label={`${t(getFileManagerRevealLabelKey())}: ${row.status.configPath}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              const path = row.status?.configPath;
+              if (!path) return;
+              void invoke("show_in_folder", { path }).catch(
+                (error: unknown) => {
+                  Message.error(
+                    error instanceof Error ? error.message : String(error)
+                  );
+                }
+              );
+            }}
           >
-            {tildePath(row.status.configPath)}
-          </span>
+            <span className="min-w-0 truncate">
+              {tildePath(row.status.configPath)}
+            </span>
+            <HugeiconsIcon
+              icon={FolderOpenIcon}
+              size={14}
+              className="shrink-0"
+              aria-hidden
+            />
+          </button>
         ) : null,
     },
     {


### PR DESCRIPTION
## Problem

Hook configuration paths are displayed as text, requiring users to find the file manually.

## Solution

Make each available config path a keyboard-activatable action that calls the existing show_in_folder command. Add a file-manager icon, localized accessible label, truncated path, and visible error feedback.

## Potential risks

The existing platform file-manager command runs only on activation; missing files or platform errors are surfaced through Message. Real file-manager behavior was not exercised. No backend, protocol, persistence or background-work changes.

## Verification

- No new test suite for this small UI/copy change; validation is source review and commit checks
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed where applicable
- Commit hook `npx tsgo --noEmit --pretty false` — passed for TypeScript changes; commitlint passed
- `git diff --cached --check` — passed before commit
- Reviewed the scoped diff for unrelated changes, secrets, private paths and generated artifacts
- No new screenshots or live desktop validation: computer control is explicitly opt-in in this workspace, and was not requested
