### PR TITLE
style(hover-card): align URL row and copy icon presentation

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/HoverCardUrlDelivery.md
+++ b/docs/frontend-ui-audit-2026-09-13/HoverCardUrlDelivery.md
@@ -1,0 +1,10 @@
+# Hover card URL presentation audit
+
+| Line                     | Element      | Verdict          | Reason                                                                                                                                                | Suggested change                               |
+| ------------------------ | ------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `HoverCardUrlRow.tsx:46` | URL icon row | keep with reason | Local edit uses HoverCardRow directly with the canonical icon size and stroke; appearance and link behavior remain equivalent to the metadata adapter | Retain requested local composition             |
+| `LinkHoverCard.tsx:168`  | Copy icon    | fix              | Explicit stroke duplicated the Button-owned icon presentation                                                                                         | Applied: inherit stroke from the shared Button |
+
+Verdict totals: **1 fix**, **1 keep with reason**, **0 abstract**.
+
+Verification: targeted ESLint, full typecheck, and three hover-card Vitest suites passed (11 tests). No desktop screenshots were captured because computer control requires explicit opt-in. No interaction, request, persistence, or lifecycle ownership was changed.

--- a/src/components/HoverCard/HoverCardUrlRow.tsx
+++ b/src/components/HoverCard/HoverCardUrlRow.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 
+import { HOVER_CARD } from "@src/components/HoverCard/tokens";
 import { createLogger } from "@src/hooks/logger";
-import { InternetIcon } from "@src/icons";
+import { HugeiconsIcon, InternetIcon } from "@src/icons";
 import { openExternalLink } from "@src/util/platform/ipcRenderer";
 
-import { HoverCardMetadataRow } from "./HoverCardMetadataRow";
+import { HoverCardRow } from "./HoverCardBase";
 
 const logger = createLogger("HoverCardUrlRow");
 
@@ -42,7 +43,16 @@ export const HoverCardUrlRow: React.FC<HoverCardUrlRowProps> = ({ url }) => {
   const label = formatCompactUrl(url);
 
   return (
-    <HoverCardMetadataRow icon={InternetIcon} dataIcon="globe">
+    <HoverCardRow
+      icon={
+        <HugeiconsIcon
+          icon={InternetIcon}
+          data-icon="globe"
+          size={HOVER_CARD.iconSize}
+          strokeWidth={HOVER_CARD.iconStrokeWidth}
+        />
+      }
+    >
       <button
         type="button"
         className={HOVER_CARD_LINK_ROW_CLASS_NAME}
@@ -51,7 +61,7 @@ export const HoverCardUrlRow: React.FC<HoverCardUrlRowProps> = ({ url }) => {
       >
         {label}
       </button>
-    </HoverCardMetadataRow>
+    </HoverCardRow>
   );
 };
 

--- a/src/components/MarkDown/LinkHoverCard.tsx
+++ b/src/components/MarkDown/LinkHoverCard.tsx
@@ -168,7 +168,6 @@ const LinkHoverCardContent: React.FC<LinkHoverCardContentProps> = ({
               icon={Copy01Icon}
               data-icon="copy"
               size={HOVER_CARD.iconSize}
-              strokeWidth={HOVER_CARD.iconStrokeWidth}
             />
           }
           iconOnly


### PR DESCRIPTION
## Problem

The remaining hover-card edits align URL-row composition and copy-icon rendering with the shared hover-card and Button presentation rules.

## Solution

Render the URL row through HoverCardRow with canonical icon geometry, and let the shared Button provide the copy icon stroke. URL formatting, link opening and card layout remain unchanged.

## Potential risks

Copy-icon appearance has not been checked in the desktop app or across themes; screenshots were not captured because desktop control requires explicit opt-in. No data, API, dependency or lifecycle behavior changes. Reverting this PR restores the previous composition.

## Verification

- `pnpm exec eslint src/components/HoverCard/HoverCardUrlRow.tsx src/components/MarkDown/LinkHoverCard.tsx` — passed.
- `pnpm typecheck:fast` — passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/components/HoverCard/HoverCardBase.test.ts src/components/HoverCard/HoverCard.test.ts src/components/MarkDown/LinkHoverCard.helpers.test.ts` — 11 tests passed.
- Normal commit hooks run staged oxlint, ESLint, Prettier and TypeScript checks.
- `git diff origin/develop...HEAD --check` — passed. No native build or visual inspection performed.
