### PR TITLE
fix(list-panel): align metadata text with avatars

### DIFF
--- a/src/components/ListPanel/ListPanelItem.tsx
+++ b/src/components/ListPanel/ListPanelItem.tsx
@@ -111,7 +111,7 @@ const ListPanelItem = forwardRef<HTMLButtonElement, ListPanelItemProps>(
           ) : null}
           {metadata ? (
             <span
-              className={`${preview ? "shrink" : "flex-1"} flex min-w-0 items-center gap-1.5 text-text-2`}
+              className={`${preview ? "shrink" : "flex-1"} flex min-w-0 items-center gap-1.5 leading-none text-text-2`}
             >
               {metadata}
             </span>


### PR DESCRIPTION
## Problem

Compact list rows inherit a 20px line height for second-line metadata text beside a 16px avatar, leaving excess vertical space in the text box.

## Solution

Add `leading-none` to the shared metadata flex container so its existing `items-center` alignment centers the compact text box beside the avatar. The primary status icon and row geometry retain their existing layout.

## Potential risks

The shared metadata styling affects all consumers of `ListPanelItem`; font metrics and mixed metadata content may render differently. In-app alignment, themes, and narrow layouts have not been visually verified. There are no data, dependency, or API changes.

## Verification

- `pnpm exec eslint src/components/ListPanel/ListPanelItem.tsx --max-warnings 0` — passed.
- `pnpm test src/modules/shared/components/CompactListPanel.test.ts src/components/ListPanel/ListPanelSkeletonRows.test.ts` — 7 tests passed; existing Vite/Sass deprecation and i18n initialization warnings were emitted.
- Commit hooks: lint-staged (oxlint, ESLint, Prettier) and the TypeScript check passed.
- `git diff origin/develop...HEAD --check` — passed; reviewed the final diff and confirmed only the one metadata class change is included.
- No rendered screenshots or desktop verification: computer control was not authorized. The automated tests cover existing list behavior and geometry assertions, not rendered optical alignment.
