### PR TITLE
fix(spotlight): cancel picker scroll completion on cleanup

### DIFF
--- a/src/scaffold/GlobalSpotlight/hooks/observePickerScrollOffset.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/observePickerScrollOffset.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { observePickerScrollOffset } from "./observePickerScrollOffset";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+function setup() {
+  const element = document.createElement("div");
+  const onChange = vi.fn();
+  const stop = observePickerScrollOffset(
+    {
+      scrollElement: element,
+      targetWindow: window,
+      options: { isScrollingResetDelay: 150 },
+    },
+    onChange
+  )!;
+  const scroll = (offset: number) => {
+    element.scrollTop = offset;
+    element.dispatchEvent(new Event("scroll"));
+  };
+  return { onChange, stop, scroll };
+}
+
+describe("picker scroll observer lifetime", () => {
+  it("coalesces scroll completion to one timer with the latest offset", () => {
+    const { onChange, stop, scroll } = setup();
+    scroll(10);
+    vi.advanceTimersByTime(100);
+    scroll(20);
+    expect(vi.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(149);
+    expect(onChange.mock.calls).toEqual([
+      [10, true],
+      [20, true],
+    ]);
+    vi.advanceTimersByTime(1);
+    expect(onChange).toHaveBeenLastCalledWith(20, false);
+    expect(vi.getTimerCount()).toBe(0);
+    stop();
+  });
+
+  it("cancels the trailing callback and listener when the picker closes", () => {
+    const { onChange, stop, scroll } = setup();
+    scroll(30);
+    expect(vi.getTimerCount()).toBe(1);
+    stop();
+    expect(vi.getTimerCount()).toBe(0);
+    scroll(40);
+    vi.advanceTimersByTime(200);
+    expect(onChange.mock.calls).toEqual([[30, true]]);
+    stop();
+  });
+});

--- a/src/scaffold/GlobalSpotlight/hooks/observePickerScrollOffset.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/observePickerScrollOffset.ts
@@ -1,0 +1,30 @@
+import type { Virtualizer } from "@tanstack/react-virtual";
+
+/** Own both the listener and its trailing callback for the vertical picker. */
+export function observePickerScrollOffset(
+  instance: Pick<
+    Virtualizer<HTMLDivElement, Element>,
+    "scrollElement" | "targetWindow"
+  > & { options: { isScrollingResetDelay: number } },
+  onChange: (offset: number, isScrolling: boolean) => void
+) {
+  const element = instance.scrollElement;
+  const targetWindow = instance.targetWindow;
+  if (!element || !targetWindow) return;
+
+  let timer: number | undefined;
+  const onScroll = () => {
+    const offset = element.scrollTop;
+    targetWindow.clearTimeout(timer);
+    timer = targetWindow.setTimeout(() => {
+      timer = undefined;
+      onChange(offset, false);
+    }, instance.options.isScrollingResetDelay);
+    onChange(offset, true);
+  };
+  element.addEventListener("scroll", onScroll, { passive: true });
+  return () => {
+    element.removeEventListener("scroll", onScroll);
+    targetWindow.clearTimeout(timer);
+  };
+}

--- a/src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.ts
@@ -5,6 +5,8 @@ import {
 } from "@tanstack/react-virtual";
 import { useCallback, useLayoutEffect, useRef } from "react";
 
+import { observePickerScrollOffset } from "./observePickerScrollOffset";
+
 const NO_STICKY_INDICES: number[] = [];
 
 export function findStickyIndex(indices: number[], startIndex: number): number {
@@ -67,6 +69,7 @@ export function usePickerVirtualization({
     getItemKey,
     estimateSize,
     getScrollElement: () => containerRef.current,
+    observeElementOffset: observePickerScrollOffset,
     overscan: 5,
     rangeExtractor,
     enabled: enabled && count > 0,


### PR DESCRIPTION
## Problem

The BranchPalette frontend suite can finish all assertions successfully and still fail CI with `window is not defined`. TanStack virtual-core 3.13.22 removes its scroll listener during teardown but leaves its debounced scroll-completion callback scheduled, which can invoke React after the picker and test environment have been disposed. This surfaced in the frontend job for #1658 and is independent of session-memory changes.

## Solution

Give the shared vertical branch/PR picker an offset observer that owns both the passive scroll listener and its single trailing timeout. New scroll events replace the pending timeout; observer cleanup removes the listener and cancels the timeout. Both spotlight and dropdown presentations use this shared boundary.

## Potential risks

The observer is intentionally scoped to vertical pickers. It preserves the configured scroll-reset delay and current scrollTop behavior; it is not a general replacement for horizontal/RTL virtualizers. No dependency, persistence, IPC, or visual layout changes are made. Other virtualizers using TanStack defaults are outside this fix. No new packaged-app performance measurement was run for this follow-up; tests verify disposal and timer bounds, not CPU improvement. Rollback is a revert of these three files.

## Verification

- `pnpm test src/scaffold/GlobalSpotlight/hooks/observePickerScrollOffset.test.ts src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.test.ts src/scaffold/GlobalSpotlight/palettes/BranchPalette/__tests__/BranchPalette.test.ts` — 14 tests passed, including real virtualized keyboard navigation and scroll pagination in both picker presentations.
- `node_modules/.bin/tsgo --noEmit --pretty false` — passed.
- `pnpm exec eslint src/scaffold/GlobalSpotlight/hooks/observePickerScrollOffset.ts src/scaffold/GlobalSpotlight/hooks/observePickerScrollOffset.test.ts src/scaffold/GlobalSpotlight/hooks/usePickerVirtualization.ts` — passed after formatting.
- `git diff --check` — passed.
- Regression tests assert one timer during a scroll burst, the latest offset at completion, zero timers immediately after disposal, and no callback from later scroll events or elapsed time.
- Final-head `e9575c5a4` [CI run 34719543356](https://github.com/org2AI/ORG2/actions/runs/34719543356) passed all applicable checks, including frontend typecheck, lint and full unit tests; Rust jobs were scope-skipped. Screenshots are not useful for this change because rendered content and layout are unchanged; packaged UI verification was not repeated for this follow-up.

## Lifecycle review

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | fix | Scroll completion outlived observer cleanup | Cancel the owned timeout with the listener | Timer count reaches zero on disposal |
| Memory | keep | At most one timeout and one listener per active observer | No retained global registry | Burst and disposal tests |
| Scope/isolation | keep | Resource belongs to one scroll element | New observer owns independent state | Shared picker integration tests |
| Rendering/hot path | keep | Same immediate offset and trailing completion notifications | No new polling or rendering subscription | Both picker presentations pass |

Performance verdict: pass for the bounded observer lifecycle covered by tests; no whole-app performance improvement claimed.
