### PR TITLE
fix(session-memory): publish summaries after guarded durable commit

### DIFF
--- a/docs/org2-performance-guard-2026-09-12/SessionMemoryCommit.md
+++ b/docs/org2-performance-guard-2026-09-12/SessionMemoryCommit.md
@@ -39,3 +39,11 @@ Performance verdict: blocked for whole-app acceptance pending packaged visible/h
 ## Remaining scope
 
 No schema migration is required; rollback is a code revert. Runtime growth-baseline persistence and compaction rebasing are a separate follow-up. Generic compaction bookkeeping writers retain their existing behavior; this change prevents extraction results based on an older transcript from overwriting them. It does not claim every historical database-failure path is now transactional.
+
+## Reactive compaction review follow-up
+
+Reactive compaction changes only the live request frame. It clears the runtime sequence anchor while leaving the durable sequence intact, because mid-turn history can contain open tool exchanges. A new extraction may therefore begin with two legitimate, different anchor values. Validate the runtime against its own candidate snapshot and the database against its own durable snapshot; do not require equality between the two anchor views. The SQL comparison still rejects a durable change occurring after the snapshot.
+
+The regression invokes the real reactive compaction pipeline, verifies the deliberate runtime/durable anchor difference, then runs the production extraction-and-commit boundary twice. This complements the existing concurrent append/compact/truncate and stale-generation rejection tests.
+
+The one-second budget applies only to admission to the process-local writer lock. Waiting for the runtime state lock, connection acquisition, SQLite locking and I/O are outside that budget; there is no one-second end-to-end latency guarantee.

--- a/docs/org2-performance-guard-2026-09-12/SessionMemoryCommit.md
+++ b/docs/org2-performance-guard-2026-09-12/SessionMemoryCommit.md
@@ -1,0 +1,41 @@
+# Session-memory commit ownership
+
+## Source and root cause
+
+`agent_sessions.sm_content` and `sm_last_seq` are authoritative. Previously the extraction helper published content, sequence, context-token baseline and consumed tool counters before `save_session_memory_state` ran. A failed SQLite update therefore left runtime ahead of durable state. A started `spawn_blocking` write also survived dropping the async task, and an UPDATE matching no session was reported as successful.
+
+Extraction now returns an uncommitted candidate. A generation-owned lease cancels queued publication synchronously when its async owner drops. The blocking commit worker holds the runtime mutex, enters the bounded shared writer, checks cancellation and durable source identity, updates SQLite, then publishes runtime state while still holding both ownership boundaries. A commit that has already passed its cancellation check is allowed to finish and publishes consistently; cancellation is not a rollback of a completed write.
+
+The source snapshot includes summary content/sequence, session creation identity and the latest durable message ID. Appends, truncations and compact-boundary insertion invalidate a prepared result. Missing rows are errors, stale snapshots are skips. Original transcript rows and existing summaries are not rewritten as historical cleanup.
+
+## Lifecycle review
+
+| Area               | Verdict              | Evidence                                                   | Change or reason kept                                                              | Verification                                                 |
+| ------------------ | -------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Background work    | fix                  | Started blocking workers survive async cancellation        | Drop invalidates the lease synchronously; writer admission limited to one second   | Aborted-owner and busy-writer tests                          |
+| Memory             | keep                 | One candidate and one lease per extraction                 | No global registry, cache, polling or repeated timer                               | Existing coordinator bounds retained                         |
+| Scope/isolation    | fix                  | Older generations and history snapshots could publish late | Check runtime generation, summary snapshot, session identity and latest message ID | Replacement, append, compact, truncate and missing-row tests |
+| Rendering/hot path | keep with limitation | Runtime mutex is held only for commit, not provider calls  | Same runtime→DB lock order as compaction; writer admission bounded                 | State publication tests; whole-app latency not measured here |
+
+The mutex can still wait for SQLite I/O after writer admission; this is not a foreground-latency or whole-app performance improvement claim. Drop cleanup queues one generation-checked state cleanup task only for interrupted owners. Normal completion cleans up inline. Physical cancellation cannot undo an already-linearized database write; the worker completes runtime publication in that case.
+
+Performance verdict: blocked for whole-app acceptance pending packaged visible/hidden/active/repeated-cycle measurements. The bounded commit lifecycle has unit evidence; this does not close the earlier WebView/aggregate CPU or retained-memory findings.
+
+## Architecture coverage
+
+| Layer            | Verdict / evidence                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------- |
+| 1 Compilation    | Targeted session-memory tests and strict all-target Clippy run; exact final results in PR       |
+| 2 Structure      | One candidate producer and one owning commit worker; no alternate summary store                 |
+| 3 Types          | Uncommitted extraction is a distinct value; conditional commit returns applied/skipped or error |
+| 4 Naming         | Extraction, commit, generation and durable snapshot have separate roles                         |
+| 5 Defaults       | Missing session errors; cancelled or stale source skips; failure never advances summary state   |
+| 6 Boundaries     | Provider helper produces a candidate; session persistence owns SQLite and publication           |
+| 7 Lifecycle      | Owner drop invalidates pending work; old cleanup cannot clear a newer generation                |
+| 8 Wire           | No provider request schema, IPC or serialized persistence-format change                         |
+| 9 Initialization | Lazy restore unchanged; tests use the production SQLite schema and writer                       |
+| 10 Resolution    | Same persisted/runtime summary pair checked before publication; provider policy unchanged       |
+
+## Remaining scope
+
+No schema migration is required; rollback is a code revert. Runtime growth-baseline persistence and compaction rebasing are a separate follow-up. Generic compaction bookkeeping writers retain their existing behavior; this change prevents extraction results based on an older transcript from overwriting them. It does not claim every historical database-failure path is now transactional.

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
@@ -104,10 +104,20 @@ pub fn should_extract(
     tool_threshold_met || natural_break
 }
 
+/// Uncommitted output. The owning session must persist it before publishing it.
+pub struct SessionMemoryExtraction {
+    pub content: String,
+    pub last_seq: Option<i64>,
+    pub expected_content: Option<String>,
+    pub expected_seq: Option<i64>,
+    pub current_tokens: usize,
+    pub consumed_tool_calls: usize,
+}
+
 /// Extract or update session memory from the conversation.
 ///
 /// Makes a single LLM side-call with the SM system prompt, current SM
-/// content, and recent messages. Returns updated markdown, or `None` while
+/// content, and recent messages. Returns an uncommitted candidate, or `None` while
 /// this account/model route is cooling down or has no usable low-cost model.
 /// Only other low-cost candidates are retried; the parent is never a fallback.
 #[allow(clippy::too_many_arguments)]
@@ -119,18 +129,22 @@ pub async fn extract_session_memory(
     provider: &dyn LLMProvider,
     model: &str,
     current_tokens: usize,
+    generation: u64,
     cancel_flag: Option<&Arc<AtomicBool>>,
-) -> Result<Option<String>, String> {
+) -> Result<Option<SessionMemoryExtraction>, String> {
     use crate::core::model_context::summarization;
 
     let selection = provider.auxiliary_model(model);
 
-    // ── Prepare: brief lock to snapshot the read-side state + flag the
-    // extraction as in-progress. The mutex is NOT held across the LLM call
+    // ── Prepare: brief lock to snapshot the read-side state. The owning
+    // lease tracks the active generation. The mutex is NOT held across the LLM call
     // below — otherwise the next turn's brief `sm_state` reads (pre-turn
     // compaction, the gate pre-check) would block for the whole extraction.
-    let (start_idx, existing_content, consumed_tool_calls, selected_model) = {
+    let (start_idx, existing_content, expected_seq, consumed_tool_calls, selected_model) = {
         let mut state = sm_state.lock().await;
+        if state.extraction_generation != generation {
+            return Ok(None);
+        }
         let Some(selected_model) =
             state
                 .auxiliary_retry
@@ -138,7 +152,6 @@ pub async fn extract_session_memory(
         else {
             return Ok(None);
         };
-        state.extraction_in_progress = true;
         let start_idx = state
             .last_summarized_seq
             .map(|seq| start_seqs.partition_point(|s| *s <= seq))
@@ -146,6 +159,7 @@ pub async fn extract_session_memory(
         (
             start_idx,
             state.content.clone(),
+            state.last_summarized_seq,
             state.tool_calls_since_extraction,
             selected_model,
         )
@@ -271,6 +285,9 @@ pub async fn extract_session_memory(
             break Err(SideQueryError::Provider(ProviderError::Cancelled));
         }
         let mut state = sm_state.lock().await;
+        if state.extraction_generation != generation {
+            return Ok(None);
+        }
         state.auxiliary_retry.reject_candidate(&active_model);
         if let Some(next) = state
             .auxiliary_retry
@@ -280,7 +297,6 @@ pub async fn extract_session_memory(
         } else {
             // All bounded low-cost candidates were rejected. Keep the old
             // memory and skip quietly; never send the parent as a fallback.
-            state.extraction_in_progress = false;
             state
                 .auxiliary_retry
                 .failed(ExtractionFailure::UnsupportedModel, Instant::now());
@@ -289,12 +305,12 @@ pub async fn extract_session_memory(
         }
     };
 
-    // ── Finalize: brief lock to merge the result back. Concurrent
-    // `record_tool_calls` increments that arrived while the LLM was running
-    // are preserved by subtracting only what we consumed at prepare time,
-    // rather than blindly resetting the counter to 0.
+    // Only retry bookkeeping changes here; summary state is published by the
+    // owning session after the durable commit succeeds.
     let mut state = sm_state.lock().await;
-    state.extraction_in_progress = false;
+    if state.extraction_generation != generation {
+        return Ok(None);
+    }
 
     match result {
         Ok(sq_result) => {
@@ -309,27 +325,17 @@ pub async fn extract_session_memory(
             } else {
                 sq_result.content
             };
-            state.content = Some(sm_content.clone());
-            state.tokens_at_last_extraction = current_tokens;
-            state.tool_calls_since_extraction = state
-                .tool_calls_since_extraction
-                .saturating_sub(consumed_tool_calls);
-            state.initialized = true;
-
-            if let Some(last_safe_idx) = find_last_safe_boundary(messages) {
-                if let Some(seq) = start_seqs.get(last_safe_idx) {
-                    state.last_summarized_seq = Some(*seq);
-                }
-            }
-
-            info!(
-                "[session_memory] Extraction complete ({} chars, boundary_seq={})",
-                sm_content.len(),
-                state.last_summarized_seq.unwrap_or(-1),
-            );
-
-            state.auxiliary_retry.succeeded();
-            Ok(Some(sm_content))
+            let last_seq = find_last_safe_boundary(messages)
+                .and_then(|idx| start_seqs.get(idx).copied())
+                .or(expected_seq);
+            Ok(Some(SessionMemoryExtraction {
+                content: sm_content,
+                last_seq,
+                expected_content: existing_content,
+                expected_seq,
+                current_tokens,
+                consumed_tool_calls,
+            }))
         }
         Err(err) => {
             warn!("[session_memory] Extraction failed: {}", err);

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/state.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/state.rs
@@ -107,7 +107,7 @@ impl AuxiliaryRetryState {
         }
     }
 
-    pub(super) fn succeeded(&mut self) {
+    pub(crate) fn succeeded(&mut self) {
         self.failure = None;
         self.retry_after = None;
         self.last_warning = None;
@@ -165,6 +165,8 @@ pub struct SessionMemoryState {
     pub initialized: bool,
     /// Guards against concurrent extractions.
     pub extraction_in_progress: bool,
+    /// Identifies the extraction allowed to publish into this runtime.
+    pub(crate) extraction_generation: u64,
     /// Transient model rejection/cooldown state; never persisted as memory.
     pub auxiliary_retry: AuxiliaryRetryState,
 }

--- a/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
@@ -1435,12 +1435,78 @@ pub fn save_session_memory_state(
 ) -> SqliteResult<()> {
     with_sessions_writer(|| -> SqliteResult<()> {
         let conn = get_connection()?;
-        conn.execute(
+        let changed = conn.execute(
             "UPDATE agent_sessions SET sm_content = ?2, sm_last_seq = ?3 WHERE session_id = ?1",
             rusqlite::params![session_id, content, last_seq],
         )?;
+        if changed == 0 {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
         Ok(())
     })
+}
+
+/// Durable source snapshot for one extraction, captured before reading history.
+/// Message identity also invalidates results across append, truncate or compact.
+pub struct SessionMemoryCommitSnapshot {
+    pub(crate) content: Option<String>,
+    pub(crate) last_seq: Option<i64>,
+    created_at: String,
+    last_message_id: Option<String>,
+}
+
+pub fn session_memory_commit_snapshot(
+    session_id: &str,
+) -> SqliteResult<SessionMemoryCommitSnapshot> {
+    let conn = get_connection()?;
+    conn.query_row(
+        "SELECT sm_content, sm_last_seq, created_at,
+            (SELECT id FROM agent_messages WHERE session_id = ?1 ORDER BY sequence DESC LIMIT 1)
+         FROM agent_sessions WHERE session_id = ?1",
+        [session_id],
+        |row| {
+            Ok(SessionMemoryCommitSnapshot {
+                content: row.get(0)?,
+                last_seq: row.get(1)?,
+                created_at: row.get(2)?,
+                last_message_id: row.get(3)?,
+            })
+        },
+    )
+}
+
+/// Commit only if the durable summary and history still match the snapshot.
+/// Cancellation is checked after acquiring the writer. Writer admission is
+/// bounded so a cancelled background worker cannot wait indefinitely while
+/// retaining the runtime state lock.
+pub fn commit_session_memory_state(
+    session_id: &str,
+    content: &str,
+    last_seq: Option<i64>,
+    expected: &SessionMemoryCommitSnapshot,
+    is_cancelled: impl FnOnce() -> bool,
+    on_committed: impl FnOnce(),
+) -> SqliteResult<bool> {
+    database::db::try_with_sessions_writer(std::time::Duration::from_secs(1), || {
+        if is_cancelled() { return Ok(false); }
+        let conn = get_connection()?;
+        let changed = conn.execute(
+            "UPDATE agent_sessions SET sm_content = ?2, sm_last_seq = ?3
+             WHERE session_id = ?1 AND sm_content IS ?4 AND sm_last_seq IS ?5
+               AND created_at = ?6
+               AND (SELECT id FROM agent_messages WHERE session_id = ?1 ORDER BY sequence DESC LIMIT 1) IS ?7",
+            rusqlite::params![session_id, content, last_seq, expected.content, expected.last_seq,
+                expected.created_at, expected.last_message_id],
+        )?;
+        if changed == 0 {
+            conn.query_row("SELECT 1 FROM agent_sessions WHERE session_id = ?1", [session_id], |_| Ok(()))?;
+        }
+        if changed == 1 { on_committed(); }
+        Ok(changed == 1)
+    }).unwrap_or_else(|| Err(rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+        Some("session memory writer admission timed out".into()),
+    )))
 }
 
 /// Clear persisted session memory state after the durable transcript has been compacted.
@@ -1592,8 +1658,8 @@ mod tests {
         .expect("create session/message tables");
         conn.execute(
             "INSERT OR IGNORE INTO agent_sessions
-             (session_id, session_type, status, created_at, updated_at, sm_content, sm_last_seq)
-             VALUES (?1, 'agent', 'running', datetime('now'), datetime('now'), NULL, NULL)",
+             (session_id, name, session_type, status, created_at, updated_at, sm_content, sm_last_seq)
+             VALUES (?1, 'Message fixture', 'agent', 'running', datetime('now'), datetime('now'), NULL, NULL)",
             [session_id],
         )
         .expect("seed session row");

--- a/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
@@ -45,18 +45,20 @@ pub use sidebar::{
 pub use messages::{
     anchor_at_or_after_created_at, append_compact_boundary,
     append_session_with_materialized_history, clear_messages, clear_session_memory_state,
-    compact_cutoff_sequence, load_agent_org_inbox_transcript_materializations, load_llm_history,
+    commit_session_memory_state, compact_cutoff_sequence,
+    load_agent_org_inbox_transcript_materializations, load_llm_history,
     load_llm_history_start_sequences, load_llm_history_text_only,
     load_llm_history_text_only_bounded, load_messages, load_session_memory_state,
-    mark_turn_cancelled, materialize_agent_org_inbox_transcript, message_anchor,
-    materialize_agent_org_inbox_transcript_for_turn, message_created_at,
+    mark_turn_cancelled, materialize_agent_org_inbox_transcript,
+    materialize_agent_org_inbox_transcript_for_turn, message_anchor, message_created_at,
     save_agent_org_assistant_msg_for_turn, save_assistant_msg, save_compact_summary_msg,
     save_session_memory_state, save_snapshot, save_subagent_transcript, save_tool_call_msg,
     save_tool_result_msg, save_user_msg, save_user_msg_with_id,
-    seed_session_with_materialized_history, seed_session_with_messages, take_turn_cancelled,
-    truncate_messages_from_sequence, update_compact_boundary_token_delta,
-    AgentOrgInboxTranscriptMaterialization, MaterializedHistoryContent,
-    MaterializedHistoryReceipt, MaterializedHistoryRole, MaterializedHistorySeed, MessageAnchor,
+    seed_session_with_materialized_history, seed_session_with_messages,
+    session_memory_commit_snapshot, take_turn_cancelled, truncate_messages_from_sequence,
+    update_compact_boundary_token_delta, AgentOrgInboxTranscriptMaterialization,
+    MaterializedHistoryContent, MaterializedHistoryReceipt, MaterializedHistoryRole,
+    MaterializedHistorySeed, MessageAnchor, SessionMemoryCommitSnapshot,
 };
 
 use rusqlite::{Connection, Result as SqliteResult};

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
@@ -32,6 +32,9 @@ use crate::session::workspace::SessionWorkspace;
 use crate::tools::registry::ToolRegistry;
 use core_types::providers::NativeHarnessType;
 
+#[path = "session_memory_commit.rs"]
+mod session_memory_commit;
+
 const SESSION_MEMORY_TIMEOUT: Duration = Duration::from_secs(60);
 const WORKSPACE_EXTRACTION_TIMEOUT: Duration = Duration::from_secs(180);
 const AUTO_DREAM_TIMEOUT: Duration = Duration::from_secs(300);
@@ -74,7 +77,6 @@ async fn acquire_session_memory_provider(
             .auxiliary_retry
             .begin_attempt(scope, std::time::Instant::now())
         {
-            state.extraction_in_progress = false;
             return Ok(None);
         }
     }
@@ -85,7 +87,6 @@ async fn acquire_session_memory_provider(
             state
                 .auxiliary_retry
                 .provider_failed(&error, std::time::Instant::now());
-            state.extraction_in_progress = false;
             Err(error)
         }
     }
@@ -262,9 +263,6 @@ fn session_memory_job(input: SessionMemoryExtractionInput<'_>) -> MemoryJob {
                 }
             }
         }
-        if outcome != MemoryJobOutcome::Completed {
-            cleanup_state.lock().await.extraction_in_progress = false;
-        }
     })
 }
 
@@ -286,34 +284,47 @@ async fn extract_and_persist_session_memory(
     ) {
         return Ok(MemoryJobCompletion::Skipped);
     }
-    let (messages, start_seqs) = load_durable_history_blocking(session_id.to_owned()).await?;
-    info!(
-        session_id,
-        current_tokens, "[memory_background] starting session-memory extraction"
-    );
-    let Some(content) = session_memory::extract_session_memory(
-        &messages,
-        &start_seqs,
-        Arc::clone(&sm_state),
-        config,
-        provider,
-        model,
-        current_tokens,
-        cancel_flag,
-    )
-    .await?
-    else {
-        return Ok(MemoryJobCompletion::Skipped);
-    };
-    let last_seq = sm_state.lock().await.last_summarized_seq;
-    let persist_sid = session_id.to_owned();
-    tokio::task::spawn_blocking(move || {
-        unified_persistence::save_session_memory_state(&persist_sid, &content, last_seq)
-    })
-    .await
-    .map_err(|err| format!("SM persist worker failed: {err}"))?
-    .map_err(|err| format!("Failed to persist session memory state: {err}"))?;
-    Ok(MemoryJobCompletion::Completed)
+    let lease = session_memory_commit::ExtractionLease::begin(Arc::clone(&sm_state)).await;
+    let result = async {
+        let snapshot_sid = session_id.to_owned();
+        let snapshot = tokio::task::spawn_blocking(move || {
+            unified_persistence::session_memory_commit_snapshot(&snapshot_sid)
+        })
+        .await
+        .map_err(|err| format!("SM snapshot worker failed: {err}"))?
+        .map_err(|err| format!("SM snapshot load failed: {err}"))?;
+        let (messages, start_seqs) = load_durable_history_blocking(session_id.to_owned()).await?;
+        info!(
+            session_id,
+            current_tokens, "[memory_background] starting session-memory extraction"
+        );
+        let Some(draft) = session_memory::extract_session_memory(
+            &messages,
+            &start_seqs,
+            Arc::clone(&sm_state),
+            config,
+            provider,
+            model,
+            current_tokens,
+            lease.generation,
+            cancel_flag,
+        )
+        .await?
+        else {
+            return Ok(MemoryJobCompletion::Skipped);
+        };
+        if lease
+            .commit(session_id.to_owned(), draft, snapshot, cancel_flag.cloned())
+            .await?
+        {
+            Ok(MemoryJobCompletion::Completed)
+        } else {
+            Ok(MemoryJobCompletion::Skipped)
+        }
+    }
+    .await;
+    lease.finish().await;
+    result
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
@@ -268,7 +268,7 @@ fn session_memory_job(input: SessionMemoryExtractionInput<'_>) -> MemoryJob {
 
 /// Shared production boundary: load authoritative history, extract, then
 /// persist content and sequence together. A deferred/failed query never writes.
-async fn extract_and_persist_session_memory(
+pub(super) async fn extract_and_persist_session_memory(
     session_id: &str,
     sm_state: Arc<Mutex<SessionMemoryState>>,
     config: &SessionMemoryConfig,

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn_memory_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn_memory_tests.rs
@@ -337,7 +337,6 @@ async fn session_memory_preflight_auth_failure_cools_down_before_acquisition() {
     let state = Arc::new(Mutex::new(SessionMemoryState {
         content: before.0.clone(),
         last_summarized_seq: before.1,
-        extraction_in_progress: true,
         ..Default::default()
     }));
     let acquisitions = AtomicUsize::new(0);
@@ -429,7 +428,6 @@ async fn session_memory_cooldown_jobs_are_skipped_not_completed() {
     }));
 
     for turn in 0..3 {
-        state.lock().await.extraction_in_progress = true;
         // No account is a local factory AuthError, never a remote request.
         // Later turns must skip this same production acquisition path.
         let job = session_memory_job(SessionMemoryExtractionInput {
@@ -494,4 +492,243 @@ async fn session_memory_no_cheap_candidate_skips_without_request_or_write() {
         assert_eq!(guard.last_summarized_seq, before.1);
         assert!(!guard.extraction_in_progress);
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_memory_database_failure_preserves_runtime_and_durable_state() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-commit-db-failure";
+    seed(sid);
+    unified_persistence::save_session_memory_state(sid, "old memory", Some(0)).unwrap();
+    let state = Arc::new(Mutex::new(SessionMemoryState {
+        content: Some("old memory".into()),
+        last_summarized_seq: Some(0),
+        tool_calls_since_extraction: 8,
+        tokens_at_last_extraction: 12_000,
+        initialized: true,
+        ..Default::default()
+    }));
+    database::db::get_connection().unwrap().execute_batch(
+        "CREATE TRIGGER reject_memory BEFORE UPDATE OF sm_content ON agent_sessions BEGIN SELECT RAISE(FAIL, 'injected memory write failure'); END;"
+    ).unwrap();
+    let fixture = provider(vec![Ok(LLMResponse::text("### Current State\nnew memory"))]);
+    assert!(run(sid, state.clone(), &fixture, None)
+        .await
+        .unwrap_err()
+        .contains("injected memory write failure"));
+    assert_eq!(persisted(sid), (Some("old memory".into()), Some(0)));
+    let current = state.lock().await;
+    assert_eq!(current.content.as_deref(), Some("old memory"));
+    assert_eq!(current.last_summarized_seq, Some(0));
+    assert_eq!(current.tokens_at_last_extraction, 12_000);
+    assert_eq!(current.tool_calls_since_extraction, 8);
+    assert!(current.initialized);
+    assert!(!current.extraction_in_progress);
+}
+
+fn commit_draft() -> session_memory::extract::SessionMemoryExtraction {
+    session_memory::extract::SessionMemoryExtraction {
+        content: "new memory".into(),
+        last_seq: Some(1),
+        expected_content: Some("old memory".into()),
+        expected_seq: Some(0),
+        current_tokens: 20_000,
+        consumed_tool_calls: 8,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_memory_dropped_owner_cancels_already_started_blocking_writer() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-commit-dropped-owner";
+    seed(sid);
+    unified_persistence::save_session_memory_state(sid, "old memory", Some(0)).unwrap();
+    let state = Arc::new(Mutex::new(SessionMemoryState {
+        content: Some("old memory".into()),
+        last_summarized_seq: Some(0),
+        tool_calls_since_extraction: 8,
+        ..Default::default()
+    }));
+    let (held_tx, held_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let holder = std::thread::spawn(move || {
+        let _writer = database::db::sessions_writer_guard();
+        held_tx.send(()).unwrap();
+        release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    });
+    held_rx.await.unwrap();
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let worker_state = state.clone();
+    let task = tokio::spawn(async move {
+        let lease = session_memory_commit::ExtractionLease::begin(worker_state).await;
+        started_tx.send(()).unwrap();
+        lease
+            .commit(
+                sid.into(),
+                commit_draft(),
+                unified_persistence::session_memory_commit_snapshot(sid).unwrap(),
+                None,
+            )
+            .await
+    });
+    started_rx.await.unwrap();
+    // The blocking worker owns the state mutex before waiting for the DB writer.
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while state.try_lock().is_ok() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    release_tx.send(()).unwrap();
+    holder.join().unwrap();
+    let current = tokio::time::timeout(Duration::from_secs(3), state.lock())
+        .await
+        .unwrap();
+    assert_eq!(current.content.as_deref(), Some("old memory"));
+    assert_eq!(current.tool_calls_since_extraction, 8);
+    assert_eq!(persisted(sid), (Some("old memory".into()), Some(0)));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_memory_old_generation_cannot_commit_or_clear_new_owner() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-commit-generation";
+    seed(sid);
+    unified_persistence::save_session_memory_state(sid, "old memory", Some(0)).unwrap();
+    let state = Arc::new(Mutex::new(SessionMemoryState {
+        content: Some("old memory".into()),
+        last_summarized_seq: Some(0),
+        tool_calls_since_extraction: 11,
+        ..Default::default()
+    }));
+    let old = session_memory_commit::ExtractionLease::begin(state.clone()).await;
+    let new = session_memory_commit::ExtractionLease::begin(state.clone()).await;
+    assert!(!old
+        .commit(
+            sid.into(),
+            commit_draft(),
+            unified_persistence::session_memory_commit_snapshot(sid).unwrap(),
+            None
+        )
+        .await
+        .unwrap());
+    old.finish().await;
+    assert!(state.lock().await.extraction_in_progress);
+    assert!(new
+        .commit(
+            sid.into(),
+            commit_draft(),
+            unified_persistence::session_memory_commit_snapshot(sid).unwrap(),
+            None
+        )
+        .await
+        .unwrap());
+    new.finish().await;
+    let current = state.lock().await;
+    assert_eq!(current.content.as_deref(), Some("new memory"));
+    assert_eq!(current.last_summarized_seq, Some(1));
+    assert_eq!(current.tokens_at_last_extraction, 20_000);
+    assert_eq!(current.tool_calls_since_extraction, 3);
+    assert!(!current.extraction_in_progress);
+    assert_eq!(persisted(sid), (Some("new memory".into()), Some(1)));
+}
+
+#[test]
+fn session_memory_commit_rejects_stale_snapshot_and_missing_session() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-commit-durable-cas";
+    seed(sid);
+    let snapshot = unified_persistence::session_memory_commit_snapshot(sid).unwrap();
+    unified_persistence::save_session_memory_state(sid, "newer memory", Some(10)).unwrap();
+    assert!(!unified_persistence::commit_session_memory_state(
+        sid,
+        "stale memory",
+        Some(1),
+        &snapshot,
+        || false,
+        || {},
+    )
+    .unwrap());
+    assert_eq!(persisted(sid), (Some("newer memory".into()), Some(10)));
+    assert!(
+        unified_persistence::save_session_memory_state("missing-session", "lost", Some(1)).is_err()
+    );
+    assert!(unified_persistence::commit_session_memory_state(
+        "missing-session",
+        "lost",
+        Some(1),
+        &snapshot,
+        || false,
+        || {},
+    )
+    .is_err());
+}
+
+#[test]
+fn session_memory_commit_rejects_changed_history_without_publishing() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    for transition in ["append", "compact", "truncate"] {
+        let sid = format!("memory-history-{transition}");
+        seed(&sid);
+        unified_persistence::save_session_memory_state(&sid, "old memory", Some(0)).unwrap();
+        let snapshot = unified_persistence::session_memory_commit_snapshot(&sid).unwrap();
+        match transition {
+            "append" => {
+                unified_persistence::save_user_msg(&sid, "new turn", None).unwrap();
+            }
+            "compact" => {
+                unified_persistence::append_compact_boundary(&sid, "compacted", 1, None, None)
+                    .unwrap();
+            }
+            "truncate" => {
+                unified_persistence::truncate_messages_from_sequence(&sid, 1).unwrap();
+            }
+            _ => unreachable!(),
+        }
+        let before = persisted(&sid);
+        assert!(!unified_persistence::commit_session_memory_state(
+            &sid,
+            "stale summary",
+            Some(1),
+            &snapshot,
+            || false,
+            || panic!("stale history must not publish runtime state"),
+        )
+        .unwrap());
+        assert_eq!(persisted(&sid), before);
+    }
+}
+
+#[test]
+fn session_memory_writer_admission_is_bounded_without_publishing() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-writer-budget";
+    seed(sid);
+    let snapshot = unified_persistence::session_memory_commit_snapshot(sid).unwrap();
+    let (held_tx, held_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let holder = std::thread::spawn(move || {
+        let _writer = database::db::sessions_writer_guard();
+        held_tx.send(()).unwrap();
+        release_rx.recv_timeout(Duration::from_secs(4)).unwrap();
+    });
+    held_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    let result = unified_persistence::commit_session_memory_state(
+        sid,
+        "new memory",
+        Some(1),
+        &snapshot,
+        || false,
+        || panic!("a busy writer must not publish"),
+    );
+    release_tx.send(()).unwrap();
+    holder.join().unwrap();
+    assert_eq!(
+        result.unwrap_err().sqlite_error_code(),
+        Some(rusqlite::ErrorCode::DatabaseBusy)
+    );
+    assert_eq!(persisted(sid), (None, None));
 }

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
@@ -766,3 +766,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "reactive_memory_tests.rs"]
+mod reactive_memory_tests;

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/reactive_memory_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/reactive_memory_tests.rs
@@ -1,0 +1,171 @@
+//! Exercises reactive compaction and the real durable summary commit together.
+use super::*;
+use crate::definitions::{resolved::ResolvedAgent, AgentDefinition};
+use crate::memory::background::MemoryJobCompletion;
+use crate::providers::{
+    auxiliary_model::AuxiliaryModel,
+    traits::{LLMProvider, LLMResponse, ProviderError},
+};
+use crate::session::turn::post_turn::extract_and_persist_session_memory;
+use crate::state::{AgentSession, SessionRuntime};
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+struct FixtureProvider {
+    calls: AtomicUsize,
+    fail: bool,
+}
+#[async_trait]
+impl LLMProvider for FixtureProvider {
+    async fn chat(
+        &self,
+        _: &[Value],
+        _: Option<&[Value]>,
+        _: &str,
+        _: u32,
+        _: f32,
+    ) -> Result<LLMResponse, ProviderError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail {
+            Err(ProviderError::RequestFailed(
+                "injected compaction failure".into(),
+            ))
+        } else {
+            Ok(LLMResponse::text(
+                "### Current State\nNew committed summary",
+            ))
+        }
+    }
+    fn default_model(&self) -> &str {
+        "test/model"
+    }
+    fn provider_name(&self) -> &str {
+        "reactive-fixture"
+    }
+    fn auxiliary_model(&self, _: &str) -> AuxiliaryModel {
+        AuxiliaryModel {
+            models: vec!["test/cheap".into()],
+            scope: 17,
+        }
+    }
+}
+
+fn fixture(sid: &str, fail: bool) -> (UnifiedMessageProcessor, Arc<FixtureProvider>) {
+    let conn = database::db::get_connection().unwrap();
+    crate::persistence::test_schema::ensure_agent_sessions_schema(&conn);
+    crate::persistence::session_snapshots::ensure_tables_with(&conn).unwrap();
+    conn.execute("INSERT INTO agent_sessions (session_id,name,session_type,status,created_at,updated_at) VALUES (?1,'Reactive fixture','agent','running',datetime('now'),datetime('now'))", [sid]).unwrap();
+    for i in 0..4 {
+        unified_persistence::save_user_msg(
+            sid,
+            &format!("turn {i}: {}", "work ".repeat(100)),
+            None,
+        )
+        .unwrap();
+        unified_persistence::save_assistant_msg(sid, "done", "test/model").unwrap();
+    }
+    unified_persistence::save_session_memory_state(sid, "old memory", Some(3)).unwrap();
+    let def = AgentDefinition {
+        selected_model_id: Some("test/model".into()),
+        ..Default::default()
+    };
+    let mut resolved = ResolvedAgent::resolve(&def, None, &Default::default()).unwrap();
+    resolved.context_window = 100_000;
+    resolved.context_window_configured = true;
+    let session = Arc::new(AgentSession::new(sid.into(), def));
+    let provider = Arc::new(FixtureProvider {
+        calls: AtomicUsize::new(0),
+        fail,
+    });
+    let policy = Arc::new(crate::tools::policy::ResolvedToolPolicy::permissive());
+    let runtime = Arc::new(SessionRuntime {
+        provider: provider.clone(),
+        tool_registry: Arc::new(crate::tools::registry::ToolRegistry::new()),
+        policy: policy.clone(),
+        model: "test/model".into(),
+        account_id: None,
+        native_harness_type: None,
+        workspace_state: Arc::new(parking_lot::RwLock::new(
+            crate::session::workspace::SessionWorkspace::new(std::env::temp_dir()),
+        )),
+        mcp_auto_approved: vec![],
+        resolved,
+        integrations_snapshot: Default::default(),
+        overrides: Default::default(),
+        agent_soul: None,
+        sovereign_prompt: false,
+        policy_context_activator: None,
+        agent_org_context: None,
+        agent_org_current_member_id: None,
+        agent_definition_id: None,
+    });
+    let mut processor = UnifiedMessageProcessor::new(super::super::ProcessorParams {
+        runtime,
+        session,
+        policy,
+        channel: None,
+        chat_id: None,
+        agent_mode: None,
+        ide_context: None,
+        app_handle: None,
+        screenshot_store: Arc::new(Default::default()),
+        event_handler_config: Default::default(),
+    });
+    processor.sm_compact_config.min_tokens_to_keep = 0;
+    processor.sm_compact_config.min_text_messages_to_keep = 1;
+    (processor, provider)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_memory_reactive_compaction_allows_new_durable_commit() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "reactive-memory-cas";
+    let (processor, provider) = fixture(sid, false);
+    {
+        let mut state = processor.sm_state.lock().await;
+        state.content = Some("old memory".into());
+        state.last_summarized_seq = Some(3);
+        state.initialized = true;
+    }
+    let mut messages = unified_persistence::load_llm_history(sid).unwrap();
+    let outcome = processor
+        .run_reactive_compaction(sid, &mut messages, None)
+        .await;
+    assert!(matches!(outcome, CompactionOutcome::Compacted { .. }));
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        0,
+        "SM compaction is local"
+    );
+    assert_eq!(processor.sm_state.lock().await.last_summarized_seq, None);
+    assert_eq!(
+        unified_persistence::load_session_memory_state(sid)
+            .unwrap()
+            .last_seq,
+        Some(3)
+    );
+    // Each view is current at extraction start: runtime anchor was reset,
+    // while reactive compaction deliberately did not write a durable boundary.
+    for tokens in [25_000, 31_000] {
+        assert_eq!(
+            extract_and_persist_session_memory(
+                sid,
+                processor.sm_state.clone(),
+                &processor.sm_config,
+                provider.as_ref(),
+                "test/model",
+                tokens,
+                None
+            )
+            .await
+            .unwrap(),
+            MemoryJobCompletion::Completed
+        );
+        let durable = unified_persistence::load_session_memory_state(sid).unwrap();
+        let state = processor.sm_state.lock().await;
+        assert_eq!(state.content, durable.content);
+        assert_eq!(state.last_summarized_seq, durable.last_seq);
+    }
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+}

--- a/src-tauri/crates/agent-core/src/core/session/turn/session_memory_commit.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/session_memory_commit.rs
@@ -1,0 +1,113 @@
+//! Cancellation-safe lifetime and durable publication for extracted summaries.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::model_context::session_memory::extract::SessionMemoryExtraction;
+use crate::model_context::session_memory::SessionMemoryState;
+use crate::session::persistence;
+
+pub(super) struct ExtractionLease {
+    state: Arc<Mutex<SessionMemoryState>>,
+    pub generation: u64,
+    alive: Arc<AtomicBool>,
+    finished: bool,
+}
+
+impl ExtractionLease {
+    pub async fn begin(state: Arc<Mutex<SessionMemoryState>>) -> Self {
+        let generation = {
+            let mut current = state.lock().await;
+            current.extraction_generation += 1;
+            current.extraction_in_progress = true;
+            current.extraction_generation
+        };
+        Self {
+            state,
+            generation,
+            alive: Arc::new(AtomicBool::new(true)),
+            finished: false,
+        }
+    }
+
+    pub async fn commit(
+        &self,
+        session_id: String,
+        draft: SessionMemoryExtraction,
+        snapshot: persistence::SessionMemoryCommitSnapshot,
+        cancel: Option<Arc<AtomicBool>>,
+    ) -> Result<bool, String> {
+        let state = self.state.clone();
+        let generation = self.generation;
+        let alive = self.alive.clone();
+        tokio::task::spawn_blocking(move || {
+            // Same lock order as compaction: runtime state, then DB writer.
+            // Never hold this mutex during the provider request. The worker
+            // owns both durable commit and publication even if its waiter drops.
+            let mut current = state.blocking_lock();
+            if current.extraction_generation != generation
+                || current.content != draft.expected_content
+                || current.last_summarized_seq != draft.expected_seq
+                || snapshot.content != draft.expected_content
+                || snapshot.last_seq != draft.expected_seq
+            {
+                return Ok(false);
+            }
+            let committed = persistence::commit_session_memory_state(
+                &session_id,
+                &draft.content,
+                draft.last_seq,
+                &snapshot,
+                || {
+                    !alive.load(Ordering::SeqCst)
+                        || cancel
+                            .as_ref()
+                            .is_some_and(|flag| flag.load(Ordering::SeqCst))
+                },
+                || {
+                    current.content = Some(draft.content.clone());
+                    current.last_summarized_seq = draft.last_seq;
+                    current.tokens_at_last_extraction = draft.current_tokens;
+                    current.tool_calls_since_extraction = current
+                        .tool_calls_since_extraction
+                        .saturating_sub(draft.consumed_tool_calls);
+                    current.initialized = true;
+                    current.auxiliary_retry.succeeded();
+                },
+            )
+            .map_err(|err| format!("Failed to persist session memory state: {err}"))?;
+            Ok(committed)
+        })
+        .await
+        .map_err(|err| format!("SM persist worker failed: {err}"))?
+    }
+
+    pub async fn finish(mut self) {
+        let mut current = self.state.lock().await;
+        if current.extraction_generation == self.generation {
+            current.extraction_in_progress = false;
+        }
+        self.finished = true;
+    }
+}
+
+impl Drop for ExtractionLease {
+    fn drop(&mut self) {
+        // Synchronous invalidation: a blocked writer sees this even if the
+        // coordinator's token-to-atomic bridge has not been scheduled yet.
+        self.alive.store(false, Ordering::SeqCst);
+        if self.finished {
+            return;
+        }
+        let state = self.state.clone();
+        let generation = self.generation;
+        tokio::spawn(async move {
+            let mut current = state.lock().await;
+            if current.extraction_generation == generation {
+                current.extraction_in_progress = false;
+            }
+        });
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/session/turn/session_memory_commit.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/session_memory_commit.rs
@@ -51,10 +51,13 @@ impl ExtractionLease {
                 || current.content != draft.expected_content
                 || current.last_summarized_seq != draft.expected_seq
                 || snapshot.content != draft.expected_content
-                || snapshot.last_seq != draft.expected_seq
             {
                 return Ok(false);
             }
+            // Reactive compaction resets the runtime frame's anchor without
+            // writing a durable boundary. Each view must still match its own
+            // snapshot; equality between the two views is not an invariant.
+            // The SQL CAS below validates snapshot.last_seq independently.
             let committed = persistence::commit_session_memory_state(
                 &session_id,
                 &draft.content,


### PR DESCRIPTION
## Problem

Session-memory extraction published runtime content, sequence, growth baseline and consumed tool counters before the database update. A failed SQLite write left runtime ahead of durable state. Started blocking writes also survived cancellation of their async owner and could overwrite newer summaries; zero-row updates incorrectly returned success.

Follow-up to #1631's explicitly unclosed commit-consistency acceptance.

## Solution

Return an uncommitted extraction candidate and publish it only after a conditional SQLite update succeeds. A generation-owned lease invalidates queued publication synchronously when its owner is dropped; old cleanup cannot clear a newer extraction. The blocking worker owns durable commit and runtime publication under the same state/writer critical section. It checks the expected runtime summary, durable summary/sequence, session creation identity and latest durable message ID, rejecting changed history, replacement generations and missing sessions.

Writer admission is bounded to one second. Failure retains summary content, sequence, context baseline and tool counters. Provider selection, cheap-only skips and authentication cooldown remain unchanged. Updated the message-test fixture to supply its required name: its previous INSERT OR IGNORE silently created no session.

## Potential risks

A commit that passes its cancellation check may finish after cancellation; the worker then publishes runtime state consistently. Cancellation is not rollback of an already-linearized write. The runtime mutex is held during the bounded writer admission and SQLite I/O, but never the provider call. Database I/O can still delay foreground state access, and heavy contention can fail an extraction rather than wait indefinitely. Interrupted owners schedule one generation-checked cleanup task; normal completion cleans up inline.

No schema, serialized persistence format, provider wire payload or public IPC changes. Existing transcript rows and summaries are not destructively repaired. Rollback is a code revert. Restart/compaction growth-baseline persistence and whole-app CPU/retention acceptance remain separate follow-ups. Generic compaction bookkeeping failure handling is not comprehensively rewritten here. CI for e3b17e794 is green (9 SUCCESS, cargo audit scope-skipped). Packaged continuation acceptance remains pending; #1664 carries the separate persisted growth-baseline fix.

## Verification

- `cargo test -p agent_core --lib session_memory --manifest-path src-tauri/Cargo.toml` — 67 passed, including database failure, owner abort while a blocking writer is already running, stale generation, preservation of later tool counters, stale durable state, missing session, append/compact/truncate invalidation and bounded writer admission.
- `cargo clippy -p agent_core --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings` — passed.
- `cargo test -p agent_core --lib core::session::persistence::messages::tests --manifest-path src-tauri/Cargo.toml` — 23 passed after fixing the invalid fixture; the first run exposed its missing required name.
- `git diff --check` — passed.
- Architecture and lifecycle review: `docs/org2-performance-guard-2026-09-12/SessionMemoryCommit.md`. No visual layout changes; screenshots would not prove the database/cancellation invariant. Whole-app performance is not claimed from these unit tests.

- GitHub checks read back for e3b17e794: all 9 executed checks SUCCESS, including frontend and Rust Clippy; Rust cargo audit SKIPPED by scope.

### Reactive compaction review follow-up

Runtime and durable sequence anchors are validated against their respective snapshots; they need not equal each other after reactive compaction, which deliberately writes no durable boundary. The real processor regression first reproduced repeated `Skipped` commits and now completes two successive extractions. Durable append/compact/truncate and cancellation guards remain intact.

At `ed0fe1307`: `cargo test -p agent_core --lib session_memory --manifest-path src-tauri/Cargo.toml` passed 68 tests; strict all-targets Clippy and commit checks passed. CI read back for this updated HEAD: 9 SUCCESS checks, cargo audit scope-skipped (including completed workspace tests in the Rust job). The one-second timeout bounds writer-lock admission only, not runtime-state locking, connection acquisition, SQLite waits or total commit duration.
