### PR TITLE
feat(sidebar): add Spotlight placement to Layout

### DIFF
--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Spotlight-Position",
     "spotlightPlacementOptions": {
       "top": "Oben",
-      "center": "Seitenmitte"
+      "center": "Mitte"
     },
     "left": "Links",
     "right": "Rechts",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -223,7 +223,7 @@
     "spotlightPlacement": "Spotlight position",
     "spotlightPlacementOptions": {
       "top": "Top",
-      "center": "Page center"
+      "center": "Middle"
     },
     "left": "Left",
     "right": "Right",

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Posición de Spotlight",
     "spotlightPlacementOptions": {
       "top": "Arriba",
-      "center": "Centro de la página"
+      "center": "Centro"
     },
     "left": "Izquierda",
     "right": "Derecha",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Position de Spotlight",
     "spotlightPlacementOptions": {
       "top": "Haut",
-      "center": "Centre de la page"
+      "center": "Milieu"
     },
     "left": "Gauche",
     "right": "Droite",

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Spotlight の位置",
     "spotlightPlacementOptions": {
       "top": "上部",
-      "center": "ページ中央"
+      "center": "中央"
     },
     "left": "左",
     "right": "右",

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Spotlight 위치",
     "spotlightPlacementOptions": {
       "top": "상단",
-      "center": "페이지 중앙"
+      "center": "중앙"
     },
     "left": "왼쪽",
     "right": "오른쪽",

--- a/src/i18n/locales/pl/settings.json
+++ b/src/i18n/locales/pl/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Pozycja Spotlight",
     "spotlightPlacementOptions": {
       "top": "Góra",
-      "center": "Środek strony"
+      "center": "Środek"
     },
     "left": "Lewa",
     "right": "Prawa",

--- a/src/i18n/locales/pt/settings.json
+++ b/src/i18n/locales/pt/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Posição do Spotlight",
     "spotlightPlacementOptions": {
       "top": "Topo",
-      "center": "Centro da página"
+      "center": "Centro"
     },
     "left": "Esquerda",
     "right": "Direita",

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Положение Spotlight",
     "spotlightPlacementOptions": {
       "top": "Сверху",
-      "center": "По центру страницы"
+      "center": "По центру"
     },
     "left": "Слева",
     "right": "Справа",

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Spotlight konumu",
     "spotlightPlacementOptions": {
       "top": "Üst",
-      "center": "Sayfa merkezi"
+      "center": "Orta"
     },
     "left": "Sol",
     "right": "Sağ",

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Vị trí Spotlight",
     "spotlightPlacementOptions": {
       "top": "Trên cùng",
-      "center": "Giữa trang"
+      "center": "Giữa"
     },
     "left": "Trái",
     "right": "Phải",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -145,7 +145,7 @@
     "spotlightPlacement": "Spotlight 位置",
     "spotlightPlacementOptions": {
       "top": "頂部",
-      "center": "頁面置中"
+      "center": "置中"
     },
     "left": "左側",
     "right": "右側",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -223,7 +223,7 @@
     "spotlightPlacement": "Spotlight 位置",
     "spotlightPlacementOptions": {
       "top": "顶部",
-      "center": "页面居中"
+      "center": "居中"
     },
     "left": "左侧",
     "right": "右侧",

--- a/src/scaffold/NavigationSidebar/blocks/SidebarLayoutSettingsSubmenu.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarLayoutSettingsSubmenu.tsx
@@ -15,6 +15,10 @@ import {
 } from "@src/store/ui/chatPanel/displayPrefsAtoms";
 import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanel/visibilityAtoms";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
+import {
+  type SpotlightPlacement,
+  spotlightPlacementAtom,
+} from "@src/store/ui/uiAtom";
 import { chatPanelPositionAtom } from "@src/store/ui/workStationLayout/chatPositionAtoms";
 import {
   workStationLayoutModeAtom,
@@ -84,6 +88,10 @@ function SwitchControlRow({
 export const SidebarLayoutSettingsSubmenu: React.FC<SidebarLayoutSettingsSubmenuProps> =
   React.memo(({ panelRef, position, onPointerDown, onMouseDown }) => {
     const { t } = useTranslation("common");
+    const { t: tSettings } = useTranslation("settings");
+    const [spotlightPlacement, setSpotlightPlacement] = useAtom(
+      spotlightPlacementAtom
+    );
     const stationMode = useAtomValue(stationModeAtom);
     const setStationChatVisible = useSetAtom(activeStationChatVisibleAtom);
     const layoutMode = useAtomValue(workStationLayoutModeAtom);
@@ -99,6 +107,16 @@ export const SidebarLayoutSettingsSubmenu: React.FC<SidebarLayoutSettingsSubmenu
     const chatPositionOptions = [
       { value: "left", label: t("layoutSettings.left") },
       { value: "right", label: t("layoutSettings.right") },
+    ] as const;
+    const spotlightPlacementOptions = [
+      {
+        value: "top",
+        label: tSettings("general.spotlightPlacementOptions.top"),
+      },
+      {
+        value: "center",
+        label: tSettings("general.spotlightPlacementOptions.center"),
+      },
     ] as const;
     const modelPickerStyleOptions = [
       { value: "spotlight", label: t("layoutSettings.modelPickerSpotlight") },
@@ -141,6 +159,12 @@ export const SidebarLayoutSettingsSubmenu: React.FC<SidebarLayoutSettingsSubmenu
             value={modelPickerStyle}
             options={modelPickerStyleOptions}
             onChange={setModelPickerStyle}
+          />
+          <SegmentedControlRow<SpotlightPlacement>
+            label={tSettings("general.spotlightPlacement")}
+            value={spotlightPlacement}
+            options={spotlightPlacementOptions}
+            onChange={setSpotlightPlacement}
           />
           <div
             className={DROPDOWN_CLASSES.menuGroupSeparator}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts
@@ -13,6 +13,8 @@ import {
   vi,
 } from "vitest";
 
+import * as rpcInvoke from "@src/api/tauri/rpc/invoke";
+import { settings as settingsProcedures } from "@src/api/tauri/rpc/procedures/settings";
 import { DROPDOWN_PANEL } from "@src/components/Dropdown/tokens";
 import {
   ORG2_CLOUD_AUTH_STORAGE_KEY,
@@ -21,6 +23,7 @@ import {
 import * as entitlementCoordinator from "@src/features/Org2Cloud/org2CloudEntitlementCoordinator";
 import { TUTORIALS_OPEN_EVENT } from "@src/scaffold/Tutorials/tutorialRegistry";
 import { devModeEnabledAtom } from "@src/store/platform/devModeAtom";
+import { settingsAtom } from "@src/store/settings";
 
 import SidebarSettingsMenuButton from "./SidebarSettingsMenuButton";
 
@@ -421,7 +424,7 @@ describe("SidebarSettingsMenuButton", () => {
     const segmentedControls = Array.from(
       document.body.querySelectorAll<HTMLElement>('[role="group"]')
     );
-    expect(segmentedControls).toHaveLength(3);
+    expect(segmentedControls).toHaveLength(4);
     expect(
       segmentedControls.every((control) => control.classList.contains("h-6"))
     ).toBe(true);
@@ -431,10 +434,38 @@ describe("SidebarSettingsMenuButton", () => {
       "layoutSettings.chatPanelLocation",
       "layoutSettings.sidebarPosition",
       "layoutSettings.modelPickerStyle",
+      "general.spotlightPlacement",
     ]);
     expect(
       document.body.querySelector('[role="switch"]')?.getAttribute("aria-label")
     ).toBe("layoutSettings.paginateChatHistory");
+  });
+
+  it("updates the shared Spotlight placement setting from Layout", async () => {
+    const rpcCall = vi.spyOn(rpcInvoke, "rpcCall").mockResolvedValue(undefined);
+    await act(async () => {
+      document
+        .querySelector('[data-testid="sidebar-settings-layout"]')
+        ?.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    const control = document.querySelector(
+      '[role="group"][aria-label="general.spotlightPlacement"]'
+    );
+    for (const placement of ["center", "top"] as const) {
+      const button = Array.from(control?.querySelectorAll("button") ?? []).find(
+        (item) =>
+          item.textContent === `general.spotlightPlacementOptions.${placement}`
+      );
+      expect(button).toBeDefined();
+      await act(async () => button?.click());
+      expect(store.get(settingsAtom)["general.spotlightPlacement"]).toBe(
+        placement
+      );
+      expect(button?.getAttribute("aria-pressed")).toBe("true");
+      expect(rpcCall).toHaveBeenCalledWith(settingsProcedures.writePartial, {
+        partial: { "general.spotlightPlacement": placement },
+      });
+    }
   });
 
   it("shows only the icon-only theme control in the appearance submenu", async () => {


### PR DESCRIPTION
## Problem

The sidebar Layout submenu lacks the Spotlight placement control available in Settings. Existing position labels such as “Page center” and “页面居中” are unnecessarily long for a compact control.

## Solution

Add a small segmented Spotlight position control using the existing spotlightPlacementAtom and shared Settings translation keys. Shorten center labels across all 13 supported locales, including “Middle” and “居中”. Verify both choices update the central setting and issue the existing partial-write RPC.

## Potential risks

The extra row increases submenu height, and translated labels may need visual review at narrow widths. Settings also displays the shortened shared labels. Persisted values remain top/center through the existing write path; there is no schema, IPC, dependency, or migration change. Reverting removes the shortcut and copy changes while preserving valid saved preferences. Native disk persistence is mocked in the component test; live rendering is unverified.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts` — passed (15 tests) in the isolated branch
- `pnpm exec eslint src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx src/scaffold/NavigationSidebar/blocks/SidebarLayoutSettingsSubmenu.tsx src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts --max-warnings 0` — passed
- `pnpm run typecheck:fast` — passed
- `git diff --check` — passed before commit; reviewed scoped diff for unrelated files and sensitive data
- Commit hooks: lint-staged (oxlint, ESLint, Prettier) and TypeScript check passed
- Live visual checks and after screenshots were not performed: desktop computer control was not authorized. Theme, narrow viewport, and translated-label rendering remain visually unverified
