### PR TITLE
style(workstation): unify shortcut rows and restore original typography

### DIFF
--- a/src/modules/WorkStation/AppShell/StartPage/index.tsx
+++ b/src/modules/WorkStation/AppShell/StartPage/index.tsx
@@ -59,14 +59,12 @@ const StartActionRow = memo<StartActionRowProps>(
           <AnyIcon
             icon={icon}
             size={SPOTLIGHT_TOKENS.iconSize}
-            strokeWidth={2}
-            className={SPOTLIGHT_CLASSES.itemIconTone}
+            strokeWidth={1.75}
+            className="shrink-0 text-text-3"
           />
         </span>
         <span className="flex min-w-0 flex-1 items-center gap-2">
-          <span
-            className={`truncate leading-none ${SPOTLIGHT_TOKENS.labelFontSize} ${SPOTLIGHT_CLASSES.itemLabelWeight} ${SPOTLIGHT_CLASSES.itemLabelTone}`}
-          >
+          <span className="truncate text-[14px] font-medium text-text-2">
             {label}
           </span>
           {showDiff ? (

--- a/src/modules/WorkStation/shared/NoTabsPlaceholder/index.tsx
+++ b/src/modules/WorkStation/shared/NoTabsPlaceholder/index.tsx
@@ -10,10 +10,7 @@
 import React, { memo } from "react";
 
 import AnyIcon from "@src/components/AnyIcon";
-import {
-  KEYBOARD_SHORTCUT_VARIANT,
-  KeyboardShortcut,
-} from "@src/components/KeyboardShortcut";
+import { KeyboardShortcut } from "@src/components/KeyboardShortcut";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
 import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import {
@@ -29,6 +26,10 @@ import {
   SmartPhone01Icon,
   WorkflowCircle05Icon,
 } from "@src/icons";
+import {
+  SPOTLIGHT_CLASSES,
+  SPOTLIGHT_TOKENS,
+} from "@src/scaffold/GlobalSpotlight/constants";
 
 import type { QuickAction } from "../QuickActionsPanel/types";
 
@@ -97,26 +98,25 @@ const ActionItem = memo<ActionItemProps>(({ action, onClick }) => {
 
   return (
     <button
+      type="button"
       onClick={handleClick}
       disabled={action.disabled}
-      className={`flex w-full items-center justify-between rounded-lg px-4 py-2.5 transition-colors ${
+      className={`${SPOTLIGHT_CLASSES.itemRow} w-full text-left transition-colors ${
         action.disabled
           ? "cursor-not-allowed opacity-50"
           : `${SURFACE_TOKENS.hover} active:bg-fill-3`
       }`}
+      style={{ height: SPOTLIGHT_TOKENS.itemHeight }}
     >
       <span
-        className={`text-[14px] font-medium ${
+        className={`min-w-0 flex-1 truncate text-[14px] font-medium ${
           action.disabled ? "text-text-4" : "text-text-3"
         }`}
       >
         {action.label}
       </span>
       {action.shortcut && (
-        <KeyboardShortcut
-          shortcut={action.shortcut}
-          variant={KEYBOARD_SHORTCUT_VARIANT.workStation}
-        />
+        <KeyboardShortcut shortcut={action.shortcut} rendering="original" />
       )}
     </button>
   );
@@ -171,7 +171,10 @@ export const NoTabsPlaceholder: React.FC<NoTabsPlaceholderProps> = memo(
 
           {/* Actions list */}
           {actions && actions.length > 0 && (
-            <div className="flex flex-col">
+            <div
+              className="flex flex-col"
+              style={{ gap: SPOTLIGHT_TOKENS.itemGap }}
+            >
               {actions.map((action) => (
                 <ActionItem
                   key={action.id}


### PR DESCRIPTION
## Problem

Workstation empty-state actions use different row geometry and shortcut rendering from Launchpad. The recent Launchpad styling change also replaced its original label and icon treatment.

## Solution

Use the shared 34px row height, 3px gap, row spacing, and original shortcut rendering for workstation empty-state actions. Preserve their original medium-weight muted labels and large illustration. Restore Launchpad's original medium-weight labels and icon tone/stroke while retaining its shared geometry and shortcut formatting.

## Potential risks

Long empty-state labels now truncate to preserve shortcut space. Theme contrast, narrow layouts, and macOS/Windows visual appearance have not been checked in the running app. No persistence, dependencies, or shortcut bindings change; reverting the commit restores the prior presentation.

## Verification

- `pnpm exec eslint src/modules/WorkStation/shared/NoTabsPlaceholder/index.tsx src/modules/WorkStation/AppShell/StartPage/index.tsx --fix` — passed
- `pnpm test src/modules/WorkStation/shared/NoTabsPlaceholder/NoTabsPlaceholder.test.ts src/components/KeyboardShortcut/index.test.ts` — 2 files, 9 tests passed
- `git diff --check` — passed
- Reviewed the two-file diff for scope and accidental sensitive data or generated files
- Screenshots and live theme/viewport checks were not run because desktop computer control was not authorized
