### PR TITLE
fix(providers): preserve all Responses system instructions

### DIFF
--- a/docs/org2-performance-guard-2026-09-12/ResponsesSystemInstructions.md
+++ b/docs/org2-performance-guard-2026-09-12/ResponsesSystemInstructions.md
@@ -1,0 +1,32 @@
+# Responses system instruction preservation
+
+The authoritative source is the ordered provider message frame. Stable prompt blocks and asynchronous workspace-memory recall are additive system messages. The shared Responses converter previously assigned `instructions` for every system message, leaving only the last block. Both Codex OAuth and public OpenAI Responses use this converter.
+
+The fix preserves every system block in order, separated by a blank line, after the existing structured-text sanitizer. User, assistant, tool, and developer-message conversion remains unchanged. Historical database rows are untouched; no migration or data cleanup is required.
+
+## Runtime evidence boundary
+
+The investigation started from a device run where reported input grew from 40,168 to 46,063 tokens after restart. The pre-restart tool iteration had an additional system block, while the next turn did not. Section telemetry is proportionally normalized before provider conversion and cannot prove an exact 5,895-token attribution. The request-builder regression independently proves the prompt-loss defect. A paired real-account request capture and retest of the corrected binary remain unperformed; this patch must not be described as complete numeric attribution or a token-cost reduction.
+
+| Area               | Verdict | Evidence                                                       | Change or reason kept                                                                                 | Verification                           |
+| ------------------ | ------- | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Background work    | keep    | Converter is synchronous per request                           | No timer, retry, worker, or subscription added                                                        | Call-chain inspection                  |
+| Memory             | fix     | Last system block replaced earlier text                        | Request-owned string appends each existing block once; linear in total system text, no retained cache | Multi-block and empty-block regression |
+| Scope/isolation    | keep    | Uses only current request messages                             | No cross-session or account state                                                                     | Codex request-builder regression       |
+| Rendering/hot path | fix     | Wire instructions omitted principal prompt after memory recall | Preserve existing text at shared provider conversion boundary                                         | Red-to-green request assertion         |
+
+| Provider                | Raw transition                                                                | App/UI state                      | Topology/boundary       | Expected invariant                              | Observed evidence                                                   |
+| ----------------------- | ----------------------------------------------------------------------------- | --------------------------------- | ----------------------- | ----------------------------------------------- | ------------------------------------------------------------------- |
+| Codex OAuth             | Stable structured prompt, then late memory system block                       | Tool iteration, synthetic fixture | Real request builder    | Stable prompt survives; input history identical | Regression fails on old code and passes after the fix               |
+| Public OpenAI Responses | Multiple structured/string system messages including nonadjacent/empty blocks | Synthetic fixture                 | Shared converter        | All system text retained in order               | Shared-boundary regression passes; independent live account not run |
+| Codex OAuth             | Tool iteration to restarted turn                                              | Previous device run               | Provider-reported usage | Explain complete request-size delta             | Exact numerical attribution not run                                 |
+
+Compatibility: requests now include instructions that were already present in the internal frame but omitted on the wire. This can increase tokens and affect behavior or context limits. No schema, API field, dependency, or persistence format changes. Reverting the code reintroduces prompt loss; no database rollback is necessary. UI screenshots do not validate this wire-only invariant.
+
+Performance verdict: blocked for full device performance and restart-growth attribution. The code introduces no retained state; this is not evidence of long-term memory stability.
+
+## Executed verification
+
+- `cargo test -p agent_core --lib build_responses_request_preserves_system_prompt_after_memory_prefetch --manifest-path src-tauri/Cargo.toml`: failed on old converter, retaining only memory text.
+- `cargo test -p agent_core --lib responses --manifest-path src-tauri/Cargo.toml`: 72 passed after the fix, including both new regressions.
+- `cargo clippy -p agent_core --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings`: passed.

--- a/src-tauri/crates/agent-core/src/core/providers/codex_native/client.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/codex_native/client.rs
@@ -274,6 +274,36 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn build_responses_request_preserves_system_prompt_after_memory_prefetch() {
+        let stable = serde_json::json!({"role":"system", "content":[
+            {"type":"text", "text":"Stable agent instructions", "orgii_system_cache_scope":"session"}
+        ]});
+        let user = serde_json::json!({"role":"user", "content":"Read the fixture"});
+        let initial = CodexNativeClient::build_responses_request(
+            &[stable.clone(), user.clone()],
+            None,
+            "gpt-5.6-luna-medium",
+            true,
+        );
+        let with_memory = CodexNativeClient::build_responses_request(
+            &[
+                stable,
+                serde_json::json!({"role":"system", "content":"Selected workspace memory"}),
+                user,
+            ],
+            None,
+            "gpt-5.6-luna-medium",
+            true,
+        );
+        assert_eq!(initial.instructions, "Stable agent instructions");
+        assert_eq!(
+            with_memory.instructions,
+            "Stable agent instructions\n\nSelected workspace memory"
+        );
+        assert_eq!(with_memory.input, initial.input);
+    }
+
+    #[test]
     fn build_responses_request_strips_reasoning_and_fast_variant_suffixes() {
         let messages = [json!({
             "role": "user",

--- a/src-tauri/crates/agent-core/src/core/providers/responses_common/converter.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/responses_common/converter.rs
@@ -76,7 +76,18 @@ pub fn convert_messages(messages: &[Value]) -> (Option<String>, Vec<Value>) {
         match role {
             "system" => {
                 if let Some(content) = msg.get("content").and_then(|c| c.as_str()) {
-                    instructions = Some(content.to_string());
+                    // Stable, volatile, and late memory blocks are additive.
+                    // Replacing instructions here silently drops the agent's
+                    // main prompt when a later system block arrives.
+                    match instructions.as_mut() {
+                        Some(existing) => {
+                            if !existing.is_empty() && !content.is_empty() {
+                                existing.push_str("\n\n");
+                            }
+                            existing.push_str(content);
+                        }
+                        None => instructions = Some(content.to_string()),
+                    }
                 }
             }
             "user" => {
@@ -312,6 +323,24 @@ fn translate_tool_choice_for_responses(override_val: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn convert_messages_preserves_all_system_blocks_in_order() {
+        let messages = vec![
+            serde_json::json!({"role":"system", "content":[{"type":"text", "text":"Stable"}]}),
+            serde_json::json!({"role":"system", "content":"Dynamic"}),
+            serde_json::json!({"role":"user", "content":"Question"}),
+            serde_json::json!({"role":"system", "content":"Late memory"}),
+            serde_json::json!({"role":"system", "content":""}),
+        ];
+        let (instructions, input) = convert_messages(&messages);
+        assert_eq!(
+            instructions.as_deref(),
+            Some("Stable\n\nDynamic\n\nLate memory")
+        );
+        assert_eq!(input, vec![messages[2].clone()]);
+        assert_eq!(convert_messages(&[]), (None, vec![]));
+    }
 
     #[test]
     fn test_convert_messages_extracts_system_as_instructions() {


### PR DESCRIPTION
## Problem

Codex OAuth and public OpenAI Responses requests keep only the last system message. The shared converter repeatedly assigns `instructions`, so a late workspace-memory prefetch block can silently replace the principal agent prompt. This was found while investigating context usage changing from 40,168 to 46,063 tokens across a tool iteration and restart; the precise 5,895-token attribution is not yet established.

## Solution

Append all sanitized system-message text in original order, separated by blank lines. Preserve non-system input conversion. Add regressions at the shared converter and actual Codex request builder: adding a memory block must preserve the existing principal prompt and leave user history unchanged. Include the scoped verification report.

This PR has one responsibility and targets develop directly; it does not depend on the session-memory commit/baseline PR stack.

## Potential risks

Previously omitted instructions now reach the model. Input tokens can increase and model behavior/context-limit handling can change; omission was not a valid cost optimization. Existing developer-message semantics remain unchanged. No database, dependency, API field or persistence-format changes; rollback is a code revert and requires no data cleanup, but restores the omission defect.

The corrected binary has not been retested against a real account. Exact restart token attribution and overall long-term memory performance remain unverified. Section telemetry is normalized before provider conversion and cannot prove numeric attribution. This is a wire-only change; UI screenshots would not validate the invariant.

## Verification

- `cargo test -p agent_core --lib build_responses_request_preserves_system_prompt_after_memory_prefetch --manifest-path src-tauri/Cargo.toml` — red on the old converter: actual instructions were only the selected memory text.
- `cargo test -p agent_core --lib responses --manifest-path src-tauri/Cargo.toml` — 72 passed after the fix, including both new regressions and existing Codex/public Responses conversion tests.
- `cargo clippy -p agent_core --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings` — passed.
- `git diff --check` — passed.
- No production database writes or historical cleanup were performed for this fix. Live paired-request verification is not complete; do not infer overall performance success from these tests.
