### PR TITLE
fix(sidebar): align submenu arrows at the right edge

### DIFF
--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -68,7 +68,7 @@ import {
 const WikiModal = React.lazy(() => import("@src/features/Wiki/WikiModal"));
 
 const MENU_ICON_CLASS_NAME = "shrink-0 text-text-2";
-const MENU_ARROW_CLASS_NAME = "text-text-3";
+const MENU_ARROW_CLASS_NAME = "shrink-0 text-text-3";
 type SettingsUtilityPanel = "ram";
 
 interface SidebarSettingsMenuTriggerProps {
@@ -406,7 +406,7 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
               )}
               <button
                 type="button"
-                className={`${DROPDOWN_CLASSES.menuActionItem} ${activeSubmenu === "presence" ? DROPDOWN_CLASSES.itemActive : ""} justify-between`}
+                className={`${DROPDOWN_CLASSES.menuActionItem} ${activeSubmenu === "presence" ? DROPDOWN_CLASSES.itemActive : ""}`}
                 onMouseEnter={(event) =>
                   openSubmenu("presence", event.currentTarget)
                 }
@@ -414,7 +414,7 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
                   openSubmenu("presence", event.currentTarget)
                 }
               >
-                <span className="flex min-w-0 items-center gap-2">
+                <span className="flex min-w-0 flex-1 items-center gap-2">
                   <HugeiconsIcon
                     icon={CircleIcon}
                     data-icon="circle"
@@ -434,7 +434,7 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
               </button>
               <button
                 type="button"
-                className={`${DROPDOWN_CLASSES.menuActionItem} ${activeSubmenu === "appearance" ? DROPDOWN_CLASSES.itemActive : ""} justify-between`}
+                className={`${DROPDOWN_CLASSES.menuActionItem} ${activeSubmenu === "appearance" ? DROPDOWN_CLASSES.itemActive : ""}`}
                 onMouseEnter={(event) =>
                   openSubmenu("appearance", event.currentTarget)
                 }
@@ -442,7 +442,7 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
                   openSubmenu("appearance", event.currentTarget)
                 }
               >
-                <span className="flex min-w-0 items-center gap-2">
+                <span className="flex min-w-0 flex-1 items-center gap-2">
                   <HugeiconsIcon
                     icon={ContrastIcon}
                     data-icon="contrast"
@@ -462,14 +462,14 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
               </button>
               <button
                 type="button"
-                className={`${DROPDOWN_CLASSES.menuActionItem} ${activeSubmenu === "layout" ? DROPDOWN_CLASSES.itemActive : ""} justify-between`}
+                className={`${DROPDOWN_CLASSES.menuActionItem} ${activeSubmenu === "layout" ? DROPDOWN_CLASSES.itemActive : ""}`}
                 onMouseEnter={(event) =>
                   openSubmenu("layout", event.currentTarget)
                 }
                 onFocus={(event) => openSubmenu("layout", event.currentTarget)}
                 data-testid="sidebar-settings-layout"
               >
-                <span className="flex min-w-0 items-center gap-2">
+                <span className="flex min-w-0 flex-1 items-center gap-2">
                   <HugeiconsIcon
                     icon={Layout01Icon}
                     data-icon="layout"


### PR DESCRIPTION
## Problem

Sidebar settings submenu arrows appear beside variable-length labels instead of sharing the right edge. Rows combine justify-start from the shared token with justify-between, leaving competing alignment rules.

## Solution

Give the three submenu labels flexible width and prevent their arrows from shrinking. Remove the competing justification utility, matching the shared dropdown item layout.

## Potential risks

This changes only row layout, with no setting, interaction, or persistence changes. Long translated labels and narrow viewports remain visually unverified; the existing truncation remains in place. Reverting the commit restores the previous layout.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts` — passed (14 tests) in the isolated branch
- `pnpm exec eslint src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx src/scaffold/NavigationSidebar/blocks/SidebarLayoutSettingsSubmenu.tsx src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts --max-warnings 0` — passed
- `pnpm run typecheck:fast` — passed
- `git diff --check` — passed before commit; reviewed scoped diff for unrelated files and sensitive data
- Commit hooks: lint-staged (oxlint, ESLint, Prettier) and TypeScript check passed
- Live visual checks and after screenshots were not performed: desktop computer control was not authorized. Theme, narrow viewport, and translated-label rendering remain visually unverified
