### PR TITLE
docs(wiki): clarify getting-started shortcut locations

### DIFF
--- a/src/features/Wiki/wikiArticles.ts
+++ b/src/features/Wiki/wikiArticles.ts
@@ -15,7 +15,7 @@ export const WIKI_ARTICLES: WikiArticle[] = [
     summary:
       "Start a conversation, choose an agent and model, and follow the work in the Chat Panel.",
     steps: [
-      "Use Start a session to open the session creator and choose a working directory and available account.",
+      "Use Start a session below to open the session creator and choose a working directory and available account.",
       "Send instructions in the Chat Panel, inspect tool activity, and follow up in the same session.",
       "Use session search to return to earlier work; imports bring supported external CLI histories into the app.",
     ],
@@ -41,7 +41,7 @@ export const WIKI_ARTICLES: WikiArticle[] = [
     steps: [
       "Open the Code Editor from the station dock and choose a file or tab.",
       "Use Source Control to inspect diffs, stage or unstage changes, and commit.",
-      "Use Git History to inspect previous commits, or use Spotlight to open repository branches.",
+      "Use Git History to inspect previous commits, or open repository branches from the shortcut below.",
     ],
   },
   {


### PR DESCRIPTION
## Problem

Getting-started Wiki instructions do not clearly point to the shortcuts shown below their articles.

## Solution

Clarify that session creation and repository-branch shortcuts are below the corresponding article.

## Potential risks

English static help copy only; application behavior and translations are unchanged. No runtime, data or compatibility changes.

## Verification

- No new test suite for this small UI/copy change; validation is source review and commit checks
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed where applicable
- Commit hook `npx tsgo --noEmit --pretty false` — passed for TypeScript changes; commitlint passed
- `git diff --cached --check` — passed before commit
- Reviewed the scoped diff for unrelated changes, secrets, private paths and generated artifacts
