### PR TITLE
fix(chat): focus composer when clicking background space

### DIFF
--- a/src/components/ComposerShell/ComposerShell.test.ts
+++ b/src/components/ComposerShell/ComposerShell.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createPortal } from "react-dom";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ComposerShell from ".";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+function renderShell(children?: React.ReactNode, editable = true) {
+  act(() => {
+    root.render(
+      createElement(
+        ComposerShell,
+        { "data-testid": "shell" },
+        createElement("div", {
+          className: "composer-input-content",
+          contentEditable: editable,
+          tabIndex: 0,
+        }),
+        createElement("div", { "data-testid": "gap" }),
+        children
+      )
+    );
+  });
+  return container.querySelector<HTMLElement>(".composer-input-content")!;
+}
+
+function click(element: Element) {
+  act(() => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("ComposerShell background focus", () => {
+  it.each(["shell", "gap"])("focuses the editor from the %s", (testId) => {
+    const editor = renderShell();
+    click(container.querySelector(`[data-testid="${testId}"]`)!);
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it.each([
+    createElement("button", null, createElement("span", null, "Model")),
+    createElement("button", { disabled: true }, "Send"),
+    createElement("a", { href: "#" }, "Attachment"),
+    createElement("div", { role: "button", tabIndex: 0 }, "Picker"),
+    createElement("input"),
+  ])("leaves controls alone (%#)", (control) => {
+    const editor = renderShell(control);
+    const focus = vi.spyOn(editor, "focus");
+    const controlElement = container.firstElementChild!.lastElementChild!;
+    click(controlElement.firstElementChild ?? controlElement);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("focuses inside an ancestor dialog", () => {
+    container.setAttribute("role", "dialog");
+    const editor = renderShell();
+    click(container.firstElementChild!);
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it("preserves native editor clicks and selection", () => {
+    const editor = renderShell();
+    const focus = vi.spyOn(editor, "focus");
+    click(editor);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("does not focus a disabled editor", () => {
+    const editor = renderShell(undefined, false);
+    const focus = vi.spyOn(editor, "focus");
+    click(container.firstElementChild!);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("respects clicks handled by child content", () => {
+    const editor = renderShell(
+      createElement(
+        "div",
+        { onClick: (event) => event.preventDefault() },
+        "Preview"
+      )
+    );
+    const focus = vi.spyOn(editor, "focus");
+    click(container.firstElementChild!.lastElementChild!);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("ignores clicks bubbling through React portals", () => {
+    const portal = document.createElement("div");
+    document.body.append(portal);
+    const editor = renderShell(
+      createPortal(createElement("div", null, "Popup"), portal)
+    );
+    const focus = vi.spyOn(editor, "focus");
+    click(portal.firstElementChild!);
+    expect(focus).not.toHaveBeenCalled();
+    portal.remove();
+  });
+});

--- a/src/components/ComposerShell/index.tsx
+++ b/src/components/ComposerShell/index.tsx
@@ -73,6 +73,31 @@ const VARIANT_INTERACTION_CLASSES: Record<ComposerShellVariant, string> = {
   historyEdit: INPUT_AREA.shellEditInteractionClasses,
 };
 
+function focusComposerFromBackground(event: React.MouseEvent<HTMLDivElement>) {
+  const shell = event.currentTarget;
+  const target = event.target;
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    !(target instanceof Element) ||
+    !shell.contains(target)
+  ) {
+    return;
+  }
+  const control = target.closest(
+    "button, a, input, textarea, select, label, summary, [role], [tabindex], [contenteditable]"
+  );
+  if (control && shell.contains(control)) return;
+
+  // Only fill the gaps around ComposerInput; clicks inside the editor retain
+  // native caret placement, and portaled controls must not steal focus back.
+  shell
+    .querySelector<HTMLElement>(
+      '.composer-input-content[contenteditable="true"]'
+    )
+    ?.focus({ preventScroll: true });
+}
+
 const ComposerShell = forwardRef<HTMLDivElement, ComposerShellProps>(
   (
     {
@@ -94,6 +119,7 @@ const ComposerShell = forwardRef<HTMLDivElement, ComposerShellProps>(
         ref={ref}
         className={`relative flex w-full ${variant === "comment" ? "flex-row items-end" : "flex-col"} transition-[padding] duration-200 ease-out ${VARIANT_INTERACTION_CLASSES[variant]} ${VARIANT_CLASSES[variant]} ${VARIANT_BG_CLASS[variant]} ${className}`}
         style={style}
+        onClick={focusComposerFromBackground}
         onKeyDown={onKeyDown}
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}


### PR DESCRIPTION
## Problem

Session creators and chat inputs only focus when users click the editor itself. Blank shell padding and toolbar gaps do not activate typing because the shared ComposerShell has no background click handler.

## Solution

Focus the editable ComposerInput when a user clicks non-interactive space inside its shell. Preserve control clicks, native editor caret placement, child-handled events, and portaled popup interactions. Add regression coverage at the shared shell boundary, including disabled editors and composers inside dialogs.

## Potential risks

The shared shell also applies this behavior to other surfaces containing ComposerInput. Native desktop caret and focus behavior remains unverified in the running app; automated tests use jsdom. No persistence, dependency, API, or layout changes are included. Reverting this commit restores the previous click behavior.

## Verification

- `pnpm test src/components/ComposerShell/ComposerShell.test.ts src/components/ComposerSurface/index.test.ts` — 14 tests passed on the isolated branch based on latest `origin/develop`.
- `pnpm exec eslint src/components/ComposerShell/index.tsx src/components/ComposerShell/ComposerShell.test.ts --max-warnings 0` — passed during implementation.
- `pnpm run typecheck:fast` — passed during implementation.
- `git diff --cached --check` — passed before commit.
- Inspected the two-file diff for scope, secrets, personal paths, debug output, and generated artifacts; none included.
- Desktop interaction/E2E checks were not run because computer control was not authorized. No visual layout changed, so static screenshots would not demonstrate the focus behavior.
