### PR TITLE
fix(workstation): restore terminal sidebar registration

### DIFF
--- a/docs/org2-performance-guard-2026-09-13/TerminalSidebar.md
+++ b/docs/org2-performance-guard-2026-09-13/TerminalSidebar.md
@@ -1,0 +1,23 @@
+# Terminal sidebar restoration
+
+The authoritative sidebar mapping is the module-local registry in `SidebarModules/registry.ts`. Commit `66e95ca31` deleted the terminal module, including its `registerTabSidebar("terminal", TerminalTabSidebar)` call and entry-point export. The terminal therefore reached `SidebarSlot`'s default explorer fallback. Restoring the module and entry-point import restores the mapping; no persisted domain data is changed or requires cleanup.
+
+| Area               | Verdict | Evidence                                                                                                                              | Change or reason kept                                                          | Verification                                                               |
+| ------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| Background work    | keep    | `useTerminalState` reads existing Jotai atoms; restored components contain no timers, effects, listeners, or mount-triggered requests | Creation, closing, and process termination remain explicit user actions        | Source inspection; desktop CPU measurements not run                        |
+| Memory             | keep    | Derived lists and PID maps are component-owned and bounded by current terminal/process records; no new global cache                   | Terminal is outside the retained-tab pools and normally unmounts when inactive | SidebarSlot activation/deactivation tests; existing retention-policy tests |
+| Scope/isolation    | keep    | Existing store supplies terminal sessions, targets, and selected repository                                                           | No new transport, persistence, auth, or cache scope                            | Source inspection; no cross-instance runtime claim                         |
+| Rendering/hot path | keep    | Sidebar subscribes to session metadata and shell-process records, not terminal output bytes                                           | Restore prior row rendering and existing shared UI components                  | Routing tests; typecheck and lint; no measured runtime improvement claim   |
+
+Lifecycle: importing the production entry point installs the terminal sidebar registration. Activating a terminal mounts its sidebar; switching to a file unmounts it under the current retention policy. The existing slot also hides/reuses a sidebar if explicitly passed a retained tab and releases it after removal. Document visibility does not start extra work. There are no new network/offline, account, provider-ingestion, or multi-instance mechanisms in this fix.
+
+Verification actually run:
+
+- `pnpm test src/modules/WorkStation/shared/SidebarModules/SidebarSlot.test.ts src/store/workstation/tabs/__tests__/tabRetention.test.ts`: seven tests passed. The new routing tests import the production module entry point and mock terminal content/services; they do not verify the full visual rows or live PTY actions.
+- `pnpm typecheck:fast`: passed.
+- `pnpm exec eslint src/modules/WorkStation/shared/SidebarModules/Terminal src/modules/WorkStation/shared/SidebarModules/index.ts src/modules/WorkStation/shared/SidebarModules/SidebarSlot.test.ts`: passed.
+- `git diff --check`: passed.
+- `pnpm check:circular`: failed on three cycles in SessionCore/ChatPanel/input hooks and HoverCard; none includes a changed module. Those cycles were not changed by this fix.
+- Desktop visual validation, live PTY actions, and visible/hidden/post-close CPU/RSS measurements were not run: the user requires explicit opt-in for desktop control. No screenshot or runtime performance claim is made.
+
+Performance verdict: blocked for desktop measurement; source inspection and targeted lifecycle tests pass.

--- a/src/modules/WorkStation/shared/SidebarModules/SidebarSlot.test.ts
+++ b/src/modules/WorkStation/shared/SidebarModules/SidebarSlot.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+
+import type { WorkStationTab } from "@src/store/workstation/tabs";
+
+// Use the same entry point as CodeEditor: importing only SidebarSlot would
+// miss the module-init registration that the dead-code cleanup removed.
+import { SidebarSlot, hasTabSidebar } from "./index";
+
+vi.mock("./SourceControl", () => ({}));
+vi.mock("@/src/engines/TerminalCore/hooks/useTerminalState", () => ({
+  useTerminalState: () => ({
+    sessions: [],
+    activeSessionId: null,
+  }),
+}));
+vi.mock("@src/store/repo", async () => {
+  const { atom } = await import("jotai");
+  return { selectedRepoPathAtom: atom("/repo") };
+});
+vi.mock("@src/store/workstation/codeEditor/terminalTargetAtom", async () => {
+  const { atom } = await import("jotai");
+  return {
+    codeEditorTerminalTargetAtom: atom(null),
+    clearTerminalTargetReferencesAtom: atom(null),
+  };
+});
+vi.mock("./Terminal/TerminalSidebarContent", () => ({
+  default: () => createElement("div", { "data-testid": "terminal-sidebar" }),
+}));
+
+const terminalTab = {
+  id: "terminal:pty-1",
+  type: "terminal",
+  title: "zsh",
+  data: { sessionId: "pty-1", sessionName: "zsh" },
+} as WorkStationTab;
+const fileTab = {
+  id: "file:readme",
+  type: "file",
+  title: "README.md",
+  data: {},
+} as WorkStationTab;
+
+it("registers the terminal sidebar through the production entry point", () => {
+  expect(hasTabSidebar("terminal")).toBe(true);
+});
+
+it("shows terminal navigation, restores explorer on file tabs, and removes closed sidebars", () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  const render = (activeTab: WorkStationTab, retainedTabs: WorkStationTab[]) =>
+    act(() =>
+      root.render(
+        createElement(SidebarSlot, {
+          activeTab,
+          retainedTabs,
+          repoPath: "/repo",
+          repoId: "repo",
+          defaultSidebar: createElement("div", { "data-testid": "file-tree" }),
+        })
+      )
+    );
+  try {
+    // Terminal tabs are normally rebuilt on activation, not kept warm.
+    render(terminalTab, []);
+    expect(
+      container.querySelector('[data-testid="terminal-sidebar"]')
+    ).not.toBeNull();
+    expect(container.querySelector('[data-testid="file-tree"]')).toBeNull();
+    render(fileTab, []);
+    expect(
+      container.querySelector('[data-testid="terminal-sidebar"]')
+    ).toBeNull();
+
+    render(terminalTab, [terminalTab]);
+    const sidebar = container.querySelector('[data-testid="terminal-sidebar"]');
+    expect(sidebar).not.toBeNull();
+    expect(container.querySelector('[data-testid="file-tree"]')).toBeNull();
+
+    render(fileTab, [terminalTab]);
+    expect(container.querySelector('[data-testid="file-tree"]')).not.toBeNull();
+    expect(sidebar?.parentElement?.getAttribute("aria-hidden")).toBe("true");
+
+    render(terminalTab, [terminalTab]);
+    expect(container.querySelector('[data-testid="terminal-sidebar"]')).toBe(
+      sidebar
+    );
+    expect(sidebar?.parentElement?.getAttribute("aria-hidden")).toBe("false");
+
+    render(fileTab, []);
+    expect(
+      container.querySelector('[data-testid="terminal-sidebar"]')
+    ).toBeNull();
+    expect(container.querySelector('[data-testid="file-tree"]')).not.toBeNull();
+  } finally {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+  }
+});

--- a/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalSidebarContent.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalSidebarContent.tsx
@@ -1,0 +1,226 @@
+import { useAtomValue } from "jotai";
+import React, { memo, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import Message from "@src/components/Message";
+import { Placeholder } from "@src/components/Placeholder";
+import {
+  PrimarySidebarLayoutWithSections,
+  type PrimarySidebarTab,
+} from "@src/modules/WorkStation/shared/PrimarySidebarLayout";
+import {
+  type NewTerminalSessionOptions,
+  TerminalNewSessionSplitButton,
+} from "@src/modules/WorkStation/shared/TerminalNewSessionSplitButton";
+import { killAgentShellProcess } from "@src/services/terminal";
+import { shellProcessMapAtom } from "@src/store/session/shellProcessAtom";
+import { terminalSessionsAtom } from "@src/store/workstation/codeEditor/terminal";
+// Deep import; the @src/store/workstation/codeEditor barrel re-exports
+// sourceControlFilterModeAtom which transitively pulls SidebarModules back
+// here, creating a circular dependency.
+import type { TerminalTarget } from "@src/store/workstation/codeEditor/terminalTargetAtom";
+
+import {
+  AgentSessionRow,
+  PtySessionRow,
+  useActiveAgentSessions,
+} from "./TerminalSidebarRows";
+
+interface TerminalSidebarContentProps {
+  activeTerminalTarget: TerminalTarget | null;
+  onOpenTerminal: (target: TerminalTarget) => void;
+  onClosePtySession: (sessionId: string) => void;
+  onNewPtySession: (options?: NewTerminalSessionOptions) => void;
+}
+
+const TerminalSidebarContent: React.FC<TerminalSidebarContentProps> = memo(
+  ({
+    activeTerminalTarget,
+    onOpenTerminal,
+    onClosePtySession,
+    onNewPtySession,
+  }) => {
+    const { t } = useTranslation("common");
+
+    const shellProcessMap = useAtomValue(shellProcessMapAtom);
+    const allTerminalSessions = useAtomValue(terminalSessionsAtom);
+    const activeAgentSessions = useActiveAgentSessions();
+    const untitledLabel = t("controlTower.sidebar.untitled", "Untitled");
+
+    const ptySessions = useMemo(
+      () => allTerminalSessions.filter((session) => !session.readOnly),
+      [allTerminalSessions]
+    );
+
+    const runningPidsBySession = useMemo(() => {
+      const map = new Map<string, Array<{ pid: number; callId: string }>>();
+      for (const [sessionId, processMap] of shellProcessMap.entries()) {
+        const pids = [...processMap.values()]
+          .filter(
+            (process) =>
+              process.status === "running" || process.status === "background"
+          )
+          .map((process) => ({
+            pid: process.pid,
+            callId: process.callId,
+          }));
+        if (pids.length > 0) map.set(sessionId, pids);
+      }
+      return map;
+    }, [shellProcessMap]);
+
+    const handleKillAgentSession = useCallback(
+      async (sessionId: string) => {
+        const processes = runningPidsBySession.get(sessionId) ?? [];
+        try {
+          await Promise.all(
+            processes.map(({ pid, callId }) =>
+              killAgentShellProcess({ pid, sessionId, callId })
+            )
+          );
+        } catch (error: unknown) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          Message.error(message || t("errors.generic"));
+        }
+      },
+      [runningPidsBySession, t]
+    );
+
+    const newTerminalSplitButton = useMemo(
+      () => (
+        <TerminalNewSessionSplitButton
+          density="sidebar"
+          onNewTerminal={onNewPtySession}
+        />
+      ),
+      [onNewPtySession]
+    );
+
+    const ptySectionContent = useMemo(
+      () => (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {ptySessions.length === 0 ? (
+            <Placeholder variant="empty" placement="sidebar" fillParentHeight />
+          ) : (
+            <div className="flex flex-col py-1">
+              {ptySessions.map((session) => (
+                <PtySessionRow
+                  key={session.id}
+                  session={session}
+                  isActive={
+                    activeTerminalTarget?.kind === "pty" &&
+                    activeTerminalTarget.ptySessionId === session.id
+                  }
+                  onOpen={() =>
+                    onOpenTerminal({ kind: "pty", ptySessionId: session.id })
+                  }
+                  onClose={(event) => {
+                    event.stopPropagation();
+                    onClosePtySession(session.id);
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      ),
+      [activeTerminalTarget, onClosePtySession, onOpenTerminal, ptySessions]
+    );
+
+    const agentSectionContent = useMemo(
+      () => (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {activeAgentSessions.length === 0 ? (
+            <Placeholder variant="empty" placement="sidebar" fillParentHeight />
+          ) : (
+            <div className="flex flex-col py-1">
+              {activeAgentSessions.map(({ sessionId, command }) => {
+                const title = command || untitledLabel;
+                return (
+                  <AgentSessionRow
+                    key={sessionId}
+                    title={title}
+                    isActive={
+                      activeTerminalTarget?.kind === "agent" &&
+                      activeTerminalTarget.sessionId === sessionId
+                    }
+                    onOpen={() => onOpenTerminal({ kind: "agent", sessionId })}
+                    onClose={(event) => {
+                      event.stopPropagation();
+                      void handleKillAgentSession(sessionId);
+                    }}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ),
+      [
+        activeAgentSessions,
+        activeTerminalTarget,
+        handleKillAgentSession,
+        onOpenTerminal,
+        untitledLabel,
+      ]
+    );
+
+    const tabs = useMemo<PrimarySidebarTab[]>(
+      () => [
+        {
+          key: "terminal-sessions",
+          label: t("terminology.myTerminal"),
+          sections: [
+            {
+              key: "terminal-sessions",
+              title: t("terminology.myTerminal"),
+              content: ptySectionContent,
+              resizable: false,
+              hideSeparator: activeAgentSessions.length > 0,
+              actions: [
+                {
+                  key: "new-terminal-session",
+                  customRender: newTerminalSplitButton,
+                  forceVisible: true,
+                },
+              ],
+            },
+            ...(activeAgentSessions.length > 0
+              ? [
+                  {
+                    key: "agent-terminal-sessions",
+                    title: t("terminology.agentTerminal"),
+                    content: agentSectionContent,
+                    resizable: false,
+                  },
+                ]
+              : []),
+          ],
+        },
+      ],
+      [
+        activeAgentSessions.length,
+        agentSectionContent,
+        newTerminalSplitButton,
+        ptySectionContent,
+        t,
+      ]
+    );
+
+    const handleTabChange = useCallback(() => {}, []);
+
+    return (
+      <PrimarySidebarLayoutWithSections
+        tabs={tabs}
+        activeTab="terminal-sessions"
+        onTabChange={handleTabChange}
+        hideTabs
+      />
+    );
+  }
+);
+
+TerminalSidebarContent.displayName = "TerminalSidebarContent";
+
+export default TerminalSidebarContent;

--- a/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalSidebarContent.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalSidebarContent.tsx
@@ -45,7 +45,7 @@ const TerminalSidebarContent: React.FC<TerminalSidebarContentProps> = memo(
     const shellProcessMap = useAtomValue(shellProcessMapAtom);
     const allTerminalSessions = useAtomValue(terminalSessionsAtom);
     const activeAgentSessions = useActiveAgentSessions();
-    const untitledLabel = t("controlTower.sidebar.untitled", "Untitled");
+    const untitledLabel = t("placeholders.untitled");
 
     const ptySessions = useMemo(
       () => allTerminalSessions.filter((session) => !session.readOnly),

--- a/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalSidebarRows.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalSidebarRows.tsx
@@ -1,0 +1,123 @@
+import { useAtomValue } from "jotai";
+import React, { memo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { ProcessStopButton } from "@src/components/ProcessStopButton";
+import { TreeRowBase, type TreeRowNode } from "@src/components/TreeRow";
+// `types`, not the `exports` barrel — the barrel re-exports the TerminalCore
+// component and would drag xterm into the sidebar-modules chunk.
+import {
+  type TerminalSession,
+  getTerminalDisplayTitle,
+} from "@src/engines/TerminalCore/types";
+import {
+  Infinity01Icon,
+  ComputerTerminal01Icon,
+  HugeiconsIcon,
+} from "@src/icons";
+import { shellProcessMapAtom } from "@src/store/session/shellProcessAtom";
+
+interface AgentSessionRowProps {
+  title: string;
+  isActive: boolean;
+  onOpen: () => void;
+  onClose: (event: React.MouseEvent) => void;
+}
+
+export const AgentSessionRow: React.FC<AgentSessionRowProps> = memo(
+  ({ title, isActive, onOpen, onClose }) => {
+    const { t } = useTranslation("sessions");
+    const node: TreeRowNode = {
+      id: title,
+      name: title,
+      path: title,
+      type: "file",
+      icon: (
+        <HugeiconsIcon
+          icon={ComputerTerminal01Icon}
+          data-icon="terminal"
+          size={14}
+          strokeWidth={1.75}
+        />
+      ),
+    };
+
+    return (
+      <TreeRowBase node={node} depth={0} isSelected={isActive} onClick={onOpen}>
+        <HugeiconsIcon
+          icon={Infinity01Icon}
+          data-icon="infinity"
+          size={14}
+          strokeWidth={1.75}
+          className="shrink-0 text-primary-6 group-focus-within/item:hidden group-hover/item:hidden"
+        />
+        <ProcessStopButton
+          size="sm"
+          className="hidden group-focus-within/item:flex group-hover/item:flex"
+          onClick={onClose}
+          label={t("common:workstation.ports.stopProcess")}
+        />
+      </TreeRowBase>
+    );
+  }
+);
+AgentSessionRow.displayName = "TerminalSidebarAgentSessionRow";
+
+interface PtySessionRowProps {
+  session: TerminalSession;
+  isActive: boolean;
+  onOpen: () => void;
+  onClose: (event: React.MouseEvent) => void;
+}
+
+export const PtySessionRow: React.FC<PtySessionRowProps> = memo(
+  ({ session, isActive, onOpen, onClose }) => {
+    const { t } = useTranslation("sessions");
+    const title = getTerminalDisplayTitle(session);
+    const node: TreeRowNode = {
+      id: session.id,
+      name: title,
+      path: session.id,
+      type: "file",
+      icon: (
+        <HugeiconsIcon
+          icon={ComputerTerminal01Icon}
+          data-icon="terminal"
+          size={14}
+          strokeWidth={1.75}
+        />
+      ),
+    };
+
+    return (
+      <TreeRowBase node={node} depth={0} isSelected={isActive} onClick={onOpen}>
+        <ProcessStopButton
+          size="sm"
+          className="hidden group-focus-within/item:flex group-hover/item:flex"
+          onClick={onClose}
+          label={t("common:tooltips.killTerminal")}
+        />
+      </TreeRowBase>
+    );
+  }
+);
+PtySessionRow.displayName = "TerminalSidebarPtySessionRow";
+
+export function useActiveAgentSessions() {
+  const shellProcessMap = useAtomValue(shellProcessMapAtom);
+
+  return [...shellProcessMap.entries()]
+    .filter(([, processMap]) =>
+      [...processMap.values()].some(
+        (process) =>
+          process.status === "running" || process.status === "background"
+      )
+    )
+    .map(([sessionId, processMap]) => {
+      const runningProcess = [...processMap.values()].find(
+        (process) =>
+          process.status === "running" || process.status === "background"
+      );
+      return { sessionId, command: runningProcess?.command ?? null };
+    });
+}

--- a/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalTabSidebar.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/Terminal/TerminalTabSidebar.tsx
@@ -1,0 +1,87 @@
+import { useTerminalState } from "@/src/engines/TerminalCore/hooks/useTerminalState";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useCallback } from "react";
+
+import { selectedRepoPathAtom } from "@src/store/repo";
+// Deep import; the @src/store/workstation/codeEditor barrel re-exports
+// sourceControlFilterModeAtom which transitively pulls SidebarModules back
+// here, creating a circular dependency.
+import {
+  type TerminalTarget,
+  clearTerminalTargetReferencesAtom,
+  codeEditorTerminalTargetAtom,
+} from "@src/store/workstation/codeEditor/terminalTargetAtom";
+
+import { type TabSidebarComponent, registerTabSidebar } from "../registry";
+import TerminalSidebarContent from "./TerminalSidebarContent";
+
+const TerminalTabSidebar: TabSidebarComponent = () => {
+  const terminalState = useTerminalState();
+  const terminalTarget = useAtomValue(codeEditorTerminalTargetAtom);
+  const selectedRepoPath = useAtomValue(selectedRepoPathAtom);
+  const setTerminalTarget = useSetAtom(codeEditorTerminalTargetAtom);
+  const clearTerminalTargetReferences = useSetAtom(
+    clearTerminalTargetReferencesAtom
+  );
+  const activeTerminalTarget =
+    terminalTarget?.kind === "agent"
+      ? terminalTarget
+      : terminalState.activeSessionId
+        ? { kind: "pty" as const, ptySessionId: terminalState.activeSessionId }
+        : null;
+
+  const handleOpenTerminal = useCallback(
+    (target: TerminalTarget) => {
+      if (target.kind === "pty") {
+        const exists = terminalState.sessions.some(
+          (session) => session.id === target.ptySessionId
+        );
+        if (exists) {
+          terminalState.setActiveSession(target.ptySessionId);
+        }
+      }
+      setTerminalTarget(target);
+    },
+    [terminalState, setTerminalTarget]
+  );
+
+  const handleNewPtySession = useCallback(
+    (options?: {
+      shell?: string;
+      args?: string[];
+      name?: string;
+      profileId?: string;
+    }) => {
+      const sessionId = terminalState.addSession({
+        ...options,
+        cwd: selectedRepoPath || undefined,
+      });
+      terminalState.setActiveSession(sessionId);
+      setTerminalTarget({ kind: "pty", ptySessionId: sessionId });
+    },
+    [terminalState, selectedRepoPath, setTerminalTarget]
+  );
+
+  const handleClosePtySession = useCallback(
+    (sessionId: string) => {
+      terminalState.closeSession(sessionId);
+      clearTerminalTargetReferences(sessionId);
+    },
+    [clearTerminalTargetReferences, terminalState]
+  );
+
+  return (
+    <TerminalSidebarContent
+      activeTerminalTarget={activeTerminalTarget}
+      onOpenTerminal={handleOpenTerminal}
+      onClosePtySession={handleClosePtySession}
+      onNewPtySession={handleNewPtySession}
+    />
+  );
+};
+
+TerminalTabSidebar.displayName = "TerminalTabSidebar";
+
+registerTabSidebar("terminal", TerminalTabSidebar);
+
+export { TerminalTabSidebar };

--- a/src/modules/WorkStation/shared/SidebarModules/Terminal/index.ts
+++ b/src/modules/WorkStation/shared/SidebarModules/Terminal/index.ts
@@ -1,0 +1,1 @@
+export { TerminalTabSidebar } from "./TerminalTabSidebar";

--- a/src/modules/WorkStation/shared/SidebarModules/index.ts
+++ b/src/modules/WorkStation/shared/SidebarModules/index.ts
@@ -18,6 +18,9 @@ export {
   type SourceControlFilterMode,
 } from "./SourceControl";
 
+// Importing terminal installs its tab-specific sidebar in the registry.
+export { TerminalTabSidebar } from "./Terminal";
+
 export {
   registerTabSidebar,
   getTabSidebarDescriptor,


### PR DESCRIPTION
## Problem

Terminal tabs show the regular file explorer instead of terminal navigation. Commit `66e95ca31` removed the terminal sidebar as unused code, but importing that module registered the terminal-specific sidebar. Removing its registration caused `SidebarSlot` to fall back to the editor explorer.

## Solution

Restore the terminal sidebar components and their production entry-point export, including module-init registration. Terminal tabs again select terminal navigation, while file tabs keep the explorer. Reuse the existing Stop Process translation for agent process controls and the shared Untitled placeholder for unnamed sessions.

Add regression tests importing the production entry point and checking registration, terminal/file switching, retained sidebar visibility, and removal. Include a focused lifecycle review of the restored path.

## Potential risks

The restored sidebar exposes existing terminal selection, creation, closing, and agent-process stopping controls. Routing tests mock terminal content and services; live PTY actions and full row rendering remain unverified. Desktop screenshots, theme/viewport checks, and visible/hidden/post-close CPU/RSS measurements were not performed because desktop control requires explicit user opt-in. The lifecycle performance verdict remains blocked on those measurements.

No dependency, schema, persistence, IPC, or wire formats change, and no historical data cleanup is needed. The sidebar reads existing store state and adds no poller or mount-triggered process. Reverting this commit restores the previous explorer fallback.

## Verification

CI initially caught a deleted `controlTower.sidebar.untitled` key in the restored component. The follow-up commit switches to `placeholders.untitled`; no baseline suppression or locale changes are needed.

Executed in an isolated worktree based on the latest fetched `origin/develop`:

- `pnpm test src/modules/WorkStation/shared/SidebarModules/SidebarSlot.test.ts src/store/workstation/tabs/__tests__/tabRetention.test.ts` — 7 tests passed.
- `pnpm run test:i18n-keys` — 27 tests passed after the translation correction.
- `pnpm run check:i18n-keys` — passed with no missing keys or new findings after the translation correction.
- `pnpm typecheck:fast` — passed.
- `pnpm exec eslint src/modules/WorkStation/shared/SidebarModules/Terminal src/modules/WorkStation/shared/SidebarModules/index.ts src/modules/WorkStation/shared/SidebarModules/SidebarSlot.test.ts` — passed.
- `git diff --cached --check` — passed.
- `pnpm check:circular` — reports 3 cycles in SessionCore/ChatPanel/input hooks and HoverCard; none includes a changed module.
- Reviewed the scoped diff for unrelated edits, secrets, personal paths, debug logs, and generated files.
- Desktop visual validation, live terminal action checks, and runtime resource measurements were not run, as described above.

