### PR TITLE
fix(source-control): clarify and localize file menu actions

### DIFF
--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1934,6 +1934,20 @@
     "title": "Sitzungen"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "Änderungen anzeigen",
+      "openFileInNewTab": "Datei in neuem Tab öffnen",
+      "stageChanges": "Änderungen vormerken",
+      "unstageChanges": "Vormerkung aufheben",
+      "discardChanges": "Änderungen verwerfen",
+      "markResolved": "Als gelöst markieren (vormerken)",
+      "acceptCurrent": "Aktuelle Änderungen übernehmen (unsere)",
+      "acceptIncoming": "Eingehende Änderungen übernehmen (deren)",
+      "stageChangesCount": "Änderungen vormerken ({{count}})",
+      "unstageChangesCount": "Vormerkung aufheben ({{count}})",
+      "discardChangesCount": "Änderungen verwerfen ({{count}})",
+      "markResolvedCount": "Als gelöst markieren ({{count}})"
+    },
     "notGitInitialized": "Git nicht initialisiert",
     "notGitInitializedSubtitle": "Initialisiere Git, um Änderungen zu verfolgen, Commits zu erstellen und Branch-Werkzeuge in diesem Arbeitsverzeichnis zu nutzen.",
     "initializeGit": "Git initialisieren",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1765,6 +1765,20 @@
     "title": "Sessions"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "View Changes",
+      "openFileInNewTab": "Open File in New Tab",
+      "stageChanges": "Stage Changes",
+      "unstageChanges": "Unstage Changes",
+      "discardChanges": "Discard Changes",
+      "markResolved": "Mark as Resolved (Stage)",
+      "acceptCurrent": "Accept Current Changes (Ours)",
+      "acceptIncoming": "Accept Incoming Changes (Theirs)",
+      "stageChangesCount": "Stage Changes ({{count}})",
+      "unstageChangesCount": "Unstage Changes ({{count}})",
+      "discardChangesCount": "Discard Changes ({{count}})",
+      "markResolvedCount": "Mark as Resolved ({{count}})"
+    },
     "notGitInitialized": "Not git initialized",
     "notGitInitializedSubtitle": "Initialize Git to track changes, create commits, and use branch tools in this working directory.",
     "initializeGit": "Initialize Git",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1934,6 +1934,20 @@
     "title": "Sesiones"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "Ver cambios",
+      "openFileInNewTab": "Abrir archivo en una pestaña nueva",
+      "stageChanges": "Preparar cambios",
+      "unstageChanges": "Quitar cambios del área de preparación",
+      "discardChanges": "Descartar cambios",
+      "markResolved": "Marcar como resuelto (preparar)",
+      "acceptCurrent": "Aceptar cambios actuales (nuestros)",
+      "acceptIncoming": "Aceptar cambios entrantes (suyos)",
+      "stageChangesCount": "Preparar cambios ({{count}})",
+      "unstageChangesCount": "Quitar cambios del área de preparación ({{count}})",
+      "discardChangesCount": "Descartar cambios ({{count}})",
+      "markResolvedCount": "Marcar como resuelto ({{count}})"
+    },
     "notGitInitialized": "Git no inicializado",
     "notGitInitializedSubtitle": "Inicializa Git para seguir cambios, crear commits y usar herramientas de ramas en este directorio de trabajo.",
     "initializeGit": "Inicializar Git",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1934,6 +1934,20 @@
     "title": "Sessions"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "Afficher les modifications",
+      "openFileInNewTab": "Ouvrir le fichier dans un nouvel onglet",
+      "stageChanges": "Indexer les modifications",
+      "unstageChanges": "Désindexer les modifications",
+      "discardChanges": "Abandonner les modifications",
+      "markResolved": "Marquer comme résolu (indexer)",
+      "acceptCurrent": "Accepter les modifications actuelles (les nôtres)",
+      "acceptIncoming": "Accepter les modifications entrantes (les leurs)",
+      "stageChangesCount": "Indexer les modifications ({{count}})",
+      "unstageChangesCount": "Désindexer les modifications ({{count}})",
+      "discardChangesCount": "Abandonner les modifications ({{count}})",
+      "markResolvedCount": "Marquer comme résolu ({{count}})"
+    },
     "notGitInitialized": "Git non initialisé",
     "notGitInitializedSubtitle": "Initialisez Git pour suivre les changements, créer des commits et utiliser les outils de branche dans ce répertoire de travail.",
     "initializeGit": "Initialiser Git",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1934,6 +1934,20 @@
     "title": "セッション"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "変更を表示",
+      "openFileInNewTab": "新しいタブでファイルを開く",
+      "stageChanges": "変更をステージ",
+      "unstageChanges": "変更のステージを解除",
+      "discardChanges": "変更を破棄",
+      "markResolved": "解決済みとしてマーク（ステージ）",
+      "acceptCurrent": "現在の変更を採用（ours）",
+      "acceptIncoming": "取り込む変更を採用（theirs）",
+      "stageChangesCount": "変更をステージ（{{count}} 件）",
+      "unstageChangesCount": "変更のステージを解除（{{count}} 件）",
+      "discardChangesCount": "変更を破棄（{{count}} 件）",
+      "markResolvedCount": "解決済みとしてマーク（{{count}} 件）"
+    },
     "notGitInitialized": "Git 未初期化",
     "notGitInitializedSubtitle": "Git を初期化すると、この作業ディレクトリで変更の追跡、コミット作成、ブランチツールを使用できます。",
     "initializeGit": "Git を初期化",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1934,6 +1934,20 @@
     "title": "세션"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "변경 사항 보기",
+      "openFileInNewTab": "새 탭에서 파일 열기",
+      "stageChanges": "변경 사항 스테이징",
+      "unstageChanges": "변경 사항 스테이징 취소",
+      "discardChanges": "변경 사항 버리기",
+      "markResolved": "해결됨으로 표시 (스테이징)",
+      "acceptCurrent": "현재 변경 사항 수락 (ours)",
+      "acceptIncoming": "들어오는 변경 사항 수락 (theirs)",
+      "stageChangesCount": "변경 사항 스테이징 ({{count}}개)",
+      "unstageChangesCount": "변경 사항 스테이징 취소 ({{count}}개)",
+      "discardChangesCount": "변경 사항 버리기 ({{count}}개)",
+      "markResolvedCount": "해결됨으로 표시 ({{count}}개)"
+    },
     "notGitInitialized": "Git 초기화 안 됨",
     "notGitInitializedSubtitle": "Git을 초기화하면 이 작업 디렉터리에서 변경 사항 추적, 커밋 생성, 브랜치 도구를 사용할 수 있습니다.",
     "initializeGit": "Git 초기화",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1934,6 +1934,20 @@
     "title": "Sesje"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "Pokaż zmiany",
+      "openFileInNewTab": "Otwórz plik w nowej karcie",
+      "stageChanges": "Dodaj zmiany do indeksu",
+      "unstageChanges": "Usuń zmiany z indeksu",
+      "discardChanges": "Odrzuć zmiany",
+      "markResolved": "Oznacz jako rozwiązane (dodaj do indeksu)",
+      "acceptCurrent": "Zaakceptuj bieżące zmiany (nasze)",
+      "acceptIncoming": "Zaakceptuj przychodzące zmiany (ich)",
+      "stageChangesCount": "Dodaj zmiany do indeksu ({{count}})",
+      "unstageChangesCount": "Usuń zmiany z indeksu ({{count}})",
+      "discardChangesCount": "Odrzuć zmiany ({{count}})",
+      "markResolvedCount": "Oznacz jako rozwiązane ({{count}})"
+    },
     "notGitInitialized": "Git nie został zainicjowany",
     "notGitInitializedSubtitle": "Zainicjuj Git, aby śledzić zmiany, tworzyć commity i używać narzędzi gałęzi w tym katalogu roboczym.",
     "initializeGit": "Zainicjuj Git",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1934,6 +1934,20 @@
     "title": "Sessões"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "Ver alterações",
+      "openFileInNewTab": "Abrir arquivo em nova aba",
+      "stageChanges": "Preparar alterações",
+      "unstageChanges": "Retirar alterações da preparação",
+      "discardChanges": "Descartar alterações",
+      "markResolved": "Marcar como resolvido (preparar)",
+      "acceptCurrent": "Aceitar alterações atuais (nossas)",
+      "acceptIncoming": "Aceitar alterações recebidas (deles)",
+      "stageChangesCount": "Preparar alterações ({{count}})",
+      "unstageChangesCount": "Retirar alterações da preparação ({{count}})",
+      "discardChangesCount": "Descartar alterações ({{count}})",
+      "markResolvedCount": "Marcar como resolvido ({{count}})"
+    },
     "notGitInitialized": "Git não inicializado",
     "notGitInitializedSubtitle": "Inicialize o Git para acompanhar alterações, criar commits e usar ferramentas de branch neste diretório de trabalho.",
     "initializeGit": "Inicializar Git",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1934,6 +1934,20 @@
     "title": "Сессии"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "Показать изменения",
+      "openFileInNewTab": "Открыть файл в новой вкладке",
+      "stageChanges": "Индексировать изменения",
+      "unstageChanges": "Убрать изменения из индекса",
+      "discardChanges": "Отменить изменения",
+      "markResolved": "Отметить как решённое (индексировать)",
+      "acceptCurrent": "Принять текущие изменения (наши)",
+      "acceptIncoming": "Принять входящие изменения (их)",
+      "stageChangesCount": "Индексировать изменения ({{count}})",
+      "unstageChangesCount": "Убрать изменения из индекса ({{count}})",
+      "discardChangesCount": "Отменить изменения ({{count}})",
+      "markResolvedCount": "Отметить как решённое ({{count}})"
+    },
     "notGitInitialized": "Git не инициализирован",
     "notGitInitializedSubtitle": "Инициализируйте Git, чтобы отслеживать изменения, создавать коммиты и использовать инструменты веток в этом рабочем каталоге.",
     "initializeGit": "Инициализировать Git",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1934,6 +1934,20 @@
     "title": "Oturumlar"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "Değişiklikleri görüntüle",
+      "openFileInNewTab": "Dosyayı yeni sekmede aç",
+      "stageChanges": "Değişiklikleri hazırla",
+      "unstageChanges": "Değişiklikleri hazırlamadan çıkar",
+      "discardChanges": "Değişiklikleri at",
+      "markResolved": "Çözüldü olarak işaretle (hazırla)",
+      "acceptCurrent": "Geçerli değişiklikleri kabul et (bizimki)",
+      "acceptIncoming": "Gelen değişiklikleri kabul et (onlarınki)",
+      "stageChangesCount": "Değişiklikleri hazırla ({{count}})",
+      "unstageChangesCount": "Değişiklikleri hazırlamadan çıkar ({{count}})",
+      "discardChangesCount": "Değişiklikleri at ({{count}})",
+      "markResolvedCount": "Çözüldü olarak işaretle ({{count}})"
+    },
     "notGitInitialized": "Git başlatılmadı",
     "notGitInitializedSubtitle": "Bu çalışma dizininde değişiklikleri izlemek, commit oluşturmak ve branch araçlarını kullanmak için Git'i başlatın.",
     "initializeGit": "Git'i başlat",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1934,6 +1934,20 @@
     "title": "Phiên"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "Xem thay đổi",
+      "openFileInNewTab": "Mở tệp trong thẻ mới",
+      "stageChanges": "Đưa thay đổi vào vùng chờ",
+      "unstageChanges": "Bỏ thay đổi khỏi vùng chờ",
+      "discardChanges": "Loại bỏ thay đổi",
+      "markResolved": "Đánh dấu đã giải quyết (đưa vào vùng chờ)",
+      "acceptCurrent": "Chấp nhận thay đổi hiện tại (của chúng ta)",
+      "acceptIncoming": "Chấp nhận thay đổi đến (của họ)",
+      "stageChangesCount": "Đưa thay đổi vào vùng chờ ({{count}})",
+      "unstageChangesCount": "Bỏ thay đổi khỏi vùng chờ ({{count}})",
+      "discardChangesCount": "Loại bỏ thay đổi ({{count}})",
+      "markResolvedCount": "Đánh dấu đã giải quyết ({{count}})"
+    },
     "notGitInitialized": "Git chưa được khởi tạo",
     "notGitInitializedSubtitle": "Khởi tạo Git để theo dõi thay đổi, tạo commit và dùng công cụ branch trong thư mục làm việc này.",
     "initializeGit": "Khởi tạo Git",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1934,6 +1934,20 @@
     "title": "會話"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "檢視變更",
+      "openFileInNewTab": "在新分頁中開啟檔案",
+      "stageChanges": "暫存變更",
+      "unstageChanges": "取消暫存變更",
+      "discardChanges": "捨棄變更",
+      "markResolved": "標記為已解決（暫存）",
+      "acceptCurrent": "接受目前的變更（我們的）",
+      "acceptIncoming": "接受傳入的變更（他們的）",
+      "stageChangesCount": "暫存 {{count}} 項變更",
+      "unstageChangesCount": "取消暫存 {{count}} 項變更",
+      "discardChangesCount": "捨棄 {{count}} 項變更",
+      "markResolvedCount": "將 {{count}} 項變更標記為已解決"
+    },
     "notGitInitialized": "尚未初始化 Git",
     "notGitInitializedSubtitle": "初始化 Git 後即可在此工作目錄追蹤變更、建立提交並使用分支工具。",
     "initializeGit": "初始化 Git",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1765,6 +1765,20 @@
     "title": "会话"
   },
   "sourceControl": {
+    "fileMenu": {
+      "viewChanges": "查看更改",
+      "openFileInNewTab": "在新标签页中打开文件",
+      "stageChanges": "暂存更改",
+      "unstageChanges": "取消暂存更改",
+      "discardChanges": "放弃更改",
+      "markResolved": "标记为已解决（暂存）",
+      "acceptCurrent": "接受当前更改（我们的）",
+      "acceptIncoming": "接受传入更改（他们的）",
+      "stageChangesCount": "暂存 {{count}} 项更改",
+      "unstageChangesCount": "取消暂存 {{count}} 项更改",
+      "discardChangesCount": "放弃 {{count}} 项更改",
+      "markResolvedCount": "将 {{count}} 项更改标记为已解决"
+    },
     "notGitInitialized": "未初始化 Git",
     "notGitInitializedSubtitle": "初始化 Git 后即可在此工作目录跟踪更改、创建提交并使用分支工具。",
     "initializeGit": "初始化 Git",

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlContextMenu.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlContextMenu.test.ts
@@ -1,11 +1,59 @@
-import { describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
+import i18next from "i18next";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import deCommon from "@src/i18n/locales/de/common.json";
+import enCommon from "@src/i18n/locales/en/common.json";
+import esCommon from "@src/i18n/locales/es/common.json";
+import frCommon from "@src/i18n/locales/fr/common.json";
+import jaCommon from "@src/i18n/locales/ja/common.json";
+import koCommon from "@src/i18n/locales/ko/common.json";
+import plCommon from "@src/i18n/locales/pl/common.json";
+import ptCommon from "@src/i18n/locales/pt/common.json";
+import ruCommon from "@src/i18n/locales/ru/common.json";
+import trCommon from "@src/i18n/locales/tr/common.json";
+import viCommon from "@src/i18n/locales/vi/common.json";
+import zhHantCommon from "@src/i18n/locales/zh-Hant/common.json";
+import zhCommon from "@src/i18n/locales/zh/common.json";
 import type { GitFile } from "@src/types/git/types";
+import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
 
-import {
+import SourceControlContextMenu, {
   getSourceControlContextMenuActionLabels,
   resolveConflictsForFiles,
 } from "./SourceControlContextMenu";
+
+vi.mock("@src/util/platform/tauri/nativeMenuPopup", () => ({
+  popupNativeMenu: vi.fn(),
+}));
+
+const resources = {
+  de: { common: deCommon },
+  en: { common: enCommon },
+  es: { common: esCommon },
+  fr: { common: frCommon },
+  ja: { common: jaCommon },
+  ko: { common: koCommon },
+  pl: { common: plCommon },
+  pt: { common: ptCommon },
+  ru: { common: ruCommon },
+  tr: { common: trCommon },
+  vi: { common: viCommon },
+  zh: { common: zhCommon },
+  "zh-Hant": { common: zhHantCommon },
+};
+
+beforeEach(async () => {
+  await i18next.init({
+    lng: "en",
+    fallbackLng: false,
+    resources,
+    defaultNS: "common",
+    initImmediate: false,
+  });
+});
 
 function gitFile(path: string): GitFile {
   return {
@@ -41,9 +89,9 @@ describe("getSourceControlContextMenuActionLabels", () => {
         changeCount: 1,
       })
     ).toMatchObject({
-      stageToggle: "Stage 1 change",
-      markResolved: "Mark 1 change as Resolved",
-      discard: "Discard 1 change",
+      stageToggle: "Stage Changes (1)",
+      markResolved: "Mark as Resolved (1)",
+      discard: "Discard Changes (1)",
     });
   });
 
@@ -55,9 +103,9 @@ describe("getSourceControlContextMenuActionLabels", () => {
         changeCount: 3,
       })
     ).toMatchObject({
-      stageToggle: "Unstage 3 changes",
-      markResolved: "Mark 3 changes as Resolved",
-      discard: "Discard 3 changes",
+      stageToggle: "Unstage Changes (3)",
+      markResolved: "Mark as Resolved (3)",
+      discard: "Discard Changes (3)",
     });
   });
 });
@@ -85,5 +133,82 @@ describe("resolveConflictsForFiles", () => {
       { path: "src/b.ts", strategy: "ours" },
       "user"
     );
+  });
+});
+
+describe("localized native source-control menu", () => {
+  it.each(Object.keys(resources))(
+    "resolves every file action in %s without fallback",
+    async (language) => {
+      await i18next.changeLanguage(language);
+      for (const isDirectory of [false, true]) {
+        for (const isStaged of [false, true]) {
+          const labels = getSourceControlContextMenuActionLabels({
+            isDirectory,
+            isStaged,
+            changeCount: 3,
+          });
+          for (const label of Object.values(labels)) {
+            expect(label).toBeTruthy();
+            expect(label).not.toContain("sourceControl.fileMenu");
+            expect(label).not.toContain("{{count}}");
+          }
+        }
+      }
+    }
+  );
+
+  it("builds Chinese open actions with distinct destinations and preserves their dispatch", async () => {
+    await i18next.changeLanguage("zh");
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const onSelect = vi.fn();
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    let items: Awaited<
+      ReturnType<Parameters<typeof popupNativeMenu>[0]["buildItems"]>
+    > = [];
+    vi.mocked(popupNativeMenu).mockImplementation(async (options) => {
+      items = await options.buildItems();
+      return { status: "closed" };
+    });
+    try {
+      await act(async () =>
+        root.render(
+          createElement(SourceControlContextMenu, {
+            file: gitFile("src/a.ts"),
+            repoPath: "/repo",
+            isConflictFile: false,
+            onSelect,
+            dispatch,
+            onClose: vi.fn(),
+          })
+        )
+      );
+      const actions = items.filter((item) => "text" in item);
+      expect(actions.map((item) => item.text)).toEqual([
+        "查看更改",
+        "在新标签页中打开文件",
+        "暂存更改",
+        "放弃更改",
+        i18next.t("actions.copyPath"),
+        i18next.t("actions.copyRelativePath"),
+        expect.any(String),
+      ]);
+      expect(actions[0]).toHaveProperty("action");
+      if ("action" in actions[0]) await actions[0].action?.("view-changes");
+      expect(onSelect).toHaveBeenCalledWith("src/a.ts");
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(actions[1]).toHaveProperty("action");
+      if ("action" in actions[1]) await actions[1].action?.("open-file");
+      expect(dispatch).toHaveBeenCalledWith(
+        "file.openAtLine",
+        { path: "/repo/src/a.ts", line: 1 },
+        "user"
+      );
+    } finally {
+      act(() => root.unmount());
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlContextMenu.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlContextMenu.tsx
@@ -20,8 +20,6 @@ import {
   popupNativeMenu,
 } from "@src/util/platform/tauri/nativeMenuPopup";
 
-import { GIT_LABELS } from "../config";
-
 const log = createLogger("SourceControlContextMenu");
 
 // ============================================
@@ -42,22 +40,27 @@ export function getSourceControlContextMenuActionLabels(options: {
   changeCount: number;
 }) {
   const { isDirectory, isStaged, changeCount } = options;
-  const changesLabel = `${changeCount} ${changeCount === 1 ? "change" : "changes"}`;
+  const t = i18next.t.bind(i18next);
+  const count = changeCount;
 
   return {
+    viewChanges: t("common:sourceControl.fileMenu.viewChanges"),
+    openFileInNewTab: t("common:sourceControl.fileMenu.openFileInNewTab"),
+    acceptCurrent: t("common:sourceControl.fileMenu.acceptCurrent"),
+    acceptIncoming: t("common:sourceControl.fileMenu.acceptIncoming"),
     stageToggle: isDirectory
       ? isStaged
-        ? `Unstage ${changesLabel}`
-        : `Stage ${changesLabel}`
+        ? t("common:sourceControl.fileMenu.unstageChangesCount", { count })
+        : t("common:sourceControl.fileMenu.stageChangesCount", { count })
       : isStaged
-        ? GIT_LABELS.unstageChanges
-        : GIT_LABELS.stageChanges,
+        ? t("common:sourceControl.fileMenu.unstageChanges")
+        : t("common:sourceControl.fileMenu.stageChanges"),
     markResolved: isDirectory
-      ? `Mark ${changesLabel} as Resolved`
-      : GIT_LABELS.markAsResolved,
+      ? t("common:sourceControl.fileMenu.markResolvedCount", { count })
+      : t("common:sourceControl.fileMenu.markResolved"),
     discard: isDirectory
-      ? `Discard ${changesLabel}`
-      : GIT_LABELS.discardChanges,
+      ? t("common:sourceControl.fileMenu.discardChangesCount", { count })
+      : t("common:sourceControl.fileMenu.discardChanges"),
   };
 }
 
@@ -137,7 +140,7 @@ export default function SourceControlContextMenu(
             if (!isDirectory) {
               // --- Open Changes (diff view) ---
               items.push({
-                text: GIT_LABELS.openChanges,
+                text: labels.viewChanges,
                 action: () => {
                   const ref = contextMenuRef.current;
                   if (ref?.onSelect) {
@@ -148,7 +151,7 @@ export default function SourceControlContextMenu(
 
               // --- Open File ---
               items.push({
-                text: t("common:tooltips.openFile"),
+                text: labels.openFileInNewTab,
                 action: () => {
                   const ref = contextMenuRef.current;
                   if (ref) {
@@ -220,7 +223,7 @@ export default function SourceControlContextMenu(
               items.push({ item: "Separator" });
 
               items.push({
-                text: GIT_LABELS.acceptCurrentChange,
+                text: labels.acceptCurrent,
                 action: async () => {
                   const ref = contextMenuRef.current;
                   if (ref) {
@@ -231,7 +234,7 @@ export default function SourceControlContextMenu(
               });
 
               items.push({
-                text: GIT_LABELS.acceptIncomingChange,
+                text: labels.acceptIncoming,
                 action: async () => {
                   const ref = contextMenuRef.current;
                   if (ref) {


### PR DESCRIPTION
## Problem

The Source Control file context menu mixes hardcoded English Git labels with translated path actions. “Open Changes” and “Open File” do not clearly distinguish reviewing a diff from opening a file editor tab.

## Solution

Rename the two actions to “View Changes” and “Open File in New Tab” and resolve file, folder-count and conflict action labels through i18next at menu construction. Add the complete key set to all 13 supported locales, including “查看更改” and “在新标签页中打开文件” in Simplified Chinese. Preserve the existing selection and file-open dispatch paths.

## Potential risks

This changes menu copy only; stage, discard, conflict resolution and file navigation behavior remain unchanged. The file editor can reuse an already-open tab, as before. Translations have automated key/interpolation coverage but have not had native-speaker review across all languages. Actual Tauri/macOS menu sizing and other platforms were not visually verified because computer control was not requested. No dependencies, schema, persistence or IPC changes; revert this commit to restore the prior labels.

## Verification

- `pnpm test -- src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlContextMenu.test.ts` — 18 tests pass, including all 13 locale bundles and Chinese native-menu construction with distinct selection/file-open dispatch
- `pnpm typecheck:fast` — pass
- `pnpm exec eslint src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlContextMenu.tsx src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlContextMenu.test.ts --max-warnings 0` — pass
- `node scripts/quality/check-missing-i18n-keys.mjs --namespace common --prefix sourceControl.fileMenu` — all languages complete, 0 missing
- `git diff --check` — pass
- Desktop screenshots/native menu visual checks were not performed; the user has not opted into computer control
