### PR TITLE
fix(session-memory): persist and rebase extraction growth baseline

### DIFF
--- a/docs/org2-performance-guard-2026-09-12/SessionMemoryBaseline.md
+++ b/docs/org2-performance-guard-2026-09-12/SessionMemoryBaseline.md
@@ -1,0 +1,33 @@
+# Session memory growth baseline
+
+## Problem and authoritative boundary
+
+`agent_sessions` stored summary text and sequence but not the context-token baseline. Restoring a summary used a zero baseline, so a small post-restart turn could appear to contain an entire context of new growth. Compaction could retain an obsolete large runtime baseline, preventing future updates.
+
+## Invariant and compatibility
+
+Persist the nullable `sm_tokens_at_last_extraction` with the summary and sequence in the guarded commit from #1663. Restore all three. Legacy summaries keep their content and sequence; the first observed context establishes the missing baseline without an LLM request. Explicit compaction clears the baseline; a lower observed context also establishes a new baseline. Subsequent extraction requires the configured growth above it.
+
+The additive nullable column is necessary for existing user databases. Existing migration machinery adds it without rewriting historical messages. Old binaries ignore the column; rollback is a code revert, leaving this harmless nullable column in place. No historical cleanup or credential change is required. Baselines are observations, not reconstructed historical token counts; legacy first-turn growth is deliberately not estimated.
+
+## Resource ownership and lifecycle
+
+| Resource/state                             | Behavior                                                   | Evidence / limitation                                                      |
+| ------------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Normal completed turn                      | In-memory baseline check only                              | Regression installs rejecting DB trigger and normal turn succeeds          |
+| Legacy restore, compaction, context shrink | One guarded metadata update, no LLM request                | SQLite regression; writer admission bounded by inherited one-second budget |
+| Summary completion                         | Content, sequence and baseline commit together             | Durable commit and reload regression                                       |
+| Write failure / stale generation           | Preserve prior baseline and retry on a later turn          | Injected DB failure and inherited commit-generation tests                  |
+| Active/idle/hidden                         | No timer or polling added; work comes from completed turns | Static call-chain inspection; packaged whole-app measurements pending      |
+| Cancellation/shutdown                      | Reuses extraction lease invalidation                       | #1663 worker cancellation tests; no new recurring resource                 |
+| Account switch/network                     | Metadata does not select models or clear retry state       | No new provider-specific behavior; live account switching not retested     |
+
+## Architecture coverage
+
+Reviewed persistence ownership, restore/compaction parity, state transitions, concurrency, API callers, and failure propagation. UI rendering, wire format and provider selection are unchanged. Production automatic and manual compaction both invalidate the baseline. This does not rewrite all generic compaction failure bookkeeping.
+
+## Verification
+
+Targeted session-memory and persistence tests plus strict Clippy are run for this change; exact outcomes are recorded in the PR. Whole-app CPU/RSS and packaged restart/compaction acceptance remain pending until separately measured. No runtime performance improvement is inferred from unit tests.
+
+Performance verdict: bounded demand-driven metadata work by inspection; whole-app acceptance not yet closed.

--- a/docs/org2-performance-guard-2026-09-12/SessionMemoryBaseline.md
+++ b/docs/org2-performance-guard-2026-09-12/SessionMemoryBaseline.md
@@ -6,28 +6,32 @@
 
 ## Invariant and compatibility
 
-Persist the nullable `sm_tokens_at_last_extraction` with the summary and sequence in the guarded commit from #1663. Restore all three. Legacy summaries keep their content and sequence; the first observed context establishes the missing baseline without an LLM request. Explicit compaction clears the baseline; a lower observed context also establishes a new baseline. Subsequent extraction requires the configured growth above it.
+Persist the nullable `sm_tokens_at_last_extraction` with the summary and sequence in the guarded commit from #1663. Restore all three. Legacy summaries keep their content and sequence; the first observed context establishes the missing baseline without an LLM request. Successful compaction clears the baseline; a lower observed context also establishes a new baseline. Subsequent extraction requires the configured growth above it.
 
-The additive nullable column is necessary for existing user databases. Existing migration machinery adds it without rewriting historical messages. Old binaries ignore the column; rollback is a code revert, leaving this harmless nullable column in place. No historical cleanup or credential change is required. Baselines are observations, not reconstructed historical token counts; legacy first-turn growth is deliberately not estimated.
+The additive nullable column is necessary for existing user databases. Existing migration machinery adds it without rewriting historical messages. Old binaries ignore the column; rollback can leave it in place, but older writers cannot maintain its semantics. If an older binary modifies summaries, clear only the baseline metadata to NULL before re-upgrading so the next observation rebuilds it. No historical cleanup or credential change is required. Baselines are observations, not reconstructed historical token counts; legacy first-turn growth is deliberately not estimated.
 
 ## Resource ownership and lifecycle
 
-| Resource/state                             | Behavior                                                   | Evidence / limitation                                                      |
-| ------------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
-| Normal completed turn                      | In-memory baseline check only                              | Regression installs rejecting DB trigger and normal turn succeeds          |
-| Legacy restore, compaction, context shrink | One guarded metadata update, no LLM request                | SQLite regression; writer admission bounded by inherited one-second budget |
-| Summary completion                         | Content, sequence and baseline commit together             | Durable commit and reload regression                                       |
-| Write failure / stale generation           | Preserve prior baseline and retry on a later turn          | Injected DB failure and inherited commit-generation tests                  |
-| Active/idle/hidden                         | No timer or polling added; work comes from completed turns | Static call-chain inspection; packaged whole-app measurements pending      |
-| Cancellation/shutdown                      | Reuses extraction lease invalidation                       | #1663 worker cancellation tests; no new recurring resource                 |
-| Account switch/network                     | Metadata does not select models or clear retry state       | No new provider-specific behavior; live account switching not retested     |
+| Resource/state                             | Behavior                                                   | Evidence / limitation                                                                                                                                   |
+| ------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Normal completed turn                      | In-memory baseline check only                              | Regression installs rejecting DB trigger and normal turn succeeds                                                                                       |
+| Legacy restore, compaction, context shrink | One guarded metadata update, no LLM request                | SQLite regression; writer admission bounded by inherited one-second budget; runtime-state locking, connection acquisition and SQLite I/O are additional |
+| Summary completion                         | Content, sequence and baseline commit together             | Durable commit and reload regression                                                                                                                    |
+| Write failure / stale generation           | Preserve prior baseline and retry on a later turn          | Injected DB failure and inherited commit-generation tests                                                                                               |
+| Active/idle/hidden                         | No timer or polling added; work comes from completed turns | Static call-chain inspection; packaged whole-app measurements pending                                                                                   |
+| Cancellation/shutdown                      | Reuses extraction lease invalidation                       | #1663 worker cancellation tests; no new recurring resource                                                                                              |
+| Account switch/network                     | Metadata does not select models or clear retry state       | No new provider-specific behavior; live account switching not retested                                                                                  |
 
 ## Architecture coverage
 
-Reviewed persistence ownership, restore/compaction parity, state transitions, concurrency, API callers, and failure propagation. UI rendering, wire format and provider selection are unchanged. Production automatic and manual compaction both invalidate the baseline. This does not rewrite all generic compaction failure bookkeeping.
+Reviewed persistence ownership, restore/compaction parity, state transitions, concurrency, API callers, and failure propagation. UI rendering, wire format and provider selection are unchanged. Successful production automatic and manual compaction invalidate the baseline. Failed or skipped reactive/pre-turn attempts retain the prior extraction frame and growth; an intermediate SM rewrite is restored if the subsequent LLM fallback fails.
 
 ## Verification
 
 Targeted session-memory and persistence tests plus strict Clippy are run for this change; exact outcomes are recorded in the PR. Whole-app CPU/RSS and packaged restart/compaction acceptance remain pending until separately measured. No runtime performance improvement is inferred from unit tests.
 
 Performance verdict: bounded demand-driven metadata work by inspection; whole-app acceptance not yet closed.
+
+## Compaction outcome integration regression
+
+The real reactive processor runs both the LLM and manual-force rescue failure paths, with SM-first enabled and disabled. It must preserve original messages, known 20,000-token baseline, durable/runtime sequence, generation, tool counters and observed context. Baseline preparation at 45,000 must still recognize 25,000 growth. Separate real reactive/pre-turn Skipped cases preserve the frame without an LLM request or durable compact boundary. The inherited successful reactive-compaction regression completes subsequent durable summary commits.

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
@@ -93,7 +93,11 @@ pub fn should_extract(
         return false;
     }
 
-    let token_growth = current_tokens.saturating_sub(state.tokens_at_last_extraction);
+    // Restored/compacted summaries establish a durable baseline before gating.
+    if state.initialized && state.tokens_at_last_extraction.is_none() {
+        return false;
+    }
+    let token_growth = current_tokens.saturating_sub(state.tokens_at_last_extraction.unwrap_or(0));
     if token_growth < config.min_tokens_between_update {
         return false;
     }

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/state.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/state.rs
@@ -158,7 +158,7 @@ pub struct SessionMemoryState {
     /// (in-turn tail) each resolve it to an index in their own array.
     pub last_summarized_seq: Option<i64>,
     /// Total context tokens at the time of the last extraction.
-    pub tokens_at_last_extraction: usize,
+    pub tokens_at_last_extraction: Option<usize>,
     /// Tool calls seen since the last extraction.
     pub tool_calls_since_extraction: usize,
     /// Whether the initialization threshold has been met at least once.
@@ -172,6 +172,15 @@ pub struct SessionMemoryState {
 }
 
 impl SessionMemoryState {
+    /// A compacted frame needs a fresh observed-context baseline. Invalidate
+    /// any extraction prepared against the previous frame at the same time.
+    pub fn reset_after_compaction(&mut self) {
+        self.last_summarized_seq = None;
+        self.tokens_at_last_extraction = None;
+        self.extraction_generation += 1;
+        self.extraction_in_progress = false;
+    }
+
     /// Record that tool calls happened (increment counter).
     pub fn record_tool_calls(&mut self, count: usize) {
         self.tool_calls_since_extraction += count;

--- a/src-tauri/crates/agent-core/src/core/model_context/tests/session_memory_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/tests/session_memory_tests.rs
@@ -66,7 +66,7 @@ fn state_default_is_empty() {
     let state = SessionMemoryState::default();
     assert!(state.content.is_none());
     assert!(state.last_summarized_seq.is_none());
-    assert_eq!(state.tokens_at_last_extraction, 0);
+    assert_eq!(state.tokens_at_last_extraction, None);
     assert_eq!(state.tool_calls_since_extraction, 0);
     assert!(!state.initialized);
     assert!(!state.extraction_in_progress);
@@ -117,7 +117,7 @@ fn should_extract_below_update_threshold() {
     let config = SessionMemoryConfig::default();
     let state = SessionMemoryState {
         initialized: true,
-        tokens_at_last_extraction: 48_000,
+        tokens_at_last_extraction: Some(48_000),
         tool_calls_since_extraction: 5,
         ..Default::default()
     };
@@ -129,7 +129,7 @@ fn should_extract_tool_calls_threshold() {
     let config = SessionMemoryConfig::default();
     let state = SessionMemoryState {
         initialized: true,
-        tokens_at_last_extraction: 10_000,
+        tokens_at_last_extraction: Some(10_000),
         tool_calls_since_extraction: 3,
         ..Default::default()
     };
@@ -141,7 +141,7 @@ fn should_extract_natural_break() {
     let config = SessionMemoryConfig::default();
     let state = SessionMemoryState {
         initialized: true,
-        tokens_at_last_extraction: 10_000,
+        tokens_at_last_extraction: Some(10_000),
         tool_calls_since_extraction: 0,
         ..Default::default()
     };
@@ -412,7 +412,7 @@ fn restore_sm_state_from_persisted_data() {
     assert_eq!(state.content, persisted_content);
     assert_eq!(state.last_summarized_seq, Some(42));
     // Counters remain zero — they track in-session activity only
-    assert_eq!(state.tokens_at_last_extraction, 0);
+    assert_eq!(state.tokens_at_last_extraction, None);
     assert_eq!(state.tool_calls_since_extraction, 0);
 }
 

--- a/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
@@ -1362,6 +1362,7 @@ pub fn save_subagent_transcript(
 pub struct PersistedSessionMemoryState {
     pub content: Option<String>,
     pub last_seq: Option<i64>,
+    pub tokens_at_last_extraction: Option<usize>,
 }
 
 // ============================================
@@ -1436,7 +1437,7 @@ pub fn save_session_memory_state(
     with_sessions_writer(|| -> SqliteResult<()> {
         let conn = get_connection()?;
         let changed = conn.execute(
-            "UPDATE agent_sessions SET sm_content = ?2, sm_last_seq = ?3 WHERE session_id = ?1",
+            "UPDATE agent_sessions SET sm_content = ?2, sm_last_seq = ?3, sm_tokens_at_last_extraction = NULL WHERE session_id = ?1",
             rusqlite::params![session_id, content, last_seq],
         )?;
         if changed == 0 {
@@ -1451,6 +1452,7 @@ pub fn save_session_memory_state(
 pub struct SessionMemoryCommitSnapshot {
     pub(crate) content: Option<String>,
     pub(crate) last_seq: Option<i64>,
+    tokens_at_last_extraction: Option<usize>,
     created_at: String,
     last_message_id: Option<String>,
 }
@@ -1460,7 +1462,7 @@ pub fn session_memory_commit_snapshot(
 ) -> SqliteResult<SessionMemoryCommitSnapshot> {
     let conn = get_connection()?;
     conn.query_row(
-        "SELECT sm_content, sm_last_seq, created_at,
+        "SELECT sm_content, sm_last_seq, sm_tokens_at_last_extraction, created_at,
             (SELECT id FROM agent_messages WHERE session_id = ?1 ORDER BY sequence DESC LIMIT 1)
          FROM agent_sessions WHERE session_id = ?1",
         [session_id],
@@ -1468,11 +1470,19 @@ pub fn session_memory_commit_snapshot(
             Ok(SessionMemoryCommitSnapshot {
                 content: row.get(0)?,
                 last_seq: row.get(1)?,
-                created_at: row.get(2)?,
-                last_message_id: row.get(3)?,
+                tokens_at_last_extraction: row.get(2)?,
+                created_at: row.get(3)?,
+                last_message_id: row.get(4)?,
             })
         },
     )
+}
+
+/// Summary and growth baseline published in one durable update.
+pub struct SessionMemoryUpdate<'a> {
+    pub content: Option<&'a str>,
+    pub last_seq: Option<i64>,
+    pub tokens_at_last_extraction: Option<usize>,
 }
 
 /// Commit only if the durable summary and history still match the snapshot.
@@ -1481,8 +1491,7 @@ pub fn session_memory_commit_snapshot(
 /// retaining the runtime state lock.
 pub fn commit_session_memory_state(
     session_id: &str,
-    content: &str,
-    last_seq: Option<i64>,
+    update: SessionMemoryUpdate<'_>,
     expected: &SessionMemoryCommitSnapshot,
     is_cancelled: impl FnOnce() -> bool,
     on_committed: impl FnOnce(),
@@ -1491,12 +1500,12 @@ pub fn commit_session_memory_state(
         if is_cancelled() { return Ok(false); }
         let conn = get_connection()?;
         let changed = conn.execute(
-            "UPDATE agent_sessions SET sm_content = ?2, sm_last_seq = ?3
+            "UPDATE agent_sessions SET sm_content = ?2, sm_last_seq = ?3, sm_tokens_at_last_extraction = ?8
              WHERE session_id = ?1 AND sm_content IS ?4 AND sm_last_seq IS ?5
                AND created_at = ?6
-               AND (SELECT id FROM agent_messages WHERE session_id = ?1 ORDER BY sequence DESC LIMIT 1) IS ?7",
-            rusqlite::params![session_id, content, last_seq, expected.content, expected.last_seq,
-                expected.created_at, expected.last_message_id],
+               AND (SELECT id FROM agent_messages WHERE session_id = ?1 ORDER BY sequence DESC LIMIT 1) IS ?7 AND sm_tokens_at_last_extraction IS ?9",
+            rusqlite::params![session_id, update.content, update.last_seq, expected.content, expected.last_seq,
+                expected.created_at, expected.last_message_id, update.tokens_at_last_extraction, expected.tokens_at_last_extraction],
         )?;
         if changed == 0 {
             conn.query_row("SELECT 1 FROM agent_sessions WHERE session_id = ?1", [session_id], |_| Ok(()))?;
@@ -1514,7 +1523,7 @@ pub fn clear_session_memory_state(session_id: &str) -> SqliteResult<()> {
     with_sessions_writer(|| -> SqliteResult<()> {
         let conn = get_connection()?;
         conn.execute(
-            "UPDATE agent_sessions SET sm_content = NULL, sm_last_seq = NULL WHERE session_id = ?1",
+            "UPDATE agent_sessions SET sm_content = NULL, sm_last_seq = NULL, sm_tokens_at_last_extraction = NULL WHERE session_id = ?1",
             [session_id],
         )?;
         Ok(())
@@ -1525,12 +1534,12 @@ pub fn clear_session_memory_state(session_id: &str) -> SqliteResult<()> {
 pub fn load_session_memory_state(session_id: &str) -> SqliteResult<PersistedSessionMemoryState> {
     let conn = get_connection()?;
     let result = conn.query_row(
-        "SELECT sm_content, sm_last_seq FROM agent_sessions WHERE session_id = ?1",
+        "SELECT sm_content, sm_last_seq, sm_tokens_at_last_extraction FROM agent_sessions WHERE session_id = ?1",
         [session_id],
         |row| {
             let content: Option<String> = row.get(0)?;
             let last_seq: Option<i64> = row.get(1)?;
-            Ok(PersistedSessionMemoryState { content, last_seq })
+            Ok(PersistedSessionMemoryState { content, last_seq, tokens_at_last_extraction: row.get(2)? })
         },
     );
     match result {
@@ -1538,6 +1547,7 @@ pub fn load_session_memory_state(session_id: &str) -> SqliteResult<PersistedSess
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(PersistedSessionMemoryState {
             content: None,
             last_seq: None,
+            tokens_at_last_extraction: None,
         }),
         Err(err) => Err(err),
     }

--- a/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
@@ -58,7 +58,7 @@ pub use messages::{
     session_memory_commit_snapshot, take_turn_cancelled, truncate_messages_from_sequence,
     update_compact_boundary_token_delta, AgentOrgInboxTranscriptMaterialization,
     MaterializedHistoryContent, MaterializedHistoryReceipt, MaterializedHistoryRole,
-    MaterializedHistorySeed, MessageAnchor, SessionMemoryCommitSnapshot,
+    MaterializedHistorySeed, MessageAnchor, SessionMemoryCommitSnapshot, SessionMemoryUpdate,
 };
 
 use rusqlite::{Connection, Result as SqliteResult};

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
@@ -266,6 +266,36 @@ fn session_memory_job(input: SessionMemoryExtractionInput<'_>) -> MemoryJob {
     })
 }
 
+/// Complete the persisted baseline before evaluating extraction growth.
+/// Normally this is only an in-memory check; a write is needed after restore
+/// without a baseline, explicit compaction, or a lower observed context size.
+pub(super) async fn prepare_session_memory_baseline(
+    session_id: &str,
+    state: Arc<Mutex<SessionMemoryState>>,
+    current_tokens: usize,
+) -> bool {
+    {
+        let current = state.lock().await;
+        if !current.initialized
+            || current
+                .tokens_at_last_extraction
+                .is_some_and(|tokens| current_tokens >= tokens)
+        {
+            return true;
+        }
+    }
+    let lease = session_memory_commit::ExtractionLease::begin(state).await;
+    let result = lease.rebase(session_id.to_owned(), current_tokens).await;
+    lease.finish().await;
+    match result {
+        Ok(applied) => applied,
+        Err(error) => {
+            tracing::warn!(session_id, %error, "Session-memory baseline deferred");
+            false
+        }
+    }
+}
+
 /// Shared production boundary: load authoritative history, extract, then
 /// persist content and sequence together. A deferred/failed query never writes.
 async fn extract_and_persist_session_memory(

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn_memory_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn_memory_tests.rs
@@ -504,7 +504,7 @@ async fn session_memory_database_failure_preserves_runtime_and_durable_state() {
         content: Some("old memory".into()),
         last_summarized_seq: Some(0),
         tool_calls_since_extraction: 8,
-        tokens_at_last_extraction: 12_000,
+        tokens_at_last_extraction: Some(12_000),
         initialized: true,
         ..Default::default()
     }));
@@ -520,10 +520,21 @@ async fn session_memory_database_failure_preserves_runtime_and_durable_state() {
     let current = state.lock().await;
     assert_eq!(current.content.as_deref(), Some("old memory"));
     assert_eq!(current.last_summarized_seq, Some(0));
-    assert_eq!(current.tokens_at_last_extraction, 12_000);
+    assert_eq!(current.tokens_at_last_extraction, Some(12_000));
     assert_eq!(current.tool_calls_since_extraction, 8);
     assert!(current.initialized);
     assert!(!current.extraction_in_progress);
+}
+
+fn commit_update(
+    content: &str,
+    last_seq: Option<i64>,
+) -> unified_persistence::SessionMemoryUpdate<'_> {
+    unified_persistence::SessionMemoryUpdate {
+        content: Some(content),
+        last_seq,
+        tokens_at_last_extraction: Some(20_000),
+    }
 }
 
 fn commit_draft() -> session_memory::extract::SessionMemoryExtraction {
@@ -630,7 +641,7 @@ async fn session_memory_old_generation_cannot_commit_or_clear_new_owner() {
     let current = state.lock().await;
     assert_eq!(current.content.as_deref(), Some("new memory"));
     assert_eq!(current.last_summarized_seq, Some(1));
-    assert_eq!(current.tokens_at_last_extraction, 20_000);
+    assert_eq!(current.tokens_at_last_extraction, Some(20_000));
     assert_eq!(current.tool_calls_since_extraction, 3);
     assert!(!current.extraction_in_progress);
     assert_eq!(persisted(sid), (Some("new memory".into()), Some(1)));
@@ -645,8 +656,7 @@ fn session_memory_commit_rejects_stale_snapshot_and_missing_session() {
     unified_persistence::save_session_memory_state(sid, "newer memory", Some(10)).unwrap();
     assert!(!unified_persistence::commit_session_memory_state(
         sid,
-        "stale memory",
-        Some(1),
+        commit_update("stale memory", Some(1)),
         &snapshot,
         || false,
         || {},
@@ -658,8 +668,7 @@ fn session_memory_commit_rejects_stale_snapshot_and_missing_session() {
     );
     assert!(unified_persistence::commit_session_memory_state(
         "missing-session",
-        "lost",
-        Some(1),
+        commit_update("lost", Some(1)),
         &snapshot,
         || false,
         || {},
@@ -691,8 +700,7 @@ fn session_memory_commit_rejects_changed_history_without_publishing() {
         let before = persisted(&sid);
         assert!(!unified_persistence::commit_session_memory_state(
             &sid,
-            "stale summary",
-            Some(1),
+            commit_update("stale summary", Some(1)),
             &snapshot,
             || false,
             || panic!("stale history must not publish runtime state"),
@@ -718,8 +726,7 @@ fn session_memory_writer_admission_is_bounded_without_publishing() {
     held_rx.recv_timeout(Duration::from_secs(2)).unwrap();
     let result = unified_persistence::commit_session_memory_state(
         sid,
-        "new memory",
-        Some(1),
+        commit_update("new memory", Some(1)),
         &snapshot,
         || false,
         || panic!("a busy writer must not publish"),
@@ -731,4 +738,152 @@ fn session_memory_writer_admission_is_bounded_without_publishing() {
         Some(rusqlite::ErrorCode::DatabaseBusy)
     );
     assert_eq!(persisted(sid), (None, None));
+}
+
+fn restored_memory_state(sid: &str) -> SessionMemoryState {
+    let saved = unified_persistence::load_session_memory_state(sid).unwrap();
+    SessionMemoryState {
+        initialized: saved.content.is_some(),
+        content: saved.content,
+        last_summarized_seq: saved.last_seq,
+        tokens_at_last_extraction: saved.tokens_at_last_extraction,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn session_memory_restart_retains_committed_growth_baseline() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-baseline-restart";
+    seed(sid);
+    unified_persistence::save_session_memory_state(sid, "old memory", Some(0)).unwrap();
+    let state = Arc::new(Mutex::new(restored_memory_state(sid)));
+    let lease = session_memory_commit::ExtractionLease::begin(state).await;
+    assert!(lease
+        .commit(
+            sid.into(),
+            commit_draft(),
+            unified_persistence::session_memory_commit_snapshot(sid).unwrap(),
+            None
+        )
+        .await
+        .unwrap());
+    lease.finish().await;
+    let restored = restored_memory_state(sid);
+    assert_eq!(restored.tokens_at_last_extraction, Some(20_000));
+    assert_eq!(restored.content.as_deref(), Some("new memory"));
+    assert_eq!(restored.last_summarized_seq, Some(1));
+    let config = SessionMemoryConfig::default();
+    assert!(
+        !crate::model_context::session_memory::extract::should_extract(
+            &restored, &config, 20_500, false
+        )
+    );
+    assert!(
+        crate::model_context::session_memory::extract::should_extract(
+            &restored, &config, 25_000, false
+        )
+    );
+}
+
+#[tokio::test]
+async fn session_memory_legacy_baseline_and_compaction_rebase_without_summary_write() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-baseline-legacy";
+    seed(sid);
+    unified_persistence::save_session_memory_state(sid, "old memory", Some(0)).unwrap();
+    let state = Arc::new(Mutex::new(restored_memory_state(sid)));
+    state.lock().await.tool_calls_since_extraction = 7;
+    assert!(prepare_session_memory_baseline(sid, state.clone(), 40_000).await);
+    assert_eq!(persisted(sid), (Some("old memory".into()), Some(0)));
+    assert_eq!(
+        restored_memory_state(sid).tokens_at_last_extraction,
+        Some(40_000)
+    );
+    assert_eq!(state.lock().await.tool_calls_since_extraction, 7);
+    // A normal turn must not issue another metadata write.
+    database::db::get_connection().unwrap().execute_batch(
+        "CREATE TRIGGER reject_baseline BEFORE UPDATE ON agent_sessions BEGIN SELECT RAISE(FAIL, 'unexpected write'); END;"
+    ).unwrap();
+    assert!(prepare_session_memory_baseline(sid, state.clone(), 40_500).await);
+    database::db::get_connection()
+        .unwrap()
+        .execute_batch("DROP TRIGGER reject_baseline")
+        .unwrap();
+    unified_persistence::save_session_memory_state(sid, "old memory", None).unwrap();
+    state.lock().await.reset_after_compaction();
+    assert!(prepare_session_memory_baseline(sid, state.clone(), 8_000).await);
+    let restored = restored_memory_state(sid);
+    assert_eq!(restored.tokens_at_last_extraction, Some(8_000));
+    assert_eq!(restored.last_summarized_seq, None);
+    let config = SessionMemoryConfig::default();
+    assert!(
+        !crate::model_context::session_memory::extract::should_extract(
+            &restored, &config, 8_500, false
+        )
+    );
+    assert!(
+        crate::model_context::session_memory::extract::should_extract(
+            &restored, &config, 13_000, false
+        )
+    );
+}
+
+#[tokio::test]
+async fn session_memory_context_shrink_rebases_and_failed_write_preserves_baseline() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-baseline-shrink";
+    seed(sid);
+    unified_persistence::save_session_memory_state(sid, "old memory", Some(0)).unwrap();
+    let state = Arc::new(Mutex::new(restored_memory_state(sid)));
+    assert!(prepare_session_memory_baseline(sid, state.clone(), 40_000).await);
+    database::db::get_connection().unwrap().execute_batch(
+        "CREATE TRIGGER reject_baseline BEFORE UPDATE ON agent_sessions BEGIN SELECT RAISE(FAIL, 'injected failure'); END;"
+    ).unwrap();
+    assert!(!prepare_session_memory_baseline(sid, state.clone(), 8_000).await);
+    assert_eq!(state.lock().await.tokens_at_last_extraction, Some(40_000));
+    assert_eq!(
+        restored_memory_state(sid).tokens_at_last_extraction,
+        Some(40_000)
+    );
+    database::db::get_connection()
+        .unwrap()
+        .execute_batch("DROP TRIGGER reject_baseline")
+        .unwrap();
+    assert!(prepare_session_memory_baseline(sid, state.clone(), 8_000).await);
+    assert_eq!(
+        restored_memory_state(sid).tokens_at_last_extraction,
+        Some(8_000)
+    );
+    assert_eq!(persisted(sid), (Some("old memory".into()), Some(0)));
+}
+
+#[test]
+fn session_memory_baseline_change_invalidates_old_commit_snapshot() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "memory-baseline-cas";
+    seed(sid);
+    unified_persistence::save_session_memory_state(sid, "old memory", Some(0)).unwrap();
+    let snapshot = unified_persistence::session_memory_commit_snapshot(sid).unwrap();
+    assert!(unified_persistence::commit_session_memory_state(
+        sid,
+        commit_update("old memory", Some(0)),
+        &snapshot,
+        || false,
+        || {},
+    )
+    .unwrap());
+    assert!(!unified_persistence::commit_session_memory_state(
+        sid,
+        commit_update("stale memory", Some(1)),
+        &snapshot,
+        || false,
+        || panic!("baseline changed while extraction was running"),
+    )
+    .unwrap());
+    assert_eq!(persisted(sid), (Some("old memory".into()), Some(0)));
+    assert_eq!(
+        restored_memory_state(sid).tokens_at_last_extraction,
+        Some(20_000)
+    );
 }

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
@@ -269,8 +269,6 @@ impl UnifiedMessageProcessor {
                     messages_kept: kept,
                 };
             }
-            let mut sm_state = self.sm_state.lock().await;
-            sm_state.reset_after_compaction();
         } else {
             // No fork-form here (unlike pre-turn): reactive compaction runs
             // right after the provider REJECTED this exact prefix as too
@@ -283,9 +281,16 @@ impl UnifiedMessageProcessor {
             let cleaned = crate::model_context::cleanup::post_compact_cleanup(compacted);
             *messages = append_compacted_tail(&prefix, cleaned);
             outcome = llm_outcome;
-            let mut sm_state = self.sm_state.lock().await;
-            sm_state.reset_after_compaction();
         }
+
+        // Only a successful rewrite invalidates the extraction frame. A failed
+        // LLM fallback may have received an intermediate SM-compacted tail;
+        // restore the original frame along with its still-valid growth state.
+        if !matches!(outcome, CompactionOutcome::Compacted { .. }) {
+            *messages = pre_compact_messages;
+            return outcome;
+        }
+        self.sm_state.lock().await.reset_after_compaction();
 
         crate::model_context::file_reinjection::reinject_files_after_compaction(
             &pre_compact_messages,
@@ -512,7 +517,7 @@ impl UnifiedMessageProcessor {
             // and the turn proceeds with the original messages — no silent
             // truncation, no boundary persist for a no-op. The failure was
             // already counted toward the circuit breaker inside `compact`.
-            if let CompactionOutcome::Failed { reason } = outcome {
+            if let CompactionOutcome::Failed { ref reason } = outcome {
                 warn!(
                     "[unified_processor] Pre-turn compaction failed for session {} — continuing uncompacted: {}",
                     session_id, reason
@@ -525,6 +530,9 @@ impl UnifiedMessageProcessor {
                     ),
                     "compaction",
                 );
+            }
+            if !matches!(outcome, CompactionOutcome::Compacted { .. }) {
+                *messages = pre_compact_messages;
                 return CompactionPhaseOutcome::Continue;
             }
 

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
@@ -270,7 +270,7 @@ impl UnifiedMessageProcessor {
                 };
             }
             let mut sm_state = self.sm_state.lock().await;
-            sm_state.last_summarized_seq = None;
+            sm_state.reset_after_compaction();
         } else {
             // No fork-form here (unlike pre-turn): reactive compaction runs
             // right after the provider REJECTED this exact prefix as too
@@ -284,7 +284,7 @@ impl UnifiedMessageProcessor {
             *messages = append_compacted_tail(&prefix, cleaned);
             outcome = llm_outcome;
             let mut sm_state = self.sm_state.lock().await;
-            sm_state.last_summarized_seq = None;
+            sm_state.reset_after_compaction();
         }
 
         crate::model_context::file_reinjection::reinject_files_after_compaction(
@@ -467,7 +467,7 @@ impl UnifiedMessageProcessor {
                 need_llm_compact = false;
 
                 let mut sm_state = self.sm_state.lock().await;
-                sm_state.last_summarized_seq = None;
+                sm_state.reset_after_compaction();
             }
         }
 
@@ -532,7 +532,7 @@ impl UnifiedMessageProcessor {
             *messages = append_compacted_tail(&prefix, cleaned_tail);
 
             let mut sm_state = self.sm_state.lock().await;
-            sm_state.last_summarized_seq = None;
+            sm_state.reset_after_compaction();
         }
 
         // Post-compact file re-injection
@@ -656,7 +656,7 @@ impl UnifiedMessageProcessor {
                 // compact summary, so the old anchor describes rows the
                 // visible window no longer contains.
                 let mut sm_state = self.sm_state.lock().await;
-                sm_state.last_summarized_seq = None;
+                sm_state.reset_after_compaction();
                 let persist_outcome = match sm_state.content.as_deref() {
                     Some(content) if !content.trim().is_empty() => {
                         unified_persistence::save_session_memory_state(session_id, content, None)

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/orchestrator.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/orchestrator.rs
@@ -73,6 +73,7 @@ impl UnifiedMessageProcessor {
                         );
                         sm_state.content = persisted.content;
                         sm_state.last_summarized_seq = persisted.last_seq;
+                        sm_state.tokens_at_last_extraction = persisted.tokens_at_last_extraction;
                         sm_state.initialized = true;
                     }
                 }

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/post_turn_dispatch.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/post_turn_dispatch.rs
@@ -145,15 +145,22 @@ impl UnifiedMessageProcessor {
         // queued can no longer lose them, and only due extractions are ever
         // submitted.
         if should_run_post_turn_work(self.sm_config.enabled, final_turn_state) {
+            let baseline_ready = post_turn_jobs::prepare_session_memory_baseline(
+                session_id,
+                self.sm_state.clone(),
+                sm_current_tokens,
+            )
+            .await;
             let should_extract_now = {
                 let mut sm_state = self.sm_state.lock().await;
                 sm_state.record_tool_calls(tool_calls_count as usize);
-                crate::model_context::session_memory::should_extract(
-                    &sm_state,
-                    &self.sm_config,
-                    sm_current_tokens,
-                    sm_last_turn_has_tool_calls,
-                )
+                baseline_ready
+                    && crate::model_context::session_memory::should_extract(
+                        &sm_state,
+                        &self.sm_config,
+                        sm_current_tokens,
+                        sm_last_turn_has_tool_calls,
+                    )
             };
             if should_extract_now {
                 post_turn_jobs::spawn_session_memory_extraction(

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/reactive_memory_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/reactive_memory_tests.rs
@@ -169,3 +169,168 @@ async fn session_memory_reactive_compaction_allows_new_durable_commit() {
     }
     assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_memory_failed_reactive_compaction_preserves_growth() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    for sm_enabled in [false, true] {
+        let sid = format!("reactive-failed-{sm_enabled}");
+        let (mut processor, provider) = fixture(&sid, true);
+        processor.sm_config.enabled = sm_enabled;
+        Arc::get_mut(&mut processor.runtime)
+            .unwrap()
+            .resolved
+            .compaction
+            .min_messages = 1;
+        {
+            let mut state = processor.sm_state.lock().await;
+            state.content = Some("old memory".into());
+            state.last_summarized_seq = Some(3);
+            state.initialized = true;
+        }
+        assert!(
+            crate::session::turn::post_turn::prepare_session_memory_baseline(
+                &sid,
+                processor.sm_state.clone(),
+                20_000
+            )
+            .await
+        );
+        {
+            let mut state = processor.sm_state.lock().await;
+            state.extraction_generation = 7;
+            state.tool_calls_since_extraction = 8;
+        }
+        processor
+            .session
+            .last_context_tokens
+            .store(45_000, Ordering::SeqCst);
+        let original: Vec<Value> = (0..8).map(|i| serde_json::json!({
+            "role": "user", "content": if i == 7 { "recent tail".to_owned() } else { "work ".repeat(40_000) }
+        })).collect();
+        let mut messages = original.clone();
+        let outcome = processor
+            .run_reactive_compaction(&sid, &mut messages, None)
+            .await;
+        assert!(
+            matches!(outcome, CompactionOutcome::Failed { .. }),
+            "{outcome:?}"
+        );
+        assert!(
+            provider.calls.load(Ordering::SeqCst) >= 2,
+            "normal and rescue must run"
+        );
+        assert_eq!(
+            messages, original,
+            "failed compaction must preserve the original frame"
+        );
+        {
+            let state = processor.sm_state.lock().await;
+            assert_eq!(state.tokens_at_last_extraction, Some(20_000));
+            assert_eq!(state.last_summarized_seq, Some(3));
+            assert_eq!(state.extraction_generation, 7);
+            assert_eq!(state.tool_calls_since_extraction, 8);
+        }
+        assert_eq!(
+            processor.session.last_context_tokens.load(Ordering::SeqCst),
+            45_000
+        );
+        assert!(
+            crate::session::turn::post_turn::prepare_session_memory_baseline(
+                &sid,
+                processor.sm_state.clone(),
+                45_000
+            )
+            .await
+        );
+        let durable = unified_persistence::load_session_memory_state(&sid).unwrap();
+        assert_eq!(durable.tokens_at_last_extraction, Some(20_000));
+        assert_eq!(durable.last_seq, Some(3));
+        assert_eq!(durable.content.as_deref(), Some("old memory"));
+        processor.sm_config.enabled = true;
+        let state = processor.sm_state.lock().await;
+        assert_eq!(state.tokens_at_last_extraction, Some(20_000));
+        assert!(session_memory::should_extract(
+            &state,
+            &processor.sm_config,
+            45_000,
+            false
+        ));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_memory_skipped_reactive_compaction_preserves_growth() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "reactive-skipped-memory";
+    let (mut processor, provider) = fixture(sid, false);
+    processor.sm_config.enabled = false;
+    {
+        let mut state = processor.sm_state.lock().await;
+        state.content = Some("old memory".into());
+        state.last_summarized_seq = Some(3);
+        state.tokens_at_last_extraction = Some(20_000);
+        state.initialized = true;
+        state.extraction_generation = 7;
+    }
+    processor
+        .session
+        .last_context_tokens
+        .store(45_000, Ordering::SeqCst);
+    let original = unified_persistence::load_llm_history(sid).unwrap();
+    let mut messages = original.clone();
+    assert!(matches!(
+        processor
+            .run_reactive_compaction(sid, &mut messages, None)
+            .await,
+        CompactionOutcome::Skipped
+    ));
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(messages, original);
+    let state = processor.sm_state.lock().await;
+    assert_eq!(state.tokens_at_last_extraction, Some(20_000));
+    assert_eq!(state.last_summarized_seq, Some(3));
+    assert_eq!(state.extraction_generation, 7);
+    assert_eq!(
+        processor.session.last_context_tokens.load(Ordering::SeqCst),
+        45_000
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn session_memory_pre_turn_skipped_compaction_preserves_baseline() {
+    let _sandbox = test_helpers::test_env::sandbox();
+    let sid = "pre-turn-skipped-memory";
+    let (mut processor, provider) = fixture(sid, false);
+    processor.sm_config.enabled = false;
+    {
+        let mut state = processor.sm_state.lock().await;
+        state.content = Some("old memory".into());
+        state.last_summarized_seq = Some(3);
+        state.tokens_at_last_extraction = Some(20_000);
+        state.initialized = true;
+        state.extraction_generation = 7;
+    }
+    // A stale provider observation opens the gate, but there is no current
+    // compactable tail. The compactor returns Skipped without an LLM call.
+    processor
+        .session
+        .last_context_tokens
+        .store(100_000, Ordering::SeqCst);
+    let mut messages = Vec::new();
+    assert!(matches!(
+        processor.run_pre_turn_compaction(sid, &mut messages).await,
+        CompactionPhaseOutcome::Continue
+    ));
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+    assert!(messages.is_empty());
+    let state = processor.sm_state.lock().await;
+    assert_eq!(state.tokens_at_last_extraction, Some(20_000));
+    assert_eq!(state.last_summarized_seq, Some(3));
+    assert_eq!(state.extraction_generation, 7);
+    assert_eq!(
+        processor.session.last_context_tokens.load(Ordering::SeqCst),
+        100_000
+    );
+    assert_eq!(unified_persistence::load_llm_history(sid).unwrap().len(), 8);
+}

--- a/src-tauri/crates/agent-core/src/core/session/turn/session_memory_commit.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/session_memory_commit.rs
@@ -57,8 +57,11 @@ impl ExtractionLease {
             }
             let committed = persistence::commit_session_memory_state(
                 &session_id,
-                &draft.content,
-                draft.last_seq,
+                persistence::SessionMemoryUpdate {
+                    content: Some(&draft.content),
+                    last_seq: draft.last_seq,
+                    tokens_at_last_extraction: Some(draft.current_tokens),
+                },
                 &snapshot,
                 || {
                     !alive.load(Ordering::SeqCst)
@@ -69,7 +72,7 @@ impl ExtractionLease {
                 || {
                     current.content = Some(draft.content.clone());
                     current.last_summarized_seq = draft.last_seq;
-                    current.tokens_at_last_extraction = draft.current_tokens;
+                    current.tokens_at_last_extraction = Some(draft.current_tokens);
                     current.tool_calls_since_extraction = current
                         .tool_calls_since_extraction
                         .saturating_sub(draft.consumed_tool_calls);
@@ -82,6 +85,50 @@ impl ExtractionLease {
         })
         .await
         .map_err(|err| format!("SM persist worker failed: {err}"))?
+    }
+
+    /// Establish a missing baseline or rebase after context shrink without an
+    /// LLM call. Restore the authoritative summary pair if local bookkeeping
+    /// had fallen behind, but leave retry state and tool counters untouched.
+    pub async fn rebase(&self, session_id: String, current_tokens: usize) -> Result<bool, String> {
+        let state = self.state.clone();
+        let generation = self.generation;
+        let alive = self.alive.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut current = state.blocking_lock();
+            if current.extraction_generation != generation {
+                return Ok(false);
+            }
+            if !current.initialized
+                || current
+                    .tokens_at_last_extraction
+                    .is_some_and(|tokens| current_tokens >= tokens)
+            {
+                return Ok(true);
+            }
+            let snapshot = persistence::session_memory_commit_snapshot(&session_id)
+                .map_err(|err| format!("SM baseline snapshot failed: {err}"))?;
+            let baseline = snapshot.content.as_ref().map(|_| current_tokens);
+            persistence::commit_session_memory_state(
+                &session_id,
+                persistence::SessionMemoryUpdate {
+                    content: snapshot.content.as_deref(),
+                    last_seq: snapshot.last_seq,
+                    tokens_at_last_extraction: baseline,
+                },
+                &snapshot,
+                || !alive.load(Ordering::SeqCst),
+                || {
+                    current.content = snapshot.content.clone();
+                    current.last_summarized_seq = snapshot.last_seq;
+                    current.tokens_at_last_extraction = baseline;
+                    current.initialized = snapshot.content.is_some();
+                },
+            )
+            .map_err(|err| format!("SM baseline commit failed: {err}"))
+        })
+        .await
+        .map_err(|err| format!("SM baseline worker failed: {err}"))?
     }
 
     pub async fn finish(mut self) {

--- a/src-tauri/crates/agent-core/src/foundation/persistence/session_snapshots.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/session_snapshots.rs
@@ -220,6 +220,10 @@ pub fn ensure_tables_with(conn: &Connection) -> SqliteResult<()> {
         conn,
         "ALTER TABLE agent_sessions ADD COLUMN sm_last_seq INTEGER",
     );
+    try_migrate(
+        conn,
+        "ALTER TABLE agent_sessions ADD COLUMN sm_tokens_at_last_extraction INTEGER",
+    );
     try_drop_column(conn, "agent_sessions", "sm_last_msg_idx");
 
     // L3 rebuild: the per-session learning toggle was replaced by a per-agent

--- a/src-tauri/crates/agent-core/src/foundation/persistence/test_schema.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/test_schema.rs
@@ -49,7 +49,8 @@ pub(crate) const AGENT_SESSIONS_TEST_DDL: &str = r#"
         reply_target_event_id TEXT,
         pinned INTEGER NOT NULL DEFAULT 0,
         sm_content TEXT,
-        sm_last_seq INTEGER
+        sm_last_seq INTEGER,
+        sm_tokens_at_last_extraction INTEGER
     );
     CREATE TABLE IF NOT EXISTS session_token_usage (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -152,6 +153,10 @@ pub(crate) fn ensure_agent_sessions_schema(conn: &rusqlite::Connection) {
         ("key_source", "key_source TEXT NOT NULL DEFAULT 'own_key'"),
         ("sm_content", "sm_content TEXT"),
         ("sm_last_seq", "sm_last_seq INTEGER"),
+        (
+            "sm_tokens_at_last_extraction",
+            "sm_tokens_at_last_extraction INTEGER",
+        ),
     ] {
         if !existing.contains(column) {
             let _ = conn.execute(&format!("ALTER TABLE agent_sessions ADD COLUMN {decl}"), []);

--- a/src-tauri/crates/agent-core/src/state/commands/session/compaction.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/compaction.rs
@@ -519,6 +519,7 @@ async fn run_manual_compact_exclusive(
         }
     };
 
+    session.sm_state.lock().await.reset_after_compaction();
     session.last_context_tokens.store(0, Ordering::SeqCst);
 
     // Instant ring/panel refresh, ahead of the frontend's full reload.


### PR DESCRIPTION
## Problem

Session memory restored the durable summary and sequence but reset its token-growth baseline to zero. A short turn after restart could therefore trigger an unnecessary summary. Compaction could retain an obsolete large baseline and suppress subsequent updates.

## Solution

Persist a nullable token baseline with the summary and sequence in the guarded commit introduced by #1663. Restore it with the summary. Legacy summaries establish their missing baseline from the first observed context without an LLM request. Successful automatic and manual compaction invalidate it; failed or skipped attempts preserve the prior frame and known growth baseline; a lower observed context also establishes a fresh baseline before evaluating growth.

Normal turns check runtime state only. Baseline writes preserve summary text, sequence, tool-call counters and retry state, and reuse the cancellation/generation guard and bounded database writer admission. A failed metadata write preserves the old baseline and defers extraction for that turn.

PR #1663 has merged. This PR now targets develop; its remaining diff only addresses baseline persistence and lifecycle. Integration verification passed on revision `337824a916f37500a4b3a9466aab448a0baffa96`, combining this PR with develop after #1663, #1665 and #1666 merged.

## Potential risks

- Adds nullable `agent_sessions.sm_tokens_at_last_extraction` through the existing additive migration path, necessary to preserve baselines across existing database restarts. No historical message rewrite or credential change. Older binaries ignore the extra column; rollback is reverting code while leaving the nullable column in place. If an older binary subsequently updates summaries, clear only this baseline metadata to NULL before upgrading again so the next observation rebuilds it; older writers cannot maintain the new baseline. Summary text and historical messages need not be deleted.
- Legacy first-turn growth cannot be reconstructed reliably; that first observation establishes the baseline and may defer one otherwise-due summary. The baseline is an observed context size, not a live price or token-billing calculation.
- A context shrink causes one bounded metadata write. The one-second deadline bounds writer-lock admission only. Waiting for the runtime-state lock, connection acquisition, SQLite locking and I/O are additional; total completed-turn latency is not capped at one second. Failures retry on a later eligible turn. No timer or polling is added.
- This does not claim to rewrite all generic compaction failure bookkeeping or close whole-app CPU/retention acceptance. Packaged restart and compaction checks are recorded separately when actually run.
- No UI or wire-format change, so visual screenshots do not verify the changed persistence invariant.

## Verification

- `cargo test -p agent_core --lib session_memory --manifest-path src-tauri/Cargo.toml`: 75 passed, including real reactive LLM+rescue failures with and without SM-first, reactive/pre-turn Skipped outcomes, successful reactive compaction followed by durable commits, and durable restart baseline, legacy initialization, compaction/re-growth, context shrink, injected write failure, normal-turn no-write and stale-baseline CAS regressions.
- `cargo test -p agent_core --lib core::session::persistence::messages::tests --manifest-path src-tauri/Cargo.toml`: 23 passed.
- `cargo clippy -p agent_core --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings`: passed.
- `cargo test -p agent_core --lib compaction --manifest-path src-tauri/Cargo.toml`: 118 passed on integrated revision `53654066c` (the Rust tree is identical to PR HEAD `864b6246c`).
- `git diff --check`: passed; inspected scope and added lines for private paths/secrets/generated churn.
- `pnpm run tauri:build:fast -- --instance 3 --frontend-only`: passed. Native package build also passed with `pnpm run tauri:build:fast -- --instance 3 --skip-frontend`. Real existing-database startup added the nullable baseline; all 24 prior test-session message rows, summary hash and sequence 23 were unchanged. Computer Use resumed using refreshed app handles and exact AX buttons. Real legacy initialization, restart/small-turn gating and sufficient-growth extraction passed; see results below. Post-compaction continuation subsequently passed on integrated revision `53654066c` with #1665, as recorded below.
- Final CI read back for current HEAD `864b6246c`: 9 SUCCESS checks, including workspace tests and strict Clippy; cargo audit scope-skipped. Performance lifecycle and compatibility analysis: `docs/org2-performance-guard-2026-09-12/SessionMemoryBaseline.md`.


## Real-device acceptance

Isolated Instance 3, existing synthetic fixture session, actual Codex Luna requests:

- Legacy short request established baseline 45,287 without changing the summary or sequence 23.
- Normal Quit/restart retained that baseline. A short request with context 45,316 returned successfully without triggering session-memory extraction.
- Three file reads grew context to 52,346. Session-memory completed in 17,436 ms and committed a 3,047-character summary, sequence 36 and baseline 52,346. All original 24 message rows remained byte-equivalent in read-back hashes.
- Manual compaction appended its boundary and preserved the summary, clearing sequence and baseline as intended. UI context estimate changed 38.9K to 13.8K.
- The earlier build exposed a native=12/canonical=1 projection failure after manual compaction. #1665 fixes that separate authoritative-read boundary. On integrated revision `53654066c` (#1664 HEAD `864b6246c` plus #1665), reopening the **same failed session** and clicking its existing Retry returned `BASELINE_COMPACT_OK`. Baseline rebuilt to 33,068 with summary unchanged. Three subsequent real file reads returned `BASELINE_REGROWTH_OK`; context 40,168 triggered a successful session-memory job (20,704 ms), committing a 3,638-character summary, sequence 48 and baseline 40,168. All 38 pre-upgrade message row hashes still matched; no deletion or prefix-guard bypass.
- Six associated processes were included in 30-second measurements: visible idle mean CPU 3.05%, after native Hide menu 3.44%, growth completion tail 4.65%. Summed physical footprint was roughly 761–866 MiB across those phases. All six exited on normal Quit. These are bounded observations, not proof of near-zero hidden overhead or absence of leaks; actual document visibility, repeated-window cycles, long-duration retention and account-switch/provider coverage remain incomplete.

## Review follow-up

Merged the current #1663 branch without rewriting reviewed history. Failed and skipped compaction now restores the pre-attempt message frame and preserves known baseline, sequence, generation, tool counters and observed context. Only `Compacted` resets these. A real processor regression reproduced the 20,000-token baseline becoming NULL after LLM and rescue failure; after the fix, baseline preparation at 45,000 still recognizes 25,000 growth. Both SM-first and direct LLM paths pass.

Post-manual-compaction native history recovery is separately addressed by #1665 (base develop). Packaged original-session recovery and re-growth passed on the integrated revision above. Injected failure branches are protocol/processor tests, not a claim of live provider failures.

### Integrated-build lifecycle observations

Normal Quit released all six Activity Monitor-attributed processes. Restart preserved the committed summary, sequence 48 and baseline 40,168. The short post-restart request succeeded, but actual complete context increased to 46,063 (+5,895), crossing the configured growth threshold; extraction completed and committed baseline 46,063/sequence 50. This proves neither a zeroed baseline nor a low-growth gating pass. The source of that full-context increase was not isolated. A second controlled restart preserved baseline 46,063. Computer Use initially blocked navigation with `noWindowsAvailable`; after the user restored the desktop, the same session returned `BASELINE_LOW_GROWTH_OK`. Actual context was 46,095 (+32), summary hash/sequence 50/baseline 46,063 stayed unchanged, and no session-memory extraction started. Thus the controlled low-growth restart case passed on the new integrated build. Separate workspace-memory work still runs through its existing path; this is not a zero-all-background-requests claim.

On integrated revision 53654066c, six-process 30-second samples measured mean CPU 3.97% at growth completion tail, 3.40% visible idle and 4.14% after native Hide; summed footprint was about 716–741 MiB. CPU is percent of one core; aggregate footprint can count shared allocations. Document visibility was not independently instrumented. No near-zero hidden-work, full active-extraction, long-retention or A/B performance claim. Whole-app performance acceptance remains incomplete.

### Retarget integration verification

After retargeting to develop, reran on integrated revision `337824a916f37500a4b3a9466aab448a0baffa96`: `cargo test -p agent_core --lib session_memory --manifest-path src-tauri/Cargo.toml` (75 passed), `cargo test -p agent_core --lib core::session::persistence::messages::tests --manifest-path src-tauri/Cargo.toml` (23 passed), and `cargo test -p agent_core --lib responses --manifest-path src-tauri/Cargo.toml` (72 passed). Published HEAD CI remains successful for applicable checks; cargo audit is scope-skipped.
