### PR TITLE
fix(workstation): unify review sidebar and editor presentation

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/ReviewSidebarDelivery.md
+++ b/docs/frontend-ui-audit-2026-09-13/ReviewSidebarDelivery.md
@@ -1,0 +1,16 @@
+# Review sidebar delivery audit
+
+| Line                                            | Element                | Verdict          | Reason                                                          | Suggested change                                                             |
+| ----------------------------------------------- | ---------------------- | ---------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `FileHeader/index.tsx:255`                      | Hosted header controls | fix              | File rows could duplicate host controls                         | Applied: explicit host ownership and one menu destination                    |
+| `GitCommitDetailContent/CommitTabHeader.tsx:76` | Commit breadcrumbs     | fix              | Slash-delimited titles were parsed as paths                     | Applied: explicit SHA and summary segments                                   |
+| `StashContent/index.tsx:405`                    | Stash navigation       | fix              | Nested headings and custom actions differed from sidebar layout | Applied: one section header with count, back navigation and standard actions |
+| `GitFileList/index.tsx:447`                     | Second-level actions   | fix              | Visibility and styling differed from the primary sidebar        | Applied: scoped shared action group and sidebar Button props                 |
+| `config/workstation/tokens.ts:55`               | Shared action geometry | fix              | Discard glyphs and compact button radius were oversized         | Applied: 12px discard glyph and small radius with unchanged hit areas        |
+| `GitHistoryContent/index.tsx:533`               | Fixed virtual rows     | keep with reason | Graph lines and virtualization require matching heights         | Retain fixed height and use horizontal insets                                |
+
+Verdict totals: **5 fix**, **1 keep with reason**, **0 abstract**.
+
+Verification: isolated branch typecheck and i18n checks passed; targeted ESLint passed. Fifteen targeted Vitest suites ran: 103 passed initially; the one failed Spotlight padding test exposed an incomplete local token change. Updating the owning body token made that test pass on rerun. The git commit hooks rerun staged checks. No desktop visual verification was performed because computer control requires explicit opt-in. No runtime performance improvement is claimed.
+
+Architecture coverage: component ownership, stale selection reset, explicit breadcrumb segments, and removal of duplicate header wrappers. No persistence schema, API, or wire changes. Existing settings and request owners remain authoritative. Mount/unmount, graph/list switching, menu placement, and category transitions have automated coverage; real-app multi-root layout and CPU/RSS remain unmeasured.

--- a/src/components/Button/index.test.ts
+++ b/src/components/Button/index.test.ts
@@ -116,7 +116,7 @@ describe("compact shared actions", () => {
   afterAll(() => {
     Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
   });
-  it("renders the sidebar icon at 20px with the standard 8px radius", () => {
+  it("renders the sidebar icon at 20px with the shared small radius", () => {
     const markup = renderToStaticMarkup(
       React.createElement(Button, {
         size: "sidebar",
@@ -129,7 +129,7 @@ describe("compact shared actions", () => {
     );
     expect(markup).toContain("height:20px");
     expect(markup).toContain("width:20px");
-    expect(markup).toContain("border-radius:8px");
+    expect(markup).toContain("border-radius:var(--radius-sm)");
     expect(markup).toContain("action-icon");
     expect(markup).toContain("enabled:hover:bg-button-hover");
     expect(markup).not.toContain("bg-button-hover-no-drop");
@@ -191,7 +191,15 @@ describe("compact shared actions", () => {
       await act(async () => root.render(React.createElement(Button, props)));
       const button = container.querySelector("button")!;
       expect(button.getAttribute("aria-label")).toBe("Discard file");
+      expect(button.className).toContain("enabled:hover:bg-danger-2");
+      expect(button.className).toContain("focus-visible:bg-danger-2");
+      await act(async () =>
+        root.render(
+          React.createElement(Button, { ...props, appearance: "soft-no-drop" })
+        )
+      );
       expect(button.className).toContain("enabled:hover:bg-danger-1");
+      expect(button.className).not.toContain("enabled:hover:bg-danger-2");
       expect(button.className).not.toContain("bg-danger-3");
       await act(async () => button.click());
       expect(clicks).toBe(1);

--- a/src/components/Button/presentation.tsx
+++ b/src/components/Button/presentation.tsx
@@ -60,11 +60,13 @@ function getButtonStyleClasses(
         ? appearance === "soft-no-drop"
           ? BUTTON_VARIANT.noDrop
           : BUTTON_VARIANT.default
-        : variant === "warning"
-          ? "text-warning-6 enabled:hover:bg-warning-3 focus-visible:bg-warning-3"
-          : variant === "merged"
-            ? "text-purple-6 enabled:hover:bg-purple-3 focus-visible:bg-purple-3"
-            : BUTTON_VARIANT[variant];
+        : variant === "danger" && appearance === "soft-no-drop"
+          ? BUTTON_VARIANT.dangerNoDrop
+          : variant === "warning"
+            ? "text-warning-6 enabled:hover:bg-warning-3 focus-visible:bg-warning-3"
+            : variant === "merged"
+              ? "text-purple-6 enabled:hover:bg-purple-3 focus-visible:bg-purple-3"
+              : BUTTON_VARIANT[variant];
     return `border-0 bg-transparent ${colors} aria-pressed:bg-surface-selected aria-pressed:text-primary-6`;
   }
   const base = (() => {
@@ -210,8 +212,8 @@ export function useButtonPresentation({
   const borderRadius = useMemo(() => {
     if (shape === "circle") return "50%";
     if (shape === "round") return "100px";
-    return "8px";
-  }, [shape]);
+    return size === "sidebar" ? "var(--radius-sm)" : "8px";
+  }, [shape, size]);
 
   const buttonStyles = useMemo<React.CSSProperties>(() => {
     const iconOnlySize =

--- a/src/components/TreePanelSidebar/types.ts
+++ b/src/components/TreePanelSidebar/types.ts
@@ -57,6 +57,8 @@ type SectionHeaderButtonAction = {
   tooltip: string;
   /** Click callback */
   onClick: () => void;
+  /** Keep the action visible while it cannot be used. */
+  disabled?: boolean;
   /** When true, forces the actions bar to remain visible (e.g. dropdown is open) */
   forceVisible?: boolean;
 };

--- a/src/components/TreeRow/TreeRowAction.tsx
+++ b/src/components/TreeRow/TreeRowAction.tsx
@@ -24,6 +24,7 @@ import { HugeiconsIcon, type IconSvgElement } from "@src/icons";
 export interface TreeRowActionProps {
   /** Hugeicons glyph data to render */
   icon: IconSvgElement;
+  iconSize?: number;
   /** Click handler */
   onClick: (event: React.MouseEvent) => void;
   /** Tooltip text */
@@ -39,7 +40,14 @@ export interface TreeRowActionProps {
 // ============================================
 
 export const TreeRowAction: React.FC<TreeRowActionProps> = memo(
-  ({ icon, onClick, title, variant = "default", showOnRowHover = true }) => {
+  ({
+    icon,
+    iconSize = HEADER_ICON_SIZE.sm,
+    onClick,
+    title,
+    variant = "default",
+    showOnRowHover = true,
+  }) => {
     const visibilityClass = showOnRowHover
       ? "hidden! group-hover/item:flex! group-focus-within/item:flex!"
       : "flex";
@@ -55,13 +63,7 @@ export const TreeRowAction: React.FC<TreeRowActionProps> = memo(
         className={`action-btn group/action ${visibilityClass}`}
         onClick={onClick}
         title={title}
-        icon={
-          <HugeiconsIcon
-            icon={icon}
-            size={HEADER_ICON_SIZE.sm}
-            strokeWidth={1.75}
-          />
-        }
+        icon={<HugeiconsIcon icon={icon} size={iconSize} strokeWidth={1.75} />}
       />
     );
   }

--- a/src/components/TreeRow/TreeRowActionGroup.tsx
+++ b/src/components/TreeRow/TreeRowActionGroup.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 const REVEAL_CLASSES = {
+  sidebar: "hidden group-focus-within/sidebar:flex group-hover/sidebar:flex",
   item: "hidden group-focus-within/item:flex group-hover/item:flex",
   header: "hidden group-focus-within/header:flex group-hover/header:flex",
   section: "hidden group-focus-within/section:flex group-hover/section:flex",

--- a/src/config/workstation/tokens.ts
+++ b/src/config/workstation/tokens.ts
@@ -53,6 +53,8 @@ export const HEADER_HEIGHT = 40;
 
 /** Icon sizes used inside header buttons */
 export const HEADER_ICON_SIZE = {
+  /** Compact discard glyph; button hit area stays unchanged. */
+  discard: 12,
   /** Standard icon size (14px) — section headers, file headers, action bars */
   sm: 14,
   /** Larger icon size (16px) — bottom panel, URL bar, tab bar */
@@ -65,17 +67,17 @@ export const HEADER_ICON_SIZE = {
 
 /** Shared icon-button geometry; callers own display/hover-reveal behavior. */
 export const ICON_BUTTON_BASE =
-  "shrink-0 items-center justify-center rounded-lg transition-colors";
+  "shrink-0 items-center justify-center transition-colors";
 const BUTTON_BASE = `flex ${ICON_BUTTON_BASE}`;
 
-/** Size classes for icon-only buttons */
+/** Size and radius classes for icon-only buttons */
 export const BUTTON_SIZE = {
   /** 20×20 — standard header / row action button (single source of truth) */
-  sm: "h-5 w-5",
+  sm: "h-5 w-5 rounded-sm",
   /** 24×24 — larger header action button */
-  md: "h-6 w-6",
+  md: "h-6 w-6 rounded-lg",
   /** 28×28 — collapse toggles, modal headers */
-  lg: "h-7 w-7",
+  lg: "h-7 w-7 rounded-lg",
 } as const;
 
 /** One palette for compact row, terminal, and header actions. */
@@ -88,6 +90,8 @@ export const BUTTON_VARIANT = {
     "text-text-2 enabled:hover:bg-button-hover-no-drop enabled:hover:text-text-1 focus-visible:bg-button-hover-no-drop focus-visible:text-text-1",
   defaultTreeRow: DEFAULT_BUTTON_VARIANT,
   danger:
+    "text-text-2 enabled:hover:bg-danger-2 enabled:hover:text-danger-6 focus-visible:bg-danger-2 focus-visible:text-danger-6",
+  dangerNoDrop:
     "text-text-2 enabled:hover:bg-danger-1 enabled:hover:text-danger-6 focus-visible:bg-danger-1 focus-visible:text-danger-6",
   primary:
     "text-text-2 enabled:hover:bg-primary-3 enabled:hover:text-primary-6 focus-visible:bg-primary-3 focus-visible:text-primary-6",
@@ -373,7 +377,7 @@ export const SECTION_ACTION_BUTTON = {
   /** Icon-only (20×20) */
   iconOnly: BUTTON_SIZE.sm,
   /** With label (compact inline) */
-  withLabel: "gap-1 px-1.5 py-0.5 text-[11px]",
+  withLabel: "gap-1 rounded-lg px-1.5 py-0.5 text-[11px]",
 } as const;
 
 // ============================================

--- a/src/engines/ChatPanel/StartPageQuotaModal.test.ts
+++ b/src/engines/ChatPanel/StartPageQuotaModal.test.ts
@@ -56,7 +56,7 @@ describe("StartPageQuotaModal", () => {
     expect(markup).toContain('data-hide-footer="true"');
     expect(markup).toContain('role="dialog"');
     expect(markup).toContain('data-icon="chevron-left"');
-    expect(markup).toContain('class="p-3"');
+    expect(markup).toContain('class="px-3 pb-3"');
     expect(markup).toContain("kanban.dataSource.views.quota");
     expect(markup).toContain('data-testid="quota-modal-refresh"');
     expect(markup).toContain('data-show-header="false"');

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts
@@ -412,7 +412,7 @@ describe("SessionHeaderActionsMenu", () => {
     render();
     expect(document.querySelector('[role="switch"]')).toBeNull();
     expect(element("session-ui-settings-submenu").textContent).toBe(
-      "chat.pageSettings"
+      "common:common.display"
     );
     click("session-ui-settings-submenu");
     const panel = element("session-ui-settings-submenu-panel");
@@ -478,7 +478,7 @@ describe("SessionHeaderActionsMenu", () => {
     expect(props.toggleHeaderActionsMenu).not.toHaveBeenCalled();
 
     render({ showTranscriptActions: false });
-    expect(document.body.textContent).not.toContain("chat.pageSettings");
+    expect(document.body.textContent).not.toContain("common:common.display");
     expect(document.querySelector('[role="switch"]')).toBeNull();
   });
 

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
@@ -495,7 +495,7 @@ export const SessionHeaderActionsMenu: React.FC<
               <>
                 <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
                 <ActionSubmenu
-                  label={t("chat.pageSettings")}
+                  label={t("common:common.display")}
                   icon={
                     <HugeiconsIcon
                       icon={Layers01Icon}

--- a/src/features/CodeMirror/Diff/index.scss
+++ b/src/features/CodeMirror/Diff/index.scss
@@ -198,7 +198,7 @@
     .cm-deletedChunk .cm-deletedLine {
       display: block;
       padding: 0 !important;
-      white-space: pre;
+      white-space: inherit;
     }
 
     .cm-deletedChunk .cm-deletedLine > del {
@@ -360,7 +360,9 @@
   margin: 0 !important;
   padding: 0 !important;
   text-indent: 0 !important;
-  white-space: pre;
+  // Follow .cm-content's shared word-wrap setting, including break-spaces
+  // for long tokens and preserved indentation, just like regular lines.
+  white-space: inherit;
 }
 
 .codemirror-diff

--- a/src/features/CodeMirror/Diff/wordWrap.test.ts
+++ b/src/features/CodeMirror/Diff/wordWrap.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { unifiedMergeView } from "@codemirror/merge";
+import { Compartment } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { compile } from "sass";
+import { afterEach, describe, expect, it } from "vitest";
+
+const diffCss = compile(`${import.meta.dirname}/index.scss`, {
+  logger: { warn() {}, debug() {} },
+}).css;
+
+let view: EditorView | undefined;
+let style: HTMLStyleElement | undefined;
+
+afterEach(() => {
+  view?.destroy();
+  style?.remove();
+  document.body.replaceChildren();
+});
+
+describe("diff word wrap", () => {
+  it("lets deleted lines inherit the content wrap mode when toggled", () => {
+    style = document.createElement("style");
+    style.textContent = diffCss;
+    document.head.append(style);
+    const parent = document.createElement("div");
+    parent.className = "codemirror-diff";
+    document.body.append(parent);
+    const wrapping = new Compartment();
+    view = new EditorView({
+      parent,
+      doc: "unchanged\nnew content\ntail",
+      extensions: [
+        wrapping.of([]),
+        unifiedMergeView({
+          original: `unchanged\n  ${"old content ".repeat(30)}\ntail`,
+          mergeControls: false,
+          allowInlineDiffs: false,
+        }),
+      ],
+    });
+
+    for (const enabled of [false, true, false]) {
+      view.dispatch({
+        effects: wrapping.reconfigure(enabled ? EditorView.lineWrapping : []),
+      });
+      expect(view.contentDOM.classList.contains("cm-lineWrapping")).toBe(
+        enabled
+      );
+      expect(getComputedStyle(view.contentDOM).whiteSpace).toBe(
+        enabled ? "break-spaces" : "pre"
+      );
+      const deletedLine = view.dom.querySelector(".cm-deletedLine");
+      expect(deletedLine).not.toBeNull();
+      // jsdom does not reliably resolve inherited styles or perform layout.
+      // Check the matching compiled rule at the real widget and its parent mode.
+      const whiteSpaceRules = Array.from(style.sheet!.cssRules)
+        .filter((rule): rule is CSSStyleRule => "selectorText" in rule)
+        .filter(
+          (rule) =>
+            !rule.selectorText.includes(":global") &&
+            rule.style.getPropertyValue("white-space") &&
+            deletedLine!.matches(rule.selectorText)
+        );
+      expect(whiteSpaceRules.length).toBeGreaterThan(0);
+      expect(
+        whiteSpaceRules.map((rule) =>
+          rule.style.getPropertyValue("white-space")
+        )
+      ).toEqual(["inherit"]);
+    }
+  });
+});

--- a/src/features/CodeMirror/config/themeConfig.ts
+++ b/src/features/CodeMirror/config/themeConfig.ts
@@ -116,6 +116,7 @@ export const CODEMIRROR_BASE_LAYOUT_THEME = EditorView.theme({
   },
   ".cm-content": {
     fontFamily: CODE_FONT_FAMILY,
+    paddingTop: "0",
   },
   ".cm-gutters": {
     fontFamily: CODE_FONT_FAMILY,

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "optional",
   "common": {
+    "display": "Anzeige",
     "on": "Ein",
     "off": "Aus",
     "default": "Standard",
@@ -526,6 +527,9 @@
     "source": "Quelle"
   },
   "labels": {
+    "stashesCount": "{{count}} Stashes",
+    "stashesCount_one": "{{count}} Stash",
+    "stashesCount_other": "{{count}} Stashes",
     "accounts": "Konten",
     "enabled": "Aktiviert",
     "disabled": "Deaktiviert",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull Request",
     "operationLog": "Operationsprotokoll",
     "gitDashboard": "Dashboard",
-    "changedFiles": "Geänderte Dateien",
+    "changedFilesCount": "{{fileCount}} geänderte Dateien",
+    "changedFilesCount_one": "{{fileCount}} geänderte Datei",
+    "changedFilesCount_other": "{{fileCount}} geänderte Dateien",
     "colorTokens": "Farb-Token",
     "terminalInfo": "Terminal-Info",
     "fileCount_one": "{{count}} Datei",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "Zur Graphansicht wechseln",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "{{count}} Aktion ausführen",
     "performActions_other": "{{count}} Aktionen ausführen",
     "showInlineDiffs": "Inline-Diffs",
-    "pageSettings": "Seitendarstellung",
     "inputSettings": "Eingabeeinstellungen",
     "replay": {
       "follow": "Folgen"

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -321,6 +321,7 @@
   },
   "optional": "optional",
   "common": {
+    "display": "Display",
     "on": "On",
     "off": "Off",
     "default": "Default",
@@ -357,6 +358,9 @@
     "source": "Source"
   },
   "labels": {
+    "stashesCount": "{{count}} stashes",
+    "stashesCount_one": "{{count}} stash",
+    "stashesCount_other": "{{count}} stashes",
     "accounts": "Accounts",
     "enabled": "Enabled",
     "disabled": "Disabled",
@@ -412,7 +416,9 @@
     },
     "operationLog": "Operation Log",
     "gitDashboard": "Dashboard",
-    "changedFiles": "Changed Files",
+    "changedFilesCount": "{{fileCount}} changed files",
+    "changedFilesCount_one": "{{fileCount}} changed file",
+    "changedFilesCount_other": "{{fileCount}} changed files",
     "colorTokens": "Color Tokens",
     "terminalInfo": "Terminal Info",
     "fileCount_one": "{{count}} file",
@@ -858,6 +864,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "Switch to graph view",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -717,7 +717,6 @@
     "performActions_one": "Perform {{count}} action",
     "performActions_other": "Perform {{count}} actions",
     "showInlineDiffs": "Inline diffs",
-    "pageSettings": "Page display",
     "inputSettings": "Input settings",
     "replay": {
       "follow": "Follow"

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "opcional",
   "common": {
+    "display": "Visualización",
     "on": "Activado",
     "off": "Desactivado",
     "default": "Predeterminado",
@@ -526,6 +527,9 @@
     "source": "Origen"
   },
   "labels": {
+    "stashesCount": "{{count}} stashes",
+    "stashesCount_one": "{{count}} stash",
+    "stashesCount_other": "{{count}} stashes",
     "accounts": "Cuentas",
     "enabled": "Habilitado",
     "disabled": "Deshabilitado",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "Registro de operaciones",
     "gitDashboard": "Panel",
-    "changedFiles": "Archivos modificados",
+    "changedFilesCount": "{{fileCount}} archivos modificados",
+    "changedFilesCount_one": "{{fileCount}} archivo modificado",
+    "changedFilesCount_other": "{{fileCount}} archivos modificados",
     "colorTokens": "Tokens de color",
     "terminalInfo": "Información del terminal",
     "fileCount_one": "{{count}} archivo",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "Cambiar a vista de gráfico",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "Realizar {{count}} acción",
     "performActions_other": "Realizar {{count}} acciones",
     "showInlineDiffs": "Diferencias en línea",
-    "pageSettings": "Visualización de página",
     "inputSettings": "Configuración de entrada",
     "replay": {
       "follow": "Seguir"

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "facultatif",
   "common": {
+    "display": "Affichage",
     "on": "Activé",
     "off": "Désactivé",
     "default": "Par défaut",
@@ -526,6 +527,9 @@
     "source": "Source"
   },
   "labels": {
+    "stashesCount": "{{count}} stashes",
+    "stashesCount_one": "{{count}} stash",
+    "stashesCount_other": "{{count}} stashes",
     "accounts": "Comptes",
     "enabled": "Activé",
     "disabled": "Désactivé",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "Journal des opérations",
     "gitDashboard": "Tableau de bord",
-    "changedFiles": "Fichiers modifiés",
+    "changedFilesCount": "{{fileCount}} fichiers modifiés",
+    "changedFilesCount_one": "{{fileCount}} fichier modifié",
+    "changedFilesCount_other": "{{fileCount}} fichiers modifiés",
     "colorTokens": "Tokens de couleur",
     "terminalInfo": "Infos du terminal",
     "fileCount_one": "{{count}} fichier",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "Passer à la vue graphique",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "Effectuer {{count}} action",
     "performActions_other": "Effectuer {{count}} actions",
     "showInlineDiffs": "Différences en ligne",
-    "pageSettings": "Affichage de la page",
     "inputSettings": "Paramètres de saisie",
     "replay": {
       "follow": "Suivre"

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "任意",
   "common": {
+    "display": "表示",
     "on": "オン",
     "off": "オフ",
     "default": "デフォルト",
@@ -526,6 +527,9 @@
     "source": "ソース"
   },
   "labels": {
+    "stashesCount": "{{count}}件のスタッシュ",
+    "stashesCount_one": "{{count}}件のスタッシュ",
+    "stashesCount_other": "{{count}}件のスタッシュ",
     "accounts": "アカウント",
     "enabled": "有効",
     "disabled": "無効",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "操作ログ",
     "gitDashboard": "ダッシュボード",
-    "changedFiles": "変更されたファイル",
+    "changedFilesCount": "{{fileCount}}件の変更",
+    "changedFilesCount_one": "{{fileCount}}件の変更",
+    "changedFilesCount_other": "{{fileCount}}件の変更",
     "colorTokens": "カラー Token",
     "terminalInfo": "ターミナル情報",
     "fileCount_one": "{{count}} 個のファイル",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "グラフ表示に切り替え",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "{{count}} 件の操作を実行",
     "performActions_other": "{{count}} 件の操作を実行",
     "showInlineDiffs": "インライン差分",
-    "pageSettings": "ページ表示",
     "inputSettings": "入力設定",
     "replay": {
       "follow": "フォロー"

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "선택",
   "common": {
+    "display": "표시",
     "on": "켜기",
     "off": "끄기",
     "default": "기본값",
@@ -526,6 +527,9 @@
     "source": "소스"
   },
   "labels": {
+    "stashesCount": "스태시 {{count}}개",
+    "stashesCount_one": "스태시 {{count}}개",
+    "stashesCount_other": "스태시 {{count}}개",
     "accounts": "계정",
     "enabled": "활성화",
     "disabled": "비활성화",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "작업 로그",
     "gitDashboard": "대시보드",
-    "changedFiles": "변경된 파일",
+    "changedFilesCount": "변경된 파일 {{fileCount}}개",
+    "changedFilesCount_one": "변경된 파일 {{fileCount}}개",
+    "changedFilesCount_other": "변경된 파일 {{fileCount}}개",
     "colorTokens": "색상 Token",
     "terminalInfo": "터미널 정보",
     "fileCount_one": "{{count}}개 파일",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "그래프 보기로 전환",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "작업 {{count}}개 수행",
     "performActions_other": "작업 {{count}}개 수행",
     "showInlineDiffs": "인라인 변경 사항",
-    "pageSettings": "페이지 표시",
     "inputSettings": "입력 설정",
     "replay": {
       "follow": "팔로우"

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "opcjonalne",
   "common": {
+    "display": "Wyświetlanie",
     "on": "Wł.",
     "off": "Wył.",
     "default": "Domyślnie",
@@ -526,6 +527,9 @@
     "source": "Źródło"
   },
   "labels": {
+    "stashesCount": "Stashe: {{count}}",
+    "stashesCount_one": "Stashe: {{count}}",
+    "stashesCount_other": "Stashe: {{count}}",
     "accounts": "Konta",
     "enabled": "Włączone",
     "disabled": "Wyłączone",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "Dziennik operacji",
     "gitDashboard": "Panel",
-    "changedFiles": "Zmienione pliki",
+    "changedFilesCount": "Zmienione pliki: {{fileCount}}",
+    "changedFilesCount_one": "{{fileCount}} zmieniony plik",
+    "changedFilesCount_other": "Zmienione pliki: {{fileCount}}",
     "colorTokens": "Tokeny kolorów",
     "terminalInfo": "Informacje o Shellu",
     "fileCount_one": "{{count}} plik",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} linii",
     "switchToTreeView": "Przełącz na widok drzewa",
     "switchToListView": "Przełącz na widok listy",
+    "switchToGraphView": "Przełącz na widok grafu",
     "discardChanges": "Odrzuć zmiany",
     "toOrigin": "do origin",
     "discardChangesConfirm": "Odrzucić zmiany w {{files}}? Tej operacji nie można cofnąć.",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "Wykonaj {{count}} działanie",
     "performActions_other": "Wykonaj {{count}} działań",
     "showInlineDiffs": "Różnice w treści",
-    "pageSettings": "Wyświetlanie strony",
     "inputSettings": "Ustawienia wprowadzania",
     "replay": {
       "follow": "Śledź"

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "opcional",
   "common": {
+    "display": "Exibição",
     "on": "Ligado",
     "off": "Desligado",
     "default": "Padrão",
@@ -526,6 +527,9 @@
     "source": "Origem"
   },
   "labels": {
+    "stashesCount": "{{count}} stashes",
+    "stashesCount_one": "{{count}} stash",
+    "stashesCount_other": "{{count}} stashes",
     "accounts": "Contas",
     "enabled": "Ativado",
     "disabled": "Desativado",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "Log de operações",
     "gitDashboard": "Painel",
-    "changedFiles": "Arquivos alterados",
+    "changedFilesCount": "{{fileCount}} arquivos alterados",
+    "changedFilesCount_one": "{{fileCount}} arquivo alterado",
+    "changedFilesCount_other": "{{fileCount}} arquivos alterados",
     "colorTokens": "Tokens de cor",
     "terminalInfo": "Informações do terminal",
     "fileCount_one": "{{count}} arquivo",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} linhas",
     "switchToTreeView": "Alternar para visualização em árvore",
     "switchToListView": "Alternar para visualização em lista",
+    "switchToGraphView": "Mudar para visualização de grafo",
     "discardChanges": "Descartar alterações",
     "toOrigin": "para origin",
     "discardChangesConfirm": "Descartar alterações em {{files}}? Esta ação não pode ser desfeita.",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "Realizar {{count}} ação",
     "performActions_other": "Realizar {{count}} ações",
     "showInlineDiffs": "Diferenças em linha",
-    "pageSettings": "Exibição da página",
     "inputSettings": "Configurações de entrada",
     "replay": {
       "follow": "Acompanhar"

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "необязательно",
   "common": {
+    "display": "Отображение",
     "on": "Вкл",
     "off": "Выкл",
     "default": "По умолчанию",
@@ -526,6 +527,9 @@
     "source": "Источник"
   },
   "labels": {
+    "stashesCount": "Стеши: {{count}}",
+    "stashesCount_one": "Стеши: {{count}}",
+    "stashesCount_other": "Стеши: {{count}}",
     "accounts": "Аккаунты",
     "enabled": "Включено",
     "disabled": "Отключено",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "Журнал операций",
     "gitDashboard": "Панель",
-    "changedFiles": "Изменённые файлы",
+    "changedFilesCount": "Изменено файлов: {{fileCount}}",
+    "changedFilesCount_one": "{{fileCount}} изменённый файл",
+    "changedFilesCount_other": "Изменено файлов: {{fileCount}}",
     "colorTokens": "Цветовые Token",
     "terminalInfo": "Информация о терминале",
     "fileCount_one": "{{count}} файл",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "Переключить на граф",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "Выполнить {{count}} действие",
     "performActions_other": "Выполнить {{count}} действий",
     "showInlineDiffs": "Встроенные различия",
-    "pageSettings": "Отображение страницы",
     "inputSettings": "Настройки ввода",
     "replay": {
       "follow": "Следовать"

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "isteğe bağlı",
   "common": {
+    "display": "Görünüm",
     "on": "Açık",
     "off": "Kapalı",
     "default": "Varsayılan",
@@ -526,6 +527,9 @@
     "source": "Kaynak"
   },
   "labels": {
+    "stashesCount": "{{count}} stash",
+    "stashesCount_one": "{{count}} stash",
+    "stashesCount_other": "{{count}} stash",
     "accounts": "Hesaplar",
     "enabled": "Etkin",
     "disabled": "Devre dışı",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "İşlem Günlüğü",
     "gitDashboard": "Gösterge Paneli",
-    "changedFiles": "Değiştirilen Dosyalar",
+    "changedFilesCount": "{{fileCount}} değişen dosya",
+    "changedFilesCount_one": "{{fileCount}} değişen dosya",
+    "changedFilesCount_other": "{{fileCount}} değişen dosya",
     "colorTokens": "Renk Token'ları",
     "terminalInfo": "Terminal Bilgisi",
     "fileCount_one": "{{count}} dosya",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "Grafik görünümüne geç",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "{{count}} işlem gerçekleştir",
     "performActions_other": "{{count}} işlem gerçekleştir",
     "showInlineDiffs": "Satır içi farklar",
-    "pageSettings": "Sayfa görünümü",
     "inputSettings": "Giriş ayarları",
     "replay": {
       "follow": "Takip et"

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "tùy chọn",
   "common": {
+    "display": "Hiển thị",
     "on": "Bật",
     "off": "Tắt",
     "default": "Mặc định",
@@ -526,6 +527,9 @@
     "source": "Nguồn"
   },
   "labels": {
+    "stashesCount": "{{count}} stash",
+    "stashesCount_one": "{{count}} stash",
+    "stashesCount_other": "{{count}} stash",
     "accounts": "Tài khoản",
     "enabled": "Đã bật",
     "disabled": "Đã tắt",
@@ -571,7 +575,9 @@
     "pullRequest": "Pull request",
     "operationLog": "Nhật ký thao tác",
     "gitDashboard": "Bảng điều khiển",
-    "changedFiles": "Tệp đã thay đổi",
+    "changedFilesCount": "{{fileCount}} tệp đã thay đổi",
+    "changedFilesCount_one": "{{fileCount}} tệp đã thay đổi",
+    "changedFilesCount_other": "{{fileCount}} tệp đã thay đổi",
     "colorTokens": "Token màu",
     "terminalInfo": "Thông tin Terminal",
     "fileCount_one": "{{count}} tệp",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} lines",
     "switchToTreeView": "Switch to tree view",
     "switchToListView": "Switch to list view",
+    "switchToGraphView": "Chuyển sang chế độ xem đồ thị",
     "discardChanges": "Discard Changes",
     "toOrigin": "to origin",
     "discardChangesConfirm": "Discard changes to {{files}}? This cannot be undone.",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "Thực hiện {{count}} thao tác",
     "performActions_other": "Thực hiện {{count}} thao tác",
     "showInlineDiffs": "Thay đổi ngay trong nội dung",
-    "pageSettings": "Hiển thị trang",
     "inputSettings": "Cài đặt nhập liệu",
     "replay": {
       "follow": "Theo dõi"

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -490,6 +490,7 @@
   },
   "optional": "可選",
   "common": {
+    "display": "顯示",
     "on": "開",
     "off": "關",
     "default": "默認",
@@ -526,6 +527,9 @@
     "source": "來源"
   },
   "labels": {
+    "stashesCount": "{{count}}個STASHES",
+    "stashesCount_one": "{{count}}個STASHES",
+    "stashesCount_other": "{{count}}個STASHES",
     "accounts": "賬戶",
     "enabled": "已啓用",
     "disabled": "已禁用",
@@ -582,7 +586,9 @@
     },
     "operationLog": "操作日誌",
     "gitDashboard": "儀表盤",
-    "changedFiles": "已更改的文件",
+    "changedFilesCount": "{{fileCount}}個變動",
+    "changedFilesCount_one": "{{fileCount}}個變動",
+    "changedFilesCount_other": "{{fileCount}}個變動",
     "colorTokens": "顏色 Token",
     "terminalInfo": "終端信息",
     "fileCount_one": "{{count}} 個文件",
@@ -1013,6 +1019,7 @@
     "nLines": "{{count}} 行",
     "switchToTreeView": "切換到樹形視圖",
     "switchToListView": "切換到列表視圖",
+    "switchToGraphView": "切換到圖形檢視",
     "discardChanges": "丟棄更改",
     "toOrigin": "到 origin",
     "discardChangesConfirm": "丟棄對 {{files}} 的更改？此操作不可撤銷。",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -716,7 +716,6 @@
     "performActions_one": "執行 {{count}} 項操作",
     "performActions_other": "執行 {{count}} 項操作",
     "showInlineDiffs": "行內差異",
-    "pageSettings": "頁面顯示",
     "inputSettings": "輸入設定",
     "replay": {
       "follow": "跟隨"

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -321,6 +321,7 @@
   },
   "optional": "可选",
   "common": {
+    "display": "显示",
     "on": "开",
     "off": "关",
     "default": "默认",
@@ -357,6 +358,9 @@
     "source": "来源"
   },
   "labels": {
+    "stashesCount": "{{count}}个STASHES",
+    "stashesCount_one": "{{count}}个STASHES",
+    "stashesCount_other": "{{count}}个STASHES",
     "accounts": "账户",
     "enabled": "已启用",
     "disabled": "已禁用",
@@ -413,7 +417,9 @@
     },
     "operationLog": "操作日志",
     "gitDashboard": "仪表盘",
-    "changedFiles": "已更改的文件",
+    "changedFilesCount": "{{fileCount}}个变动",
+    "changedFilesCount_one": "{{fileCount}}个变动",
+    "changedFilesCount_other": "{{fileCount}}个变动",
     "colorTokens": "颜色 Token",
     "terminalInfo": "终端信息",
     "fileCount_one": "{{count}} 个文件",
@@ -858,6 +864,7 @@
     "nLines": "{{count}} 行",
     "switchToTreeView": "切换到树形视图",
     "switchToListView": "切换到列表视图",
+    "switchToGraphView": "切换到图形视图",
     "discardChanges": "丢弃更改",
     "toOrigin": "到 origin",
     "discardChangesConfirm": "丢弃对 {{files}} 的更改？此操作不可撤销。",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -717,7 +717,6 @@
     "performActions_one": "执行 {{count}} 项操作",
     "performActions_other": "执行 {{count}} 项操作",
     "showInlineDiffs": "行内差异",
-    "pageSettings": "页面显示",
     "inputSettings": "输入设置",
     "replay": {
       "follow": "跟随"

--- a/src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesPanel.test.ts
+++ b/src/modules/ProjectManager/shared/components/PropertiesPanel/PropertiesPanel.test.ts
@@ -44,7 +44,7 @@ describe("PropertiesPanel", () => {
     expect(markup).toContain("h-6");
     expect(markup).toContain("height:20px");
     expect(markup).toContain("width:20px");
-    expect(markup).toContain("border-radius:8px");
+    expect(markup).toContain("border-radius:var(--radius-sm)");
     expect(markup).toContain("justify-between pr-[3px] pl-1");
     expect(markup).toContain("px-1 text-[11px]");
     expect(markup).toContain("max-h-full");

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts
@@ -3,7 +3,11 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import type { WorkStationTab } from "@src/store/workstation/tabs";
+import type { SourceControlFilterMode } from "@src/modules/WorkStation/shared/SidebarModules";
+import type {
+  SourceControlHistorySelection,
+  WorkStationTab,
+} from "@src/store/workstation/tabs";
 
 import { SourceControlHeaderContent } from "./SourceControlHeaderContent";
 
@@ -63,15 +67,19 @@ vi.mock("./SourceControlDiffSettingsMenu", () => ({
 function renderHeader(
   mode: "focus" | "all-changes",
   focusPath: string | null = null,
-  navigationTotal = focusPath ? 1 : 0
+  navigationTotal = focusPath ? 1 : 0,
+  historySelection: SourceControlHistorySelection | null = null,
+  showSourceControlModePill = true,
+  sourceControlFilterMode: SourceControlFilterMode = "uncommitted"
 ): string {
   const tab = sourceControlTab(mode);
   tab.data.focusPath = focusPath;
+  tab.data.historySelection = historySelection;
   return renderToStaticMarkup(
     createElement(SourceControlHeaderContent, {
       activeTab: tab,
-      sourceControlFilterMode: "uncommitted",
-      showSourceControlModePill: true,
+      sourceControlFilterMode,
+      showSourceControlModePill,
       gitReviewNavigationTotal: navigationTotal,
       selectedIssue: null,
       sourceControlRefreshSpinClass: undefined,
@@ -79,7 +87,6 @@ function renderHeader(
       t,
       onDiffViewModeChange: vi.fn(),
       onModeChange: vi.fn(),
-      onOpenHistoryInNewTab: vi.fn(),
       onReviewPrevFile: vi.fn(),
       onReviewNextFile: vi.fn(),
       onCollapseAll: vi.fn(),
@@ -89,6 +96,50 @@ function renderHeader(
 }
 
 describe("SourceControlHeaderContent diff view controls", () => {
+  it.each(["stashed", "history", "pr", "issues"] as const)(
+    "keeps Split, More, and Refresh in order in %s mode before selection",
+    (filter) => {
+      const markup = renderHeader("focus", null, 0, null, false, filter);
+      const split = markup.indexOf(
+        'aria-label="workstation.switchToUnifiedDiff"'
+      );
+      const menu = markup.indexOf('data-menu="diff-settings"');
+      const refresh = markup.indexOf('aria-label="common:actions.refresh"');
+      expect(split).toBeGreaterThan(-1);
+      expect(menu).toBeGreaterThan(split);
+      expect(refresh).toBeGreaterThan(menu);
+      expect(markup.match(/data-menu="diff-settings"/g)).toHaveLength(1);
+    }
+  );
+  it("shows the split toggle even without mode tabs or a selection", () => {
+    const markup = renderHeader("focus", null, 0, null, false);
+    expect(markup).toContain('aria-label="workstation.switchToUnifiedDiff"');
+    expect(markup).not.toContain('data-tabs="focus,all-changes"');
+  });
+  it.each(["commit", "stash"] as const)(
+    "shows history diff controls for %s without file review navigation",
+    (type) => {
+      const selection = {
+        type,
+        commitSha: "abc1234",
+        shortSha: "abc1234",
+        commitMessage: "Saved changes",
+        ...(type === "stash"
+          ? {
+              stashIndex: 0,
+              stashRef: "stash@{0}",
+              stashIdentity: "abc1234",
+              stashCommitSha: "abc1234",
+            }
+          : {}),
+      } as SourceControlHistorySelection;
+      const markup = renderHeader("all-changes", null, 0, selection);
+      expect(markup).toContain('aria-label="workstation.switchToUnifiedDiff"');
+      expect(markup).not.toContain('data-tabs="focus,all-changes"');
+      expect(markup).not.toContain("common:actions.reviewNextFile");
+      expect(markup).not.toContain('data-menu="diff-settings"');
+    }
+  );
   it("shows the shared unified/split control in All Changes", () => {
     const markup = renderHeader("all-changes");
 
@@ -148,10 +199,14 @@ describe("SourceControlHeaderContent diff view controls", () => {
     expect(markup).not.toContain('data-menu="diff-settings"');
   });
 
-  it("keeps the aggregate diff control out of empty Focus mode", () => {
+  it("keeps the full toolbar visible before a file is selected", () => {
     const markup = renderHeader("focus");
 
-    expect(markup).not.toContain("workstation.switchToUnifiedDiff");
+    expect(markup).toContain("workstation.switchToUnifiedDiff");
+    expect(markup).toContain("common:actions.reviewPreviousFile");
+    expect(markup).toContain("common:actions.reviewNextFile");
+    expect(markup).toContain('data-menu="diff-settings"');
+    expect(markup).toContain("common:actions.refresh");
     expect(markup).toContain('data-tabs="focus,all-changes"');
   });
 });

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
@@ -104,9 +104,7 @@ export const SourceControlHeaderContent: React.FC<
     !hasFocusPath || gitReviewNavigationTotal === 0;
   const showIssueHeader = isIssuesMode && selectedIssue;
   return (
-    <div
-      className={`flex min-w-0 flex-1 items-center gap-1.5 ${mode === "all-changes" ? "pr-2" : ""}`}
-    >
+    <div className="flex min-w-0 flex-1 items-center gap-1.5">
       {sourceControlHeaderLeadingSlot}
       {sourceControlHeaderLeadingSlot && sourceControlHeaderTrailingSlot ? (
         <span

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
@@ -20,7 +20,6 @@ import {
   ArrowUp01Icon,
   CircleDotIcon,
   HugeiconsIcon,
-  LinkSquare02Icon,
   ListChevronsDownUpIcon,
   Refresh04Icon,
 } from "@src/icons";
@@ -51,7 +50,6 @@ export interface SourceControlHeaderContentProps {
   t: TFunction;
   onDiffViewModeChange: (mode: DiffViewMode) => void;
   onModeChange: (mode: "focus" | "all-changes") => void;
-  onOpenHistoryInNewTab: (selection: SourceControlHistorySelection) => void;
   onReviewPrevFile: () => void;
   onReviewNextFile: () => void;
   onCollapseAll: () => void;
@@ -74,7 +72,6 @@ export const SourceControlHeaderContent: React.FC<
   t,
   onDiffViewModeChange,
   onModeChange,
-  onOpenHistoryInNewTab,
   onReviewPrevFile,
   onReviewNextFile,
   onCollapseAll,
@@ -87,6 +84,8 @@ export const SourceControlHeaderContent: React.FC<
     | null
     | undefined;
   const isIssuesMode = sourceControlFilterMode === "issues";
+  const showHistoryDiff =
+    historySelection?.type === "commit" || historySelection?.type === "stash";
   const showModePill =
     showSourceControlModePill && !isIssuesMode && !historySelection;
   const sourceControlModeTabs = [
@@ -99,11 +98,15 @@ export const SourceControlHeaderContent: React.FC<
   const showCollapseAll =
     showModePill && mode === "all-changes" && !historySelection;
   const showReviewNavigation = showModePill && mode === "focus";
+  const showDetailToolbar =
+    showHistoryDiff || (showModePill && mode === "focus" && hasFocusPath);
   const reviewNavigationDisabled =
     !hasFocusPath || gitReviewNavigationTotal === 0;
   const showIssueHeader = isIssuesMode && selectedIssue;
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-1.5">
+    <div
+      className={`flex min-w-0 flex-1 items-center gap-1.5 ${mode === "all-changes" ? "pr-2" : ""}`}
+    >
       {sourceControlHeaderLeadingSlot}
       {sourceControlHeaderLeadingSlot && sourceControlHeaderTrailingSlot ? (
         <span
@@ -165,28 +168,6 @@ export const SourceControlHeaderContent: React.FC<
             onClick={(e) => e.stopPropagation()}
           />
         )}
-        {historySelection &&
-          (historySelection.type === "commit" ||
-            historySelection.type === "stash") && (
-            <Button
-              htmlType="button"
-              variant="tertiary"
-              size="small"
-              iconOnly
-              className="shrink-0"
-              onClick={() => onOpenHistoryInNewTab(historySelection)}
-              title={t("common:actions.openInNewTab")}
-              aria-label={t("common:actions.openInNewTab")}
-              icon={
-                <HugeiconsIcon
-                  icon={LinkSquare02Icon}
-                  data-icon="link-square-02"
-                  size={HEADER_ICON_SIZE.sm}
-                />
-              }
-            />
-          )}
-
         {showReviewNavigation && (
           <>
             <Button
@@ -257,21 +238,17 @@ export const SourceControlHeaderContent: React.FC<
             aria-hidden
           />
         )}
-        {showModePill && (mode === "all-changes" || hasFocusPath) && (
-          <DiffViewModeToggle
-            viewMode={diffViewMode}
-            onChange={onDiffViewModeChange}
-            t={t}
-          />
-        )}
-        {showModePill && mode === "focus" && hasFocusPath && (
+        <DiffViewModeToggle
+          viewMode={diffViewMode}
+          onChange={onDiffViewModeChange}
+          t={t}
+        />
+        {showDetailToolbar ? (
           <span
             ref={focusToolbarRef}
             className="flex shrink-0 items-center gap-px"
           />
-        )}
-
-        {(showCollapseAll || (showReviewNavigation && !hasFocusPath)) && (
+        ) : (
           <SourceControlDiffSettingsMenu />
         )}
         <Button

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitInfoPanel.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitInfoPanel.test.ts
@@ -1,0 +1,30 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, it } from "vitest";
+
+import type { CommitDiffResult } from "@src/api/http/git/types";
+
+import { CommitInfoPanel } from "./CommitInfoPanel";
+
+it.each(["", "  \n\t"])(
+  "omits the entire strip for an empty body %j",
+  (body) => {
+    expect(
+      renderToStaticMarkup(
+        createElement(CommitInfoPanel, {
+          commitDiff: { body } as CommitDiffResult,
+        })
+      )
+    ).toBe("");
+  }
+);
+
+it("preserves a populated commit body", () => {
+  const markup = renderToStaticMarkup(
+    createElement(CommitInfoPanel, {
+      commitDiff: { body: "Details\n  with indentation" } as CommitDiffResult,
+    })
+  );
+  expect(markup).toContain("Details\n  with indentation");
+  expect(markup).toContain("border-b");
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitInfoPanel.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitInfoPanel.tsx
@@ -12,19 +12,19 @@ interface CommitInfoPanelProps {
  */
 export const CommitInfoPanel: React.FC<CommitInfoPanelProps> = memo(
   function CommitInfoPanel({ commitDiff, hasInlineHeaderAbove = false }) {
+    if (!commitDiff.body?.trim()) return null;
+
     const paddingClassName = hasInlineHeaderAbove ? "pb-3" : "pb-3 pt-3";
 
     return (
       <div
         className={`max-h-40 shrink-0 overflow-hidden border-b border-border-2 px-3 ${paddingClassName}`}
       >
-        {commitDiff.body ? (
-          <div className="scrollbar-overlay max-h-[148px] overflow-y-auto pr-2">
-            <p className="max-w-[860px] cursor-text text-[12px] leading-5 whitespace-pre-wrap text-text-2 select-text">
-              {commitDiff.body}
-            </p>
-          </div>
-        ) : null}
+        <div className="scrollbar-overlay max-h-[148px] overflow-y-auto pr-2">
+          <p className="max-w-[860px] cursor-text text-[12px] leading-5 whitespace-pre-wrap text-text-2 select-text">
+            {commitDiff.body}
+          </p>
+        </div>
       </div>
     );
   }

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitTabHeader.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitTabHeader.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import type { CommitDiffResult } from "@src/api/http/git/types";
+import { FileHeaderToolbarContext } from "@src/modules/shared/components/FileHeader/FileHeaderToolbarContext";
+import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
+
+import { CommitTabHeader } from "./CommitTabHeader";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@src/util/ui/theme/themeUtils", () => ({
+  useCurrentTheme: () => ({ isDark: false }),
+}));
+
+it("shares file controls, moves the menu to the host, and cleans it up on close", () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const disconnect = vi.fn();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect = disconnect;
+    }
+  );
+  const container = document.createElement("div");
+  const toolbar = document.createElement("div");
+  document.body.append(container, toolbar);
+  const root = createRoot(container);
+  const store = createStore();
+  store.set(diffViewModeAtom, "split");
+  const onClose = vi.fn();
+  const onOpenInNewTab = vi.fn();
+  const author = {
+    name: "Ada",
+    email: "ada@example.com",
+    date: new Date(Date.now() - 86_400_000).toISOString(),
+  };
+  const commitDiff: CommitDiffResult = {
+    author,
+    committer: author,
+    commit_sha: "abc1234",
+    short_sha: "abc1234",
+    summary: "Merge pull request #1683 from Harry19081/dev/row-action",
+    body: "",
+    files: [],
+    stats: { insertions: 1, deletions: 2, files_changed: 1 },
+    parent_mode: "first-parent",
+    parent_sha: "parent",
+    parent_shas: ["parent"],
+    selected_parent_index: 0,
+  };
+  const render = (target: HTMLElement | null) =>
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(
+            FileHeaderToolbarContext.Provider,
+            { value: target },
+            createElement(CommitTabHeader, {
+              shortSha: "abc1234",
+              commitMessage: "Saved changes",
+              commitDiff,
+              publishToWorkstationHeader: false,
+              onClose,
+              onOpenInNewTab,
+            })
+          )
+        )
+      )
+    );
+  try {
+    render(null);
+    const summary = container.querySelector(
+      '[title="Merge pull request #1683 from Harry19081/dev/row-action"]'
+    );
+    expect(summary?.textContent).toBe(commitDiff.summary);
+    expect(
+      container.querySelectorAll('[data-icon="chevron-right"]')
+    ).toHaveLength(1);
+    expect(
+      summary?.previousElementSibling?.previousElementSibling?.textContent
+    ).toBe("abc1234");
+    expect(summary?.childElementCount).toBe(0);
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[aria-label="workstation.switchToUnifiedDiff"]'
+    );
+    expect(toggle).not.toBeNull();
+    act(() => toggle!.click());
+    expect(store.get(diffViewModeAtom)).toBe("unified");
+
+    render(toolbar);
+    expect(container.querySelector('[aria-haspopup="menu"]')).toBeNull();
+    expect(toolbar.querySelector('[aria-haspopup="menu"]')).not.toBeNull();
+    expect(
+      container.querySelector('[aria-label="workstation.switchToSplitDiff"]')
+    ).toBeNull();
+    const close = container.querySelector<HTMLButtonElement>(
+      '[aria-label="common:actions.close"]'
+    );
+    expect(close).not.toBeNull();
+    const open = container.querySelector<HTMLButtonElement>(
+      '[aria-label="common:actions.openInNewTab"]'
+    );
+    expect(open).not.toBeNull();
+    expect(close!.previousElementSibling).toBe(open);
+    expect(open!.parentElement?.previousElementSibling?.textContent).toContain(
+      "Ada1d"
+    );
+    act(() => open!.click());
+    expect(onOpenInNewTab).toHaveBeenCalledOnce();
+    act(() => close!.click());
+    expect(onClose).toHaveBeenCalledOnce();
+    act(() => root.render(null));
+    expect(toolbar.childElementCount).toBe(0);
+  } finally {
+    act(() => root.unmount());
+    container.remove();
+    toolbar.remove();
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitTabHeader.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitTabHeader.tsx
@@ -1,19 +1,30 @@
-import React, { memo, useMemo } from "react";
+import { useAtom, useAtomValue } from "jotai";
+import React, { memo, useCallback, useMemo } from "react";
 
 import type { CommitDiffResult } from "@src/api/http/git/types";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
 import { FileHeader } from "@src/modules/WorkStation/shared";
-import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
+import BreadcrumbFileHeader from "@src/modules/shared/components/FileHeader/BreadcrumbFileHeader";
+import {
+  editorHighlightActiveLineAtom,
+  editorLineNumbersAtom,
+  editorWordWrapAtom,
+} from "@src/store/ui/editorSettingsAtom";
+import { activeStatusBarCallbacksAtom } from "@src/store/ui/workStationLayout/statusBarAtoms";
+import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
+import { formatCompactAge } from "@src/util/time/formatRelativeTime";
 
 interface CommitTabHeaderProps {
   shortSha: string;
   commitMessage: string;
   commitDiff: CommitDiffResult | null;
   publishToWorkstationHeader: boolean;
+  onClose?: () => void;
+  onOpenInNewTab?: () => void;
 }
 
 /**
- * Renders the commit breadcrumb (shortSha › message [author + stats]) either
+ * Renders the commit SHA and plain-text summary with author and stats either
  * inline as a 36px file bar or in the global Workstation tab-header strip.
  */
 export const CommitTabHeader: React.FC<CommitTabHeaderProps> = memo(
@@ -22,8 +33,21 @@ export const CommitTabHeader: React.FC<CommitTabHeaderProps> = memo(
     commitMessage,
     commitDiff,
     publishToWorkstationHeader,
+    onClose,
+    onOpenInNewTab,
   }) {
-    const extraActions = useMemo(
+    const [viewMode, setViewMode] = useAtom(diffViewModeAtom);
+    const [lineNumbers, setLineNumbers] = useAtom(editorLineNumbersAtom);
+    const [wordWrap, setWordWrap] = useAtom(editorWordWrapAtom);
+    const [highlightActiveLine, setHighlightActiveLine] = useAtom(
+      editorHighlightActiveLineAtom
+    );
+    const { onOpenSettings } = useAtomValue(activeStatusBarCallbacksAtom);
+    const handleLineNumbersChange = useCallback(
+      (enabled: boolean) => setLineNumbers(enabled ? "on" : "off"),
+      [setLineNumbers]
+    );
+    const metadata = useMemo(
       () =>
         commitDiff?.author || commitDiff?.stats ? (
           <div className="ml-auto flex shrink-0 items-center gap-1.5">
@@ -34,7 +58,7 @@ export const CommitTabHeader: React.FC<CommitTabHeaderProps> = memo(
             )}
             {commitDiff?.author?.date && (
               <span className="shrink-0 text-[12px] text-text-3">
-                {formatRelativeTime(commitDiff.author.date, "nano")}
+                {formatCompactAge(commitDiff.author.date)}
               </span>
             )}
             {commitDiff?.stats && (
@@ -48,25 +72,37 @@ export const CommitTabHeader: React.FC<CommitTabHeaderProps> = memo(
       [commitDiff]
     );
 
-    // The caller-supplied `commitMessage` can be a placeholder (the short SHA
-    // itself) when the commit was selected before its `summary` had resolved
-    // — that would render the breadcrumb as `21b1bc64 / 21b1bc64`. Prefer the
-    // authoritative message from `commitDiff` once it has loaded, and fall
-    // back to the caller's value only while the diff is still in flight.
+    // The loaded summary is authoritative; the caller may only have a SHA.
     const resolvedMessage = commitDiff?.summary?.trim() || commitMessage;
-    const breadcrumbTitle =
-      resolvedMessage && resolvedMessage !== shortSha ? resolvedMessage : "";
-    const breadcrumbPath = breadcrumbTitle
-      ? `${shortSha}/${breadcrumbTitle}`
-      : shortSha;
+    const title = resolvedMessage !== shortSha ? resolvedMessage : "";
 
     return (
       <FileHeader
-        filePath={breadcrumbPath}
+        filePath={shortSha}
         useFileTypeIcon={false}
-        disableNavigation
-        plainTitle={false}
-        extraActions={extraActions}
+        titleSlot={
+          <BreadcrumbFileHeader
+            filePath={shortSha}
+            displaySegments={
+              title
+                ? [{ label: shortSha }, { label: title, title }]
+                : [{ label: shortSha }]
+            }
+            disableNavigation
+          />
+        }
+        metadata={metadata}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        lineNumbersEnabled={lineNumbers !== "off"}
+        onLineNumbersChange={handleLineNumbersChange}
+        wordWrapEnabled={wordWrap}
+        onWordWrapChange={setWordWrap}
+        highlightActiveLineEnabled={highlightActiveLine}
+        onHighlightActiveLineChange={setHighlightActiveLine}
+        onMoreSettings={onOpenSettings}
+        onClose={onClose}
+        onOpenInNewTab={onOpenInNewTab}
         publishToHost={publishToWorkstationHeader ? "code" : undefined}
       />
     );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/index.tsx
@@ -31,12 +31,6 @@ import {
   gitFileListWidthAtom,
 } from "@src/modules/WorkStation/shared";
 import { VerticalResizeHandle, useColumnResize } from "@src/scaffold/Resize";
-import {
-  editorHighlightActiveLineAtom,
-  editorLineNumbersAtom,
-  editorWordWrapAtom,
-} from "@src/store/ui/editorSettingsAtom";
-import { activeStatusBarCallbacksAtom } from "@src/store/ui/workStationLayout/statusBarAtoms";
 import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import type { GitFile } from "@src/types/git/types";
 import { decodeOctalPath } from "@src/util/file/pathUtils";
@@ -54,8 +48,8 @@ interface GitCommitDetailContentProps {
   repoId: string;
   isRepoReady?: boolean;
   onFileSelect?: (filePath: string) => void;
-  headerVariant?: "commit" | "stash";
-  headerRootLabel?: string;
+  onClose?: () => void;
+  onOpenInNewTab?: () => void;
   publishHeaderToWorkstation?: boolean;
   prNumber?: number;
 }
@@ -68,21 +62,15 @@ const GitCommitDetailContent: React.FC<GitCommitDetailContentProps> = ({
   repoId,
   isRepoReady = true,
   onFileSelect,
-  headerVariant = "commit",
-  headerRootLabel,
+  onClose,
+  onOpenInNewTab,
   publishHeaderToWorkstation = true,
   prNumber,
 }) => {
   const { t } = useTranslation();
 
   const [fileListCollapsed, setFileListCollapsed] = useState(false);
-  const [viewMode, setViewMode] = useAtom(diffViewModeAtom);
-  const [lineNumbers, setLineNumbers] = useAtom(editorLineNumbersAtom);
-  const [wordWrap, setWordWrap] = useAtom(editorWordWrapAtom);
-  const [highlightActiveLine, setHighlightActiveLine] = useAtom(
-    editorHighlightActiveLineAtom
-  );
-  const { onOpenSettings } = useAtomValue(activeStatusBarCallbacksAtom);
+  const viewMode = useAtomValue(diffViewModeAtom);
   const [fileListWidth, setFileListWidth] = useAtom(gitFileListWidthAtom);
   const [fetchingPrCommit, setFetchingPrCommit] = useState(false);
   const [fetchPrError, setFetchPrError] = useState<{
@@ -175,13 +163,6 @@ const GitCommitDetailContent: React.FC<GitCommitDetailContentProps> = ({
     setFileListCollapsed((prev) => !prev);
   }, []);
 
-  const handleLineNumbersChange = useCallback(
-    (enabled: boolean) => {
-      setLineNumbers(enabled ? "on" : "off");
-    },
-    [setLineNumbers]
-  );
-
   const handleFetchPrCommit = useCallback(() => {
     if (!prNumber || !repoId || !repoPath || fetchingPrCommit) return;
 
@@ -253,25 +234,22 @@ const GitCommitDetailContent: React.FC<GitCommitDetailContentProps> = ({
   const currentFetchPrError =
     fetchPrError?.key === prCommitFetchKey ? fetchPrError.message : null;
 
-  const stashHeaderPath = `${headerRootLabel ?? shortSha}/${commitMessage}`;
-
   const hasInlineHeaderAbove = !publishHeaderToWorkstation;
-
-  const stashHeaderPublisher =
-    headerVariant === "stash" ? (
-      <FileHeader
-        filePath={stashHeaderPath}
-        repoPath={undefined}
-        useFileTypeIcon={false}
-        disableNavigation
-        publishToHost={publishHeaderToWorkstation ? "code" : undefined}
-      />
-    ) : null;
+  const header = (
+    <CommitTabHeader
+      shortSha={shortSha}
+      commitMessage={commitMessage}
+      commitDiff={commitDiff}
+      publishToWorkstationHeader={publishHeaderToWorkstation}
+      onClose={onClose}
+      onOpenInNewTab={onOpenInNewTab}
+    />
+  );
 
   if (!isRepoReady) {
     return (
       <>
-        {stashHeaderPublisher}
+        {header}
         <Placeholder
           variant="empty"
           placement="detail-panel"
@@ -287,15 +265,7 @@ const GitCommitDetailContent: React.FC<GitCommitDetailContentProps> = ({
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <CommitTabHeader
-        shortSha={shortSha}
-        commitMessage={commitMessage}
-        commitDiff={commitDiff}
-        publishToWorkstationHeader={
-          publishHeaderToWorkstation && headerVariant === "commit"
-        }
-      />
-      {stashHeaderPublisher}
+      {header}
       {commitLoadState === "loading" ? (
         <Placeholder
           variant="loading"
@@ -405,15 +375,6 @@ const GitCommitDetailContent: React.FC<GitCommitDetailContentProps> = ({
                     repoPath={repoPath}
                     additions={selectedFile.insertions}
                     deletions={selectedFile.deletions}
-                    viewMode={viewMode}
-                    onViewModeChange={setViewMode}
-                    lineNumbersEnabled={lineNumbers !== "off"}
-                    onLineNumbersChange={handleLineNumbersChange}
-                    wordWrapEnabled={wordWrap}
-                    onWordWrapChange={setWordWrap}
-                    highlightActiveLineEnabled={highlightActiveLine}
-                    onHighlightActiveLineChange={setHighlightActiveLine}
-                    onMoreSettings={onOpenSettings}
                     loading={fileLoadState === "loading"}
                     onFileSelect={onFileSelect}
                   />

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
@@ -54,8 +54,9 @@ interface SourceControlMainContentProps {
   onForceReload?: () => void;
   /** Open the focused file as a regular file tab */
   onFileSelect?: (path: string) => void;
-  /** Clear the focused file without closing Source Control. */
+  /** Clear the focused file or history selection without closing Source Control. */
   onCloseFocus?: () => void;
+  onOpenHistoryInNewTab?: (selection: SourceControlHistorySelection) => void;
   /** Sync git-diff local edits to tab bar unsaved indicator */
   onGitDiffUnsavedChange?: (hasUnsaved: boolean) => void;
   /** Selected commit/stash rendered in the Source Control right pane. */
@@ -85,6 +86,7 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
   onForceReload,
   onFileSelect,
   onCloseFocus,
+  onOpenHistoryInNewTab,
   onGitDiffUnsavedChange,
   historySelection,
   files,
@@ -208,12 +210,10 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
             repoId={resolvedRepoId ?? ""}
             isRepoReady={repoReady}
             onFileSelect={onFileSelect}
-            headerVariant={
-              historySelection.type === "stash" ? "stash" : "commit"
-            }
-            headerRootLabel={
-              historySelection.type === "stash"
-                ? historySelection.stashRef
+            onClose={onCloseFocus}
+            onOpenInNewTab={
+              onOpenHistoryInNewTab
+                ? () => onOpenHistoryInNewTab(historySelection)
                 : undefined
             }
             publishHeaderToWorkstation={false}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
@@ -15,6 +15,7 @@ import {
 import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
 import { useGitHubIssueDetailState } from "@src/modules/shared/hooks/useGitHubIssueDetailState";
 import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
+import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 import type { GitFile } from "@src/types/git/types";
 
 import {
@@ -50,6 +51,7 @@ export interface SourceControlMainPaneProps {
   onForceReload?: () => void;
   onFileSelect?: (path: string) => void;
   onCloseFocus?: () => void;
+  onOpenHistoryInNewTab?: (selection: SourceControlHistorySelection) => void;
   onGitDiffUnsavedChange?: (hasUnsaved: boolean) => void;
   /**
    * Owning tab id; per-tab view state is saved under it so this active-only
@@ -72,6 +74,7 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
   onForceReload,
   onFileSelect,
   onCloseFocus,
+  onOpenHistoryInNewTab,
   onGitDiffUnsavedChange,
   viewStateKey,
 }) => {
@@ -156,6 +159,7 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
           onForceReload={onForceReload}
           onFileSelect={onFileSelect}
           onCloseFocus={onCloseFocus}
+          onOpenHistoryInNewTab={onOpenHistoryInNewTab}
           onGitDiffUnsavedChange={onGitDiffUnsavedChange}
           historySelection={historySelection}
           files={allFiles}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.test.ts
@@ -9,6 +9,10 @@ import { useSourceControlActions } from "@src/modules/WorkStation/CodeEditor/Pan
 import SourceControlTabSidebarContent from "@src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlTabSidebarContent";
 import type { TabSidebarProps } from "@src/modules/WorkStation/shared/SidebarModules/registry";
 import { sourceControlRefreshHandlerAtom } from "@src/store/workstation/codeEditor/sourceControlRefreshAtom";
+import {
+  type PanelState,
+  createSourceControlTab,
+} from "@src/store/workstation/tabs";
 
 import { useSourceControlPaneActions } from "./useSourceControlPaneActions";
 
@@ -37,6 +41,72 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 vi.mock("../config", () => ({ createSourceControlQuickActions: () => [] }));
+
+it.each(["file", "commit", "stash"] as const)(
+  "closes the selected %s without closing Source Control and is idempotent",
+  (kind) => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const root = createRoot(document.createElement("div"));
+    const tab = createSourceControlTab(1);
+    if (kind === "file") {
+      tab.data.focusPath = "src/index.ts";
+    } else {
+      tab.data.historySelection = {
+        type: kind,
+        commitSha: "abc1234",
+        shortSha: "abc1234",
+        commitMessage: "Saved changes",
+        ...(kind === "stash"
+          ? {
+              stashIndex: 0,
+              stashRef: "stash@{0}",
+              stashIdentity: "abc1234",
+              stashCommitSha: "abc1234",
+            }
+          : {}),
+      };
+    }
+    let state: PanelState = { tabs: [tab], activeTabId: tab.id };
+    let close!: () => void;
+    const Harness = () => {
+      const closeSelection = useSourceControlPaneActions({
+        t: ((key: string) => key) as TFunction,
+        updatePaneState: (update) => {
+          state = update(state);
+        },
+        forceRefresh: vi.fn(async () => {}),
+        gitDiffLoading: false,
+        sourceControlFilterMode: "uncommitted",
+      }).handleSourceControlCloseFocus;
+      useEffect(() => {
+        close = closeSelection;
+      }, [closeSelection]);
+      return null;
+    };
+    try {
+      act(() =>
+        root.render(
+          createElement(
+            Provider,
+            { store: createStore() },
+            createElement(Harness)
+          )
+        )
+      );
+      act(() => close());
+      expect(state.tabs).toHaveLength(1);
+      expect(state.activeTabId).toBe(tab.id);
+      expect(state.tabs[0].data.focusPath).toBeNull();
+      expect(state.tabs[0].data.historySelection).toBeNull();
+      const closed = state;
+      act(() => close());
+      expect(state).toBe(closed);
+    } finally {
+      act(() => root.unmount());
+      vi.unstubAllGlobals();
+    }
+  }
+);
 
 it("routes the header to the mounted scope, avoids duplicate refresh, and falls back after unmount", async () => {
   vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.ts
@@ -3,11 +3,10 @@
  *
  * Owns every Source-Control-flavoured interaction the editor host exposes:
  * refresh (with spin state), Focus/All-Changes mode switching, collapse-all
- * signalling, focus dismissal, review prev/next navigation, opening a history
+ * signalling, file/history dismissal, review prev/next navigation, opening a history
  * entry (commit or stash) in its own tab, and the empty-state quick actions
  * that navigate the sidebar between Source Control destinations.
  *
- * Extracted verbatim from `EditorMainPane` — no behavior change.
  */
 import type { TFunction } from "i18next";
 import { useAtomValue, useSetAtom } from "jotai";
@@ -58,6 +57,7 @@ export interface UseSourceControlPaneActionsReturn {
   sourceControlCollapseAllSignal: number;
   handleSourceControlModeChange: (mode: SourceControlMainMode) => void;
   handleSourceControlCollapseAll: () => void;
+  /** Dismiss the focused file or history detail, retaining the Source Control tab. */
   handleSourceControlCloseFocus: () => void;
   /** Current review-sequence snapshot (`{ current, total }`) */
   gitReviewNavigation: GitReviewNavigationSnapshot;
@@ -121,7 +121,8 @@ export function useSourceControlPaneActions({
       if (tabIndex === -1) return state;
 
       const existing = state.tabs[tabIndex];
-      if (!existing.data.focusPath) return state;
+      if (!existing.data.focusPath && !existing.data.historySelection)
+        return state;
 
       const nextTabs = [...state.tabs];
       nextTabs[tabIndex] = {
@@ -129,6 +130,7 @@ export function useSourceControlPaneActions({
         data: {
           ...existing.data,
           focusPath: null,
+          historySelection: null,
         },
       };
       return { ...state, tabs: nextTabs };

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
@@ -329,7 +329,6 @@ const EditorContent: React.FC<EditorContentProps> = memo(
           t={t}
           onDiffViewModeChange={setDiffViewMode}
           onModeChange={handleSourceControlModeChange}
-          onOpenHistoryInNewTab={handleOpenSourceControlHistoryInNewTab}
           onReviewPrevFile={handleReviewPrevFile}
           onReviewNextFile={handleReviewNextFile}
           onCollapseAll={handleSourceControlCollapseAll}
@@ -340,7 +339,6 @@ const EditorContent: React.FC<EditorContentProps> = memo(
       activeTab,
       diffViewMode,
       gitReviewNavigation.total,
-      handleOpenSourceControlHistoryInNewTab,
       handleReviewNextFile,
       handleReviewPrevFile,
       handleSourceControlCollapseAll,
@@ -538,13 +536,9 @@ const EditorContent: React.FC<EditorContentProps> = memo(
                 <Suspense fallback={<LazyFallback />}>
                   <FileHeaderToolbarContext.Provider
                     value={
-                      sourceControlPaneVisible &&
-                      sourceControlTab.data.mode !== "all-changes" &&
-                      !sourceControlTab.data.historySelection &&
-                      sourceControlFilterMode !== "issues" &&
-                      sourceControlFilterMode !== "pr"
-                        ? focusToolbarTarget
-                        : null
+                      sourceControlPaneVisible
+                        ? (focusToolbarTarget ?? "host")
+                        : "host"
                     }
                   >
                     <SourceControlMainPane
@@ -565,6 +559,9 @@ const EditorContent: React.FC<EditorContentProps> = memo(
                       onForceReload={forceRefresh}
                       onFileSelect={onFileSelect}
                       onCloseFocus={handleSourceControlCloseFocus}
+                      onOpenHistoryInNewTab={
+                        handleOpenSourceControlHistoryInNewTab
+                      }
                       onGitDiffUnsavedChange={handleGitDiffUnsavedChange}
                       viewStateKey={sourceControlTab.id}
                     />

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitCommitRow.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitCommitRow.tsx
@@ -4,7 +4,7 @@ import type { GitCommitInfo, GitCommitPerson } from "@src/api/http/git/types";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
 import { PRIMARY_SIDEBAR_HOVER } from "@src/config/workstation/tokens";
 import { useImmediateCursorReset } from "@src/hooks/ui/useImmediateCursorReset";
-import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
+import { formatCompactAge } from "@src/util/time/formatRelativeTime";
 
 import type { CommitGraphNode } from "./graphLayout";
 import { DOT_RADIUS, LANE_WIDTH } from "./graphLayout";
@@ -137,9 +137,7 @@ function GitCommitRowComponent<TCommit extends GitCommitRowBaseCommit>({
         <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-3">
           <span className="truncate">{authorName}</span>
           {authorDate && (
-            <span className="shrink-0">
-              {formatRelativeTime(authorDate, "nano")}
-            </span>
+            <span className="shrink-0">{formatCompactAge(authorDate)}</span>
           )}
         </div>
       </div>

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitHistoryContent.remount.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitHistoryContent.remount.test.ts
@@ -135,6 +135,27 @@ describe("GitHistoryContent remount continuity", () => {
     });
     expect(container.textContent).toContain("Cached commit");
 
+    for (const viewMode of ["graph", "list"] as const) {
+      await act(async () => {
+        root.render(
+          createElement(GitHistoryContent, {
+            repoId: "repo-1",
+            repoPath: "/repo",
+            viewMode,
+          })
+        );
+      });
+      const row = container.querySelector<HTMLButtonElement>(
+        'button[title*="Cached commit"]'
+      )!;
+      expect(row.classList.contains("rounded-md")).toBe(true);
+      expect(row.parentElement!.classList.contains("mx-1")).toBe(true);
+      expect(Boolean(row.querySelector("svg circle"))).toBe(
+        viewMode === "graph"
+      );
+      expect(getGitCommitsMock).toHaveBeenCalledTimes(1);
+    }
+
     act(() => root.unmount());
     root = createRoot(container);
     await act(async () => {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/index.tsx
@@ -22,6 +22,10 @@ import { useActionSystem } from "@src/ActionSystem";
 import { getGitCommits } from "@src/api/http/git/commits";
 import type { GitCommitInfo } from "@src/api/http/git/types";
 import { Placeholder } from "@src/components/Placeholder";
+import {
+  TREE_ROW_INSET_CLASS,
+  TREE_ROW_ROUNDED_CLASS,
+} from "@src/components/TreeRow/config";
 import { SPINNER_TOKENS } from "@src/config/spinnerTokens";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
 import { PRIMARY_SIDEBAR_HOVER } from "@src/config/workstation/tokens";
@@ -42,7 +46,7 @@ import {
   type SourceControlHistorySelection,
   createGitCommitDetailTab,
 } from "@src/store/workstation/tabs";
-import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
+import { formatCompactAge } from "@src/util/time/formatRelativeTime";
 
 import GitHistoryContextMenu from "./GitHistoryContextMenu";
 import {
@@ -171,7 +175,7 @@ const CommitRow: React.FC<CommitRowProps> = memo(
 
     return (
       <button
-        className={`group flex w-full items-center gap-1 pr-3 pl-2 text-left transition-colors ${
+        className={`group flex w-full items-center gap-1 px-2 text-left transition-colors ${TREE_ROW_ROUNDED_CLASS} ${
           cursorReset || isSelected ? "cursor-default" : "cursor-pointer"
         } ${isSelected ? SURFACE_TOKENS.selected : PRIMARY_SIDEBAR_HOVER.row}`}
         style={{ height: `${ROW_HEIGHT}px` }}
@@ -199,9 +203,7 @@ const CommitRow: React.FC<CommitRowProps> = memo(
           <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-3">
             <span className="truncate">{authorName}</span>
             {authorDate && (
-              <span className="shrink-0">
-                {formatRelativeTime(authorDate, "nano")}
-              </span>
+              <span className="shrink-0">{formatCompactAge(authorDate)}</span>
             )}
           </div>
         </div>
@@ -535,34 +537,34 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
             void handleLoadMore();
           }}
           itemContent={(index, commit) => (
-            <CommitRow
-              commit={commit}
-              isSelected={commit.sha === activeCommitSha}
-              graphNode={
-                isGraphMode && !filterQuery
-                  ? graphData.nodeMap.get(commit.sha)
-                  : undefined
-              }
-              svgWidth={graphSvgWidth}
-              isFirst={index === 0}
-              onSelect={handleCommitSelect}
-              onContextMenu={handleCommitContextMenu}
-            />
+            <div className={TREE_ROW_INSET_CLASS}>
+              <CommitRow
+                commit={commit}
+                isSelected={commit.sha === activeCommitSha}
+                graphNode={
+                  isGraphMode && !filterQuery
+                    ? graphData.nodeMap.get(commit.sha)
+                    : undefined
+                }
+                svgWidth={graphSvgWidth}
+                isFirst={index === 0}
+                onSelect={handleCommitSelect}
+                onContextMenu={handleCommitContextMenu}
+              />
+            </div>
           )}
         />
       )}
 
       {/* Loading indicator remains outside the virtual window. */}
-      {hasMore && (
+      {loadingMore && (
         <div className="flex h-8 shrink-0 items-center justify-center">
-          {loadingMore && (
-            <HugeiconsIcon
-              icon={Loading03Icon}
-              data-icon="loader-2"
-              size={SPINNER_TOKENS.default}
-              className="animate-spin text-text-3"
-            />
-          )}
+          <HugeiconsIcon
+            icon={Loading03Icon}
+            data-icon="loader-2"
+            size={SPINNER_TOKENS.default}
+            className="animate-spin text-text-3"
+          />
         </div>
       )}
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrSidebar.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrSidebar.test.ts
@@ -147,7 +147,7 @@ describe("PrSidebar", () => {
     );
     expect(reviewerTrigger?.style.height).toBe("20px");
     expect(reviewerTrigger?.style.width).toBe("20px");
-    expect(reviewerTrigger?.style.borderRadius).toBe("8px");
+    expect(reviewerTrigger?.style.borderRadius).toBe("var(--radius-sm)");
     const reviewers = container.querySelector(
       "[data-testid='pr-sidebar-reviewers']"
     );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SectionHeader.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SectionHeader.tsx
@@ -18,7 +18,8 @@ import { ArrowDown01Icon, ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
 
 export interface SectionHeaderProps {
   title: string;
-  count: number;
+  /** Omit when the count is already part of the title. */
+  count?: number;
   /** Optional display text when the numeric count is a lower bound. */
   countLabel?: string;
   isCollapsed: boolean;
@@ -58,7 +59,7 @@ export const SectionHeader: React.FC<SectionHeaderProps> = memo(
 
     return (
       <div
-        className={`group/header ${TREE_ROW_INSET_CLASS} flex ${heightClassName} min-w-0 items-center gap-1.5 px-2 ${TREE_ROW_ROUNDED_CLASS} ${
+        className={`group/header ${TREE_ROW_INSET_CLASS} flex ${heightClassName} min-w-0 items-center gap-1.5 pr-1 pl-2 ${TREE_ROW_ROUNDED_CLASS} ${
           useWarningText ? "hover:bg-warning-1" : ""
         }`}
       >
@@ -99,11 +100,13 @@ export const SectionHeader: React.FC<SectionHeaderProps> = memo(
             </div>
           )}
           {/* Count badge */}
-          <span
-            className={`${COUNT_BADGE.base} ${getCountBadgeSizeClass(count)} ${countBadgeVariant}`}
-          >
-            {countLabel ?? count}
-          </span>
+          {count !== undefined && (
+            <span
+              className={`${COUNT_BADGE.base} ${getCountBadgeSizeClass(count)} ${countBadgeVariant}`}
+            >
+              {countLabel ?? count}
+            </span>
+          )}
         </div>
       </div>
     );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlTreeRow.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlTreeRow.tsx
@@ -24,6 +24,7 @@ import {
 import type { GitStatusInfo, TreeRowNode } from "@src/components/TreeRow";
 import {
   COUNT_BADGE,
+  HEADER_ICON_SIZE,
   PRIMARY_SIDEBAR_HOVER,
   getCountBadgeSizeClass,
 } from "@src/config/workstation/tokens";
@@ -162,7 +163,7 @@ const SectionHeaderRow: React.FC<SectionHeaderRowProps> = memo(
               <HugeiconsIcon
                 icon={Undo03Icon}
                 data-icon="undo-3"
-                size={14}
+                size={HEADER_ICON_SIZE.discard}
                 strokeWidth={1.75}
               />
             }
@@ -527,6 +528,7 @@ const FileDirectoryRow: React.FC<FileDirectoryRowProps> = memo(
                   <TreeRowAction
                     showOnRowHover={false}
                     icon={Undo03Icon}
+                    iconSize={HEADER_ICON_SIZE.discard}
                     variant="danger"
                     onClick={handleDiscard}
                     title={GIT_LABELS.discardChanges}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/StashContent/StashContent.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/StashContent/StashContent.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import { HEADER_CLASSES } from "@src/config/workstation/tokens";
+
+import StashContent from ".";
+import { StashHeaderContext } from "./StashHeaderContext";
+
+const mocks = vi.hoisted(() => ({ language: "en" }));
+vi.mock("@src/hooks/tabHost/useWorkStationTabs", () => ({
+  useWorkStationTabs: () => ({ openTab: vi.fn(), activeTab: null }),
+}));
+vi.mock("react-i18next", async () => {
+  const { createInstance } = await import("i18next");
+  const { default: en } = await import("@src/i18n/locales/en/common.json");
+  const { default: zh } = await import("@src/i18n/locales/zh/common.json");
+  const instance = createInstance();
+  await instance.init({
+    lng: "en",
+    defaultNS: "common",
+    resources: { en: { common: en }, zh: { common: zh } },
+  });
+  return { useTranslation: () => ({ t: instance.getFixedT(mocks.language) }) };
+});
+
+it.each(["en", "zh"])(
+  "uses one 32px navigation/action row in %s, including zero stashes",
+  (language) => {
+    mocks.language = language;
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+    const onBack = vi.fn();
+    const action = vi.fn();
+    try {
+      for (const count of [0, 63]) {
+        act(() =>
+          root.render(
+            createElement(
+              StashHeaderContext.Provider,
+              {
+                value: {
+                  onBack,
+                  actions: [
+                    {
+                      key: "filter",
+                      icon: "filter",
+                      tooltip: "filter",
+                      onClick: action,
+                      forceVisible: true,
+                    },
+                  ],
+                },
+              },
+              createElement(StashContent, {
+                stashes: Array.from({ length: count }, (_, index) => ({
+                  index,
+                  message: `Saved ${index}`,
+                  commit_sha: `sha-${index}`,
+                  branch: "main",
+                })),
+                operationLoading: true,
+                onStashApply: vi.fn(),
+                onStashPop: vi.fn(),
+                onStashDrop: vi.fn(),
+              })
+            )
+          )
+        );
+        const headers = Array.from(container.querySelectorAll("div")).filter(
+          (node) => node.className === HEADER_CLASSES.sectionHeader
+        );
+        expect(headers).toHaveLength(1);
+        const header = headers[0];
+        expect(header.classList.contains("h-8")).toBe(true);
+        expect(header.textContent).toContain(
+          language === "zh" ? `${count}个STASHES` : `${count} stashes`
+        );
+        expect(header.querySelector('[data-icon="chevron-down"]')).toBeNull();
+        const pop = header.querySelector<HTMLButtonElement>("button[disabled]");
+        expect(pop?.disabled).toBe(true);
+        const back = header.querySelector<HTMLButtonElement>("button");
+        act(() => back!.click());
+        const filter =
+          header.querySelector<HTMLButtonElement>('[title="filter"]');
+        expect(filter).not.toBeNull();
+        expect(pop!.className).toBe(filter!.className);
+        expect(pop!.parentElement!.parentElement).toBe(
+          filter!.parentElement!.parentElement
+        );
+        expect(
+          pop!.compareDocumentPosition(filter!) &
+            Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy();
+        act(() => filter!.click());
+      }
+      expect(onBack).toHaveBeenCalledTimes(2);
+      expect(action).toHaveBeenCalledTimes(2);
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+      vi.unstubAllGlobals();
+    }
+  }
+);

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/StashContent/StashHeaderContext.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/StashContent/StashHeaderContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
+
+/** Navigation and actions supplied by the sidebar hosting the stash list. */
+export const StashHeaderContext = createContext<{
+  onBack: () => void;
+  actions: SectionHeaderAction[];
+} | null>(null);

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/StashContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/StashContent/index.tsx
@@ -1,15 +1,15 @@
 /**
  * StashContent Component
  *
- * Displays git stashes in a collapsible section with:
+ * Displays git stashes with a shared sidebar header:
  * - List of stashes with index and message
  * - Actions: Apply, Pop, Drop per stash
  * - Pop All button in header
  *
- * Only renders when there are stashes.
- * Follows the same layout pattern as SourceControlChanges.
+ * In the Stashes destination, the header includes back navigation and remains
+ * available for an empty list. Embedded lists retain their collapse behavior.
  */
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, { memo, useCallback, useContext, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { StashEntry } from "@src/api/http/git/types";
@@ -18,37 +18,30 @@ import HoverCard from "@src/components/HoverCard";
 import { HoverCardPanel } from "@src/components/HoverCard/HoverCardBase";
 import { HoverCardMetadataRow } from "@src/components/HoverCard/HoverCardMetadataRow";
 import {
-  TREE_ROW_INSET_CLASS,
-  TREE_ROW_ROUNDED_CLASS,
   TreeRowActionGroup,
   TreeRowBase,
   type TreeRowNode,
 } from "@src/components/TreeRow";
-import { SPINNER_TOKENS } from "@src/config/spinnerTokens";
-import {
-  COUNT_BADGE,
-  HEADER_BUTTON,
-  HEADER_ICON_SIZE,
-  PRIMARY_SIDEBAR_HOVER,
-  getCountBadgeSizeClass,
-} from "@src/config/workstation/tokens";
+import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import { useWorkStationTabs } from "@src/hooks/tabHost/useWorkStationTabs";
 import {
   ArchiveArrowUpIcon,
-  ArrowDown01Icon,
   ArrowDownToLineIcon,
-  ArrowRight01Icon,
+  ArrowLeft02Icon,
   Delete02Icon,
   HugeiconsIcon,
   Loading03Icon,
   PackageIcon,
   WorkflowCircle05Icon,
 } from "@src/icons";
+import CollapsibleSection from "@src/modules/WorkStation/shared/PrimarySidebarLayout/CollapsibleSection";
 import {
   type SourceControlHistorySelection,
   createStashDetailTab,
 } from "@src/store/workstation/tabs";
 import { confirmDestructiveAction } from "@src/util/dialogs/confirmDestructiveAction";
+
+import { StashHeaderContext } from "./StashHeaderContext";
 
 // ============================================
 // Types
@@ -325,6 +318,7 @@ export const StashContent: React.FC<StashContentProps> = memo(
   }) => {
     const { t } = useTranslation();
     const { openTab, activeTab } = useWorkStationTabs();
+    const header = useContext(StashHeaderContext);
     const [collapsed, setCollapsed] = useState(initialCollapsed);
     const [isPoppingAll, setIsPoppingAll] = useState(false);
 
@@ -389,94 +383,70 @@ export const StashContent: React.FC<StashContentProps> = memo(
     }, [hasStashes, stashCount, onStashPop, t]);
 
     // Don't render section if no stashes
-    if (!hasStashes) {
+    if (!hasStashes && !header) {
       return null;
     }
 
+    const title = t("common:labels.stashesCount", { count: stashCount });
+    const popAllAction = {
+      key: "pop-all-stashes",
+      icon: (
+        <HugeiconsIcon
+          icon={isPoppingAll ? Loading03Icon : ArchiveArrowUpIcon}
+          size={HEADER_ICON_SIZE.sm}
+          className={isPoppingAll ? "animate-spin" : undefined}
+        />
+      ),
+      tooltip: t("tooltips.popAllStashes"),
+      onClick: handlePopAll,
+      disabled: !hasStashes || operationLoading || isPoppingAll,
+      forceVisible: true,
+    };
     return (
-      <div className="mb-1">
-        {/* Section header */}
-        <div
-          className={`group/header ${TREE_ROW_INSET_CLASS} flex h-[28px] items-center gap-1.5 px-2 ${TREE_ROW_ROUNDED_CLASS} ${PRIMARY_SIDEBAR_HOVER.row}`}
-        >
-          <button
-            className="flex items-center gap-1.5"
-            onClick={() => setCollapsed(!collapsed)}
-          >
-            {collapsed ? (
-              <HugeiconsIcon
-                icon={ArrowRight01Icon}
-                data-icon="chevron-right"
-                size={14}
-                className="text-text-3"
-              />
-            ) : (
-              <HugeiconsIcon
-                icon={ArrowDown01Icon}
-                data-icon="chevron-down"
-                size={14}
-                className="text-text-3"
-              />
-            )}
-            <span className="text-[11px] font-medium text-text-2 uppercase">
-              Stashes
-            </span>
-          </button>
-          <div className="flex-1" />
-
-          {/* Action buttons - show on hover */}
-          <button
-            className={`${HEADER_BUTTON.actionTreeRow} hidden shrink-0 group-focus-within/header:flex group-hover/header:flex disabled:opacity-50`}
-            onClick={handlePopAll}
-            disabled={operationLoading || isPoppingAll}
-            title={t("tooltips.popAllStashes")}
-          >
-            {isPoppingAll ? (
-              <HugeiconsIcon
-                icon={Loading03Icon}
-                data-icon="loader-2"
-                size={SPINNER_TOKENS.default}
-                className="animate-spin text-text-3"
-              />
-            ) : (
-              <HugeiconsIcon
-                icon={ArchiveArrowUpIcon}
-                data-icon="archive-restore"
-                size={HEADER_ICON_SIZE.sm}
-                strokeWidth={1.75}
-              />
-            )}
-          </button>
-
-          {/* Count badge */}
-          <span
-            className={`${COUNT_BADGE.base} ${getCountBadgeSizeClass(stashCount)} ${COUNT_BADGE.primary}`}
-          >
-            {stashCount}
-          </span>
-        </div>
-
-        {/* Content */}
-        {!collapsed && (
-          <div>
-            {/* Stash list */}
-            <div className="flex flex-col">
-              {stashes.map((stash) => (
-                <StashItem
-                  key={getStashIdentity(stash)}
-                  stash={stash}
-                  operationLoading={operationLoading}
-                  isSelected={activeStashIdentity === getStashIdentity(stash)}
-                  onApply={onStashApply}
-                  onPop={onStashPop}
-                  onDrop={onStashDrop}
-                  onOpenDetail={handleOpenStashDetail}
+      <CollapsibleSection
+        title={
+          header ? (
+            <button
+              type="button"
+              className="flex min-w-0 items-center gap-1.5 normal-case"
+              onClick={header.onBack}
+              aria-label={t("tabs.sourceControl")}
+              title={t("tabs.sourceControl")}
+            >
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+                <HugeiconsIcon
+                  icon={ArrowLeft02Icon}
+                  size={14}
+                  className="text-text-3"
                 />
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
+              </span>
+              <span className="truncate">{title}</span>
+            </button>
+          ) : (
+            title
+          )
+        }
+        collapsible={!header}
+        collapsed={collapsed}
+        onCollapseChange={setCollapsed}
+        actions={[popAllAction, ...(header?.actions ?? [])]}
+        isLast
+      >
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          {stashes.map((stash) => (
+            <StashItem
+              key={getStashIdentity(stash)}
+              stash={stash}
+              operationLoading={operationLoading}
+              isSelected={activeStashIdentity === getStashIdentity(stash)}
+              onApply={onStashApply}
+              onPop={onStashPop}
+              onDrop={onStashDrop}
+              onOpenDetail={handleOpenStashDetail}
+            />
+          ))}
+        </div>
+      </CollapsibleSection>
     );
   }
 );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.tsx
@@ -165,7 +165,7 @@ export function useSourceControlTabConfig({
       );
     }
 
-    if (isMultiRoot && workspaceFolders.length > 1) {
+    if (isMultiRoot && workspaceFolders.length > 1 && !showOnlyStashes) {
       return (
         <MultiRootSourceControlContent
           ref={

--- a/src/modules/WorkStation/CodeEditor/__tests__/sourceControlStateTransitions.test.ts
+++ b/src/modules/WorkStation/CodeEditor/__tests__/sourceControlStateTransitions.test.ts
@@ -7,6 +7,7 @@ import { deriveSourceControlMainProps } from "../Panels/EditorMainPane/content/s
 import {
   rememberSourceControlFocusPath,
   setSourceControlMainMode,
+  switchSourceControlCategory,
 } from "../sourceControlStateTransitions";
 
 function sourceControlTab(data: Record<string, unknown> = {}): WorkStationTab {
@@ -132,5 +133,56 @@ describe("Source Control Focus hand-off", () => {
     expect(setSourceControlMainMode(withoutSourceControl, "focus")).toBe(
       withoutSourceControl
     );
+  });
+});
+
+describe("Source Control category switching", () => {
+  const counts = { uncommitted: 86, unstaged: 80, staged: 6, stashed: 64 };
+  it.each([
+    "uncommitted",
+    "unstaged",
+    "staged",
+    "stashed",
+    "history",
+    "pr",
+    "issues",
+  ] as const)("clears the previous detail when switching to %s", (category) => {
+    const initial = panel({
+      mode: "all-changes",
+      focusPath: "/repo/src/a.ts",
+      historySelection: { type: "stash", commitSha: "abc" },
+      staged: false,
+      fileCount: 86,
+    });
+    const updated = switchSourceControlCategory(initial, category, counts);
+    expect(updated.tabs[0]).toBe(initial.tabs[0]);
+    expect(updated.activeTabId).toBe(initial.activeTabId);
+    expect(updated.tabs[1].data).toMatchObject({
+      mode: "focus",
+      focusPath: null,
+      historySelection: null,
+    });
+    if (category in counts) {
+      expect(updated.tabs[1].data.staged).toBe(category === "staged");
+      expect(updated.tabs[1].data.fileCount).toBe(
+        counts[category as keyof typeof counts]
+      );
+    }
+    const view = deriveSourceControlMainProps({
+      tabData: updated.tabs[1].data,
+      gitFilesByPath: new Map([["src/a.ts", changedFile()]]),
+      sourceControlFiles: [changedFile()],
+      sourceControlFilterMode: category,
+      repoPath: "/repo",
+      activeRepoRoot: "/repo",
+    });
+    expect(view.hasFocus).toBe(false);
+    expect(view.focusGitFile).toBeNull();
+    expect(view.historySelection).toBeNull();
+    expect(view.mode).toBe("focus");
+  });
+  it("does not create a Source Control tab when none is open", () => {
+    const state = { tabs: [fileTab()], activeTabId: "file:/repo/README.md" };
+    expect(switchSourceControlCategory(state, "stashed", counts)).toBe(state);
   });
 });

--- a/src/modules/WorkStation/CodeEditor/sourceControlStateTransitions.ts
+++ b/src/modules/WorkStation/CodeEditor/sourceControlStateTransitions.ts
@@ -1,5 +1,10 @@
 import type { PanelState } from "@src/store/workstation/tabs";
 
+import type {
+  SourceControlFilterCounts,
+  SourceControlFilterMode,
+} from "../shared/SidebarModules";
+
 export type SourceControlMainMode = "focus" | "all-changes";
 
 /**
@@ -60,4 +65,32 @@ export function setSourceControlMainMode(
   };
 
   return { ...state, tabs: nextTabs };
+}
+
+/** A category change dismisses detail from the previous category. */
+export function switchSourceControlCategory(
+  state: PanelState,
+  category: SourceControlFilterMode,
+  counts: SourceControlFilterCounts
+): PanelState {
+  const tabIndex = state.tabs.findIndex((tab) => tab.type === "source-control");
+  if (tabIndex === -1) return state;
+
+  const existing = state.tabs[tabIndex];
+  const isFileCategory =
+    category !== "history" && category !== "pr" && category !== "issues";
+  const tabs = [...state.tabs];
+  tabs[tabIndex] = {
+    ...existing,
+    data: {
+      ...existing.data,
+      ...(isFileCategory
+        ? { staged: category === "staged", fileCount: counts[category] }
+        : {}),
+      mode: "focus",
+      focusPath: null,
+      historySelection: null,
+    },
+  };
+  return { ...state, tabs };
 }

--- a/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
+++ b/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
@@ -38,7 +38,10 @@ import {
 import { useGitFiles } from "./hooks/sourceControl/useGitFiles";
 import type { UseGitDiffStateReturn } from "./hooks/useGitDiffState";
 import { resolveGitDiffSelection } from "./sourceControlSelection";
-import { rememberSourceControlFocusPath } from "./sourceControlStateTransitions";
+import {
+  rememberSourceControlFocusPath,
+  switchSourceControlCategory,
+} from "./sourceControlStateTransitions";
 import { useStashCount } from "./useStashCount";
 
 interface UseSourceControlSetupParams {
@@ -196,40 +199,18 @@ export function useSourceControlSetup({
 
   const handleSourceControlFilterModeChange = useCallback(
     (mode: SourceControlFilterMode) => {
+      if (mode === sourceControlFilterMode) return;
       setSourceControlFilterMode(mode);
-      if (mode === "history" || mode === "pr" || mode === "issues") return;
-      setPrimaryPanel((prev: PanelState) => {
-        const tabIndex = prev.tabs.findIndex(
-          (item) => item.type === "source-control"
-        );
-        if (tabIndex === -1) return prev;
-        const existing = prev.tabs[tabIndex];
-        const nextStaged = mode === "staged";
-        const nextFileCount = sourceControlFilterCounts[mode];
-        const shouldUpdateStaged = existing.data.staged !== nextStaged;
-        const shouldUpdateFileCount = existing.data.fileCount !== nextFileCount;
-        const shouldClearHistory = Boolean(existing.data.historySelection);
-        if (
-          !shouldUpdateStaged &&
-          !shouldUpdateFileCount &&
-          !shouldClearHistory
-        ) {
-          return prev;
-        }
-        const nextTabs = [...prev.tabs];
-        nextTabs[tabIndex] = {
-          ...existing,
-          data: {
-            ...existing.data,
-            staged: nextStaged,
-            fileCount: nextFileCount,
-            historySelection: null,
-          },
-        };
-        return { ...prev, tabs: nextTabs };
-      });
+      setPrimaryPanel((prev) =>
+        switchSourceControlCategory(prev, mode, sourceControlFilterCounts)
+      );
     },
-    [setPrimaryPanel, setSourceControlFilterMode, sourceControlFilterCounts]
+    [
+      setPrimaryPanel,
+      setSourceControlFilterMode,
+      sourceControlFilterMode,
+      sourceControlFilterCounts,
+    ]
   );
 
   const setSourceControlFilterModeHandler = useSetAtom(

--- a/src/modules/WorkStation/TabContent/renderers/gitStashDetail.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/gitStashDetail.tsx
@@ -1,10 +1,7 @@
 /**
  * Renderer wrapper for `git-stash-detail` tabs.
  *
- * Same shape as `git-commit-detail` with a stash-flavoured header
- * (`headerVariant="stash"`, `headerRootLabel={stashRef}`) — a 1:1 mirror of
- * `TabContentRenderer`'s `case "git-stash-detail"`. Pulls repoPath / repoId /
- * file-select from the hoisted Code Editor host context.
+ * Uses the shared commit detail header and diff controls.
  */
 import React, { Suspense, memo } from "react";
 
@@ -29,7 +26,6 @@ const GitStashDetailTabRenderer: React.FC<UnifiedTabContentProps> = memo(
     const commitSha = String(tab.data.commitSha || "");
     const commitShortSha = String(tab.data.shortSha || "");
     const commitMsg = String(tab.data.commitMessage || "");
-    const stashRef = String(tab.data.stashRef || commitShortSha);
     const resolvedRepoId = repoId ?? repoPath;
     const repoReady = Boolean(repoPath && resolvedRepoId);
 
@@ -43,8 +39,6 @@ const GitStashDetailTabRenderer: React.FC<UnifiedTabContentProps> = memo(
           repoId={resolvedRepoId}
           isRepoReady={repoReady}
           onFileSelect={onFileSelect}
-          headerVariant="stash"
-          headerRootLabel={stashRef}
         />
       </Suspense>
     );

--- a/src/modules/WorkStation/shared/GitFileList/index.test.ts
+++ b/src/modules/WorkStation/shared/GitFileList/index.test.ts
@@ -16,9 +16,13 @@ import type { GitFile } from "@src/types/git/types";
 
 import GitFileList from ".";
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
+vi.mock("react-i18next", async () => {
+  const { createInstance } = await import("i18next");
+  const { default: en } = await import("@src/i18n/locales/en/common.json");
+  const instance = createInstance();
+  await instance.init({ lng: "en", resources: { en: { translation: en } } });
+  return { useTranslation: () => ({ t: instance.t.bind(instance) }) };
+});
 
 vi.mock("@src/components/FileTypeIcon", () => ({
   default: ({ fileName }: { fileName: string }) =>
@@ -127,6 +131,33 @@ describe("GitFileList row styling", () => {
       );
     });
 
-    expect(container.textContent).toContain("3000+");
+    expect(
+      container.querySelector(".group\\/header button")?.textContent
+    ).toContain("3000+ changed file");
+    expect(container.querySelector(".group\\/header > div > span")).toBeNull();
   });
+  it.each([0, 1, 2])(
+    "puts %i changed files in the title without a badge",
+    (count) => {
+      act(() =>
+        root.render(
+          React.createElement(GitFileList, {
+            files: Array.from({ length: count }, (_, i) => ({
+              ...file,
+              id: `file-${i}`,
+              path: `file-${i}.ts`,
+            })),
+            selectedFileId: null,
+            onFileSelect: vi.fn(),
+          })
+        )
+      );
+      expect(
+        container.querySelector(".group\\/header button")?.textContent
+      ).toBe(`${count} changed ${count === 1 ? "file" : "files"}`);
+      expect(
+        container.querySelector(".group\\/header > div > span")
+      ).toBeNull();
+    }
+  );
 });

--- a/src/modules/WorkStation/shared/GitFileList/index.tsx
+++ b/src/modules/WorkStation/shared/GitFileList/index.tsx
@@ -14,11 +14,13 @@
 import React, { memo, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import Button from "@src/components/Button";
 import FileTypeIcon from "@src/components/FileTypeIcon";
 import Input from "@src/components/Input";
 import {
   GitStatusBadge,
   TREE_ROW_HEIGHT,
+  TreeRowActionGroup,
   TreeRowBase,
 } from "@src/components/TreeRow";
 import type { GitStatusInfo, TreeRowNode } from "@src/components/TreeRow";
@@ -33,7 +35,6 @@ import {
   stickyRowPadding,
 } from "@src/components/VirtualizedStickyTree";
 import { getStatusColorForFile } from "@src/config/gitStatus";
-import { HEADER_BUTTON } from "@src/config/workstation/tokens";
 import {
   ArrowDown01Icon,
   ArrowRight01Icon,
@@ -446,52 +447,54 @@ const GitFileList: React.FC<GitFileListProps> = ({
   // Section header actions
   const sectionActions = useMemo(
     () => (
-      <div className="flex items-center gap-0.5 opacity-0 group-focus-within/header:opacity-100 group-hover/header:opacity-100">
+      <TreeRowActionGroup hoverGroup="sidebar">
         {showFilterToggle && (
-          <button
-            className={`${HEADER_BUTTON.actionTreeRow} ${showFilter ? "text-primary-6" : ""}`}
+          <Button
+            size="sidebar"
+            variant="tertiary"
+            appearance="soft-no-drop"
+            iconOnly
             onClick={handleFilterToggle}
             title={t("actions.search")}
             aria-label={t("actions.search")}
             aria-expanded={showFilter}
-          >
-            <HugeiconsIcon
-              icon={Search01Icon}
-              data-icon="search-icon"
-              size={14}
-              strokeWidth={1.75}
-              className={showFilter ? "text-primary-6" : "text-text-3"}
-            />
-          </button>
+            aria-pressed={showFilter}
+            icon={
+              <HugeiconsIcon
+                icon={Search01Icon}
+                data-icon="search-icon"
+                size={14}
+                strokeWidth={1.75}
+              />
+            }
+          />
         )}
-        <button
-          className={HEADER_BUTTON.actionTreeRow}
+        <Button
+          size="sidebar"
+          variant="tertiary"
+          appearance="soft-no-drop"
+          iconOnly
           onClick={handleViewModeToggle}
           title={
             viewMode === "list"
               ? t("workstation.switchToTreeView")
               : t("workstation.switchToListView")
           }
-        >
-          {viewMode === "list" ? (
+          aria-label={
+            viewMode === "list"
+              ? t("workstation.switchToTreeView")
+              : t("workstation.switchToListView")
+          }
+          icon={
             <HugeiconsIcon
-              icon={HierarchyFilesIcon}
-              data-icon="list-tree"
+              icon={viewMode === "list" ? HierarchyFilesIcon : ListIcon}
+              data-icon={viewMode === "list" ? "list-tree" : "list"}
               size={14}
               strokeWidth={1.75}
-              className="text-text-3"
             />
-          ) : (
-            <HugeiconsIcon
-              icon={ListIcon}
-              data-icon="list"
-              size={14}
-              strokeWidth={1.75}
-              className="text-text-3"
-            />
-          )}
-        </button>
-      </div>
+          }
+        />
+      </TreeRowActionGroup>
     ),
     [
       viewMode,
@@ -503,16 +506,19 @@ const GitFileList: React.FC<GitFileListProps> = ({
     ]
   );
 
-  const displayTitle = title ?? t("labels.changedFiles");
   const displayCountLabel = filterQuery ? undefined : unfilteredCountLabel;
+  const displayTitle =
+    title ??
+    t("labels.changedFilesCount", {
+      count: filteredFiles.length,
+      fileCount: displayCountLabel ?? filteredFiles.length,
+    });
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="group/sidebar flex h-full flex-col overflow-hidden">
       {/* Section header */}
       <SectionHeader
         title={displayTitle}
-        count={filteredFiles.length}
-        countLabel={displayCountLabel}
         isCollapsed={isCollapsed}
         onToggle={() => setIsCollapsed((prev) => !prev)}
         actions={sectionActions}

--- a/src/modules/WorkStation/shared/PrimarySidebarLayout/CollapsibleSection.tsx
+++ b/src/modules/WorkStation/shared/PrimarySidebarLayout/CollapsibleSection.tsx
@@ -191,11 +191,12 @@ export const CollapsibleSection: React.FC<CollapsibleSectionProps> = memo(
                 const hasLabel = !!action.label;
                 const button = (
                   <button
+                    disabled={action.disabled}
                     onClick={(event) => {
                       event.stopPropagation();
                       action.onClick();
                     }}
-                    className={`${SECTION_ACTION_BUTTON.base} ${
+                    className={`${SECTION_ACTION_BUTTON.base} disabled:opacity-50 ${
                       hasLabel
                         ? SECTION_ACTION_BUTTON.withLabel
                         : SECTION_ACTION_BUTTON.iconOnly

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.test.ts
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.test.ts
@@ -14,17 +14,23 @@ vi.mock("@src/components/Select", () => ({
   default: ({
     options,
     value,
+    showTriggerIcon,
   }: {
-    options: { value: string }[];
+    options: { value: string; icon?: unknown }[];
+    showTriggerIcon?: boolean;
     value: string;
   }) =>
     createElement(
       "select",
-      { value, readOnly: true },
+      { value, readOnly: true, "data-trigger-icon": String(showTriggerIcon) },
       options.map((option) =>
         createElement(
           "option",
-          { key: option.value, value: option.value },
+          {
+            key: option.value,
+            value: option.value,
+            "data-has-icon": String(Boolean(option.icon)),
+          },
           option.value
         )
       )
@@ -51,6 +57,14 @@ it.each(["staged", "unstaged"] as const)(
       [...container.querySelectorAll("option")].map((option) => option.value);
     try {
       render();
+      expect(container.querySelector("select")!.dataset.triggerIcon).toBe(
+        "false"
+      );
+      expect(
+        [...container.querySelectorAll("option")].every(
+          (option) => option.dataset.hasIcon === "true"
+        )
+      ).toBe(true);
       expect(values()).toEqual([
         "uncommitted",
         "unstaged",

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.tsx
@@ -19,7 +19,18 @@ import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip"
 import Select from "@src/components/Select";
 import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
-import { EllipsisIcon, HugeiconsIcon, Refresh04Icon } from "@src/icons";
+import {
+  Archive03Icon,
+  CircleDotIcon,
+  EllipsisIcon,
+  FileDiffIcon,
+  GitCommitIcon,
+  GitPullRequestIcon,
+  HugeiconsIcon,
+  MinusSignIcon,
+  Refresh04Icon,
+  Tick01Icon,
+} from "@src/icons";
 import type { SourceControlFilterMode } from "@src/store/workstation/codeEditor/sourceControlTypes";
 
 export type { SourceControlFilterMode } from "@src/store/workstation/codeEditor/sourceControlTypes";
@@ -29,6 +40,20 @@ export interface SourceControlFilterCounts {
   unstaged: number;
   staged: number;
   stashed: number;
+}
+
+const FILTER_ICONS = {
+  uncommitted: FileDiffIcon,
+  unstaged: MinusSignIcon,
+  staged: Tick01Icon,
+  stashed: Archive03Icon,
+  history: GitCommitIcon,
+  pr: GitPullRequestIcon,
+  issues: CircleDotIcon,
+} as const;
+
+function filterIcon(mode: SourceControlFilterMode) {
+  return <HugeiconsIcon icon={FILTER_ICONS[mode]} size={HEADER_ICON_SIZE.sm} />;
 }
 
 interface FilterRowEntry {
@@ -123,6 +148,7 @@ const SourceControlFilterHeader: React.FC<SourceControlFilterHeaderProps> =
             typeof count === "number" ? getCountLabel(count, label) : label;
           return {
             value: row.id,
+            icon: filterIcon(row.id),
             label: <span className="whitespace-nowrap">{triggerLabel}</span>,
             triggerLabel,
           };
@@ -132,6 +158,7 @@ const SourceControlFilterHeader: React.FC<SourceControlFilterHeaderProps> =
           ...fileOptions,
           {
             value: "history",
+            icon: filterIcon("history"),
             label: (
               <span className="whitespace-nowrap">
                 {t("common:labels.gitHistory")}
@@ -141,6 +168,7 @@ const SourceControlFilterHeader: React.FC<SourceControlFilterHeaderProps> =
           },
           {
             value: "pr",
+            icon: filterIcon("pr"),
             label: (
               <span className="whitespace-nowrap">
                 {t("common:labels.pullRequest", "Pull request")}
@@ -150,6 +178,7 @@ const SourceControlFilterHeader: React.FC<SourceControlFilterHeaderProps> =
           },
           {
             value: "issues",
+            icon: filterIcon("issues"),
             label: (
               <span className="whitespace-nowrap">
                 {t("common:labels.issues", "Issues")}
@@ -183,6 +212,7 @@ const SourceControlFilterHeader: React.FC<SourceControlFilterHeaderProps> =
             value={stageModeHidden ? "uncommitted" : mode}
             onChange={handleSelect}
             options={options}
+            showTriggerIcon={false}
             size="small"
             appearance="ghost"
             radius="lg"

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
@@ -18,6 +18,7 @@ import type { GitWorktreeEntry } from "@src/api/http/git/types";
 import AnyIcon from "@src/components/AnyIcon";
 import { Placeholder } from "@src/components/Placeholder";
 import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
+import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import { useGitStatus } from "@src/contexts/git/GitStatusContext/useGitStatus";
 import { sessionIdAtom } from "@src/engines/SessionCore";
 import { useFileReviewBatchActions } from "@src/hooks/fileReview";
@@ -38,6 +39,7 @@ import {
   ICON_CONFIG,
   PANEL_CONSTANTS,
 } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/config";
+import { StashHeaderContext } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/StashContent/StashHeaderContext";
 import { useSourceControlActions } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks";
 import { useSectionFilter } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSectionFilter";
 import {
@@ -135,6 +137,9 @@ export function useSourceControlSidebarModule({
   useMountedCleanup(mountedRef);
 
   const [showFilter, setShowFilter] = useState(false);
+  const [historyViewMode, setHistoryViewMode] = useState<"graph" | "list">(
+    "graph"
+  );
   const [viewMode, setViewMode] = useState<"list-tree" | "list">("list-tree");
   const {
     isOpen: showPrFilter,
@@ -198,6 +203,28 @@ export function useSourceControlSidebarModule({
         tooltip: t("common:actions.search"),
       }),
       {
+        key: "history-view-mode",
+        icon: (
+          <AnyIcon
+            icon={
+              historyViewMode === "graph"
+                ? ICON_CONFIG.list
+                : ICON_CONFIG.listTree
+            }
+            size={PANEL_CONSTANTS.ACTION_ICON_SIZE}
+            strokeWidth={PANEL_CONSTANTS.ACTION_ICON_STROKE}
+          />
+        ),
+        tooltip: t(
+          historyViewMode === "graph"
+            ? "common:workstation.switchToListView"
+            : "common:workstation.switchToGraphView"
+        ),
+        onClick: () =>
+          setHistoryViewMode((mode) => (mode === "graph" ? "list" : "graph")),
+        forceVisible: true,
+      },
+      {
         key: "refresh-git-history",
         icon: (
           <AnyIcon
@@ -217,6 +244,7 @@ export function useSourceControlSidebarModule({
       handleToggleHistoryFilter,
       handleHistoryRefreshClick,
       historyRefreshSpinClass,
+      historyViewMode,
       t,
     ]
   );
@@ -253,7 +281,7 @@ export function useSourceControlSidebarModule({
         <HugeiconsIcon
           icon={RotateLeft01Icon}
           data-icon="rotate-ccw"
-          size={PANEL_CONSTANTS.ACTION_ICON_SIZE}
+          size={HEADER_ICON_SIZE.discard}
           strokeWidth={PANEL_CONSTANTS.ACTION_ICON_STROKE}
         />
       ),
@@ -432,7 +460,7 @@ export function useSourceControlSidebarModule({
           <GitHistoryContent
             repoPath={repoPath}
             repoId={repoId}
-            viewMode="graph"
+            viewMode={historyViewMode}
             onRefreshReady={handleHistoryRefreshReady}
             onHistorySelectionChange={onGitHistorySelectionChange}
             filterQuery={historyFilterQuery}
@@ -442,6 +470,7 @@ export function useSourceControlSidebarModule({
     ),
     [
       showHistoryFilter,
+      historyViewMode,
       historyFilterQuery,
       setHistoryFilterQuery,
       clearHistoryFilter,
@@ -542,5 +571,30 @@ export function useSourceControlSidebarModule({
           : undefined,
   });
 
-  return useMemo(() => ({ tab, ref: sourceControlRef }), [tab]);
+  const stashHeader = useMemo(
+    () => ({
+      onBack: () => onFilterModeChange?.("uncommitted"),
+      actions: actions.map((action) => ({ ...action, forceVisible: true })),
+    }),
+    [actions, onFilterModeChange]
+  );
+
+  return useMemo(
+    () => ({
+      tab:
+        filterMode === "stashed"
+          ? {
+              ...tab,
+              sections: undefined,
+              rawContent: (
+                <StashHeaderContext.Provider value={stashHeader}>
+                  {tab.sections?.[0]?.content}
+                </StashHeaderContext.Provider>
+              ),
+            }
+          : tab,
+      ref: sourceControlRef,
+    }),
+    [tab, filterMode, stashHeader]
+  );
 }

--- a/src/modules/WorkStation/shared/UnsavedChangesBar/index.tsx
+++ b/src/modules/WorkStation/shared/UnsavedChangesBar/index.tsx
@@ -76,7 +76,7 @@ const FloatingBarUnsaved: React.FC<UnsavedChangesBarProps> = memo(
               <HugeiconsIcon
                 icon={Undo03Icon}
                 data-icon="undo-3"
-                size={HEADER_ICON_SIZE.sm}
+                size={HEADER_ICON_SIZE.discard}
                 strokeWidth={1.75}
               />
             }

--- a/src/modules/shared/components/FileHeader/FileHeader.test.ts
+++ b/src/modules/shared/components/FileHeader/FileHeader.test.ts
@@ -25,8 +25,9 @@ it("moves the live file menu into its host toolbar and releases it on unmount", 
   document.body.append(container, toolbar);
   const root = createRoot(container);
   const onSearch = vi.fn();
+  const onClose = vi.fn();
   const store = createStore();
-  const render = (target: HTMLElement | null) =>
+  const render = (target: HTMLElement | "host" | null) =>
     act(() =>
       root.render(
         createElement(
@@ -41,6 +42,9 @@ it("moves the live file menu into its host toolbar and releases it on unmount", 
               viewMode: "split",
               onViewModeChange: vi.fn(),
               onSearchRequest: onSearch,
+              showOpenFileAction: true,
+              onFileSelect: vi.fn(),
+              onClose,
             })
           )
         )
@@ -55,9 +59,28 @@ it("moves the live file menu into its host toolbar and releases it on unmount", 
     ).toBeNull();
     act(() => toolbar.querySelector("button")!.click());
     expect(onSearch).toHaveBeenCalledOnce();
+    render("host");
+    expect(toolbar.childElementCount).toBe(0);
+    expect(container.textContent).not.toContain("file menu");
+    expect(container.querySelector('[data-icon="file-symlink"]')).toBeNull();
+    expect(
+      container.querySelector('[aria-label="workstation.switchToUnifiedDiff"]')
+    ).toBeNull();
+    expect(container.querySelectorAll("button")).toHaveLength(1);
+    act(() =>
+      container
+        .querySelector<HTMLButtonElement>(
+          '[aria-label="common:actions.close"]'
+        )!
+        .click()
+    );
+    expect(onClose).toHaveBeenCalledOnce();
     render(null);
     expect(toolbar.childElementCount).toBe(0);
     expect(container.textContent).toContain("file menu");
+    expect(
+      container.querySelector('[data-icon="file-symlink"]')
+    ).not.toBeNull();
     expect(
       container.querySelector('[aria-label="workstation.switchToUnifiedDiff"]')
     ).not.toBeNull();

--- a/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts
+++ b/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts
@@ -135,7 +135,7 @@ describe("FileHeaderMoreMenu", () => {
       showReloadButton: false,
     });
     const menu = element("file-header-more-menu");
-    expect(menu.textContent).toContain("sessions:chat.pageSettings");
+    expect(menu.textContent).toContain("common:common.display");
     expect(
       [...menu.children].filter(
         (child) => child.className === DROPDOWN_CLASSES.menuGroupSeparator

--- a/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.tsx
+++ b/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.tsx
@@ -320,7 +320,7 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
                   <HugeiconsIcon
                     icon={Undo03Icon}
                     data-icon="undo-3"
-                    size={HEADER_ICON_SIZE.sm}
+                    size={HEADER_ICON_SIZE.discard}
                   />
                 }
                 disabled={discardDisabled}
@@ -456,7 +456,7 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
               )}
             {hasDisplaySettings && (
               <ActionSubmenu
-                label={t("sessions:chat.pageSettings")}
+                label={t("common:common.display")}
                 icon={
                   <HugeiconsIcon
                     icon={Layers01Icon}

--- a/src/modules/shared/components/FileHeader/FileHeaderToolbarContext.ts
+++ b/src/modules/shared/components/FileHeader/FileHeaderToolbarContext.ts
@@ -1,4 +1,6 @@
 import { createContext } from "react";
 
-/** Optional file-menu destination; the host toolbar owns the diff toggle. */
-export const FileHeaderToolbarContext = createContext<HTMLElement | null>(null);
+/** A host may supply its own menu or a destination for the active file's menu. */
+export const FileHeaderToolbarContext = createContext<
+  HTMLElement | "host" | null
+>(null);

--- a/src/modules/shared/components/FileHeader/index.tsx
+++ b/src/modules/shared/components/FileHeader/index.tsx
@@ -33,7 +33,12 @@ import TabPill from "@src/components/TabPill";
 import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import type { WorkstationTabHeaderHost } from "@src/hooks/tabHost/useWorkstationTabHeader";
 import { useRefreshSpin } from "@src/hooks/ui/useRefreshSpin";
-import { Cancel01Icon, FileSymlinkIcon, HugeiconsIcon } from "@src/icons";
+import {
+  Cancel01Icon,
+  FileSymlinkIcon,
+  HugeiconsIcon,
+  LinkSquare02Icon,
+} from "@src/icons";
 import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader/tokens";
 import type { DiffViewMode } from "@src/types/git/types";
 import { copyText } from "@src/util/data/clipboard";
@@ -84,6 +89,8 @@ export interface FileHeaderProps {
   renderFileActions?: (close: () => void) => React.ReactNode;
   /** Extra actions to render on the right */
   extraActions?: React.ReactNode;
+  /** Read-only labels shown before the trailing action group. */
+  metadata?: React.ReactNode;
   /** Optional control rendered immediately before the trailing more menu. */
   beforeMoreMenuSlot?: React.ReactNode;
   /** For git diffs: current view mode */
@@ -102,6 +109,8 @@ export interface FileHeaderProps {
   showOpenFileAction?: boolean;
   /** Optional adjacent close action for dismissible file previews. */
   onClose?: () => void;
+  /** Open this detail in its own tab, immediately before Close. */
+  onOpenInNewTab?: () => void;
   /** Callback when reload is requested */
   onReload?: () => void;
   /** Callback when editor search is requested from the more menu. */
@@ -191,6 +200,7 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
     additions,
     deletions,
     extraActions,
+    metadata,
     renderFileActions,
     beforeMoreMenuSlot,
     viewMode,
@@ -201,6 +211,7 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
     onFileSelect,
     showOpenFileAction = false,
     onClose,
+    onOpenInNewTab,
     onReload,
     onSearchRequest,
     onGoToLineRequest,
@@ -241,7 +252,9 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
         loading ?? false,
         reloadSpinPersistenceKey
       );
-    const toolbarTarget = useContext(FileHeaderToolbarContext);
+    const toolbar = useContext(FileHeaderToolbarContext);
+    const hostOwnsControls = toolbar !== null;
+    const toolbarTarget = toolbar === "host" ? null : toolbar;
     const [moreMenuVisible, setMoreMenuVisible] = useState(false);
     const [reloadMenuCoolingDown, setReloadMenuCoolingDown] = useState(false);
     const reloadMenuCooldownTimerRef = useRef<ReturnType<
@@ -352,7 +365,8 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
     }, [onMoreSettings]);
 
     const hasStats = additions !== undefined || deletions !== undefined;
-    const showViewModeToggle = viewMode && onViewModeChange;
+    const showViewModeToggle =
+      !hostOwnsControls && viewMode && onViewModeChange;
     const showCustomToggle = toggleOptions && toggleValue && onToggleChange;
     const showReloadButton = !!onReload;
     const showSearchAction = !!onSearchRequest;
@@ -384,9 +398,15 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
     const showPreviewButton = isMarkdownFile && onTogglePreview && !hasStats;
     const showAnyTabSwitch =
       showViewModeToggle || showCustomToggle || showPreviewButton;
+    const showInlineMoreMenu = showMoreMenu && !hostOwnsControls;
+    const showInlineOpenFileAction =
+      showOpenFileAction && !!onFileSelect && !hostOwnsControls;
     const showCloseAction = !!onClose;
     const showHeaderActionButtons =
-      showMoreMenu || showOpenFileAction || showCloseAction;
+      showInlineMoreMenu ||
+      showInlineOpenFileAction ||
+      !!onOpenInNewTab ||
+      showCloseAction;
     const breadcrumbLastSegmentIcon = headerIcon ? (
       headerIcon
     ) : useFileTypeIcon && filePath ? (
@@ -402,9 +422,11 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
       showCustomToggle ||
       showPreviewButton ||
       !!beforeMoreMenuSlot ||
-      showMoreMenu ||
-      showOpenFileAction ||
+      showInlineMoreMenu ||
+      showInlineOpenFileAction ||
       showCloseAction ||
+      !!onOpenInNewTab ||
+      !!metadata ||
       !!extraActions;
 
     const viewModeToggle = showViewModeToggle ? (
@@ -495,9 +517,7 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
             )}
 
             {/* Separator before tab pills */}
-            {((showViewModeToggle && !toolbarTarget) ||
-              showCustomToggle ||
-              showPreviewButton) &&
+            {(showViewModeToggle || showCustomToggle || showPreviewButton) &&
               hasStats &&
               (additions! > 0 || deletions! > 0) && (
                 <div
@@ -507,7 +527,7 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
                 />
               )}
             {/* View Mode Toggle (for diffs) */}
-            {showViewModeToggle && !toolbarTarget && viewModeToggle}
+            {viewModeToggle}
 
             {/* Custom Toggle — TabPill pill (matches source control / preview) */}
             {showCustomToggle && (
@@ -564,24 +584,23 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
             )}
 
             {/* Vertical separator: tab switches | other buttons */}
-            {showAnyTabSwitch &&
-              !toolbarTarget &&
-              (showHeaderActionButtons || extraActions) && (
-                <div
-                  className={`${PANEL_HEADER_TOKENS.verticalSeparator} mx-1.5`}
-                  role="separator"
-                  aria-hidden
-                />
-              )}
+            {showAnyTabSwitch && (showHeaderActionButtons || extraActions) && (
+              <div
+                className={`${PANEL_HEADER_TOKENS.verticalSeparator} mx-1.5`}
+                role="separator"
+                aria-hidden
+              />
+            )}
 
+            {metadata}
             {(showHeaderActionButtons || beforeMoreMenuSlot) && (
               <span className="flex items-center gap-px">
                 {beforeMoreMenuSlot}
 
                 {/* More actions */}
-                {showMoreMenu && !toolbarTarget && moreMenu}
+                {showInlineMoreMenu && moreMenu}
 
-                {showOpenFileAction && onFileSelect && (
+                {showInlineOpenFileAction && (
                   <Button
                     htmlType="button"
                     variant="tertiary"
@@ -601,6 +620,24 @@ export const FileHeader: React.FC<FileHeaderProps> = memo(
                   />
                 )}
 
+                {onOpenInNewTab && (
+                  <Button
+                    htmlType="button"
+                    variant="tertiary"
+                    size="small"
+                    iconOnly
+                    onClick={onOpenInNewTab}
+                    title={t("common:actions.openInNewTab")}
+                    aria-label={t("common:actions.openInNewTab")}
+                    className="shrink-0"
+                    icon={
+                      <HugeiconsIcon
+                        icon={LinkSquare02Icon}
+                        size={HEADER_ICON_SIZE.sm}
+                      />
+                    }
+                  />
+                )}
                 {showCloseAction && (
                   <Button
                     htmlType="button"

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.test.ts
@@ -162,7 +162,7 @@ describe("docked terminal controls", () => {
       } else {
         expect(button.style.height).toBe("20px");
         expect(button.style.width).toBe("20px");
-        expect(button.style.borderRadius).toBe("8px");
+        expect(button.style.borderRadius).toBe("var(--radius-sm)");
       }
     }
     expect(

--- a/src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts
+++ b/src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts
@@ -72,7 +72,7 @@ describe("WorkstationTrailSurface", () => {
     expect(markup).toContain("height:20px");
     expect(markup).toContain("width:20px");
     expect(markup).toContain("items-center gap-px");
-    expect(markup).toContain("border-radius:8px");
+    expect(markup).toContain("border-radius:var(--radius-sm)");
   });
 
   it("shares the labelled trail section used by property and detail rails", () => {

--- a/src/scaffold/GlobalSpotlight/forms/shared/SpotlightFormShell.test.ts
+++ b/src/scaffold/GlobalSpotlight/forms/shared/SpotlightFormShell.test.ts
@@ -22,7 +22,7 @@ describe("SpotlightFormShell", () => {
         "[--modal-chrome-padding:--spacing(3)]",
       ])
     );
-    expect(markup).toContain('class="p-3"');
+    expect(markup).toContain('class="px-3 pb-3"');
     expect(markup).not.toContain("border");
     expect(markup).not.toContain("rounded");
   });

--- a/src/scaffold/GlobalSpotlight/forms/shared/SpotlightFormShell.tsx
+++ b/src/scaffold/GlobalSpotlight/forms/shared/SpotlightFormShell.tsx
@@ -39,7 +39,7 @@ interface SpotlightFormBodyProps {
 }
 
 /**
- * Standard body region for a form panel. Applies the canonical `p-3`
+ * Standard body region for a form panel. Applies the canonical `px-3 pb-3`
  * inset so the body and the `PanelFooter` (`px-3 h-12`) line up on the
  * horizontal axis.
  */

--- a/src/scaffold/GlobalSpotlight/forms/shared/spotlightModalFormTokens.ts
+++ b/src/scaffold/GlobalSpotlight/forms/shared/spotlightModalFormTokens.ts
@@ -1,6 +1,6 @@
 import { INPUT_AREA } from "@src/config/inputAreaTokens";
 
 export const SPOTLIGHT_MODAL_FORM_TOKENS = {
-  bodyClassName: "p-3",
+  bodyClassName: "px-3 pb-3",
   shellClassName: `overflow-hidden [--modal-chrome-padding:--spacing(3)] ${INPUT_AREA.backgroundChatPanelClass}`,
 } as const;


### PR DESCRIPTION
## Problem

Review and Source Control surfaces duplicate headers and editor controls, retain stale detail after category switches, and use inconsistent row/action styling. Diff deleted lines also ignore the shared word-wrap setting, and commit titles containing slashes become multiple path breadcrumbs.

## Solution

Consolidate the remaining review/editor presentation changes into one PR: one owner for top-level controls; dismissible detail and category reset; explicit commit breadcrumb segments; single stash navigation/count header; graph/list history toggle with inset rows; shared display labels; and shared compact button, no-drop, danger and discard-icon tokens. Second-level actions follow their sidebar hover/focus state. Category dropdown options show icons while the header trigger stays text-only. All Changes uses only the shared shell right padding, avoiding a doubled inset. Remove extra CodeMirror top padding and finish the existing Spotlight body-padding change at its owning token.

## Potential risks

Shared button geometry affects compact actions beyond Source Control. Narrow layouts, dark theme, multi-root/worktree navigation, and real-app hover behavior have not been visually checked. No screenshots were captured because desktop control requires explicit user opt-in; the user-provided screenshots show the original issues, not proof of the final result. Existing settings and mutation owners are reused; there are no dependency, persisted-schema, public API or wire changes. Reverting this PR restores the prior presentation and selection behavior.

## Verification

- `pnpm typecheck:fast` — passed in the isolated branch.
- `pnpm check:i18n-keys` — passed, with no new missing keys or locale gaps.
- Targeted ESLint across every changed TypeScript file — passed; normal commit hooks also run oxlint, ESLint, Prettier and the staged TypeScript gate.
- 15 targeted Vitest suites: 103 tests passed initially; the one Spotlight padding failure identified an incomplete local edit. After fixing the owning token, `pnpm exec vitest run --config config/vitest.config.ts src/scaffold/GlobalSpotlight/forms/shared/SpotlightFormShell.test.ts` passed. Total: 104 passing tests across those runs.
- `git diff origin/develop...HEAD --check` — passed; final diff reviewed for unrelated files and sensitive data.
- No native build or desktop visual/performance measurements were run. This PR does not claim a runtime performance improvement.

- Follow-up: `pnpm exec vitest run --config config/vitest.config.ts src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts` — 16 tests passed in the isolated branch. Normal commit hooks passed for the follow-up.

Targeted suite command:

```sh
pnpm exec vitest run --config config/vitest.config.ts src/components/Button/index.test.ts src/engines/ChatPanel/components/SessionHeaderActionsMenu.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitHistoryContent.remount.test.ts src/modules/WorkStation/CodeEditor/__tests__/sourceControlStateTransitions.test.ts src/modules/WorkStation/shared/GitFileList/index.test.ts src/modules/shared/components/FileHeader/FileHeader.test.ts src/modules/shared/components/FileHeader/FileHeaderMoreMenu.test.ts src/scaffold/GlobalSpotlight/forms/shared/SpotlightFormShell.test.ts src/features/CodeMirror/Diff/wordWrap.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitInfoPanel.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/CommitTabHeader.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/StashContent/StashContent.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/SourceControlTreeRow.test.ts
```
