### PR TITLE
fix(workstation-trail): align repository rows and collapsed summaries

### DIFF
--- a/docs/frontend-ui-audit-2026-09-13/WorkstationTrail.md
+++ b/docs/frontend-ui-audit-2026-09-13/WorkstationTrail.md
@@ -1,0 +1,24 @@
+# Workstation trail UI audit
+
+| Line                                                             | Element             | Verdict          | Reason                                                                                                         | Suggested change |
+| ---------------------------------------------------------------- | ------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `FocusedChatWorkstationRail/index.tsx:659`                       | Repository sections | keep with reason | Each repository supplies its heading; no duplicate local repository row; session folder precedes harness       | None             |
+| `FocusedChatWorkstationRail/WorkstationItemRow.tsx:57`           | Action rows         | keep with reason | Shared Button uses soft-no-drop with shared row typography, 14px icon box and left-aligned label               | None             |
+| `blocks/workstationTrailTokens.ts:40`                            | Row appearance      | keep with reason | Shared constants align passive and clickable rows; wide and compact retain their respective original sizes     | None             |
+| `blocks/WorkstationTrailSurface.tsx:88`                          | Header titles       | keep with reason | Original muted title style, tight chevron gap and transparent hover; other controls use shared sidebar buttons | None             |
+| `FocusedChatWorkstationRail/WorkstationCollapsedDiffStats.tsx:7` | Folded totals       | keep with reason | Shared DiffStatsBadge follows the chevron, without another interactive control                                 | None             |
+
+Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.
+
+## Performance guard
+
+| Area            | Verdict | Evidence                                                                     | Change or reason kept                                                  | Verification                              |
+| --------------- | ------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------- |
+| Background work | keep    | Existing shared numstat store owns push listeners and single-flight requests | Folded headings intentionally display live summaries; no polling added | Shared-store and rail tests               |
+| Memory          | keep    | Last subscriber removes listener and evicts store entry                      | Expanded row and collapsed badge use the same repository store         | Store cleanup tests and source inspection |
+| Scope/isolation | keep    | Repository ID and path from each section                                     | Secondary summaries retain their own totals                            | Wide and compact multi-repository tests   |
+| Rendering       | keep    | Small badge owns totals subscription                                         | No rail-wide totals subscription                                       | Source inspection                         |
+
+Performance verdict: pass for the changed subscription lifecycle. CPU/RSS and native visual checks were not performed. No runtime performance improvement is claimed.
+
+Visual checks were not performed because local computer control requires explicit opt-in. Automated verification and its exact commands are recorded in the pull request.

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
@@ -46,13 +46,13 @@ describe("shouldMountFocusedChatWorkstationControls", () => {
 describe("resolveFocusedChatWorkstationRailTrackClass", () => {
   it("drives the expanded column from the resizable track-width variable", () => {
     expect(resolveFocusedChatWorkstationRailTrackClass(false)).toBe(
-      "w-0 @[850px]/focusedchat:w-9 @[1100px]/focusedchat:w-(--workstation-trail-track-width) @[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2"
+      "w-0 @[850px]/focusedchat:w-9 @[1100px]/focusedchat:w-(--workstation-trail-track-width) @[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:mr-2"
     );
   });
 
   it("keeps the collapsed track at the fixed button-controlled width", () => {
     expect(resolveFocusedChatWorkstationRailTrackClass(true)).toBe(
-      "w-0 @[850px]/focusedchat:w-9 @[1100px]/focusedchat:w-11 @[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2"
+      "w-0 @[850px]/focusedchat:w-9 @[1100px]/focusedchat:w-11 @[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1"
     );
   });
 

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.ts
@@ -101,7 +101,7 @@ export function resolveFocusedChatWorkstationRailTrackClass(
 ): string {
   return collapsed
     ? `w-0 @[850px]/focusedchat:w-9 ${WORKSTATION_TRAIL_WIDTH.collapsedResponsiveClass} ${FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS}`
-    : `w-0 @[850px]/focusedchat:w-9 ${WORKSTATION_TRAIL_WIDTH.resizableResponsiveClass} ${FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS}`;
+    : `w-0 @[850px]/focusedchat:w-9 ${WORKSTATION_TRAIL_WIDTH.resizableResponsiveClass} ${FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS} @[1100px]/focusedchat:mr-2`;
 }
 
 /** Keep the rail below overlaid chat chrome while the transcript scrolls behind it. */

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/EnvironmentKindRow.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/EnvironmentKindRow.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
+import Button from "@src/components/Button";
 import Dropdown from "@src/components/Dropdown";
 import DropdownSelectedCheck from "@src/components/Dropdown/DropdownSelectedCheck";
 import {
@@ -16,6 +17,7 @@ import {
 } from "@src/components/Dropdown/tokens";
 import { CloudIcon, LaptopIcon } from "@src/icons";
 
+import { WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS } from "../blocks/workstationTrailTokens";
 import { WorkspaceContextRow } from "./WorkspaceContextRow";
 
 export type EnvironmentKind = "local" | "cloud";
@@ -75,16 +77,19 @@ export function EnvironmentKindRow({
             {ENVIRONMENT_KIND_OPTIONS.map((option) => {
               const isSelected = option.id === kind;
               return (
-                <button
+                <Button
                   key={option.id}
-                  type="button"
+                  htmlType="button"
+                  variant="tertiary"
+                  appearance="soft-no-drop"
+                  size="small"
                   disabled={option.disabled}
-                  className={`${DROPDOWN_CLASSES.item} ${
+                  className={`${WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS} h-8! [&>span]:justify-between ${DROPDOWN_CLASSES.item} ${
                     option.disabled
                       ? "cursor-not-allowed opacity-40"
                       : isSelected
                         ? DROPDOWN_CLASSES.itemSelected
-                        : DROPDOWN_CLASSES.itemHover
+                        : ""
                   } w-full justify-between`}
                   onClick={() => setOpen(false)}
                 >
@@ -97,7 +102,7 @@ export function EnvironmentKindRow({
                     <span>{t(option.labelKey)}</span>
                   </div>
                   {isSelected && <DropdownSelectedCheck />}
-                </button>
+                </Button>
               );
             })}
           </div>

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/FocusedChatWorkstationRail.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/FocusedChatWorkstationRail.test.ts
@@ -213,7 +213,7 @@ describe.each(["wide rail", "compact menu"])(
         );
 
         for (const [label, key] of [
-          ["Review", "E"],
+          ["Changes", "E"],
           ["Terminal", "J"],
           ["Files", "G"],
           ["Browser", null],
@@ -252,7 +252,7 @@ describe.each(["wide rail", "compact menu"])(
         }
 
         // Expanding before the delay expires must not leave a stale popup.
-        const review = container.querySelector('button[aria-label="Review"]')!;
+        const review = container.querySelector('button[aria-label="Changes"]')!;
         act(() =>
           review.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }))
         );
@@ -267,27 +267,55 @@ describe.each(["wide rail", "compact menu"])(
       });
 
       it("folds the workspace group from the panel title and widens the gap to section rhythm", async () => {
+        store.set(activeWorkspaceIdAtom, "workspace:single");
+        store.set(workspaceFoldersAtom, [
+          {
+            id: "primary",
+            name: "Rail Repo",
+            path: "/workspace/primary",
+            uri: "file:///workspace/primary",
+            isPrimary: true,
+            kind: "git",
+          },
+        ]);
         await mount();
         const titleButton = () =>
           [...container.querySelectorAll("button")].find((candidate) =>
-            candidate.textContent?.includes("Local env")
+            candidate.textContent?.includes("Rail Repo")
           )!;
         const headerRow = () => titleButton().parentElement!;
 
+        expect(container.textContent?.match(/Rail Repo/g)).toHaveLength(1);
+        const changesRow = [...container.querySelectorAll("button")].find(
+          (button) => button.textContent === "Changes"
+        )!;
+        expect(changesRow.querySelector("svg")).not.toBeNull();
+        const changesLabel = [...changesRow.querySelectorAll("span")].find(
+          (span) =>
+            span.textContent === "Changes" && span.classList.contains("flex-1")
+        );
+        expect(changesLabel?.classList.contains("text-left")).toBe(true);
+        expect(changesRow.className).toContain(
+          "enabled:hover:bg-button-hover-no-drop"
+        );
+        expect(titleButton().className).toContain(
+          "enabled:hover:bg-button-hover-no-drop"
+        );
+        expect(changesRow.closest("section")!.textContent).toMatch(/^Changes/);
         expect(headerRow().className).toContain("mb-1");
-        expect(container.textContent).toContain("Review");
+        expect(container.textContent).toContain("Changes");
 
         act(() => titleButton().click());
-        expect(container.textContent).not.toContain("Review");
+        expect(container.textContent).not.toContain("Changes");
         expect(headerRow().className).toContain("mb-3");
 
         act(() => titleButton().click());
-        expect(container.textContent).toContain("Review");
+        expect(container.textContent).toContain("Changes");
         expect(headerRow().className).toContain("mb-1");
       });
     }
 
-    it("expands only the first multi-workspace root and loads secondary Git totals on demand", async () => {
+    it("shows folded repository totals while keeping secondary details collapsed", async () => {
       store.set(activeWorkspaceIdAtom, "workspace:multi");
       store.set(workspaceFoldersAtom, [
         {
@@ -334,16 +362,25 @@ describe.each(["wide rail", "compact menu"])(
       const secondaryToggle = host.querySelector<HTMLButtonElement>(
         '[data-workstation-group-toggle="workspace:secondary"]'
       )!;
-      expect(host.textContent).toContain("Primary Repo");
+      expect(host.textContent?.match(/Primary Repo/g)).toHaveLength(1);
       expect(host.textContent).toContain("primary-branch");
-      expect(host.textContent).toContain("Secondary Repo");
+      expect(host.textContent!.indexOf("primary-branch")).toBeLessThan(
+        host.textContent!.indexOf("Changes")
+      );
+      expect(host.textContent?.match(/Secondary Repo/g)).toHaveLength(1);
       expect(host.textContent).not.toContain("secondary-branch");
       expect(secondaryToggle.getAttribute("aria-expanded")).toBe("false");
 
       const requestedPaths = () =>
         gitMocks.useWorkingTreeDiffTotals.mock.calls.map((call) => call[1]);
       expect(requestedPaths()).toContain("/workspace/primary");
-      expect(requestedPaths()).not.toContain("/workspace/secondary");
+      expect(requestedPaths()).toContain("/workspace/secondary");
+      expect(secondaryToggle.textContent).toContain("+8");
+      expect(secondaryToggle.textContent).toContain("-2");
+      expect(
+        secondaryToggle.querySelector('[data-icon="chevron-right"]')
+          ?.nextElementSibling?.textContent
+      ).toBe("+8-2");
 
       act(() => secondaryToggle.click());
 

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/OwnerIdentityRow.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/OwnerIdentityRow.tsx
@@ -1,7 +1,10 @@
 /** Cloud session owner row, using the shared people-avatar treatment. */
 import PersonAvatar from "@src/components/PersonAvatar";
-import { WORKSTATION_TRAIL_CONTENT } from "@src/config/workstation/tokens";
 
+import {
+  WORKSTATION_TRAIL_ROW,
+  WORKSTATION_TRAIL_ROW_HOVER_CLASS,
+} from "../blocks/workstationTrailTokens";
 import type { FocusedChatSessionContext } from "./types";
 
 export function OwnerIdentityRow({
@@ -17,29 +20,24 @@ export function OwnerIdentityRow({
     displayName && displayName !== owner.identityId
       ? `${identityLabel} · ${owner.identityId}`
       : identityLabel;
-  const className = compact
-    ? "flex h-8 min-w-0 items-center gap-2 overflow-hidden rounded-md px-2 text-text-1"
-    : `${WORKSTATION_TRAIL_CONTENT.row} ${WORKSTATION_TRAIL_CONTENT.rowHorizontalPadding} gap-1.5 overflow-hidden text-text-1`;
+  const rowClass = `${WORKSTATION_TRAIL_ROW.shell} ${compact ? WORKSTATION_TRAIL_ROW.compact : WORKSTATION_TRAIL_ROW.wide} ${WORKSTATION_TRAIL_ROW_HOVER_CLASS}`;
+  const contentClass = `${WORKSTATION_TRAIL_ROW.content} ${compact ? WORKSTATION_TRAIL_ROW.compactContent : WORKSTATION_TRAIL_ROW.wideContent}`;
 
   return (
     <div
-      className={className}
+      className={`${rowClass} ${contentClass}`}
       title={title}
       data-owner-id={owner.identityId}
       data-testid="session-environment-owner"
     >
-      <PersonAvatar
-        name={displayName || owner.identityId}
-        src={owner.avatarUrl}
-        size={14}
-      />
-      <span
-        className={`min-w-0 flex-1 truncate ${
-          compact ? "text-[13px]" : "text-[12px]"
-        }`}
-      >
-        {identityLabel}
+      <span className={WORKSTATION_TRAIL_ROW.icon}>
+        <PersonAvatar
+          name={displayName || owner.identityId}
+          src={owner.avatarUrl}
+          size={WORKSTATION_TRAIL_ROW.iconSize}
+        />
       </span>
+      <span className={WORKSTATION_TRAIL_ROW.label}>{identityLabel}</span>
     </div>
   );
 }

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/RailItemStatus.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/RailItemStatus.tsx
@@ -56,7 +56,7 @@ export function RailItemStatus({
         ? "text-danger-6"
         : status.state === "checking" || status.state === "pending"
           ? "text-warning-6"
-          : "text-text-3";
+          : "text-text-1";
 
   return (
     <span
@@ -65,7 +65,9 @@ export function RailItemStatus({
       aria-label={status.title}
     >
       {icon}
-      {status.iconOnly ? null : <span>{status.label}</span>}
+      {status.iconOnly ? null : (
+        <span className="text-text-1">{status.label}</span>
+      )}
     </span>
   );
 }

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/TrailPanelResizeHandle.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/TrailPanelResizeHandle.tsx
@@ -1,3 +1,5 @@
+import Button from "@src/components/Button";
+
 import { type TrailPanelSize } from "./trailPanelSize";
 import { useTrailPanelResize } from "./useTrailPanelResize";
 
@@ -17,27 +19,32 @@ export function TrailPanelResizeHandle({
 }: TrailPanelResizeHandleProps) {
   const handlers = useTrailPanelResize(options);
   return (
-    <button
-      type="button"
+    <Button
+      htmlType="button"
+      variant="tertiary"
+      appearance="soft-no-drop"
+      size="sidebar"
+      iconOnly
+      icon={
+        <svg
+          aria-hidden="true"
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          fill="none"
+        >
+          <path
+            d="m3 5 8 8M3 9l4 4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      }
       aria-label={label}
       title={label}
       {...handlers}
-      className="absolute bottom-0 left-0 z-40 flex h-5 w-5 cursor-nesw-resize touch-none items-center justify-center rounded-tr rounded-bl-xl text-text-3 select-none hover:text-primary-6 focus-visible:ring-2 focus-visible:ring-primary-6 focus-visible:outline-none focus-visible:ring-inset"
-    >
-      <svg
-        aria-hidden="true"
-        width="14"
-        height="14"
-        viewBox="0 0 16 16"
-        fill="none"
-      >
-        <path
-          d="m3 5 8 8M3 9l4 4"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-        />
-      </svg>
-    </button>
+      className="absolute bottom-0 left-0 z-40 flex h-5 w-5 cursor-nesw-resize touch-none items-center justify-center rounded-tr rounded-bl-xl text-text-3 select-none focus-visible:ring-2 focus-visible:ring-primary-6 focus-visible:outline-none focus-visible:ring-inset"
+    />
   );
 }

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkspaceContextRow.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkspaceContextRow.tsx
@@ -3,11 +3,15 @@
  * repo, branch, worktree, or the linked work item.
  */
 import AnyIcon from "@src/components/AnyIcon";
+import Button from "@src/components/Button";
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
 import Tooltip from "@src/components/Tooltip";
-import { WORKSTATION_TRAIL_CONTENT } from "@src/config/workstation/tokens";
 import { ArrowDown01Icon, ArrowUp01Icon, HugeiconsIcon } from "@src/icons";
 
+import {
+  WORKSTATION_TRAIL_ROW,
+  WORKSTATION_TRAIL_ROW_HOVER_CLASS,
+} from "../blocks/workstationTrailTokens";
 import type { FocusedChatRailIcon } from "./types";
 
 export function WorkspaceContextRow({
@@ -35,25 +39,24 @@ export function WorkspaceContextRow({
   testId?: string;
   title?: string;
 }) {
-  const className = compact
-    ? "flex h-8 min-w-0 items-center gap-2 overflow-hidden rounded-md px-2 text-text-1"
-    : `${WORKSTATION_TRAIL_CONTENT.row} ${WORKSTATION_TRAIL_CONTENT.rowHorizontalPadding} gap-1.5 overflow-hidden text-text-1`;
+  const rowClass = `${WORKSTATION_TRAIL_ROW.shell} ${compact ? WORKSTATION_TRAIL_ROW.compact : WORKSTATION_TRAIL_ROW.wide} ${WORKSTATION_TRAIL_ROW_HOVER_CLASS}`;
+  const contentClass = `${WORKSTATION_TRAIL_ROW.content} ${compact ? WORKSTATION_TRAIL_ROW.compactContent : WORKSTATION_TRAIL_ROW.wideContent}`;
   const content = (
     <>
-      <AnyIcon icon={icon} className="shrink-0" size={14} strokeWidth={1.75} />
-      <span
-        className={`min-w-0 flex-1 truncate ${
-          compact ? "text-[13px]" : "text-[12px]"
-        }`}
-      >
-        {label}
+      <span className={WORKSTATION_TRAIL_ROW.icon}>
+        <AnyIcon
+          icon={icon}
+          size={WORKSTATION_TRAIL_ROW.iconSize}
+          strokeWidth={1.75}
+        />
       </span>
+      <span className={WORKSTATION_TRAIL_ROW.label}>{label}</span>
       {chevron && (
         <HugeiconsIcon
           icon={active ? ArrowUp01Icon : ArrowDown01Icon}
           data-icon={active ? "chevron-up" : "chevron-down"}
           aria-hidden
-          className="shrink-0 text-text-2"
+          className="shrink-0 text-text-1"
           size={14}
           strokeWidth={1.75}
         />
@@ -66,9 +69,12 @@ export function WorkspaceContextRow({
     // tooltip; other clickable rows keep the native title.
     const styledTooltip = chevron && title ? title : undefined;
     const button = (
-      <button
-        type="button"
-        className={`${className} w-full text-left transition-colors hover:bg-fill-2 ${
+      <Button
+        htmlType="button"
+        variant="tertiary"
+        appearance="soft-no-drop"
+        size="sidebar"
+        className={`${rowClass} ${WORKSTATION_TRAIL_ROW.button} ${compact ? "h-8!" : "h-7!"} w-full text-left ${
           active ? "bg-fill-2" : ""
         }`}
         title={styledTooltip ? undefined : (title ?? label)}
@@ -81,8 +87,8 @@ export function WorkspaceContextRow({
           onClick();
         }}
       >
-        {content}
-      </button>
+        <span className={contentClass}>{content}</span>
+      </Button>
     );
 
     if (styledTooltip) {
@@ -102,7 +108,11 @@ export function WorkspaceContextRow({
   }
 
   return (
-    <div className={className} title={title ?? label} data-testid={testId}>
+    <div
+      className={`${rowClass} ${contentClass}`}
+      title={title ?? label}
+      data-testid={testId}
+    >
       {content}
     </div>
   );

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationCollapsedDiffStats.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationCollapsedDiffStats.tsx
@@ -1,0 +1,27 @@
+import DiffStatsBadge from "@src/components/DiffStatsBadge";
+import { useWorkingTreeDiffTotals } from "@src/hooks/git/useWorkingTreeDiffTotals";
+
+import type { FocusedChatRailItem } from "./types";
+
+/** Visible folded repository summaries share the same numstat store as rows. */
+export function WorkstationCollapsedDiffStats({
+  item,
+}: {
+  item: FocusedChatRailItem;
+}) {
+  const totals = useWorkingTreeDiffTotals(
+    item.workingTreeRepo?.repoId,
+    item.workingTreeRepo?.repoPath
+  );
+  return (
+    <DiffStatsBadge
+      additions={item.workingTreeRepo ? totals.additions : item.additions}
+      deletions={item.workingTreeRepo ? totals.deletions : item.deletions}
+      variant="plain"
+      size="sm"
+      reserveValueWidth={false}
+      valueClassName="font-normal"
+      className="ml-1 shrink-0"
+    />
+  );
+}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationItemRow.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationItemRow.tsx
@@ -7,20 +7,22 @@ import type React from "react";
 import AnyIcon from "@src/components/AnyIcon";
 import Button from "@src/components/Button";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
-import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
 import FileTypeIcon from "@src/components/FileTypeIcon";
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
-import { ProcessStopButton } from "@src/components/ProcessStopButton";
 import Tooltip from "@src/components/Tooltip";
-import { WORKSTATION_TRAIL_CONTENT } from "@src/config/workstation/tokens";
 import { useWorkingTreeDiffTotals } from "@src/hooks/git/useWorkingTreeDiffTotals";
 import {
   ArrowRight01Icon,
   ArrowUpRight01Icon,
   Cancel01Icon,
   HugeiconsIcon,
+  StopIcon,
 } from "@src/icons";
 
+import {
+  WORKSTATION_TRAIL_ROW,
+  WORKSTATION_TRAIL_ROW_HOVER_CLASS,
+} from "../blocks/workstationTrailTokens";
 import { RailItemStatus } from "./RailItemStatus";
 import type { FocusedChatRailItem } from "./types";
 
@@ -52,76 +54,75 @@ export function WorkstationItemRow({
   };
 
   const action = (
-    <button
-      type="button"
-      className={
-        compact
-          ? `${DROPDOWN_CLASSES.item} min-w-0 flex-1 px-2! text-left ${
-              item.onClick
-                ? DROPDOWN_CLASSES.itemHover
-                : `${DROPDOWN_CLASSES.itemDisabled} text-text-3`
-            }`
-          : `${WORKSTATION_TRAIL_CONTENT.rowContent} ${
-              item.onClick ? "text-text-1" : "cursor-default text-text-3"
-            }`
-      }
+    <Button
+      htmlType="button"
+      variant="tertiary"
+      appearance="soft-no-drop"
+      size={compact ? "small" : "sidebar"}
+      className={`${WORKSTATION_TRAIL_ROW.button} h-full! ${compact ? WORKSTATION_TRAIL_ROW.compact : WORKSTATION_TRAIL_ROW.wide} ${item.onClick ? "" : "cursor-default"}`}
       onClick={runAction}
       disabled={!item.onClick}
       role={compact ? "menuitem" : undefined}
       aria-haspopup={item.submenu ? "menu" : undefined}
     >
-      <span className="flex shrink-0 items-center text-text-1">
-        {item.fileName ? (
-          <FileTypeIcon fileName={item.fileName} size="small" />
-        ) : (
-          <AnyIcon icon={item.icon} size={14} strokeWidth={1.75} />
-        )}
+      <span
+        className={`${WORKSTATION_TRAIL_ROW.content} ${compact ? WORKSTATION_TRAIL_ROW.compactContent : WORKSTATION_TRAIL_ROW.wideContent}`}
+      >
+        <span className={WORKSTATION_TRAIL_ROW.icon}>
+          {item.fileName ? (
+            <FileTypeIcon
+              fileName={item.fileName}
+              size="small"
+              className="size-3.5"
+            />
+          ) : (
+            <AnyIcon
+              icon={item.icon}
+              size={WORKSTATION_TRAIL_ROW.iconSize}
+              strokeWidth={1.75}
+            />
+          )}
+        </span>
+        <span className={WORKSTATION_TRAIL_ROW.label}>{item.label}</span>
+        {(additions ?? 0) > 0 || (deletions ?? 0) > 0 ? (
+          <DiffStatsBadge
+            additions={additions}
+            deletions={deletions}
+            variant="plain"
+            size="sm"
+            reserveValueWidth={false}
+            valueClassName="font-normal"
+            className="shrink-0"
+          />
+        ) : null}
+        {item.status ? <RailItemStatus status={item.status} /> : null}
+        {item.external ? (
+          <HugeiconsIcon
+            icon={ArrowUpRight01Icon}
+            data-icon="arrow-up-right"
+            aria-hidden
+            className="shrink-0 text-text-1"
+            size={14}
+            strokeWidth={1.75}
+          />
+        ) : null}
+        {item.submenu ? (
+          <HugeiconsIcon
+            icon={ArrowRight01Icon}
+            data-icon="chevron-right"
+            aria-hidden
+            className="shrink-0 text-text-1"
+            size={14}
+            strokeWidth={1.75}
+          />
+        ) : null}
       </span>
-      <span className="min-w-0 flex-1 truncate">{item.label}</span>
-      {(additions ?? 0) > 0 || (deletions ?? 0) > 0 ? (
-        <DiffStatsBadge
-          additions={additions}
-          deletions={deletions}
-          variant="plain"
-          size="sm"
-          reserveValueWidth={false}
-          valueClassName="font-normal"
-          className="shrink-0"
-        />
-      ) : null}
-      {item.status ? <RailItemStatus status={item.status} /> : null}
-      {item.external ? (
-        <HugeiconsIcon
-          icon={ArrowUpRight01Icon}
-          data-icon="arrow-up-right"
-          aria-hidden
-          className="shrink-0 text-text-2"
-          size={14}
-          strokeWidth={1.75}
-        />
-      ) : null}
-      {item.submenu ? (
-        <HugeiconsIcon
-          icon={ArrowRight01Icon}
-          data-icon="chevron-right"
-          aria-hidden
-          className="shrink-0 text-text-2"
-          size={14}
-          strokeWidth={1.75}
-        />
-      ) : null}
-    </button>
+    </Button>
   );
 
   return (
     <div
-      className={
-        compact
-          ? "group flex min-w-0 items-center"
-          : `group ${WORKSTATION_TRAIL_CONTENT.row} transition-colors duration-150 ${
-              item.onClick ? "focus-within:bg-fill-2 hover:bg-fill-2" : ""
-            }`
-      }
+      className={`group ${WORKSTATION_TRAIL_ROW.shell} ${compact ? WORKSTATION_TRAIL_ROW.compact : WORKSTATION_TRAIL_ROW.wide} ${WORKSTATION_TRAIL_ROW_HOVER_CLASS}`}
     >
       {item.shortcut ? (
         <Tooltip
@@ -142,11 +143,19 @@ export function WorkstationItemRow({
         action
       )}
       {item.onStop ? (
-        <ProcessStopButton
-          size="sm"
-          label={item.stopLabel ?? item.label}
+        <Button
+          variant="tertiary"
+          appearance="soft-no-drop"
+          iconOnly
+          icon={<HugeiconsIcon icon={StopIcon} data-icon="stop" size={14} />}
+          size="sidebar"
+          aria-label={item.stopLabel ?? item.label}
+          title={item.stopLabel ?? item.label}
           className={`opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 ${compact ? "ml-0.5" : "mr-1"}`}
-          onClick={item.onStop}
+          onClick={(event) => {
+            event.stopPropagation();
+            item.onStop?.();
+          }}
           role={compact ? "menuitem" : undefined}
         />
       ) : item.onClose ? (
@@ -162,7 +171,7 @@ export function WorkstationItemRow({
           }}
           aria-label={item.closeLabel}
           role={compact ? "menuitem" : undefined}
-          appearance="soft"
+          appearance="soft-no-drop"
           iconOnly
           icon={<HugeiconsIcon icon={Cancel01Icon} data-icon="x" size={12} />}
         />

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationSections.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationSections.test.ts
@@ -74,7 +74,7 @@ describe("WorkstationSections", () => {
     expect(markup).not.toContain("@Alice");
   });
 
-  it("shows the agent harness directly below the environment kind", () => {
+  it("shows the repository between the environment kind and agent harness", () => {
     const markup = renderToStaticMarkup(
       createElement(WorkstationSections, {
         compact: true,
@@ -97,11 +97,9 @@ describe("WorkstationSections", () => {
     );
 
     expect(markup).toContain('data-testid="session-environment-agent-harness"');
-    expect(markup.indexOf("Local")).toBeLessThan(
+    expect(markup.indexOf("Local")).toBeLessThan(markup.indexOf("ORGII"));
+    expect(markup.indexOf("ORGII")).toBeLessThan(
       markup.indexOf("Codex Harness")
-    );
-    expect(markup.indexOf("Codex Harness")).toBeLessThan(
-      markup.indexOf("ORGII")
     );
   });
 

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationSections.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationSections.tsx
@@ -1,3 +1,4 @@
+import Button from "@src/components/Button";
 /**
  * WorkstationSections — renders the rail's section list in both the wide
  * (trail) and compact (dropdown menu) presentations.
@@ -13,9 +14,14 @@ import {
   WorkflowCircle05Icon,
 } from "@src/icons";
 
+import {
+  WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS,
+  WORKSTATION_TRAIL_TITLE_BUTTON_CLASS,
+} from "../blocks/workstationTrailTokens";
 import { EnvironmentKindRow } from "./EnvironmentKindRow";
 import { OwnerIdentityRow } from "./OwnerIdentityRow";
 import { WorkspaceContextRow } from "./WorkspaceContextRow";
+import { WorkstationCollapsedDiffStats } from "./WorkstationCollapsedDiffStats";
 import { WorkstationItemRow } from "./WorkstationItemRow";
 import type { WorkstationSectionsProps } from "./types";
 
@@ -42,6 +48,10 @@ export function WorkstationSections({
         // unlabelled section when that group is collapsed.
         if (groupCollapsed && !section.label) return null;
 
+        const changesItem = section.items.find(
+          (item) => item.key === "changes" || item.key.startsWith("changes:")
+        );
+
         return (
           <section
             key={section.key}
@@ -54,9 +64,12 @@ export function WorkstationSections({
                 // The whole heading row is the fold toggle, with an
                 // always-visible chevron right after the label — matching the
                 // panel header's own title toggle.
-                <button
-                  type="button"
-                  className="group/section-toggle flex h-6 w-full items-center"
+                <Button
+                  htmlType="button"
+                  variant="tertiary"
+                  appearance="soft-no-drop"
+                  size="sidebar"
+                  className={`${WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS} ${WORKSTATION_TRAIL_TITLE_BUTTON_CLASS} group/section-toggle h-6! w-full bg-transparent p-0!`}
                   data-workstation-group-toggle={section.key}
                   aria-expanded={!groupCollapsed}
                   aria-label={
@@ -79,7 +92,10 @@ export function WorkstationSections({
                     size={14}
                     strokeWidth={1.75}
                   />
-                </button>
+                  {groupCollapsed && changesItem ? (
+                    <WorkstationCollapsedDiffStats item={changesItem} />
+                  ) : null}
+                </Button>
               ) : (
                 <div className="flex h-6 items-center">
                   <div className={WORKSTATION_TRAIL_CONTENT.sectionLabelInline}>
@@ -108,19 +124,19 @@ export function WorkstationSections({
                       kind={section.environment.environmentKind}
                     />
                   )}
+                  {section.environment.repoName && (
+                    <WorkspaceContextRow
+                      compact={compact}
+                      icon={FolderClosedIcon}
+                      label={section.environment.repoName}
+                    />
+                  )}
                   {section.environment.agentHarness && (
                     <WorkspaceContextRow
                       compact={compact}
                       icon={section.environment.agentHarness.icon}
                       label={section.environment.agentHarness.label}
                       testId="session-environment-agent-harness"
-                    />
-                  )}
-                  {section.environment.repoName && (
-                    <WorkspaceContextRow
-                      compact={compact}
-                      icon={FolderClosedIcon}
-                      label={section.environment.repoName}
                     />
                   )}
                   {section.environment.branchName && (
@@ -160,15 +176,25 @@ export function WorkstationSections({
                   )}
                 </>
               )}
+            {!groupCollapsed && changesItem ? (
+              <WorkstationItemRow
+                key={changesItem.key}
+                compact={compact}
+                item={changesItem}
+                onRequestClose={onRequestClose}
+              />
+            ) : null}
             {!groupCollapsed &&
-              section.items.map((item) => (
-                <WorkstationItemRow
-                  key={item.key}
-                  compact={compact}
-                  item={item}
-                  onRequestClose={onRequestClose}
-                />
-              ))}
+              section.items
+                .filter((item) => item !== changesItem)
+                .map((item) => (
+                  <WorkstationItemRow
+                    key={item.key}
+                    compact={compact}
+                    item={item}
+                    onRequestClose={onRequestClose}
+                  />
+                ))}
           </section>
         );
       })}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.test.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminal.test.ts
@@ -155,10 +155,6 @@ describe("docked terminal controls", () => {
     for (const button of header.querySelectorAll("button")) {
       if (button.getAttribute("role") === "tab") {
         expect(button.classList.contains("h-5")).toBe(true);
-      } else if (button.querySelector('[data-icon="stop"]')) {
-        // ProcessStopButton still owns its compact geometry through tokens.
-        expect(button.classList.contains("h-5")).toBe(true);
-        expect(button.classList.contains("w-5")).toBe(true);
       } else {
         expect(button.style.height).toBe("20px");
         expect(button.style.width).toBe("20px");

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminalHeader.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/WorkstationTrailTerminalHeader.tsx
@@ -1,17 +1,19 @@
 import { useLayoutEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import { ProcessStopButton } from "@src/components/ProcessStopButton";
+import Button from "@src/components/Button";
 import {
   Add01Icon,
   ArrowDown01Icon,
   ArrowRight01Icon,
   Cancel01Icon,
   HugeiconsIcon,
+  StopIcon,
 } from "@src/icons";
 import { MINI_TERMINAL_SESSION_LIMIT } from "@src/store/ui/miniTerminalAtom";
 
 import { WorkstationTrailHeader, WorkstationTrailIconButton } from "../blocks";
+import { WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS } from "../blocks/workstationTrailTokens";
 
 export interface TrailTerminalTab {
   key: string;
@@ -97,10 +99,20 @@ export function WorkstationTrailTerminalHeader({
       actions={
         <>
           {!collapsed && activeTab ? (
-            <ProcessStopButton
-              size="sm"
-              label={t("common:tooltips.killTerminal")}
-              onClick={() => onStop(activeTab.key)}
+            <Button
+              variant="tertiary"
+              appearance="soft-no-drop"
+              iconOnly
+              icon={
+                <HugeiconsIcon icon={StopIcon} data-icon="stop" size={14} />
+              }
+              size="sidebar"
+              aria-label={t("common:tooltips.killTerminal")}
+              title={t("common:tooltips.killTerminal")}
+              onClick={(event) => {
+                event.stopPropagation();
+                onStop(activeTab.key);
+              }}
             />
           ) : null}
           {tabs.length < MINI_TERMINAL_SESSION_LIMIT ? (
@@ -165,9 +177,12 @@ export function WorkstationTrailTerminalHeader({
           }}
         >
           {tabs.map((tab) => (
-            <button
+            <Button
               key={tab.key}
-              type="button"
+              htmlType="button"
+              variant="tertiary"
+              appearance="soft-no-drop"
+              size="sidebar"
               role="tab"
               id={`${panelId}-tab-${tab.key}`}
               aria-controls={panelId}
@@ -175,10 +190,10 @@ export function WorkstationTrailTerminalHeader({
               tabIndex={tab.key === activeId ? 0 : -1}
               title={tab.label}
               onClick={() => onSelect(tab.key)}
-              className={`h-5 max-w-28 shrink-0 truncate rounded-lg px-2 text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-6 ${tab.key === activeId ? "bg-fill-2 font-medium text-text-1" : "text-text-3 hover:bg-fill-2 hover:text-text-1"}`}
+              className={`${WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS} h-5 max-w-28 shrink-0 truncate rounded-lg px-2 text-xs focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-6 ${tab.key === activeId ? "bg-fill-2 text-text-1 [&>span]:font-medium" : "text-text-1"}`}
             >
               {tab.label}
-            </button>
+            </Button>
           ))}
         </div>
       ) : null}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/index.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/index.tsx
@@ -90,6 +90,7 @@ import {
   WorkstationTrailIconButton,
   WorkstationTrailSurface,
 } from "../blocks";
+import { WorkstationCollapsedDiffStats } from "./WorkstationCollapsedDiffStats";
 import { WorkstationSections } from "./WorkstationSections";
 import {
   WorkstationSubagentsSubmenu,
@@ -461,7 +462,7 @@ export function FocusedChatWorkstationRail({
     () => [
       {
         key: "changes",
-        label: t("common:actions.review"),
+        label: t("common:git.pr.tabs.changes"),
         icon: FileDiffIcon,
         shortcutId: "open_source_control_tab",
         ...(repoId && activeRepoPath
@@ -658,7 +659,7 @@ export function FocusedChatWorkstationRail({
   const isMultiWorkspace = workspaceFolders.length > 1;
   const primaryWorkspaceTitle = isMultiWorkspace
     ? (workspaceFolders[0]?.name ?? localEnvironmentLabel)
-    : localEnvironmentLabel;
+    : activeRepoName || workspaceFolders[0]?.name || localEnvironmentLabel;
 
   const workspaceSections = useMemo<FocusedChatRailSection[]>(() => {
     const branchAction: FocusedChatSessionContext["branchAction"] = {
@@ -675,7 +676,6 @@ export function FocusedChatWorkstationRail({
         {
           ...FOCUSED_CHAT_RAIL_SECTIONS.workspace,
           environment: {
-            repoName: activeRepoName,
             branchName: activeBranchName,
             branchAction,
           },
@@ -725,7 +725,6 @@ export function FocusedChatWorkstationRail({
     });
   }, [
     activeBranchName,
-    activeRepoName,
     activeWorkspaceRoot,
     branchSwitcherOpen,
     isMultiWorkspace,
@@ -879,6 +878,7 @@ export function FocusedChatWorkstationRail({
             <Button
               htmlType="button"
               variant="tertiary"
+              appearance="soft-no-drop"
               size="small"
               iconOnly
               className={menuOpen ? "bg-fill-1! text-primary-6!" : ""}
@@ -940,6 +940,14 @@ export function FocusedChatWorkstationRail({
           >
             <WorkstationTrailHeader
               title={wideHeaderTitle}
+              titleSuffix={
+                wideHeaderSectionKey === "workspace" &&
+                collapsedGroupKeys.has("workspace") ? (
+                  <WorkstationCollapsedDiffStats
+                    item={workspaceSections[0].items[0]}
+                  />
+                ) : undefined
+              }
               collapsed={collapsed}
               // With its own group folded, the next visible line is another
               // section title, so the gap below must match the section rhythm
@@ -1029,7 +1037,7 @@ export function FocusedChatWorkstationRail({
                         htmlType="button"
                         size="small"
                         variant="tertiary"
-                        appearance="soft"
+                        appearance="soft-no-drop"
                         iconOnly
                         className="relative"
                         onClick={item.onClick}

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail/types.ts
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail/types.ts
@@ -41,9 +41,8 @@ export type FocusedChatRailItem = {
   additions?: number;
   deletions?: number;
   /**
-   * Resolve live working-tree totals while this row is mounted. Collapsed
-   * workspace groups do not mount their rows, so secondary repositories stay
-   * demand-driven instead of opening background subscriptions eagerly.
+   * Resolve live working-tree totals in the expanded row or folded heading.
+   * Both presentations share the per-repository numstat store.
    */
   workingTreeRepo?: {
     repoId: string;

--- a/src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx
+++ b/src/modules/shared/layouts/blocks/WorkstationTrailSurface.tsx
@@ -13,7 +13,11 @@ import {
 } from "@src/config/workstation/tokens";
 import { ArrowDown01Icon, ArrowRight01Icon, HugeiconsIcon } from "@src/icons";
 
-import { WORKSTATION_TRAIL_SURFACE_CLASS } from "./workstationTrailTokens";
+import {
+  WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS,
+  WORKSTATION_TRAIL_SURFACE_CLASS,
+  WORKSTATION_TRAIL_TITLE_BUTTON_CLASS,
+} from "./workstationTrailTokens";
 
 export {
   WORKSTATION_TRAIL_SURFACE_CLASS,
@@ -41,6 +45,8 @@ export interface WorkstationTrailHeaderProps {
   standalone?: boolean;
   title: ReactNode;
   titleActions?: ReactNode;
+  /** Noninteractive summary immediately after the title fold chevron. */
+  titleSuffix?: ReactNode;
   /**
    * Makes the whole title area (everything left of `actions`) a fold toggle
    * for the header's own group, with an always-visible chevron after the
@@ -66,6 +72,7 @@ export const WorkstationTrailHeader: FC<WorkstationTrailHeaderProps> = ({
   standalone = false,
   title,
   titleActions,
+  titleSuffix,
   onTitleToggle,
   titleToggleCollapsed = false,
   titleToggleLabels,
@@ -81,9 +88,12 @@ export const WorkstationTrailHeader: FC<WorkstationTrailHeaderProps> = ({
     {!collapsed ? (
       onTitleToggle ? (
         <>
-          <button
-            type="button"
-            className="group/trail-title flex h-full min-w-0 flex-1 items-center gap-px text-left"
+          <Button
+            htmlType="button"
+            variant="tertiary"
+            appearance="soft-no-drop"
+            size="sidebar"
+            className={`${WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS} ${WORKSTATION_TRAIL_TITLE_BUTTON_CLASS} group/trail-title h-full! min-w-0 flex-1 bg-transparent p-0! text-left`}
             onClick={onTitleToggle}
             aria-expanded={!titleToggleCollapsed}
             aria-label={
@@ -109,7 +119,8 @@ export const WorkstationTrailHeader: FC<WorkstationTrailHeaderProps> = ({
               size={14}
               strokeWidth={1.75}
             />
-          </button>
+            {titleSuffix}
+          </Button>
           {titleActions}
           {children}
         </>
@@ -147,10 +158,10 @@ export const WorkstationTrailIconButton: FC<
     htmlType={type}
     size={size}
     variant="tertiary"
-    appearance="soft"
+    appearance="soft-no-drop"
     iconOnly
     icon={children}
-    className={className}
+    className={`text-text-1! ${className}`}
   />
 );
 
@@ -199,7 +210,7 @@ export const WorkstationTrailSection: FC<WorkstationTrailSectionProps> = ({
 /** Muted empty-state line inside a trail section. */
 export const WorkstationTrailEmptyText: FC<{ children?: ReactNode }> = ({
   children,
-}) => <div className="px-2 text-[12px] text-text-3">{children}</div>;
+}) => <div className="px-2 text-[12px] text-text-1">{children}</div>;
 
 /** Shared scroll container directly below a Workstation trail header. */
 export const WorkstationTrailBody: FC<HTMLAttributes<HTMLDivElement>> = ({

--- a/src/modules/shared/layouts/blocks/workstationTrailTokens.ts
+++ b/src/modules/shared/layouts/blocks/workstationTrailTokens.ts
@@ -20,4 +20,30 @@ export const WORKSTATION_TRAIL_WIDTH = {
 } as const;
 export const WORKSTATION_TRAIL_RAIL_PADDING_CLASS = "px-1 pb-1 pt-2";
 export const FOCUSED_CHAT_WORKSTATION_TRAIL_RAIL_PADDING_CLASS =
-  "@[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1 @[1100px]/focusedchat:pt-2";
+  "@[1100px]/focusedchat:px-1 @[1100px]/focusedchat:pb-1";
+
+/** Composite trail buttons keep row content aligned inside the shared Button label. */
+export const WORKSTATION_TRAIL_COMPOSITE_BUTTON_CLASS =
+  "justify-start rounded-lg! font-normal! [&>span]:flex [&>span]:w-full [&>span]:items-center [&>span]:gap-1.5 [&>span]:leading-[inherit]";
+export const WORKSTATION_TRAIL_ROW_HOVER_CLASS =
+  "transition-colors hover:bg-fill-2 focus-within:bg-fill-2";
+
+/** Section titles fold content without drawing a button backdrop. */
+export const WORKSTATION_TRAIL_TITLE_BUTTON_CLASS =
+  "bg-transparent! enabled:hover:bg-transparent! focus-visible:bg-transparent! [&>span]:gap-0!";
+
+/** One row geometry for harness, repository, identity and actionable entries. */
+export const WORKSTATION_TRAIL_ROW = {
+  iconSize: 14,
+  icon: "flex size-3.5 shrink-0 items-center justify-center",
+  label: "min-w-0 flex-1 truncate text-left",
+  shell:
+    "flex min-w-0 items-center rounded-lg font-normal text-text-1 leading-normal",
+  wide: "h-7 text-[12px]!",
+  compact: "h-8 text-[13px]!",
+  content: "flex min-w-0 w-full items-center",
+  wideContent: "gap-1.5 pl-2 pr-1.5",
+  compactContent: "gap-2 px-2",
+  button:
+    "min-w-0 flex-1 p-0! rounded-lg! font-normal! text-text-1! leading-normal! [&>span]:flex [&>span]:w-full [&>span]:leading-[inherit]",
+} as const;


### PR DESCRIPTION
## Problem

The workstation trail repeats repository identity in a folder row, hides change totals when repository details are folded, and has inconsistent row alignment and button styling. Repository, branch and change information is harder to scan in both the wide trail and compact menu.

## Solution

Use repository names as section titles, with a separate section for each workspace repository and no duplicate local repository folder row. Rename Review to Changes, keep its original icon, and order repository rows as Branch, Changes, then Compare. In the session environment, put the repository folder above the harness.

Align row icons, normal-weight text, padding and corners, restore left-aligned Changes/Compare labels, and use shared soft-no-drop controls with fill-2 hover. Preserve the original header typography, remove title backdrops and tighten title-chevron spacing. Folded repository sections show their live +/− totals immediately after the chevron using the existing shared numstat store. Remove the trail's top padding and add an 8px right-edge gap only while expanded.

## Potential risks

Folded repository headings now intentionally keep live diff-summary subscriptions, including secondary repositories; requests and listeners still use the existing per-repository shared store and cleanup. Shared trail-header styling also affects other consumers of that component. Native visual verification across themes, narrow viewports and empty/error states was not performed because local computer control requires explicit opt-in; automated DOM tests do not prove pixel-level rendering.

No dependencies, persistence formats, schemas or wire APIs change. Reverting this commit restores the prior presentation and subscription demand without data migration.

## Verification

- `pnpm test -- src/modules/shared/layouts/FocusedChatWorkstationRail src/modules/shared/layouts/blocks/WorkstationTrailSurface.test.ts src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts src/hooks/git/useWorkingTreeDiffTotals.test.ts` — 78 tests passed across 10 files on the latest develop base. Covers repository grouping, row order, fold-summary placement, terminal controls, resizing, responsive layout and shared diff-store behavior.
- `pnpm run typecheck:fast` — passed.
- `git diff --cached --check` — passed before commit.
- Standard commit hooks — lint-staged oxlint, ESLint, Prettier and staged-file TypeScript gate passed. Rust checks skipped because no Rust files changed.
- Reviewed the final diff for scope and accidental secrets, private configuration, local paths, build artifacts and unrelated edits; only trail source, tests and its audit report are included.
- No native app screenshots or runtime CPU/RSS measurements were collected. The supplied screenshots describe earlier states, not final-result verification.

## Audit

UI audit: 0 remaining fixes, 5 keep-with-reason findings, 0 proposed abstractions. Performance review retains shared push-driven totals, repository scoping and last-subscriber cleanup. See `docs/frontend-ui-audit-2026-09-13/WorkstationTrail.md`.
