### PR TITLE
test(editor): cover search lifecycle and dirty diff updates

### DIFF
--- a/src/features/CodeMirror/config/dirtyDiff.test.ts
+++ b/src/features/CodeMirror/config/dirtyDiff.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { EditorView, lineNumbers } from "@codemirror/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dirtyDiffGutter } from "./dirtyDiff";
+
+const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+const mounted: EditorView[] = [];
+function editor() {
+  const view = new EditorView({
+    parent: document.body,
+    doc: "new\nchanged\nsame",
+    extensions: [lineNumbers(), dirtyDiffGutter({ current: "old\nsame" })],
+  });
+  mounted.push(view);
+  return view;
+}
+const result = (line: number, type = "added") => ({
+  markers: [{ line, type }],
+});
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.invoke.mockReset();
+});
+afterEach(() => {
+  mounted.splice(0).forEach((view) => view.destroy());
+  document.body.replaceChildren();
+  vi.useRealTimers();
+});
+
+describe("dirty diff rendering", () => {
+  it("marks the number gutter and code row from the backend result", async () => {
+    mocks.invoke.mockResolvedValue({
+      markers: [
+        { line: 1, type: "added" },
+        { line: 2, type: "modified" },
+        { line: 3, type: "deleted" },
+      ],
+    });
+    const view = editor();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(
+      view.dom.querySelector(".cm-lineNumbers .cm-dirty-diff-row-added")
+        ?.textContent
+    ).toBe("1");
+    expect(
+      view.dom.querySelector(".cm-lineNumbers .cm-dirty-diff-row-modified")
+        ?.textContent
+    ).toBe("2");
+    expect(
+      view.dom.querySelector(".cm-line.cm-dirty-diff-row-added")?.textContent
+    ).toBe("new");
+    // A deletion anchor points to surviving text, not a deleted code row.
+    expect(
+      view.dom.querySelector(".cm-line.cm-dirty-diff-row-deleted")
+    ).toBeNull();
+    expect(view.dom.querySelector(".cm-dirty-diff-deleted")).not.toBeNull();
+  });
+
+  it("rejects a result for an obsolete document before applying fresh markers", async () => {
+    let resolve!: (value: ReturnType<typeof result>) => void;
+    mocks.invoke
+      .mockReturnValueOnce(
+        new Promise((done) => {
+          resolve = done;
+        })
+      )
+      .mockResolvedValueOnce(result(2, "modified"));
+    const view = editor();
+    await vi.advanceTimersByTimeAsync(50);
+    view.dispatch({ changes: { from: 0, to: 3, insert: "latest" } });
+    resolve(result(1));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(view.dom.querySelector(".cm-dirty-diff-row-added")).toBeNull();
+    await vi.advanceTimersByTimeAsync(150);
+    expect(
+      view.dom.querySelector(".cm-lineNumbers .cm-dirty-diff-row-modified")
+        ?.textContent
+    ).toBe("2");
+    expect(mocks.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves existing markers on backend failure and stops work on close", async () => {
+    mocks.invoke
+      .mockResolvedValueOnce(result(1))
+      .mockRejectedValueOnce(new Error("offline"));
+    const view = editor();
+    await vi.advanceTimersByTimeAsync(50);
+    view.dispatch({ changes: { from: view.state.doc.length, insert: "!" } });
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.dom.querySelector(".cm-dirty-diff-row-added")).not.toBeNull();
+    view.dispatch({ changes: { from: view.state.doc.length, insert: "!" } });
+    view.destroy();
+    mounted.pop();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(mocks.invoke).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeMirrorSearchPanel/index.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeMirrorSearchPanel/index.test.ts
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+import {
+  closeSearchPanel,
+  getSearchQuery,
+  openSearchPanel,
+} from "@codemirror/search";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { act, createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerFindTarget } from "@src/components/FindCard/findCoordinator";
+import { CURRENT_SHORTCUT_PLATFORM } from "@src/config/keyboard/shortcutBindings";
+
+import { findReplaceExtension } from ".";
+
+const mocks = vi.hoisted(() => ({ card: vi.fn(), replace: vi.fn() }));
+vi.mock("@src/components/FindCard", () => ({
+  default: (props: { children?: React.ReactNode }) => {
+    mocks.card(props);
+    return props.children ?? null;
+  },
+}));
+vi.mock("@src/scaffold/GlobalSpotlight/components/SpotlightSearchBar", () => ({
+  SpotlightSearchBar: (props: { trailingSlot?: React.ReactNode }) => {
+    mocks.replace(props);
+    return createElement(
+      "div",
+      null,
+      createElement("input"),
+      props.trailingSlot
+    );
+  },
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+const environment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+let view: EditorView;
+let host: HTMLDivElement;
+let previous: boolean | undefined;
+let unregisterPeer: (() => void) | undefined;
+beforeEach(() => {
+  previous = environment.IS_REACT_ACT_ENVIRONMENT;
+  environment.IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  host = document.createElement("div");
+  host.dataset.chatPanel = "";
+  host.dataset.findScopeSwitching = "true";
+  document.body.append(host);
+  view = new EditorView({
+    parent: host,
+    state: EditorState.create({
+      doc: "alpha beta alpha",
+      extensions: [findReplaceExtension("/workspace/src/long-file-name.ts")],
+    }),
+  });
+});
+afterEach(async () => {
+  unregisterPeer?.();
+  unregisterPeer = undefined;
+  await act(async () => {
+    view.destroy();
+    await Promise.resolve();
+  });
+  host.remove();
+  vi.useRealTimers();
+  environment.IS_REACT_ACT_ENVIRONMENT = previous;
+});
+function card() {
+  return mocks.card.mock.calls.at(-1)![0];
+}
+async function open() {
+  await act(async () => {
+    openSearchPanel(view);
+  });
+}
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("CodeMirror consolidated Find", () => {
+  it("anchors Find to the outer split view instead of the editor pane", async () => {
+    const split = document.createElement("div");
+    split.dataset.paneSurfaceUnderlay = "";
+    document.body.append(split);
+    split.append(host);
+    try {
+      await open();
+      expect(
+        split.querySelector(":scope > .pointer-events-none")
+      ).not.toBeNull();
+      expect(host.querySelector(":scope > .pointer-events-none")).toBeNull();
+      await act(async () => {
+        closeSearchPanel(view);
+      });
+      expect(split.querySelector(":scope > .pointer-events-none")).toBeNull();
+    } finally {
+      document.body.append(host);
+      split.remove();
+    }
+  });
+  it("selects modes before typing and uses them for the first query", async () => {
+    await open();
+    act(() => card().search.toggleCaseSensitive());
+    act(() => card().search.toggleWholeWord());
+    act(() => card().search.toggleRegex());
+    expect(card().search).toMatchObject({
+      query: "",
+      caseSensitive: true,
+      wholeWord: true,
+      useRegex: true,
+    });
+    act(() => card().search.setQuery("alpha"));
+    await advance(500);
+    expect(getSearchQuery(view.state)).toMatchObject({
+      search: "alpha",
+      caseSensitive: true,
+      wholeWord: true,
+      regexp: true,
+    });
+  });
+  it("floats outside the editor panel and debounces query application", async () => {
+    await open();
+    expect(
+      host.querySelector(".cm-search-panel-wrapper")?.getAttribute("style")
+    ).toContain("display: none");
+    expect(host.querySelector(":scope > .pointer-events-none")).not.toBeNull();
+    act(() => card().search.setQuery("alpha"));
+    await advance(499);
+    expect(getSearchQuery(view.state).search).toBe("");
+    await advance(1);
+    expect(getSearchQuery(view.state).search).toBe("alpha");
+    expect(card().search.resultCount).toBe(2);
+  });
+  it("flushes the latest query before navigation and replacement", async () => {
+    await open();
+    act(() => card().search.setQuery("beta"));
+    act(() => card().search.nextResult());
+    expect(
+      view.state.sliceDoc(
+        view.state.selection.main.from,
+        view.state.selection.main.to
+      )
+    ).toBe("beta");
+    act(() => card().extraControls.props.children.props.onClick());
+    act(() => mocks.replace.mock.calls.at(-1)![0].onSearchQueryChange("gamma"));
+    act(() =>
+      host
+        .querySelector<HTMLElement>('[data-icon="replace-all"]')!
+        .closest("button")!
+        .click()
+    );
+    expect(view.state.doc.toString()).toBe("alpha gamma alpha");
+  });
+  it("guards replacement Enter during composition and uses the compact input", async () => {
+    await open();
+    act(() => card().search.setQuery("alpha"));
+    act(() => card().extraControls.props.children.props.onClick());
+    act(() => mocks.replace.mock.calls.at(-1)![0].onSearchQueryChange("gamma"));
+    const input = mocks.replace.mock.calls.at(-1)![0];
+    expect(input.density).toBe("compact");
+    expect(card().targetName).toBe("long-file-name.ts");
+    const replaceButton = host
+      .querySelector<HTMLElement>('[data-icon="replace"]')!
+      .closest("button")!;
+    expect(replaceButton.hasAttribute("title")).toBe(false);
+    expect(replaceButton.hasAttribute("aria-label")).toBe(false);
+    const event = {
+      key: "Enter",
+      shiftKey: false,
+      nativeEvent: { isComposing: true },
+      preventDefault: vi.fn(),
+    };
+    act(() => input.onKeyDown(event));
+    expect(view.state.doc.toString()).toBe("alpha beta alpha");
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    act(() =>
+      input.onKeyDown({ ...event, nativeEvent: { isComposing: false } })
+    );
+    // CodeMirror first selects a match, then replaces the selected match.
+    expect(
+      view.state.sliceDoc(
+        view.state.selection.main.from,
+        view.state.selection.main.to
+      )
+    ).toBe("alpha");
+    act(() =>
+      input.onKeyDown({ ...event, nativeEvent: { isComposing: false } })
+    );
+    expect(view.state.doc.toString()).toBe("gamma beta alpha");
+  });
+  it("removes floating chrome and cancels pending search when closed", async () => {
+    await open();
+    act(() => card().search.setQuery("alpha"));
+    await act(async () => {
+      closeSearchPanel(view);
+      await Promise.resolve();
+    });
+    await advance(1000);
+    expect(host.querySelector(":scope > .pointer-events-none")).toBeNull();
+    expect(getSearchQuery(view.state).search).toBe("");
+  });
+  it("cycles from the actual editor to Session and then closes", async () => {
+    view.dom.getClientRects = () => [{}] as unknown as DOMRectList;
+    const session = document.createElement("input");
+    session.getClientRects = () => [{}] as unknown as DOMRectList;
+    host.append(session);
+    const openSession = vi.fn(),
+      closeSession = vi.fn();
+    unregisterPeer = registerFindTarget({
+      scope: "session",
+      element: () => session,
+      open: openSession,
+      close: closeSession,
+    });
+    view.contentDOM.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    const press = () =>
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          code: "KeyF",
+          bubbles: true,
+          cancelable: true,
+          metaKey: CURRENT_SHORTCUT_PLATFORM === "mac",
+          ctrlKey: CURRENT_SHORTCUT_PLATFORM !== "mac",
+        })
+      );
+    await act(async () => {
+      press();
+    });
+    expect(host.querySelector(".cm-search-panel-wrapper")).not.toBeNull();
+    await act(async () => {
+      press();
+    });
+    expect(host.querySelector(".cm-search-panel-wrapper")).toBeNull();
+    expect(openSession).toHaveBeenCalledOnce();
+    await act(async () => {
+      press();
+    });
+    expect(closeSession).toHaveBeenCalledOnce();
+  });
+  it("does not expose replacement for read-only editors", async () => {
+    view.destroy();
+    view = new EditorView({
+      parent: host,
+      state: EditorState.create({
+        doc: "alpha",
+        extensions: [findReplaceExtension(), EditorState.readOnly.of(true)],
+      }),
+    });
+    await open();
+    expect(card().extraControls).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Editor search and dirty-diff lifecycle behavior lack focused regression coverage.

## Solution

Add CodeMirror tests for search anchoring, modes, debouncing, navigation/replacement, composition and cleanup, plus dirty-diff marker rendering, obsolete-result rejection and failure/close behavior.

## Potential risks

Test-only change using mocked IPC and jsdom. It does not exercise an actual Tauri webview or backend diff implementation and makes no production performance claim.

## Verification

- `pnpm test src/features/CodeMirror/config/dirtyDiff.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeMirrorSearchPanel/index.test.ts` — 11 tests passed in the isolated branch worktree
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed where applicable
- Commit hook `npx tsgo --noEmit --pretty false` — passed for TypeScript changes; commitlint passed
- `git diff --cached --check` — passed before commit
- Reviewed the scoped diff for unrelated changes, secrets, private paths and generated artifacts
