### PR TITLE
fix(review): always search the full review

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/ReviewSearch.md
+++ b/docs/frontend-ui-audit-2026-09-13/ReviewSearch.md
@@ -1,0 +1,14 @@
+# ReviewSearch UI audit
+
+| Line                                                                            | Element          | Verdict          | Reason                                                                                                                                                                     | Suggested change |
+| ------------------------------------------------------------------------------- | ---------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `src/modules/WorkStation/shared/DiffSectionList/search/useReviewSearch.tsx:250` | Review Find card | keep with reason | Uses the existing FindCard with an explicit false scopeControls value, suppressing both the custom and fallback scope switches. Existing match modes and navigation remain | None             |
+| `src/modules/WorkStation/shared/DiffSectionList/index.tsx:373`                  | Review root      | keep with reason | Removes the pointer-capture handler used only to select a single search file; no new visual primitives                                                                     | None             |
+
+Verdict totals: **0 fix**, **2 keep with reason**, **0 abstract**.
+
+Architecture: full-review scope is enforced at both eager worker requests and lazy file enumeration, not only hidden in the UI. Removed file-scope state, focused-path plumbing and click tracking. Existing per-file editor search remains separate. No persistence or wire changes.
+
+Lifecycle: existing debounce, visibility pause/restart, generation checks, sequential lazy loading, match limit and worker termination remain. Navigation between files no longer restarts search solely because a focused path changes. No new timers, listeners, retained caches or polling. Source-level verdict: bounded; live CPU/RAM unmeasured.
+
+Verification: `pnpm test src/modules/WorkStation/shared/DiffSectionList/search` — 10 tests passed, covering full file payload, no scope controls, lazy loading, stale-result rejection, close cleanup and visibility restart. Live desktop visual verification was not run because computer control is explicitly opt-in.

--- a/src/modules/WorkStation/shared/DiffSectionList/index.tsx
+++ b/src/modules/WorkStation/shared/DiffSectionList/index.tsx
@@ -151,7 +151,6 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
     files: reviewSearchFiles ?? reviewFiles,
     loadFile: loadReviewFile,
     containerRef: searchRootRef,
-    focusedPath,
     onNavigate: navigateSearch,
   });
 
@@ -373,16 +372,6 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
     <div
       ref={searchRootRef}
       className="relative flex h-full min-h-0 flex-col overflow-hidden"
-      onPointerDownCapture={
-        enableReviewSearch
-          ? (event) => {
-              const path = (event.target as HTMLElement).closest<HTMLElement>(
-                "[data-diff-section-path]"
-              )?.dataset.diffSectionPath;
-              if (path) reviewSearch.selectPath(path);
-            }
-          : undefined
-      }
     >
       {reviewSearch.card}
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/src/modules/WorkStation/shared/DiffSectionList/search/useReviewSearch.test.ts
+++ b/src/modules/WorkStation/shared/DiffSectionList/search/useReviewSearch.test.ts
@@ -49,7 +49,6 @@ function Harness() {
     loadFile,
     files,
     containerRef: ref,
-    focusedPath: "b",
     onNavigate: mocks.navigate,
   });
   // eslint-disable-next-line react-hooks/refs -- createElement forwards the ref to React without reading it
@@ -176,14 +175,14 @@ describe("review search lifecycle", () => {
     expect(mocks.navigate).toHaveBeenCalledOnce();
     expect(card().search.resultCount).toBe(1);
   });
-  it("supports review and selected-file scopes and immediate Enter flush", async () => {
+  it("always searches all review files without a scope switch and supports immediate Enter flush", async () => {
     act(() => card().search.setQuery("old"));
     act(() => card().search.nextResult());
     await advance(0);
     expect(workers[0].postMessage.mock.calls.at(-1)![0].path).toBeUndefined();
-    act(() => card().scopeControls.props.onChange("file"));
-    await advance(500);
-    expect(workers.at(-1)!.postMessage.mock.calls.at(-1)![0].path).toBe("b");
+    expect(workers[0].postMessage.mock.calls[0][0].files).toEqual(files);
+    expect(card().scopeControls).toBe(false);
+    expect(card().targetName).toBe("actions.review");
   });
   it("releases work on close and pauses while hidden", async () => {
     act(() => card().search.setQuery("old"));

--- a/src/modules/WorkStation/shared/DiffSectionList/search/useReviewSearch.tsx
+++ b/src/modules/WorkStation/shared/DiffSectionList/search/useReviewSearch.tsx
@@ -15,8 +15,6 @@ import {
   closeFindTarget,
   registerFindTarget,
 } from "@src/components/FindCard/findCoordinator";
-import SegmentedTextPill from "@src/components/SegmentedTextPill";
-import { getFileName } from "@src/util/file/pathUtils";
 
 import {
   REVIEW_SEARCH_LIMIT,
@@ -29,21 +27,17 @@ export function useReviewSearch({
   enabled,
   files,
   containerRef,
-  focusedPath,
   onNavigate,
   loadFile,
 }: {
   enabled: boolean;
   files: readonly ReviewSearchFile[];
   containerRef: RefObject<HTMLDivElement | null>;
-  focusedPath?: string | null;
   onNavigate: (match: ReviewSearchMatch) => void;
   loadFile?: (path: string) => Promise<ReviewSearchFile | null>;
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const [scope, setScope] = useState<"review" | "file">("review");
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [modes, setModes] = useState({
     caseSensitive: false,
@@ -65,10 +59,6 @@ export function useReviewSearch({
   useLayoutEffect(() => {
     navigateRef.current = onNavigate;
   }, [onNavigate]);
-  const path =
-    [selectedPath, focusedPath].find(
-      (path) => path && files.some((file) => file.path === path)
-    ) ?? files[0]?.path;
   useEffect(() => {
     if (!enabled) return;
     const target: FindTarget = {
@@ -158,14 +148,12 @@ export function useReviewSearch({
           type: "search",
           id,
           query: config,
-          path: scope === "file" ? path : undefined,
         });
       } else {
         const scan = async () => {
           const matches: ReviewSearchMatch[] = [];
           let error = false;
           for (const file of files) {
-            if (scope === "file" && file.path !== path) continue;
             if (!live || id !== generation.current || !worker) return;
             let loaded: ReviewSearchFile | null = null;
             try {
@@ -231,7 +219,7 @@ export function useReviewSearch({
       stop();
       document.removeEventListener("visibilitychange", visibility);
     };
-  }, [enabled, open, query, modes, scope, path, files, flush, loadFile]);
+  }, [enabled, open, query, modes, files, flush, loadFile]);
   const move = (delta: number) => {
     if (pending) {
       setFlush((v) => v + 1);
@@ -263,36 +251,8 @@ export function useReviewSearch({
             <div className="pointer-events-auto ml-auto w-full max-w-sm">
               <FindCard
                 scope="file"
-                targetName={
-                  scope === "file" && path
-                    ? getFileName(path)
-                    : t("actions.review")
-                }
-                scopeControls={
-                  <SegmentedTextPill
-                    ariaLabel={t("actions.find")}
-                    value={scope}
-                    onChange={(value) => {
-                      generation.current++;
-                      setPending(Boolean(query.trim()));
-                      if (value === "file" && !selectedPath)
-                        setSelectedPath(
-                          result.matches[index]?.path ?? path ?? null
-                        );
-                      setFlush(0);
-                      setScope(value);
-                    }}
-                    className="gap-px"
-                    options={[
-                      { value: "review", label: t("actions.review") },
-                      {
-                        value: "file",
-                        label: t("windowChrome.menus.file"),
-                        disabled: !path,
-                      },
-                    ]}
-                  />
-                }
+                targetName={t("actions.review")}
+                scopeControls={false}
                 statusText={
                   result.error
                     ? t("status.error")
@@ -327,6 +287,5 @@ export function useReviewSearch({
     card,
     match: open ? (result.matches[index] ?? null) : null,
     appliedQuery: open ? result.query : null,
-    selectPath: setSelectedPath,
   };
 }


### PR DESCRIPTION
## Problem

Review Find offers a Review/File switch and can restrict results to the clicked or focused file. The review surface should always search the full review.

## Solution

Remove review-specific file-scope state, pointer tracking and focused-file input. Always send every review file to eager search and enumerate all files during lazy search. Hide the scope controls in the review Find card, including its generic fallback switch. Keep existing match modes and next/previous navigation.

## Potential risks

Single-file search is intentionally unavailable in review Find; regular editor-file search is unchanged. Existing debounce, worker limits, visibility pause and generation cancellation remain. No new network calls, timers, persistence or public protocol changes.

Live desktop screenshots and CPU/RAM measurements were not captured because computer control is explicitly opt-in. The existing full-review path is now the only review search path.

## Verification

- `pnpm test src/modules/WorkStation/shared/DiffSectionList/search` — 10 tests passed, including full-review requests, lazy loading and lifecycle cleanup
- Commit hook `npx lint-staged` — scoped oxlint, ESLint and Prettier passed
- Commit hook `npx tsgo --noEmit --pretty false` and commitlint — passed
- `git diff --cached --check` — passed
- Scoped diff reviewed; no unrelated changes, secrets or generated artifacts
- No live desktop verification; limitation described above

## Audit

UI audit: 0 fixes, 2 keeps with reasons, 0 abstractions. Existing bounded worker lifecycle retained; no runtime performance improvement claimed.
