### PR TITLE
fix(workstation): simplify station header padding

### DIFF
--- a/src/modules/WorkStation/AppShell/WorkstationTabHeader.test.ts
+++ b/src/modules/WorkStation/AppShell/WorkstationTabHeader.test.ts
@@ -119,7 +119,8 @@ describe("WorkstationTabHeader", () => {
     );
 
     expect(markup).toContain("Work Items");
-    expect(markup).toContain("pl-0");
+    expect(markup).not.toContain("pl-1.5");
+    expect(markup).not.toContain("pl-0");
     expect(markup).not.toContain('data-icon="list"');
   });
 
@@ -139,7 +140,7 @@ describe("WorkstationTabHeader", () => {
     );
 
     expect(markup).toContain("develop");
-    expect(markup).toContain("pl-0");
+    expect(markup).not.toContain("pl-0");
     expect(markup).not.toContain("pl-2");
     expect(markup).not.toContain("pl-[15px]");
   });

--- a/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
+++ b/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
@@ -50,9 +50,7 @@ const WorkstationTabHeader: React.FC = memo(() => {
   // WebUrlBar), so it starts flush with the shell edge rather than behind a
   // redundant leading gutter.
   const joinsSidebarGroup = isSourceControlTab || isBrowserTab;
-  const publishedHeaderPaddingLeftClassName = joinsSidebarGroup
-    ? "pl-0"
-    : "pl-2";
+  const publishedHeaderPaddingLeftClassName = joinsSidebarGroup ? "" : "pl-2";
 
   if (headerSlots?.hidden) return null;
 
@@ -64,7 +62,7 @@ const WorkstationTabHeader: React.FC = memo(() => {
     <div
       className={`flex h-9 shrink-0 items-center ${
         isBrowserTab ? "gap-px" : "gap-2"
-      } pr-2 ${shellLeadingChromeHidden ? "pl-0" : "pl-1.5"} ${
+      } pr-2 ${shellLeadingChromeHidden ? "" : "pl-1.5"} ${
         headerSlots?.joinWithFollowingRow ? "" : "border-b border-border-2"
       }`}
       data-tauri-drag-region={windowsHost ? undefined : true}

--- a/src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx
+++ b/src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx
@@ -65,7 +65,7 @@ const SimulatorWorkstationTabHeaderComponent: React.FC<
         ) : null}
       </NoDragRegion>
       <HeaderSectionSeparator />
-      <PublishedHeaderSlotsView slots={headerSlots} />
+      <PublishedHeaderSlotsView slots={headerSlots} paddingLeftClassName="" />
     </div>
   );
 };


### PR DESCRIPTION
## Problem

Agent Station title rows inherited the shared published header's 15px left inset, adding unwanted space after the sidebar separator. My Station also emitted explicit zero-padding classes for Browser, Source Control, and surfaces that hide shell-leading controls.

## Solution

Use the existing empty-string padding option in Agent Station to omit the inset. In My Station, omit the class in both zero-inset branches while preserving the existing 8px title inset and 6px outer inset wherever applicable. This follows the existing Chat header convention without adding an API or changing shared defaults. Update existing My Station header assertions to verify the omitted classes.

## Potential risks

Agent Station titles move 15px left as requested. My Station spacing should remain equivalent because these divs have no other left-padding rule to override. Desktop rendering across themes and viewport sizes has not been visually verified; desktop UI control was not authorized. No state, event handling, dependencies, persistence, or public API changes are included. Reverting this commit restores the prior spacing.

## Verification

- `pnpm exec eslint src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx src/modules/WorkStation/AppShell/WorkstationTabHeader.test.ts src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx --max-warnings 0` — passed.
- `pnpm test src/modules/WorkStation/AppShell/WorkstationTabHeader.test.ts src/engines/ChatPanel/ChatPanelHeader.test.ts src/engines/ChatPanel/header/ChatPanelPublishedHeader.test.ts src/features/DiscussionChannels/ChannelPanelView/ChannelPanelView.test.ts` — all 44 tests across four files passed.
- Commit hook lint-staged checks and TypeScript check — passed.
- `git diff --cached --check` — passed; inspected the complete three-file diff for unrelated changes and sensitive content.
- Fetched `origin/develop`; branch includes the latest target state at verification time.
- No desktop screenshots or manual UI checks were collected, per the workspace's explicit opt-in requirement. Full test suite not run for this small styling change. The UI audit skill excludes pure styling touch-ups without structural changes.
