### PR TITLE
fix(session-replay): preserve compacted agent effective context

### DIFF
--- a/docs/org2-performance-guard-2026-09-12/CompactedNativeHistory.md
+++ b/docs/org2-performance-guard-2026-09-12/CompactedNativeHistory.md
@@ -1,0 +1,32 @@
+# Compacted Agent history projection
+
+## Authoritative source and root cause
+
+`agent_messages` stores immutable history. The latest boundary's `compact_from_sequence` selects the retained tail, even when those retained rows precede the newly appended boundary in storage order. Rust `load_llm_history` sends the full stored boundary as a user message followed by that tail.
+
+The authoritative frontend adapter previously converted every raw row into display-shaped events. Its boundary renderer stripped the continuation wrapper, and the native projector cleared all preceding items at that marker. That both lost the retained tail and changed the summary's semantic kind. A real manual compact therefore produced native=12 versus canonical=1 and blocked continuation before any provider call.
+
+## Source-level invariant
+
+The authoritative adapter now selects the same effective frame as Rust before converting rows: latest full boundary as a user message, then ordinary rows from its cutoff onward. Only a copy of the boundary changes projection metadata. The display reader still loads the complete original timeline and renders its collapsed boundary normally. The semantic-prefix guard stays strict.
+
+No database rows, user arguments or credentials are rewritten. Historical remediation is a fresh authoritative read through the fixed adapter; recovery of the original failed session is required in packaged acceptance, not replacement by a new session.
+
+## Lifecycle and performance
+
+| Surface                    | Behavior                                                                    | Verification                                   |
+| -------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------- |
+| Authoritative history read | Two linear passes over rows already fetched; no extra RPC or database query | Adapter regression and call-chain inspection   |
+| Repeated reads/display     | Original row array and full display history preserved                       | Repeated-read and display assertions           |
+| Compaction/restart         | Latest sequence wins; zero cutoff and summary-only frames supported         | Owning adapter through native projection tests |
+| Active/idle/hidden         | No timer, listener, cache, worker or background loop added                  | Static resource inventory                      |
+| Abort                      | Existing signal check remains before projection                             | Existing authoritative-reader suite            |
+| Provider/scope             | Rust Agent adapter only; imported CLI adapters unchanged                    | No cross-provider runtime claim                |
+
+Architecture coverage: types/compilation, source ownership, effective-context versus display semantics, compaction initialization parity, and provider comparison contract. No wire, schema, configuration or UI layout change. No broad unrelated cleanup.
+
+## Verification limits
+
+Two new regressions fail on the old adapter and pass on the fix. Four targeted suites pass (88 tests); TypeScript checking passes. Exact commands and packaged original-session recovery are recorded in the PR. Runtime CPU or long-duration retention improvement is not inferred from this projection fix. Rollback is a code revert; no data migration or cleanup is needed.
+
+Performance verdict: no new retained or recurring work; whole-app lifecycle acceptance remains separate.

--- a/src/engines/SessionCore/sync/adapters/__tests__/createRustAgentAdapter.authoritative.test.ts
+++ b/src/engines/SessionCore/sync/adapters/__tests__/createRustAgentAdapter.authoritative.test.ts
@@ -149,4 +149,101 @@ describe("Rust Agent authoritative history", () => {
       )
     ).toMatchObject({ arguments: JSON.stringify(args) });
   });
+
+  it("projects the persisted compact summary and retained tail in effective-context order", async () => {
+    const summary =
+      "[Session Memory] Compacted 3 messages\n\nPersisted summary with continuation instructions";
+    const rows = [
+      row("old", "user", { sequence: 0, content: "superseded" }),
+      row("older-boundary", "system", {
+        sequence: 1,
+        content: "old summary",
+        compactFromSequence: 0,
+      }),
+      row("kept-user", "user", { sequence: 2, content: "retained user" }),
+      row("kept-call", "tool_call", {
+        sequence: 3,
+        toolName: "read_file",
+        toolCallId: "retained-call",
+        toolInput: '{"path":"fixture.txt"}',
+      }),
+      row("kept-result", "tool_result", {
+        sequence: 4,
+        toolName: "read_file",
+        toolCallId: "retained-call",
+        toolOutput: "retained result",
+      }),
+      row("boundary", "system", {
+        sequence: 5,
+        content: summary,
+        compactFromSequence: 2,
+      }),
+      row("after", "assistant", { sequence: 6, content: "after boundary" }),
+    ];
+    const before = structuredClone(rows);
+    const adapter = createRustAgentAdapter({
+      category: "agent",
+      features: {},
+      loadMessages: async () => rows,
+      cancel: async () => {},
+    });
+    const signal = new AbortController().signal;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const events = await adapter.loadAuthoritativeHistory!(
+        "sdeagent-parent",
+        signal
+      );
+      expect(projectNativeConversationItems(events)).toMatchObject([
+        { kind: "message", role: "user", text: summary },
+        { kind: "message", role: "user", text: "retained user" },
+        {
+          kind: "tool_call",
+          callId: "retained-call",
+          arguments: '{"path":"fixture.txt"}',
+        },
+        {
+          kind: "tool_result",
+          callId: "retained-call",
+          output: "retained result",
+        },
+        { kind: "message", role: "assistant", text: "after boundary" },
+      ]);
+    }
+    const display = await adapter.loadHistory("sdeagent-parent", signal);
+    expect(display.some((event) => event.id === "old")).toBe(true);
+    expect(display.find((event) => event.id === "boundary")?.functionName).toBe(
+      "context_compacted"
+    );
+    expect(rows).toEqual(before);
+  });
+
+  it("honors a zero cutoff and a summary-only boundary without mutating history", async () => {
+    for (const cutoff of [0, 3]) {
+      const rows = [
+        row("u", "user", { sequence: 0, content: "retained" }),
+        row("b", "system", {
+          sequence: 2,
+          content: "summary",
+          compactFromSequence: cutoff,
+        }),
+      ];
+      const adapter = createRustAgentAdapter({
+        category: "agent",
+        features: {},
+        loadMessages: async () => rows,
+        cancel: async () => {},
+      });
+      const items = projectNativeConversationItems(
+        await adapter.loadAuthoritativeHistory!(
+          "sdeagent-parent",
+          new AbortController().signal
+        )
+      );
+      expect(
+        items.map((item) => (item.kind === "message" ? item.text : item.kind))
+      ).toEqual(cutoff === 0 ? ["summary", "retained"] : ["summary"]);
+      expect(rows[1].role).toBe("system");
+      expect(rows[1].compactFromSequence).toBe(cutoff);
+    }
+  });
 });

--- a/src/engines/SessionCore/sync/adapters/createRustAgentAdapter.ts
+++ b/src/engines/SessionCore/sync/adapters/createRustAgentAdapter.ts
@@ -265,8 +265,32 @@ export function createRustAgentAdapter(
   ): Promise<SessionEvent[]> => {
     const messages = await loadMessages(sessionId);
     if (signal.aborted || !messages?.length) return [];
+    // Match Rust load_llm_history's effective frame, not the display timeline.
+    // The boundary is appended after its retained tail, so simply clearing
+    // projected items on encountering the marker loses that entire tail.
+    const boundary = messages.reduce<PersistedMessage | undefined>(
+      (latest, message) =>
+        message.compactFromSequence != null &&
+        (!latest || message.sequence > latest.sequence)
+          ? message
+          : latest,
+      undefined
+    );
+    const effectiveMessages = boundary
+      ? [
+          // Rust sends the complete persisted boundary (including continuation
+          // instructions) as a user message. Remove only projection metadata
+          // on this copy so the display adapter does not strip its wrapper.
+          { ...boundary, role: "user", compactFromSequence: null },
+          ...messages.filter(
+            (message) =>
+              message.compactFromSequence == null &&
+              message.sequence >= boundary.compactFromSequence!
+          ),
+        ]
+      : messages;
     return mergeToolResults(
-      messages.map((message) =>
+      effectiveMessages.map((message) =>
         persistedMessageToSessionEvent(message, sessionId)
       )
     );


### PR DESCRIPTION
## Problem

Continuing an SDE Agent session after manual compaction failed before the provider request: the provider-native transcript had 12 items while canonical projection had only one context_summary. The authoritative adapter converted the entire persisted display timeline; its compact marker stripped the summary wrapper and cleared preceding items, including the retained tail selected by the database cutoff.

## Solution

Match Rust load_llm_history at the authoritative adapter boundary: select the latest compact_from_sequence marker, project its complete stored content as a user message, then append ordinary rows at or after its retained-tail cutoff. Only a copied boundary changes projection metadata. Display history still contains all original rows and its collapsed compact marker. The semantic prefix guard remains strict.

This is separate from #1663/#1664 and targets develop directly. Those changes exposed this failure during real-device compaction acceptance; their memory commit/baseline policies are not part of this diff.

## Potential risks

The frontend effective-frame selection must stay aligned with Rust load_llm_history. Regressions cover the owning adapter through final native projection, including retained tool pairs, multiple boundaries, zero cutoff, summary-only context, repeated reads and unchanged display/raw data. Imported CLI adapters are unchanged; no claim of newly validated provider-specific compaction behavior.

No schema, IPC, provider wire contract, configuration or historical-data migration. Recovery is a fresh authoritative read of the existing failed session; no transcript deletion or prefix-guard bypass. Rollback is a code revert. The projection uses two linear passes over rows already loaded, with no new RPC, timer, cache or worker. No whole-app CPU or memory improvement is inferred.

## Verification

- Before the fix, the two new adapter regressions failed (two existing tests passed).
- `pnpm exec vitest run --config config/vitest.config.ts src/engines/SessionCore/sync/adapters/__tests__/createRustAgentAdapter.authoritative.test.ts src/engines/SessionCore/conversations/nativeConversationMaterializer.test.ts src/engines/SessionCore/sync/__tests__/authoritativeSessionEvents.test.ts src/engines/SessionCore/ingestion/__tests__/agentMessageAdapters.test.ts`: 88 passed across four files.
- `pnpm exec tsgo --noEmit`: passed.
- Pre-commit ESLint, formatting and scoped TypeScript checks: passed.
- `git diff --check`: passed. Inspected added lines for private data, credentials and unrelated churn.
- Packaged recovery of the original failed session passed on integrated revision `53654066c` (#1664 `864b6246c` plus this PR). Reopened the same session and clicked its existing Retry: the real Luna request returned `BASELINE_COMPACT_OK`. Subsequent three file reads returned `BASELINE_REGROWTH_OK` and successfully committed session memory. All 38 original message row hashes were unchanged; no history deletion or prefix-guard bypass. Both frontend and native Instance 3 build commands passed. No layout change; screenshots alone would not prove the model-history invariant.
- CI at `ab323886a`: 8 SUCCESS checks; Rust clippy and cargo audit scope-skipped.
- Lifecycle/source-boundary report: `docs/org2-performance-guard-2026-09-12/CompactedNativeHistory.md`.
