### PR TITLE
fix(source-control): unify diff toolbar actions

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/SourceControlToolbar.md
+++ b/docs/frontend-ui-audit-2026-09-13/SourceControlToolbar.md
@@ -1,0 +1,15 @@
+# Source Control toolbar UI audit
+
+Scope: Focus and All Changes share the existing 36px workstation header. Navigation/collapse controls precede one separator; the split toggle and ellipsis menu occupy the trailing action group without a separator between them. Focus retains editor-owned file callbacks through a portal. Empty Focus keeps disabled navigation arrows and the shared settings menu visible.
+
+| Line                                   | Element                                    | Verdict          | Reason                                                                                                                                                                                                      | Suggested change |
+| -------------------------------------- | ------------------------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `SourceControlHeaderContent.tsx:252`   | Navigation separator and trailing controls | keep with reason | Existing theme border utilities, shared DiffViewModeToggle and small DS buttons preserve the workstation header sizing. No new pixel or color values.                                                       | None             |
+| `SourceControlDiffSettingsMenu.tsx:26` | All Changes ellipsis menu                  | keep with reason | Reuses FileHeaderMoreMenu and canonical editor preference atoms; excludes operations requiring one editable file. Existing menu keyboard behavior remains shared.                                           | None             |
+| `FileHeader/index.tsx:462`             | Focus menu portal                          | keep with reason | Keeps file-specific callbacks and menu state with the editor while moving its rendered button into the owning pane's toolbar. The inline breadcrumb, stats, open and close controls remain in the file row. | None             |
+
+Verdict totals: **0 fix**, **3 keep with reason**, **0 abstract**.
+
+D1–D5 reviewed within the changed controls: shared DS primitives, existing spacing/theme tokens, existing accessible toggle/menu implementations, no new three-site duplication or sweep candidate.
+
+Verification: SourceControlHeaderContent tests (7), FileHeaderMoreMenu tests (6), and FileHeader portal lifecycle test (1) pass. `pnpm typecheck:fast` passes. No desktop visual verification was performed because computer control was not requested.

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlDiffSettingsMenu.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlDiffSettingsMenu.tsx
@@ -1,0 +1,67 @@
+import { useAtom, useAtomValue } from "jotai";
+import React, { useState } from "react";
+
+import { FileHeaderMoreMenu } from "@src/modules/shared/components/FileHeader/FileHeaderMoreMenu";
+import {
+  activeStatusBarCallbacksAtom,
+  editorHighlightActiveLineAtom,
+  editorLineNumbersAtom,
+  editorWordWrapAtom,
+} from "@src/store/ui";
+
+const noop = () => {};
+
+/** Aggregate diffs expose shared editor preferences without single-file actions. */
+export function SourceControlDiffSettingsMenu() {
+  const [menuVisible, setMenuVisible] = useState(false);
+  const [lineNumbers, setLineNumbers] = useAtom(editorLineNumbersAtom);
+  const [wordWrap, setWordWrap] = useAtom(editorWordWrapAtom);
+  const [highlightActiveLine, setHighlightActiveLine] = useAtom(
+    editorHighlightActiveLineAtom
+  );
+  const { onOpenSettings } = useAtomValue(activeStatusBarCallbacksAtom);
+  return (
+    <FileHeaderMoreMenu
+      showReloadButton={false}
+      showSearchAction={false}
+      showGoToLineAction={false}
+      showSaveAction={false}
+      showDiscardAction={false}
+      showCopyRelativePathAction={false}
+      showRevealInFileManagerAction={false}
+      showLineNumbersToggle
+      showWordWrapToggle
+      showMinimapToggle={false}
+      showHighlightActiveLineToggle
+      showGitBlameToggle={false}
+      showMoreSettingsAction={!!onOpenSettings}
+      lineNumbersEnabled={lineNumbers !== "off"}
+      wordWrapEnabled={wordWrap}
+      minimapEnabled={false}
+      highlightActiveLineEnabled={highlightActiveLine}
+      gitBlameEnabled={false}
+      loading={false}
+      hasUnsavedChanges={false}
+      reloadSpinClass={undefined}
+      reloadMenuCoolingDown={false}
+      menuVisible={menuVisible}
+      setMenuVisible={setMenuVisible}
+      onSaveClick={noop}
+      onDiscardClick={noop}
+      onSearchClick={noop}
+      onGoToLineClick={noop}
+      onCopyRelativePathClick={noop}
+      onRevealInFileManagerClick={noop}
+      onReloadClick={noop}
+      onLineNumbersChange={(enabled) => setLineNumbers(enabled ? "on" : "off")}
+      onWordWrapChange={setWordWrap}
+      onMinimapChange={noop}
+      onHighlightActiveLineChange={setHighlightActiveLine}
+      onGitBlameChange={noop}
+      onMoreSettingsClick={() => {
+        onOpenSettings?.();
+        setMenuVisible(false);
+      }}
+    />
+  );
+}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts
@@ -10,11 +10,18 @@ import { SourceControlHeaderContent } from "./SourceControlHeaderContent";
 vi.mock("@src/components/Button", () => ({
   default: ({
     title,
+    disabled,
     "aria-label": label,
   }: {
     title?: string;
+    disabled?: boolean;
     "aria-label"?: string;
-  }) => createElement("button", { "data-title": title, "aria-label": label }),
+  }) =>
+    createElement("button", {
+      "data-title": title,
+      "aria-label": label,
+      disabled,
+    }),
 }));
 
 vi.mock("@src/components/TabPill", () => ({
@@ -48,13 +55,24 @@ function sourceControlTab(mode: "focus" | "all-changes"): WorkStationTab {
   } as WorkStationTab;
 }
 
-function renderHeader(mode: "focus" | "all-changes"): string {
+vi.mock("./SourceControlDiffSettingsMenu", () => ({
+  SourceControlDiffSettingsMenu: () =>
+    createElement("button", { "data-menu": "diff-settings" }),
+}));
+
+function renderHeader(
+  mode: "focus" | "all-changes",
+  focusPath: string | null = null,
+  navigationTotal = focusPath ? 1 : 0
+): string {
+  const tab = sourceControlTab(mode);
+  tab.data.focusPath = focusPath;
   return renderToStaticMarkup(
     createElement(SourceControlHeaderContent, {
-      activeTab: sourceControlTab(mode),
+      activeTab: tab,
       sourceControlFilterMode: "uncommitted",
       showSourceControlModePill: true,
-      gitReviewNavigationTotal: 0,
+      gitReviewNavigationTotal: navigationTotal,
       selectedIssue: null,
       sourceControlRefreshSpinClass: undefined,
       diffViewMode: "split",
@@ -78,7 +96,59 @@ describe("SourceControlHeaderContent diff view controls", () => {
     expect(markup).not.toContain('data-tabs="unified,split"');
   });
 
-  it("keeps the aggregate diff control out of Focus mode", () => {
+  it("places focused diff controls after navigation and its separator", () => {
+    const markup = renderHeader("focus", "src/index.ts");
+    const next = markup.indexOf('aria-label="common:actions.reviewNextFile"');
+    const separator = markup.indexOf('role="separator"', next);
+    const split = markup.indexOf(
+      'aria-label="workstation.switchToUnifiedDiff"'
+    );
+    expect(markup).not.toContain("disabled");
+    expect(next).toBeGreaterThan(-1);
+    expect(separator).toBeGreaterThan(next);
+    expect(split).toBeGreaterThan(separator);
+    expect(markup.slice(split)).not.toContain('role="separator"');
+  });
+
+  it("keeps aggregate split and menu adjacent after collapse controls", () => {
+    const markup = renderHeader("all-changes");
+    const collapse = markup.indexOf('data-title="actions.collapseAll"');
+    const separator = markup.indexOf('role="separator"', collapse);
+    const split = markup.indexOf(
+      'aria-label="workstation.switchToUnifiedDiff"'
+    );
+    const menu = markup.indexOf('data-menu="diff-settings"');
+    expect(separator).toBeGreaterThan(collapse);
+    expect(split).toBeGreaterThan(separator);
+    expect(menu).toBeGreaterThan(split);
+    expect(markup.slice(split, menu)).not.toContain('role="separator"');
+  });
+
+  it.each([0, 3])(
+    "keeps empty Focus arrows disabled and its menu visible with %i review files",
+    (total) => {
+      const markup = renderHeader("focus", null, total);
+      for (const action of ["reviewPreviousFile", "reviewNextFile"]) {
+        expect(markup).toContain(
+          `aria-label="common:actions.${action}" disabled=""`
+        );
+      }
+      expect(markup).toContain('data-menu="diff-settings"');
+      expect(markup.indexOf('role="separator"')).toBeLessThan(
+        markup.indexOf('data-menu="diff-settings"')
+      );
+    }
+  );
+
+  it("disables navigation when a selected file has no review sequence", () => {
+    const markup = renderHeader("focus", "src/index.ts", 0);
+    expect(markup).toContain(
+      'aria-label="common:actions.reviewNextFile" disabled=""'
+    );
+    expect(markup).not.toContain('data-menu="diff-settings"');
+  });
+
+  it("keeps the aggregate diff control out of empty Focus mode", () => {
     const markup = renderHeader("focus");
 
     expect(markup).not.toContain("workstation.switchToUnifiedDiff");

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
@@ -33,6 +33,8 @@ import type {
 } from "@src/store/workstation/tabs";
 import type { DiffViewMode } from "@src/types/git/types";
 
+import { SourceControlDiffSettingsMenu } from "./SourceControlDiffSettingsMenu";
+
 export interface SourceControlHeaderContentProps {
   /** The active `source-control` tab (host guarantees the type). */
   activeTab: WorkStationTab;
@@ -44,6 +46,7 @@ export interface SourceControlHeaderContentProps {
   sourceControlHeaderLeadingSlot?: ReactNode;
   sourceControlHeaderTrailingSlot?: ReactNode;
   sourceControlRefreshSpinClass: string | undefined;
+  focusToolbarRef?: React.Ref<HTMLSpanElement>;
   diffViewMode: DiffViewMode;
   t: TFunction;
   onDiffViewModeChange: (mode: DiffViewMode) => void;
@@ -66,6 +69,7 @@ export const SourceControlHeaderContent: React.FC<
   sourceControlHeaderLeadingSlot,
   sourceControlHeaderTrailingSlot,
   sourceControlRefreshSpinClass,
+  focusToolbarRef,
   diffViewMode,
   t,
   onDiffViewModeChange,
@@ -94,12 +98,9 @@ export const SourceControlHeaderContent: React.FC<
   ];
   const showCollapseAll =
     showModePill && mode === "all-changes" && !historySelection;
-  const showReviewNavigation =
-    showModePill &&
-    mode === "focus" &&
-    !historySelection &&
-    hasFocusPath &&
-    gitReviewNavigationTotal > 0;
+  const showReviewNavigation = showModePill && mode === "focus";
+  const reviewNavigationDisabled =
+    !hasFocusPath || gitReviewNavigationTotal === 0;
   const showIssueHeader = isIssuesMode && selectedIssue;
   return (
     <div className="flex min-w-0 flex-1 items-center gap-1.5">
@@ -193,6 +194,7 @@ export const SourceControlHeaderContent: React.FC<
               variant="tertiary"
               size="small"
               iconOnly
+              disabled={reviewNavigationDisabled}
               onClick={onReviewPrevFile}
               title={t("common:actions.reviewPreviousFile")}
               aria-label={t("common:actions.reviewPreviousFile")}
@@ -211,6 +213,7 @@ export const SourceControlHeaderContent: React.FC<
               variant="tertiary"
               size="small"
               iconOnly
+              disabled={reviewNavigationDisabled}
               onClick={onReviewNextFile}
               title={t("common:actions.reviewNextFile")}
               aria-label={t("common:actions.reviewNextFile")}
@@ -229,16 +232,6 @@ export const SourceControlHeaderContent: React.FC<
 
         {showCollapseAll && (
           <>
-            <DiffViewModeToggle
-              viewMode={diffViewMode}
-              onChange={onDiffViewModeChange}
-              t={t}
-            />
-            <span
-              className="mx-1.5 h-4 w-px shrink-0 bg-border-2"
-              role="separator"
-              aria-hidden
-            />
             <Button
               htmlType="button"
               variant="tertiary"
@@ -256,6 +249,30 @@ export const SourceControlHeaderContent: React.FC<
               }
             />
           </>
+        )}
+        {(showReviewNavigation || showCollapseAll) && (
+          <span
+            className="mx-1.5 h-4 w-px shrink-0 bg-border-2"
+            role="separator"
+            aria-hidden
+          />
+        )}
+        {showModePill && (mode === "all-changes" || hasFocusPath) && (
+          <DiffViewModeToggle
+            viewMode={diffViewMode}
+            onChange={onDiffViewModeChange}
+            t={t}
+          />
+        )}
+        {showModePill && mode === "focus" && hasFocusPath && (
+          <span
+            ref={focusToolbarRef}
+            className="flex shrink-0 items-center gap-px"
+          />
+        )}
+
+        {(showCollapseAll || (showReviewNavigation && !hasFocusPath)) && (
+          <SourceControlDiffSettingsMenu />
         )}
         <Button
           htmlType="button"

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
@@ -28,6 +28,7 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -39,6 +40,7 @@ import { useWorkStationTabShortcutBridge } from "@src/hooks/tabHost/useWorkStati
 import { usePublishWorkstationTabHeader } from "@src/hooks/tabHost/useWorkstationTabHeader";
 import UnifiedTabContent from "@src/modules/WorkStation/TabContent/UnifiedTabContent";
 import { NoTabsPlaceholder } from "@src/modules/WorkStation/shared";
+import { FileHeaderToolbarContext } from "@src/modules/shared/components/FileHeader/FileHeaderToolbarContext";
 import { workStationPrimarySidebarCollapsedAtom } from "@src/store/ui/workStationLayout/primarySidebarAtoms";
 import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import { workstationSelectedIssueAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
@@ -304,6 +306,9 @@ const EditorContent: React.FC<EditorContentProps> = memo(
       sourceControlFilterMode,
     });
 
+    const [focusToolbarTarget, setFocusToolbarTarget] =
+      useState<HTMLSpanElement | null>(null);
+
     // Memoized so `usePublishWorkstationTabHeader` sees a stable `content`
     // identity — a fresh element every render would re-publish the global
     // header slot on each pass.
@@ -312,6 +317,7 @@ const EditorContent: React.FC<EditorContentProps> = memo(
       return (
         <SourceControlHeaderContent
           activeTab={activeTab}
+          focusToolbarRef={setFocusToolbarTarget}
           sourceControlFilterMode={sourceControlFilterMode}
           showSourceControlModePill={showSourceControlModePill}
           gitReviewNavigationTotal={gitReviewNavigation.total}
@@ -530,25 +536,39 @@ const EditorContent: React.FC<EditorContentProps> = memo(
                 aria-hidden={!sourceControlPaneVisible}
               >
                 <Suspense fallback={<LazyFallback />}>
-                  <SourceControlMainPane
-                    tabData={sourceControlTab.data as SourceControlMainTabData}
-                    repoPath={repoPath}
-                    repoId={repoId ?? null}
-                    gitFilesByPath={gitFilesByPath}
-                    sourceControlFiles={sourceControlBaseFiles}
-                    sourceControlFilterMode={sourceControlFilterMode}
-                    activeRepoRoot={sourceControlActiveRepoRoot}
-                    gitDiffLoading={gitDiffLoading}
-                    sourceControlCollapseAllSignal={
-                      sourceControlCollapseAllSignal
+                  <FileHeaderToolbarContext.Provider
+                    value={
+                      sourceControlPaneVisible &&
+                      sourceControlTab.data.mode !== "all-changes" &&
+                      !sourceControlTab.data.historySelection &&
+                      sourceControlFilterMode !== "issues" &&
+                      sourceControlFilterMode !== "pr"
+                        ? focusToolbarTarget
+                        : null
                     }
-                    sourceControlQuickActions={sourceControlQuickActions}
-                    onForceReload={forceRefresh}
-                    onFileSelect={onFileSelect}
-                    onCloseFocus={handleSourceControlCloseFocus}
-                    onGitDiffUnsavedChange={handleGitDiffUnsavedChange}
-                    viewStateKey={sourceControlTab.id}
-                  />
+                  >
+                    <SourceControlMainPane
+                      tabData={
+                        sourceControlTab.data as SourceControlMainTabData
+                      }
+                      repoPath={repoPath}
+                      repoId={repoId ?? null}
+                      gitFilesByPath={gitFilesByPath}
+                      sourceControlFiles={sourceControlBaseFiles}
+                      sourceControlFilterMode={sourceControlFilterMode}
+                      activeRepoRoot={sourceControlActiveRepoRoot}
+                      gitDiffLoading={gitDiffLoading}
+                      sourceControlCollapseAllSignal={
+                        sourceControlCollapseAllSignal
+                      }
+                      sourceControlQuickActions={sourceControlQuickActions}
+                      onForceReload={forceRefresh}
+                      onFileSelect={onFileSelect}
+                      onCloseFocus={handleSourceControlCloseFocus}
+                      onGitDiffUnsavedChange={handleGitDiffUnsavedChange}
+                      viewStateKey={sourceControlTab.id}
+                    />
+                  </FileHeaderToolbarContext.Provider>
                 </Suspense>
               </div>
             )}

--- a/src/modules/shared/components/FileHeader/FileHeader.test.ts
+++ b/src/modules/shared/components/FileHeader/FileHeader.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { FileHeaderToolbarContext } from "./FileHeaderToolbarContext";
+import { FileHeader } from "./index";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("./BreadcrumbFileHeader", () => ({
+  default: () => createElement("span", null, "file breadcrumb"),
+}));
+vi.mock("./FileHeaderMoreMenu", () => ({
+  FileHeaderMoreMenu: ({ onSearchClick }: { onSearchClick: () => void }) =>
+    createElement("button", { onClick: onSearchClick }, "file menu"),
+}));
+
+it("moves the live file menu into its host toolbar and releases it on unmount", () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  const toolbar = document.createElement("div");
+  document.body.append(container, toolbar);
+  const root = createRoot(container);
+  const onSearch = vi.fn();
+  const store = createStore();
+  const render = (target: HTMLElement | null) =>
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(
+            FileHeaderToolbarContext.Provider,
+            { value: target },
+            createElement(FileHeader, {
+              filePath: "src/index.ts",
+              useFileTypeIcon: false,
+              viewMode: "split",
+              onViewModeChange: vi.fn(),
+              onSearchRequest: onSearch,
+            })
+          )
+        )
+      )
+    );
+  try {
+    render(toolbar);
+    expect(container.textContent).toContain("file breadcrumb");
+    expect(container.textContent).not.toContain("file menu");
+    expect(
+      container.querySelector('[aria-label="workstation.switchToUnifiedDiff"]')
+    ).toBeNull();
+    act(() => toolbar.querySelector("button")!.click());
+    expect(onSearch).toHaveBeenCalledOnce();
+    render(null);
+    expect(toolbar.childElementCount).toBe(0);
+    expect(container.textContent).toContain("file menu");
+    expect(
+      container.querySelector('[aria-label="workstation.switchToUnifiedDiff"]')
+    ).not.toBeNull();
+    render(toolbar);
+  } finally {
+    act(() => root.unmount());
+    expect(toolbar.childElementCount).toBe(0);
+    container.remove();
+    toolbar.remove();
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/modules/shared/components/FileHeader/FileHeaderToolbarContext.ts
+++ b/src/modules/shared/components/FileHeader/FileHeaderToolbarContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from "react";
+
+/** Optional file-menu destination; the host toolbar owns the diff toggle. */
+export const FileHeaderToolbarContext = createContext<HTMLElement | null>(null);

--- a/src/modules/shared/components/FileHeader/index.tsx
+++ b/src/modules/shared/components/FileHeader/index.tsx
@@ -14,7 +14,15 @@
  *   - `FileHeaderMoreMenu`    → the trailing ellipsis dropdown menu.
  *   - `FileHeaderShell`       → inline vs teleport-to-workstation wrapper.
  */
-import React, { memo, useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
@@ -34,6 +42,7 @@ import { DiffViewModeToggle } from "../DiffViewModeToggle";
 import BreadcrumbFileHeader from "./BreadcrumbFileHeader";
 import { FileHeaderMoreMenu } from "./FileHeaderMoreMenu";
 import { FileHeaderShell } from "./FileHeaderShell";
+import { FileHeaderToolbarContext } from "./FileHeaderToolbarContext";
 
 const RELOAD_MENU_COOLDOWN_MS = 1200;
 
@@ -232,6 +241,7 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
         loading ?? false,
         reloadSpinPersistenceKey
       );
+    const toolbarTarget = useContext(FileHeaderToolbarContext);
     const [moreMenuVisible, setMoreMenuVisible] = useState(false);
     const [reloadMenuCoolingDown, setReloadMenuCoolingDown] = useState(false);
     const reloadMenuCooldownTimerRef = useRef<ReturnType<
@@ -397,8 +407,59 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
       showCloseAction ||
       !!extraActions;
 
+    const viewModeToggle = showViewModeToggle ? (
+      <DiffViewModeToggle
+        viewMode={viewMode}
+        onChange={onViewModeChange}
+        t={t}
+      />
+    ) : null;
+    const moreMenu = showMoreMenu ? (
+      <FileHeaderMoreMenu
+        renderFileActions={renderFileActions}
+        showReloadButton={showReloadButton}
+        showSearchAction={showSearchAction}
+        showGoToLineAction={showGoToLineAction}
+        showSaveAction={showSaveAction}
+        showDiscardAction={showDiscardAction}
+        showCopyRelativePathAction={showCopyRelativePathAction}
+        showRevealInFileManagerAction={showRevealInFileManagerAction}
+        showLineNumbersToggle={showLineNumbersToggle}
+        showWordWrapToggle={showWordWrapToggle}
+        showMinimapToggle={showMinimapToggle}
+        showHighlightActiveLineToggle={showHighlightActiveLineToggle}
+        showGitBlameToggle={showGitBlameToggle}
+        showMoreSettingsAction={showMoreSettingsAction}
+        lineNumbersEnabled={lineNumbersEnabled}
+        wordWrapEnabled={wordWrapEnabled}
+        minimapEnabled={minimapEnabled}
+        highlightActiveLineEnabled={highlightActiveLineEnabled}
+        gitBlameEnabled={gitBlameEnabled}
+        loading={!!loading}
+        hasUnsavedChanges={hasUnsavedChanges}
+        reloadSpinClass={reloadSpinClass}
+        reloadMenuCoolingDown={reloadMenuCoolingDown}
+        menuVisible={moreMenuVisible}
+        setMenuVisible={setMoreMenuVisible}
+        onSaveClick={handleSaveMenuClick}
+        onDiscardClick={handleDiscardMenuClick}
+        onSearchClick={handleSearchMenuClick}
+        onGoToLineClick={handleGoToLineMenuClick}
+        onCopyRelativePathClick={handleCopyRelativePathMenuClick}
+        onRevealInFileManagerClick={handleRevealInFileManagerMenuClick}
+        onReloadClick={handleReloadMenuClick}
+        onLineNumbersChange={handleLineNumbersChange}
+        onWordWrapChange={handleWordWrapChange}
+        onMinimapChange={handleMinimapChange}
+        onHighlightActiveLineChange={handleHighlightActiveLineChange}
+        onGitBlameChange={handleGitBlameChange}
+        onMoreSettingsClick={handleMoreSettingsMenuClick}
+      />
+    ) : null;
+
     const headerInner = (
       <>
+        {toolbarTarget && createPortal(moreMenu, toolbarTarget)}
         {/* Optional leading content (rendered before the breadcrumb) */}
         {leadingSlot && (
           <div className="flex shrink-0 items-center">{leadingSlot}</div>
@@ -434,7 +495,9 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
             )}
 
             {/* Separator before tab pills */}
-            {(showViewModeToggle || showCustomToggle || showPreviewButton) &&
+            {((showViewModeToggle && !toolbarTarget) ||
+              showCustomToggle ||
+              showPreviewButton) &&
               hasStats &&
               (additions! > 0 || deletions! > 0) && (
                 <div
@@ -444,13 +507,7 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
                 />
               )}
             {/* View Mode Toggle (for diffs) */}
-            {showViewModeToggle && (
-              <DiffViewModeToggle
-                viewMode={viewMode}
-                onChange={onViewModeChange}
-                t={t}
-              />
-            )}
+            {showViewModeToggle && !toolbarTarget && viewModeToggle}
 
             {/* Custom Toggle — TabPill pill (matches source control / preview) */}
             {showCustomToggle && (
@@ -507,69 +564,22 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
             )}
 
             {/* Vertical separator: tab switches | other buttons */}
-            {showAnyTabSwitch && (showHeaderActionButtons || extraActions) && (
-              <div
-                className={`${PANEL_HEADER_TOKENS.verticalSeparator} mx-1.5`}
-                role="separator"
-                aria-hidden
-              />
-            )}
+            {showAnyTabSwitch &&
+              !toolbarTarget &&
+              (showHeaderActionButtons || extraActions) && (
+                <div
+                  className={`${PANEL_HEADER_TOKENS.verticalSeparator} mx-1.5`}
+                  role="separator"
+                  aria-hidden
+                />
+              )}
 
             {(showHeaderActionButtons || beforeMoreMenuSlot) && (
               <span className="flex items-center gap-px">
                 {beforeMoreMenuSlot}
 
                 {/* More actions */}
-                {showMoreMenu && (
-                  <FileHeaderMoreMenu
-                    renderFileActions={renderFileActions}
-                    showReloadButton={showReloadButton}
-                    showSearchAction={showSearchAction}
-                    showGoToLineAction={showGoToLineAction}
-                    showSaveAction={showSaveAction}
-                    showDiscardAction={showDiscardAction}
-                    showCopyRelativePathAction={showCopyRelativePathAction}
-                    showRevealInFileManagerAction={
-                      showRevealInFileManagerAction
-                    }
-                    showLineNumbersToggle={showLineNumbersToggle}
-                    showWordWrapToggle={showWordWrapToggle}
-                    showMinimapToggle={showMinimapToggle}
-                    showHighlightActiveLineToggle={
-                      showHighlightActiveLineToggle
-                    }
-                    showGitBlameToggle={showGitBlameToggle}
-                    showMoreSettingsAction={showMoreSettingsAction}
-                    lineNumbersEnabled={lineNumbersEnabled}
-                    wordWrapEnabled={wordWrapEnabled}
-                    minimapEnabled={minimapEnabled}
-                    highlightActiveLineEnabled={highlightActiveLineEnabled}
-                    gitBlameEnabled={gitBlameEnabled}
-                    loading={!!loading}
-                    hasUnsavedChanges={hasUnsavedChanges}
-                    reloadSpinClass={reloadSpinClass}
-                    reloadMenuCoolingDown={reloadMenuCoolingDown}
-                    menuVisible={moreMenuVisible}
-                    setMenuVisible={setMoreMenuVisible}
-                    onSaveClick={handleSaveMenuClick}
-                    onDiscardClick={handleDiscardMenuClick}
-                    onSearchClick={handleSearchMenuClick}
-                    onGoToLineClick={handleGoToLineMenuClick}
-                    onCopyRelativePathClick={handleCopyRelativePathMenuClick}
-                    onRevealInFileManagerClick={
-                      handleRevealInFileManagerMenuClick
-                    }
-                    onReloadClick={handleReloadMenuClick}
-                    onLineNumbersChange={handleLineNumbersChange}
-                    onWordWrapChange={handleWordWrapChange}
-                    onMinimapChange={handleMinimapChange}
-                    onHighlightActiveLineChange={
-                      handleHighlightActiveLineChange
-                    }
-                    onGitBlameChange={handleGitBlameChange}
-                    onMoreSettingsClick={handleMoreSettingsMenuClick}
-                  />
-                )}
+                {showMoreMenu && !toolbarTarget && moreMenu}
 
                 {showOpenFileAction && onFileSelect && (
                   <Button


### PR DESCRIPTION
## Problem

Source Control Focus puts the diff toggle and file menu in the file breadcrumb row, while All Changes puts its toggle in the global header. Switching views changes the action layout, and empty Focus hides navigation and settings.

## Solution

Use the existing shared 36px Source Control header for both views. Place navigation/collapse controls before a separator, followed by the split toggle, ellipsis menu and refresh without separators inside that trailing group. Keep Focus arrows visible but disabled without a selected file or review sequence, and expose shared settings when Focus is empty.

Render the selected file menu into the header through a pane-scoped React portal so Save, Search and other file callbacks remain owned by the editor. All Changes uses the same menu component for editor preferences. Keep breadcrumb, diff statistics, open-file and close controls in the file row.

## Potential risks

The toolbar destination is a DOM reference scoped to the owning pane; header unmount clears it and the provider excludes inactive, history, issue and PR views. A rendered unit test verifies menu relocation, action dispatch, fallback and unmount cleanup, but full Tauri tab switching, native appearance, themes and narrow viewport layouts were not visually checked because computer control was not requested. Shared FileHeader consumers without a destination retain their existing controls. No dependencies, persistence formats, schema or IPC contracts change; revert this commit to restore the previous layout.

## Verification

- `pnpm test -- src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts src/modules/shared/components/FileHeader/FileHeader.test.ts src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts` — 14 tests pass
- `pnpm typecheck:fast` — pass
- `pnpm exec eslint src/modules/shared/components/FileHeader/index.tsx src/modules/shared/components/FileHeader/FileHeaderToolbarContext.ts src/modules/shared/components/FileHeader/FileHeader.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControl{HeaderContent,DiffSettingsMenu}.tsx src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts --max-warnings 0` — pass
- `git diff --check` — pass
- Frontend UI audit: 0 fix, 3 keep with reason, 0 abstract; report included
- Desktop screenshots and Tauri visual checks were not performed; the user has not opted into computer control
